### PR TITLE
Implement MuHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "wasm",
     "misc",
     "crypto/hashes",
+    "crypto/muhash",
 ]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -9,12 +9,10 @@ include = [
 ]
 
 [dependencies]
-async-std = "1.11.0"
-regex = "1"
 hex = "0.4.3"
 thiserror = "1.0.31"
 serde = { version = "1.0", features = ["derive", "rc"] }
-rocksdb = "0.18.0"
+rocksdb = "0.19.0"
 moka = "0.9"
 bincode = "1.3.3"
 parking_lot = "0.12.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,22 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.7.3"
-log = "0.4.16"
-console = "0.15.0"
 wasm-bindgen = "0.2.79"
-wasm-bindgen-futures = "0.4.29"
-web-sys = { version = "0.3.56", features = ['console'] }
-js-sys = "0.3.56"
-bs58 = "0.4.0"
-async-std = "1.11.0"
-regex = "1"
-#derivative = "2.2.0"
 ctrlc = "3.1.9"
-chrono = "*"
-crossbeam-channel="0.5"
-crossbeam = "*"
-num-format = "0.4.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 intertrait="*"

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -11,7 +11,7 @@ no-asm = ["keccak"]
 
 [dependencies]
 hex = "0.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 blake2b_simd = "1"
 sha2 = "0.10"
 once_cell = "1"

--- a/crypto/hashes/src/hashers.rs
+++ b/crypto/hashes/src/hashers.rs
@@ -15,7 +15,7 @@ pub trait Hasher: Clone + Default {
 
 // Implemented manually in pow_hashers:
 //  struct PowHash => `cSHAKE256("ProofOfWorkHash")
-//  struct KHeavyHash => `cSHAKE256("KHeavyHash")
+//  struct KHeavyHash => `cSHAKE256("HeavyHash")
 pub use crate::pow_hashers::{KHeavyHash, PowHash};
 blake2b_hasher! {
     struct TransactionHash => b"TransactionHash",

--- a/crypto/hashes/src/hashers.rs
+++ b/crypto/hashes/src/hashers.rs
@@ -38,7 +38,7 @@ macro_rules! sha256_hasher {
         pub struct $name(sha2::Sha256);
 
         impl $name {
-            #[inline(always)]
+            #[inline]
             pub fn new() -> Self {
                 use sha2::{Sha256, Digest};
                 // We use Lazy in order to avoid rehashing it
@@ -103,20 +103,23 @@ macro_rules! blake2b_hasher {
 macro_rules! impl_hasher {
     (struct $name:ident) => {
         impl Hasher for $name {
+            #[inline(always)]
             fn update<A: AsRef<[u8]>>(&mut self, data: A) -> &mut Self {
                 self.write(data);
                 self
             }
+            #[inline(always)]
             fn finalize(self) -> crate::Hash {
                 // Call the method
                 $name::finalize(self)
             }
-
+            #[inline(always)]
             fn reset(&mut self) {
                 *self = Self::new();
             }
         }
         impl Default for $name {
+            #[inline(always)]
             fn default() -> Self {
                 Self::new()
             }

--- a/crypto/hashes/src/pow_hashers.rs
+++ b/crypto/hashes/src/pow_hashers.rs
@@ -37,7 +37,7 @@ impl PowHash {
 }
 
 impl KHeavyHash {
-    // The initial state of `cSHAKE256("KHeavyHash")`
+    // The initial state of `cSHAKE256("HeavyHash")`
     // [4] -> 16654558671554924254 ^ 0x04(padding byte) = 16654558671554924250
     // [16] -> 9793466274154320918 ^ 0x8000000000000000(final padding) = 570094237299545110
     #[rustfmt::skip]

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "muhash"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand_chacha = "0.3"
+hashes = { path = "../hashes" }
+hex = "*"
+

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -13,7 +13,7 @@ hex = "*"
 
 [dev-dependencies]
 criterion = "0.3"
-
+rand = "0.8"
 [[bench]]
 name = "bench"
 harness = false

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -10,3 +10,11 @@ rand_chacha = "0.3"
 hashes = { path = "../hashes" }
 hex = "*"
 
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "bench"
+harness = false
+

--- a/crypto/muhash/benches/bench.rs
+++ b/crypto/muhash/benches/bench.rs
@@ -1,10 +1,11 @@
-use rand_chacha::{ChaCha8Rng, rand_core::{SeedableRng, RngCore}};
-use std::time::UNIX_EPOCH;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand_chacha::{
+    rand_core::{RngCore, SeedableRng},
+    ChaCha8Rng,
+};
+use std::time::UNIX_EPOCH;
 
 use muhash::MuHash;
-
-
 
 fn bench_muhash(c: &mut Criterion) {
     let time = UNIX_EPOCH.elapsed().unwrap().as_micros();
@@ -17,7 +18,6 @@ fn bench_muhash(c: &mut Criterion) {
     let mut rand_set_serialized = [0u8; 384];
     rng.fill_bytes(&mut rand_set_serialized);
     let mut rand_set = MuHash::deserialize(rand_set_serialized).unwrap();
-
 
     c.bench_function("MuHash::add_element", |b| {
         let mut muhash = MuHash::new();
@@ -55,35 +55,26 @@ fn bench_muhash(c: &mut Criterion) {
     c.bench_function("MuHash::serialize worst", |b| {
         let mut muhash_serialized = [255u8; 384];
         //  make sure it's lower than the prime
-        muhash_serialized[0..4].copy_from_slice(&[130, 193, 152, 0]);
-        muhash_serialized[192..196].copy_from_slice(&[129, 193, 152, 0]);
+        muhash_serialized[0..3].copy_from_slice(&[154, 40, 239]);
+        muhash_serialized[192..195].copy_from_slice(&[153, 40, 239]);
         let muhash = MuHash::deserialize(muhash_serialized).unwrap();
-        b.iter(|| {
-            black_box(muhash.clone()).serialize()
-        });
+        b.iter(|| black_box(muhash.clone()).serialize());
     });
 
     c.bench_function("MuHash::serialize best", |b| {
         let muhash = MuHash::new();
-        b.iter(|| {
-            black_box(muhash.clone()).serialize()
-        })
+        b.iter(|| black_box(muhash.clone()).serialize())
     });
 
     c.bench_function("MuHash::serialize rand", |b| {
         let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
-        b.iter(|| {
-            black_box(muhash.clone()).serialize()
-        })
+        b.iter(|| black_box(muhash.clone()).serialize())
     });
 
     c.bench_function("MuHash::finalize", |b| {
         let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
-        b.iter(|| {
-            black_box(muhash.clone()).finalize()
-        });
+        b.iter(|| black_box(muhash.clone()).finalize());
     });
-
 }
 
 criterion_group!(benches, bench_muhash);

--- a/crypto/muhash/benches/bench.rs
+++ b/crypto/muhash/benches/bench.rs
@@ -1,0 +1,90 @@
+use rand_chacha::{ChaCha8Rng, rand_core::{SeedableRng, RngCore}};
+use std::time::UNIX_EPOCH;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use muhash::MuHash;
+
+
+
+fn bench_muhash(c: &mut Criterion) {
+    let time = UNIX_EPOCH.elapsed().unwrap().as_micros();
+    let mut seed = [0u8; 32];
+    seed[0..16].copy_from_slice(&time.to_ne_bytes());
+    let mut rng = ChaCha8Rng::from_seed(seed);
+
+    let mut data = [0u8; 100];
+    rng.fill_bytes(&mut data);
+    let mut rand_set_serialized = [0u8; 384];
+    rng.fill_bytes(&mut rand_set_serialized);
+    let mut rand_set = MuHash::deserialize(rand_set_serialized).unwrap();
+
+
+    c.bench_function("MuHash::add_element", |b| {
+        let mut muhash = MuHash::new();
+        b.iter(|| {
+            black_box(&mut data);
+            muhash.add_element(&data);
+        });
+        black_box(muhash);
+    });
+
+    c.bench_function("MuHash::remove_element", |b| {
+        let mut muhash = MuHash::new();
+        b.iter(|| {
+            black_box(&mut data);
+            muhash.remove_element(&data);
+        });
+        black_box(muhash);
+    });
+    c.bench_function("MuHash::combine", |b| {
+        let mut muhash = MuHash::new();
+        b.iter(|| {
+            black_box((&mut rand_set, &mut muhash));
+            muhash.combine(&rand_set);
+        });
+        black_box(muhash);
+    });
+
+    c.bench_function("MuHash::clone", |b| {
+        b.iter(|| {
+            black_box(&mut rand_set);
+            rand_set.clone()
+        });
+    });
+
+    c.bench_function("MuHash::serialize worst", |b| {
+        let mut muhash_serialized = [255u8; 384];
+        //  make sure it's lower than the prime
+        muhash_serialized[0..4].copy_from_slice(&[130, 193, 152, 0]);
+        muhash_serialized[192..196].copy_from_slice(&[129, 193, 152, 0]);
+        let muhash = MuHash::deserialize(muhash_serialized).unwrap();
+        b.iter(|| {
+            black_box(muhash.clone()).serialize()
+        });
+    });
+
+    c.bench_function("MuHash::serialize best", |b| {
+        let muhash = MuHash::new();
+        b.iter(|| {
+            black_box(muhash.clone()).serialize()
+        })
+    });
+
+    c.bench_function("MuHash::serialize rand", |b| {
+        let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
+        b.iter(|| {
+            black_box(muhash.clone()).serialize()
+        })
+    });
+
+    c.bench_function("MuHash::finalize", |b| {
+        let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
+        b.iter(|| {
+            black_box(muhash.clone()).finalize()
+        });
+    });
+
+}
+
+criterion_group!(benches, bench_muhash);
+criterion_main!(benches);

--- a/crypto/muhash/fuzz/.gitignore
+++ b/crypto/muhash/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+#corpus
+artifacts

--- a/crypto/muhash/fuzz/Cargo.toml
+++ b/crypto/muhash/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "muhash-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+num-bigint = "0.4"
+num-traits = "0.2"
+num-integer = "0.1"
+
+[dependencies.muhash]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "u3072"
+path = "fuzz_targets/u3072.rs"
+test = false
+doc = false

--- a/crypto/muhash/fuzz/fuzz.sh
+++ b/crypto/muhash/fuzz/fuzz.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+rustc --version
+cargo install cargo-fuzz
+
+cargo fuzz run u3072 --debug-assertions --release -- -use_counters=1 -use_value_profile=1 "$@"

--- a/crypto/muhash/fuzz/fuzz_targets/u3072.rs
+++ b/crypto/muhash/fuzz/fuzz_targets/u3072.rs
@@ -1,0 +1,58 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use muhash::u3072::{self, U3072};
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::{One, Signed};
+use std::mem::size_of;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < muhash::SERIALIZED_MUHASH_SIZE {
+        return;
+    }
+
+    let prime_num = prime_num();
+    let mut start_uint = U3072::one();
+    let mut start_num = BigInt::one();
+    for current in data.chunks_exact(muhash::SERIALIZED_MUHASH_SIZE) {
+        let current_uint = U3072::from_le_bytes(current.try_into().unwrap());
+        let mut current_num = BigInt::from_bytes_le(num_bigint::Sign::Plus, current);
+
+        if current[0] & 1 == 1 {
+            start_uint /= current_uint;
+            current_num = inverse_num(&current_num, &prime_num);
+            start_num *= current_num;
+        } else {
+            start_uint *= current_uint;
+            start_num *= current_num;
+        }
+        start_num %= &prime_num;
+    }
+    assert_eq!(start_uint.to_le_bytes(), num_to_le(&start_num));
+});
+
+fn num_to_le(n: &BigInt) -> [u8; muhash::SERIALIZED_MUHASH_SIZE] {
+    let mut res = [0u8; muhash::SERIALIZED_MUHASH_SIZE];
+    for (i, word) in n.iter_u64_digits().enumerate() {
+        let part = &mut res[i*size_of::<u64>()..(i+1)*size_of::<u64>()];
+        part.copy_from_slice(&word.to_le_bytes());
+    }
+    res
+}
+
+fn prime_num() -> BigInt {
+    let mut prime = BigInt::one();
+    prime <<= 3072;
+    prime -= u3072::PRIME_DIFF;
+    prime
+}
+
+fn inverse_num(n: &BigInt, prime: &BigInt) -> BigInt {
+    let e_gcd = n.extended_gcd(prime);
+    assert!(e_gcd.gcd.is_one() || &e_gcd.gcd == prime);
+    if e_gcd.x.is_negative() {
+        e_gcd.x + prime
+    } else {
+        e_gcd.x
+    }
+}

--- a/crypto/muhash/fuzz/rust-toolchain.toml
+++ b/crypto/muhash/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/crypto/muhash/src/lib.rs
+++ b/crypto/muhash/src/lib.rs
@@ -40,12 +40,14 @@ impl Display for OverflowError {
 impl Error for OverflowError {}
 
 impl MuHash {
+    #[inline]
     /// return an empty initialized set.
     /// when finalized it should be equal to a finalized set with all elements removed.
     pub fn new() -> Self {
         Self { numerator: U3072::one(), denominator: U3072::one() }
     }
 
+    #[inline]
     // hashes the data and adds it to the muhash.
     // Supports arbitrary length data (subject to the underlying hash function(Blake2b) limits)
     pub fn add_element(&mut self, data: &[u8]) {
@@ -53,6 +55,7 @@ impl MuHash {
         self.numerator *= element;
     }
 
+    #[inline]
     // hashes the data and removes it from the muhash.
     // Supports arbitrary length data (subject to the underlying hash function(Blake2b) limits)
     pub fn remove_element(&mut self, data: &[u8]) {
@@ -60,6 +63,7 @@ impl MuHash {
         self.denominator *= element;
     }
 
+    #[inline]
     // will add the MuHash together. Equivalent to manually adding all the data elements
     // from one set to the other.
     pub fn combine(&mut self, other: &Self) {
@@ -67,22 +71,25 @@ impl MuHash {
         self.denominator *= other.numerator;
     }
 
-    // #[inline]
+    #[inline]
     pub fn finalize(&mut self) -> Hash {
         let serialized = self.serialize();
         MuHashFinalizeHash::hash(serialized)
     }
 
+    #[inline]
     fn normalize(&mut self) {
         self.numerator /= self.denominator;
         self.denominator = U3072::one();
     }
 
+    #[inline]
     pub fn serialize(&mut self) -> [u8; SERIALIZED_MUHASH_SIZE] {
         self.normalize();
         self.numerator.to_le_bytes()
     }
 
+    #[inline]
     pub fn deserialize(data: [u8; SERIALIZED_MUHASH_SIZE]) -> Result<Self, OverflowError> {
         let numerator = U3072::from_le_bytes(data);
         if numerator.is_overflow() {
@@ -93,6 +100,7 @@ impl MuHash {
     }
 }
 
+#[inline]
 fn data_to_element(data: &[u8]) -> U3072 {
     let hash = MuHashElementHash::hash(data);
     let mut stream = ChaCha20Rng::from_seed(hash.as_bytes());
@@ -102,6 +110,7 @@ fn data_to_element(data: &[u8]) -> U3072 {
 }
 
 impl Default for MuHash {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/crypto/muhash/src/lib.rs
+++ b/crypto/muhash/src/lib.rs
@@ -1,3 +1,7 @@
+// Make u3072 public if we're fuzzing
+#[cfg(fuzzing)]
+pub mod u3072;
+#[cfg(not(fuzzing))]
 mod u3072;
 
 use crate::u3072::U3072;

--- a/crypto/muhash/src/lib.rs
+++ b/crypto/muhash/src/lib.rs
@@ -1,0 +1,227 @@
+mod u3072;
+
+use crate::u3072::U3072;
+use hashes::{Hash, Hasher, MuHashElementHash, MuHashFinalizeHash};
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use std::error::Error;
+use std::fmt::Display;
+
+pub const HASH_SIZE: usize = 32;
+pub const SERIALIZED_MUHASH_SIZE: usize = ELEMENT_BYTE_SIZE;
+// The hash of `NewMuHash().Finalize()`
+pub const EMPTY_MUHASH: Hash = Hash::from_bytes([
+    0x54, 0x4e, 0xb3, 0x14, 0x2c, 0x0, 0xf, 0xa, 0xd2, 0xc7, 0x6a, 0xc4, 0x1f, 0x42, 0x22, 0xab, 0xba, 0xba, 0xbe,
+    0xd8, 0x30, 0xee, 0xaf, 0xee, 0x4b, 0x6d, 0xc5, 0x6b, 0x52, 0xd5, 0xca, 0xc0,
+]);
+
+pub(crate) const ELEMENT_BIT_SIZE: usize = 3072;
+pub(crate) const ELEMENT_BYTE_SIZE: usize = ELEMENT_BIT_SIZE / 8;
+
+/// MuHash is a type used to create a Multiplicative Hash
+/// which is a rolling(homomorphic) hash that you can add and remove elements from
+/// and receive the same resulting hash as-if you never hashed them.
+/// Because of that the order of adding and removing elements doesn't matter.
+#[derive(Clone, Debug)]
+pub struct MuHash {
+    numerator: U3072,
+    denominator: U3072,
+}
+
+#[derive(Debug)]
+pub struct OverflowError;
+
+impl Display for OverflowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Overflow in the MuHash field")
+    }
+}
+
+impl Error for OverflowError {}
+
+impl MuHash {
+    /// return an empty initialized set.
+    /// when finalized it should be equal to a finalized set with all elements removed.
+    pub fn new() -> Self {
+        Self { numerator: U3072::one(), denominator: U3072::one() }
+    }
+
+    // hashes the data and adds it to the muhash.
+    // Supports arbitrary length data (subject to the underlying hash function(Blake2b) limits)
+    pub fn add_element(&mut self, data: &[u8]) {
+        let element = data_to_element(data);
+        self.numerator *= element;
+    }
+
+    // hashes the data and removes it from the muhash.
+    // Supports arbitrary length data (subject to the underlying hash function(Blake2b) limits)
+    pub fn remove_element(&mut self, data: &[u8]) {
+        let element = data_to_element(data);
+        self.denominator *= element;
+    }
+
+    // will add the MuHash together. Equivalent to manually adding all the data elements
+    // from one set to the other.
+    pub fn combine(&mut self, other: &Self) {
+        self.numerator *= other.denominator;
+        self.denominator *= other.numerator;
+    }
+
+    pub fn finalize(mut self) -> Hash {
+        let serialized = self.serialize();
+        MuHashFinalizeHash::hash(serialized)
+    }
+
+    fn normalize(&mut self) {
+        self.numerator /= self.denominator;
+        self.denominator = U3072::one();
+    }
+
+    pub fn serialize(&mut self) -> [u8; SERIALIZED_MUHASH_SIZE] {
+        self.normalize();
+        self.numerator.to_le_bytes()
+    }
+
+    pub fn deserialize(data: [u8; SERIALIZED_MUHASH_SIZE]) -> Result<Self, OverflowError> {
+        let numerator = U3072::from_le_bytes(data);
+        if numerator.is_overflow() {
+            Err(OverflowError)
+        } else {
+            Ok(Self { numerator, denominator: U3072::one() })
+        }
+    }
+}
+
+fn data_to_element(data: &[u8]) -> U3072 {
+    let hash = MuHashElementHash::hash(data);
+    let mut stream = ChaCha20Rng::from_seed(hash.as_bytes());
+    let mut bytes = [0u8; ELEMENT_BYTE_SIZE];
+    stream.fill_bytes(&mut bytes);
+    U3072::from_le_bytes(bytes)
+}
+
+impl Default for MuHash {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::u3072;
+    use crate::{MuHash, EMPTY_MUHASH, U3072};
+    use hashes::Hash;
+    use rand_chacha::rand_core::{RngCore, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    struct TestVector {
+        data: &'static [u8],
+        multiset_hash: Hash,
+        cumulative_hash: Hash,
+    }
+
+    const TEST_VECTORS: [TestVector; 3] = [
+        TestVector {
+            data: &[
+                152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123, 161, 163, 195, 84, 11,
+                247, 177, 205, 182, 6, 232, 87, 35, 62, 14, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 242, 5, 42, 1, 0, 0, 0, 67,
+                65, 4, 150, 181, 56, 232, 83, 81, 156, 114, 106, 44, 145, 230, 30, 193, 22, 0, 174, 19, 144, 129, 58,
+                98, 124, 102, 251, 139, 231, 148, 123, 230, 60, 82, 218, 117, 137, 55, 149, 21, 212, 224, 166, 4, 248,
+                20, 23, 129, 230, 34, 148, 114, 17, 102, 191, 98, 30, 115, 168, 44, 191, 35, 66, 200, 88, 238, 172,
+            ],
+            multiset_hash: Hash::from_bytes([
+                44, 55, 150, 32, 253, 244, 236, 10, 194, 83, 203, 228, 186, 130, 194, 187, 220, 15, 237, 172, 127, 224,
+                228, 82, 149, 125, 147, 117, 123, 191, 245, 193,
+            ]),
+            cumulative_hash: Hash::from_bytes([
+                44, 55, 150, 32, 253, 244, 236, 10, 194, 83, 203, 228, 186, 130, 194, 187, 220, 15, 237, 172, 127, 224,
+                228, 82, 149, 125, 147, 117, 123, 191, 245, 193,
+            ]),
+        },
+        TestVector {
+            data: &[
+                213, 253, 204, 84, 30, 37, 222, 28, 122, 90, 221, 237, 242, 72, 88, 184, 187, 102, 92, 159, 54, 239,
+                116, 78, 228, 44, 49, 96, 34, 201, 15, 155, 0, 0, 0, 0, 2, 0, 0, 0, 1, 0, 242, 5, 42, 1, 0, 0, 0, 67,
+                65, 4, 114, 17, 168, 36, 245, 91, 80, 82, 40, 228, 195, 213, 25, 76, 31, 207, 170, 21, 164, 86, 171,
+                223, 55, 249, 185, 217, 122, 64, 64, 175, 192, 115, 222, 230, 200, 144, 100, 152, 79, 3, 56, 82, 55,
+                217, 33, 103, 193, 62, 35, 100, 70, 180, 23, 171, 121, 160, 252, 174, 65, 42, 227, 49, 107, 119, 172,
+            ],
+            multiset_hash: Hash::from_bytes([
+                102, 139, 178, 146, 239, 21, 44, 84, 219, 15, 87, 20, 191, 69, 255, 141, 167, 177, 212, 28, 12, 80, 38,
+                173, 101, 91, 47, 158, 27, 230, 126, 33,
+            ]),
+            cumulative_hash: Hash::from_bytes([
+                177, 91, 209, 18, 74, 107, 82, 230, 78, 218, 60, 48, 35, 197, 135, 228, 85, 167, 158, 116, 140, 140,
+                149, 77, 215, 65, 29, 13, 189, 151, 56, 99,
+            ]),
+        },
+        TestVector {
+            data: &[
+                68, 246, 114, 34, 96, 144, 216, 93, 185, 169, 242, 251, 254, 95, 15, 150, 9, 179, 135, 175, 123, 229,
+                183, 251, 183, 161, 118, 124, 131, 28, 158, 153, 0, 0, 0, 0, 3, 0, 0, 0, 1, 0, 242, 5, 42, 1, 0, 0, 0,
+                67, 65, 4, 148, 185, 211, 231, 108, 91, 22, 41, 236, 249, 127, 255, 149, 215, 164, 187, 218, 200, 124,
+                194, 96, 153, 173, 162, 128, 102, 198, 255, 30, 185, 25, 18, 35, 205, 137, 113, 148, 160, 141, 12, 39,
+                38, 197, 116, 127, 29, 180, 158, 140, 249, 14, 117, 220, 62, 53, 80, 174, 155, 48, 8, 111, 60, 213,
+                170, 172,
+            ],
+            multiset_hash: Hash::from_bytes([
+                244, 11, 32, 189, 196, 62, 242, 240, 26, 23, 59, 118, 124, 185, 198, 184, 219, 86, 2, 235, 83, 95, 203,
+                152, 39, 56, 95, 155, 14, 58, 250, 244,
+            ]),
+            cumulative_hash: Hash::from_bytes([
+                230, 156, 110, 5, 4, 16, 118, 22, 72, 206, 98, 118, 168, 28, 128, 68, 185, 239, 177, 113, 94, 166, 246,
+                251, 159, 140, 247, 168, 193, 232, 3, 150,
+            ]),
+        },
+    ];
+
+    const MAX_MU_HASH: MuHash = MuHash { numerator: U3072::MAX, denominator: U3072::MAX };
+
+    #[test]
+    fn test_random_muhash_arithmetic() {
+        let element_from_byte = |b| [b; 32];
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let rng_get_byte = |rng: &mut ChaCha8Rng| {
+            let mut byte = [0u8; 1];
+            rng.fill_bytes(&mut byte);
+            byte[0]
+        };
+        for _ in 0..10 {
+            let mut res = Hash::default();
+            let mut table = [0u8; 4];
+            rng.fill_bytes(&mut table);
+
+            for order in 0..4 {
+                let mut acc = MuHash::new();
+                for i in 0..4 {
+                    let t = table[i ^ order];
+                    if (t & 4) == 1 {
+                        acc.remove_element(&element_from_byte(t & 3));
+                    } else {
+                        acc.add_element(&element_from_byte(t & 3));
+                    }
+                }
+                let out = acc.finalize();
+                if order == 0 {
+                    res = out;
+                } else {
+                    assert_eq!(res, out);
+                }
+            }
+            let mut x = element_from_byte(rng_get_byte(&mut rng)); // x=X
+            let mut y = element_from_byte(rng_get_byte(&mut rng)); // x=X, y=Y
+            let mut z = MuHash::new(); // x=X, y=X, z=1
+            let mut yx = MuHash::new(); // x=X, y=Y, z=1 yx=1
+            yx.add_element(&y); // x=X, y=X, z=1, yx=Y
+            yx.add_element(&x); // x=X, y=X, z=1, yx=Y*X
+            yx.normalize();
+            z.add_element(&x); // x=X, y=Y, z=X, yx=Y*X
+            z.add_element(&y); // x=X, y=Y, z=X*Y, yx = Y*X
+            z.denominator *= yx.numerator; // x=X, y=Y, z=1, yx=Y*X
+
+            let empty = MuHash::new();
+            assert_eq!(EMPTY_MUHASH, empty.finalize());
+            assert_eq!(z.finalize(), EMPTY_MUHASH);
+        }
+    }
+}

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -1,0 +1,362 @@
+use crate::ELEMENT_BYTE_SIZE;
+use std::ops::{DivAssign, MulAssign};
+
+#[cfg(target_pointer_width = "64")]
+pub(crate) type Limb = u64;
+#[cfg(target_pointer_width = "64")]
+pub(crate) type DoubleLimb = u128;
+
+#[cfg(target_pointer_width = "32")]
+pub(crate) type Limb = u32;
+#[cfg(target_pointer_width = "32")]
+pub(crate) type DoubleLimb = u64;
+
+const LIMB_SIZE_BYTES: usize = std::mem::size_of::<Limb>();
+const LIMB_SIZE: usize = std::mem::size_of::<Limb>() * 8;
+pub(crate) const LIMBS: usize = crate::ELEMENT_BYTE_SIZE / LIMB_SIZE_BYTES;
+
+pub(crate) const PRIME_DIFF: Limb = 1103717;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct U3072 {
+    limbs: [Limb; LIMBS],
+}
+
+impl U3072 {
+    pub(crate) const MAX: Self = U3072 { limbs: [Limb::MAX; LIMBS] };
+
+    #[inline(always)]
+    pub(super) const fn zero() -> Self {
+        Self { limbs: [0; LIMBS] }
+    }
+
+    #[inline(always)]
+    pub(super) const fn one() -> Self {
+        let mut s = Self::zero();
+        s.limbs[0] = 1;
+        s
+    }
+    #[inline]
+    #[must_use]
+    pub(super) fn is_overflow(&self) -> bool {
+        // If the smallest limb is smaller than MAX-PRIME_DIFF then it is not overflown.
+        if self.limbs[0] <= Limb::MAX - PRIME_DIFF {
+            return false;
+        }
+        // If all other limbs == MAX it is overflown.
+        self.limbs[1..]
+            .iter()
+            .all(|&limb| limb == Limb::MAX)
+    }
+
+    #[inline(always)]
+    pub(super) fn from_le_bytes(bytes: [u8; ELEMENT_BYTE_SIZE]) -> Self {
+        let mut res = Self::zero();
+        bytes
+            .chunks_exact(LIMB_SIZE_BYTES)
+            .zip(res.limbs.iter_mut())
+            .for_each(|(chunk, word)| {
+                *word = Limb::from_le_bytes(chunk.try_into().unwrap());
+            });
+        res
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub(super) fn to_le_bytes(self) -> [u8; ELEMENT_BYTE_SIZE] {
+        let mut res = [0u8; ELEMENT_BYTE_SIZE];
+        self.limbs
+            .iter()
+            .zip(res.chunks_exact_mut(LIMB_SIZE_BYTES))
+            .for_each(|(limb, chunk)| {
+                chunk.copy_from_slice(&limb.to_le_bytes());
+            });
+        res
+    }
+
+    #[inline]
+    fn full_reduce(&mut self) {
+        let mut low = PRIME_DIFF;
+        let mut high: Limb = 0;
+        for limb in &mut self.limbs {
+            let mut overflow;
+            (low, overflow) = low.overflowing_add(*limb);
+            (high, overflow) = high.overflowing_add(overflow as _);
+            // Extract the result into self and shift the carries.
+            (*limb, low, high) = (low, high, overflow as _);
+        }
+    }
+
+    #[inline]
+    fn mul(&mut self, other: &U3072) {
+        let (mut carry_low, mut carry_high, mut carry_highest) = (0, 0, 0);
+        let mut tmp = Self::one();
+
+        // Compute limbs 0..N-2 of this*a into tmp, including one reduction.
+        for j in 0..LIMBS - 1 {
+            let (mut low, mut high) = mul_wide(self.limbs[j + 1], other.limbs[LIMBS + j - (1 + j)]);
+            let mut carry = 0;
+            for i in 2 + j..LIMBS {
+                (low, high, carry) = muladd3(self.limbs[i], other.limbs[LIMBS + j - i], low, high, carry);
+            }
+            (carry_low, carry_high, carry_highest) = mulnadd3(carry_low, carry_high, low, high, carry, PRIME_DIFF);
+
+            for i in 0..j + 1 {
+                (carry_low, carry_high, carry_highest) =
+                    muladd3(self.limbs[i], other.limbs[j - i], carry_low, carry_high, carry_highest);
+            }
+
+            // Extract the lowest limb of [low,high,carry] into n, and left shift the number by 1 limb
+            (tmp.limbs[j], carry_low, carry_high, carry_highest) = (carry_low, carry_high, carry_highest, 0);
+        }
+
+        // Compute limb N-1 of a*b into tmp
+        assert_eq!(carry_highest, 0);
+
+        for i in 0..LIMBS {
+            (carry_low, carry_high, carry_highest) =
+                muladd3(self.limbs[i], other.limbs[LIMBS - 1 - i], carry_low, carry_high, carry_highest);
+        }
+
+        // Extract the lowest limb into temp and shift all the rest.
+        (tmp.limbs[LIMBS - 1], carry_low, carry_high) = (carry_low, carry_high, carry_highest);
+
+        // Perform a second reduction
+        (carry_low, carry_high) = muln2(carry_low, carry_high, PRIME_DIFF);
+        for i in 0..LIMBS {
+            let mut overflow;
+            (carry_low, overflow) = carry_low.overflowing_add(tmp.limbs[i]);
+            (carry_high, overflow) = carry_high.overflowing_add(overflow as _);
+
+            // Extract the result into self and shift the carries.
+            (self.limbs[i], carry_low, carry_high) = (carry_low, carry_high, overflow as _);
+        }
+        assert_eq!(carry_high, 0);
+        assert!(carry_low == 0 || carry_low == 1);
+        //  Perform up to two more reductions if the internal state has already overflown the MAX of u3072
+        //  or if it is larger than the modulus or if both are the case.
+
+        if self.is_overflow() {
+            self.full_reduce();
+        }
+        if carry_low != 0 {
+            self.full_reduce();
+        }
+    }
+
+    fn square(&mut self) {
+        let (mut c0, mut c1, mut c2) = (0, 0, 0);
+        let mut tmp = Self::zero();
+        // Compute limbs 0..N-2 of this*this into tmp, including one reduction
+        for j in 0..LIMBS - 1 {
+            let (mut d0, mut d1, mut d2) = (0, 0, 0);
+            for i in 0..(LIMBS - 1 - j) / 2 {
+                (d0, d1, d2) = mul_double_add(d0, d1, d2, self.limbs[i + j + 1], self.limbs[LIMBS - 1 - i]);
+            }
+            if (j + 1) & 1 == 1 {
+                (d0, d1, d2) = muladd3(
+                    self.limbs[(LIMBS - 1 - j) / 2 + j + 1],
+                    self.limbs[LIMBS - 1 - (LIMBS - 1 - j) / 2],
+                    d0,
+                    d1,
+                    d2,
+                );
+            }
+            (c0, c1, c2) = mulnadd3(c0, c1, d0, d1, d2, PRIME_DIFF);
+
+            for i in 0..(j + 1) / 2 {
+                (c0, c1, c2) = mul_double_add(c0, c1, c2, self.limbs[i], self.limbs[j - i]);
+            }
+            if (j + 1) & 1 == 1 {
+                (c0, c1, c2) = muladd3(self.limbs[(j + 1) / 2], self.limbs[j - ((j + 1) / 2)], c0, c1, c2);
+            }
+
+            (tmp.limbs[j], c0, c1, c2) = (c0, c1, c2, 0);
+        }
+
+        assert_eq!(c2, 0);
+
+        for i in 0..LIMBS / 2 {
+            (c0, c1, c2) = mul_double_add(c0, c1, c2, self.limbs[i], self.limbs[LIMBS - 1 - i]);
+        }
+
+        (tmp.limbs[LIMBS - 1], c0, c1) = (c0, c1, c2);
+
+        // Perform a second reduction
+        (c0, c1) = muln2(c0, c1, PRIME_DIFF);
+        for i in 0..LIMBS {
+            let mut overflow;
+            (c0, overflow) = c0.overflowing_add(tmp.limbs[i]);
+            (c1, overflow) = c1.overflowing_add(overflow as _);
+            // Extract the result into self and shift the carries.
+            (self.limbs[i], c0, c1) = (c0, c1, overflow as _);
+        }
+
+        assert_eq!(c1, 0);
+        assert!(c0 == 0 || c0 == 1);
+
+        // Perform up to two more reductions if the internal state has already overflown the MAX of Num3072
+        // or if it is larger than the modulus or if both are the case.
+        if self.is_overflow() {
+            self.full_reduce();
+        }
+        if c0 != 0 {
+            self.full_reduce();
+        }
+    }
+
+    #[inline(always)]
+    fn square_and_multiply(&mut self, sequence: usize, mul: &Self) {
+        for _ in 0..sequence {
+            self.square();
+        }
+        self.mul(mul);
+    }
+
+    #[must_use]
+    fn inverse(&self) -> Self {
+        // TODO: Replace with a generic extended Euclidean algorithm.
+
+        // For fast exponentiation a sliding window exponentiation with repunit
+        // precomputation is utilized. See "Fast Point Decompression for Standard
+        // Elliptic Curves" (Brumley, Järvinen, 2008).
+
+        let mut p = [Self::zero(); 12]; // p[i] = a^(2^(2^i)-1)
+
+        p[0] = *self;
+
+        for i in 0..11 {
+            p[i + 1] = p[i];
+            for _ in 0..(1 << i) {
+                p[i + 1].square();
+            }
+
+            // Due to the borrow checker we can't do `p[i + 1].mul(&p[i]);`
+            // so instead we split the slice right in between so we can achieve the same without overhead.
+            let (pi, pi1) = p.split_at_mut(i + 1);
+            pi1[0].mul(&pi[i]);
+        }
+
+        let mut out = p[11];
+
+        out.square_and_multiply(512, &p[9]);
+        out.square_and_multiply(256, &p[8]);
+        out.square_and_multiply(128, &p[7]);
+        out.square_and_multiply(64, &p[6]);
+        out.square_and_multiply(32, &p[5]);
+        out.square_and_multiply(8, &p[3]);
+        out.square_and_multiply(2, &p[1]);
+        out.square_and_multiply(1, &p[0]);
+        out.square_and_multiply(5, &p[2]);
+        out.square_and_multiply(3, &p[0]);
+        out.square_and_multiply(2, &p[0]);
+        out.square_and_multiply(4, &p[0]);
+        out.square_and_multiply(4, &p[1]);
+        out.square_and_multiply(3, &p[0]);
+
+        out
+    }
+
+    fn div(&mut self, other: &Self) {
+        let inv = if other.is_overflow() {
+            let mut new = *other;
+            new.full_reduce();
+            new.inverse()
+        } else {
+            other.inverse()
+        };
+        if self.is_overflow() {
+            self.full_reduce();
+        }
+
+        self.mul(&inv);
+        if self.is_overflow() {
+            self.full_reduce();
+        }
+    }
+}
+
+impl DivAssign for U3072 {
+    fn div_assign(&mut self, rhs: Self) {
+        self.div(&rhs);
+    }
+}
+
+impl MulAssign for U3072 {
+    fn mul_assign(&mut self, rhs: Self) {
+        self.mul(&rhs);
+    }
+}
+
+#[inline(always)]
+#[must_use]
+// Input: [limb_0,limb_1,limb_2] Output: [limb_0,limb_1,limb_2] +=  2 * a * b
+fn mul_double_add(limb_0: Limb, limb_1: Limb, mut limb_2: Limb, a: Limb, b: Limb) -> (Limb, Limb, Limb) {
+    let (low, high) = mul_wide(a, b);
+
+    let (limb_0, overflow) = limb_0.overflowing_add(low);
+    let (limb_1, overflow) = limb_1.overflowing_add(high + overflow as Limb);
+    limb_2 += overflow as Limb;
+
+    let (limb_0, overflow) = limb_0.overflowing_add(low);
+    let (limb_1, overflow) = limb_1.overflowing_add(high + overflow as Limb);
+    limb_2 += overflow as Limb;
+
+    (limb_0, limb_1, limb_2)
+}
+
+// TODO: Use https://github.com/rust-lang/rust/issues/85532 once stabilized.
+#[inline(always)]
+#[must_use]
+fn mul_wide(a: Limb, b: Limb) -> (Limb, Limb) {
+    let t = a as DoubleLimb * b as DoubleLimb;
+    (t as Limb, (t >> LIMB_SIZE) as Limb)
+}
+
+/// Accepts a [c0, c1] integer, adds n * [d0, d1, d2] and returns the result including the carry
+/// [c0,c1,c2] += n * [d0,d1,d2]. c2 is 0 initially
+#[inline(always)]
+#[must_use]
+fn mulnadd3(c0: Limb, c1: Limb, d0: Limb, d1: Limb, d2: Limb, n: Limb) -> (Limb, Limb, Limb) {
+    let mut t = d0 as DoubleLimb * n as DoubleLimb + c0 as DoubleLimb;
+    let c0 = t as Limb;
+    t >>= LIMB_SIZE;
+
+    t += d1 as DoubleLimb * n as DoubleLimb + c1 as DoubleLimb;
+    let c1 = t as Limb;
+    t >>= LIMB_SIZE;
+    let c2 = t as Limb + d2 * n;
+
+    (c0, c1, c2)
+}
+
+/// accepts a,b and [low, high, carry] and returns a new [low, high, carry]
+#[inline(always)]
+#[must_use]
+fn muladd3(a: Limb, b: Limb, low: Limb, high: Limb, mut carry: Limb) -> (Limb, Limb, Limb) {
+    let (tl, mut th) = mul_wide(a, b);
+    let (low, overflow) = low.overflowing_add(tl);
+    th += overflow as Limb;
+    let (high, overflow) = high.overflowing_add(th);
+    carry += overflow as Limb;
+    (low, high, carry)
+}
+
+/// [low,high] *= n and return [low, high]
+#[inline(always)]
+#[must_use]
+fn muln2(low: Limb, high: Limb, n: Limb) -> (Limb, Limb) {
+    let mut tmp = low as DoubleLimb * n as DoubleLimb;
+    let low = tmp as Limb;
+
+    tmp >>= LIMB_SIZE;
+    tmp += high as DoubleLimb * n as DoubleLimb;
+
+    (low, tmp as Limb)
+}
+
+impl Default for U3072 {
+    fn default() -> Self {
+        Self::zero()
+    }
+}

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -34,7 +34,8 @@ impl U3072 {
         s.limbs[0] = 1;
         s
     }
-    #[inline]
+
+    #[inline(always)]
     #[must_use]
     pub(super) fn is_overflow(&self) -> bool {
         // If the smallest limb is smaller than MAX-PRIME_DIFF then it is not overflown.
@@ -72,7 +73,7 @@ impl U3072 {
         res
     }
 
-    #[inline]
+    #[inline(always)]
     fn full_reduce(&mut self) {
         let mut low = PRIME_DIFF;
         let mut high: Limb = 0;
@@ -85,7 +86,6 @@ impl U3072 {
         }
     }
 
-    #[inline]
     fn mul(&mut self, other: &U3072) {
         let (mut carry_low, mut carry_high, mut carry_highest) = (0, 0, 0);
         let mut tmp = Self::one();
@@ -109,7 +109,7 @@ impl U3072 {
         }
 
         // Compute limb N-1 of a*b into tmp
-        assert_eq!(carry_highest, 0);
+        debug_assert_eq!(carry_highest, 0);
 
         for i in 0..LIMBS {
             (carry_low, carry_high, carry_highest) =
@@ -129,8 +129,8 @@ impl U3072 {
             // Extract the result into self and shift the carries.
             (self.limbs[i], carry_low, carry_high) = (carry_low, carry_high, overflow as _);
         }
-        assert_eq!(carry_high, 0);
-        assert!(carry_low == 0 || carry_low == 1);
+        debug_assert_eq!(carry_high, 0);
+        debug_assert!(carry_low == 0 || carry_low == 1);
         //  Perform up to two more reductions if the internal state has already overflown the MAX of u3072
         //  or if it is larger than the modulus or if both are the case.
 
@@ -172,7 +172,7 @@ impl U3072 {
             (tmp.limbs[j], c0, c1, c2) = (c0, c1, c2, 0);
         }
 
-        assert_eq!(c2, 0);
+        debug_assert_eq!(c2, 0);
 
         for i in 0..LIMBS / 2 {
             (c0, c1, c2) = mul_double_add(c0, c1, c2, self.limbs[i], self.limbs[LIMBS - 1 - i]);
@@ -190,8 +190,8 @@ impl U3072 {
             (self.limbs[i], c0, c1) = (c0, c1, overflow as _);
         }
 
-        assert_eq!(c1, 0);
-        assert!(c0 == 0 || c0 == 1);
+        debug_assert_eq!(c1, 0);
+        debug_assert!(c0 == 0 || c0 == 1);
 
         // Perform up to two more reductions if the internal state has already overflown the MAX of Num3072
         // or if it is larger than the modulus or if both are the case.
@@ -275,12 +275,14 @@ impl U3072 {
 }
 
 impl DivAssign for U3072 {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: Self) {
         self.div(&rhs);
     }
 }
 
 impl MulAssign for U3072 {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: Self) {
         self.mul(&rhs);
     }
@@ -354,6 +356,7 @@ fn muln2(low: Limb, high: Limb, n: Limb) -> (Limb, Limb) {
 }
 
 impl Default for U3072 {
+    #[inline(always)]
     fn default() -> Self {
         Self::zero()
     }

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -17,14 +17,12 @@ pub(crate) const LIMBS: usize = crate::ELEMENT_BYTE_SIZE / LIMB_SIZE_BYTES;
 
 pub(crate) const PRIME_DIFF: Limb = 1103717;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct U3072 {
     limbs: [Limb; LIMBS],
 }
 
 impl U3072 {
-    pub(crate) const MAX: Self = U3072 { limbs: [Limb::MAX; LIMBS] };
-
     #[inline(always)]
     pub(super) const fn zero() -> Self {
         Self { limbs: [0; LIMBS] }

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -13,23 +13,22 @@ pub(crate) type DoubleLimb = u64;
 
 const LIMB_SIZE_BYTES: usize = std::mem::size_of::<Limb>();
 const LIMB_SIZE: usize = std::mem::size_of::<Limb>() * 8;
-pub(crate) const LIMBS: usize = crate::ELEMENT_BYTE_SIZE / LIMB_SIZE_BYTES;
+pub const LIMBS: usize = crate::ELEMENT_BYTE_SIZE / LIMB_SIZE_BYTES;
 
-pub(crate) const PRIME_DIFF: Limb = 1103717;
+pub const PRIME_DIFF: Limb = 1103717;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct U3072 {
+pub struct U3072 {
     limbs: [Limb; LIMBS],
 }
-
 impl U3072 {
     #[inline(always)]
-    pub(super) const fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self { limbs: [0; LIMBS] }
     }
 
     #[inline(always)]
-    pub(super) const fn one() -> Self {
+    pub const fn one() -> Self {
         let mut s = Self::zero();
         s.limbs[0] = 1;
         s
@@ -37,7 +36,7 @@ impl U3072 {
 
     #[inline(always)]
     #[must_use]
-    pub(super) fn is_overflow(&self) -> bool {
+    pub fn is_overflow(&self) -> bool {
         // If the smallest limb is smaller than MAX-PRIME_DIFF then it is not overflown.
         if self.limbs[0] <= Limb::MAX - PRIME_DIFF {
             return false;
@@ -49,7 +48,7 @@ impl U3072 {
     }
 
     #[inline(always)]
-    pub(super) fn from_le_bytes(bytes: [u8; ELEMENT_BYTE_SIZE]) -> Self {
+    pub fn from_le_bytes(bytes: [u8; ELEMENT_BYTE_SIZE]) -> Self {
         let mut res = Self::zero();
         bytes
             .chunks_exact(LIMB_SIZE_BYTES)
@@ -62,7 +61,7 @@ impl U3072 {
 
     #[inline(always)]
     #[must_use]
-    pub(super) fn to_le_bytes(self) -> [u8; ELEMENT_BYTE_SIZE] {
+    pub fn to_le_bytes(self) -> [u8; ELEMENT_BYTE_SIZE] {
         let mut res = [0u8; ELEMENT_BYTE_SIZE];
         self.limbs
             .iter()

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -9,8 +9,6 @@ include = [
 ]
 
 [dependencies]
-async-std = "1.11.0"
-regex = "1"
 hex = "0.4.3"
 thiserror = "1.0.31"
 rand_distr = "0.4.3"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -4,14 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.7.3"
-log = "0.4.16"
-console = "0.15.0"
-wasm-bindgen = "0.2.79"
-wasm-bindgen-futures = "0.4.29"
-web-sys = { version = "0.3.56", features = ['console'] }
-js-sys = "0.3.56"
-bs58 = "0.4.0"
-async-std = "1.11.0"
-regex = "1"
-#derivative = "2.2.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -17,6 +17,3 @@ kaspa-core = { path = "../core" }
 kaspa-wallet = { path = "../wallet" }
 
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.29"
-js-sys = "0.3.56"
-async-std = "1.11.0"


### PR DESCRIPTION
A pure rust MuHash implementation of the logic in: https://github.com/kaspanet/go-muhash
I ran the fuzzer for 1.5 weeks and nothing has crashed yet.
Still trying to figure out the best way to store the fuzzing corpuses (as there are ~20k of those), probably a dedicated repository.

Note: The tests might fail for 32bit machines right now, but the logic itself should work just fine (we can decide if 32 bit machines should receive the same attention or not later)

Note2: Currently this is faster than the go+C version for everything except `Finalize()` which will get much faster by adding a `U3072` type and implementing an extended euclidean algorithm in order to invert the element 