### PR TITLE
Small rust changes - stylistic and performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
   # test-release:
   #   name: Test Suite Release
   #   runs-on: ${{ matrix.os }}
-    
+
   #   strategy:
   #     fail-fast: false
   #     matrix:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Kaspa on Rust  
+# Kaspa on Rust
 
 
-Work in progress to implement the Kaspa full-node and related libraries in the Rust programming language. 
+Work in progress to implement the Kaspa full-node and related libraries in the Rust programming language.
 
-## Getting started 
+## Getting started
 
 - Install the [rust toolchain](https://rustup.rs/).
 
@@ -14,7 +14,7 @@ $ cd rusty-kaspa/kaspad
 $ cargo run --release
 ```
 
-- This will run a short simulation producing a random DAG and processing it (applying all currently implemented logic). 
+- This will run a short simulation producing a random DAG and processing it (applying all currently implemented logic).
 
 - To run all current tests use:
 ```bash

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -28,7 +28,7 @@ consensus-core = { path = "./core" }
 kaspa-core = { path = "../core" }
 
 [dev-dependencies]
-criterion = "0.3.6"
+criterion = { version = "0.4", default-features = false }
 serde_json = "1.0"
 flate2 = "1.0.24"
 rand = "0.8"

--- a/consensus/core/src/hashing/mod.rs
+++ b/consensus/core/src/hashing/mod.rs
@@ -6,11 +6,11 @@ pub mod header;
 pub mod tx;
 
 pub(crate) trait HasherExtensions {
-    /// Writes the len as u64 little endian bytes  
+    /// Writes the len as u64 little endian bytes
     fn write_len(&mut self, len: usize) -> &mut Self;
 
     /// Writes blue work as big endian bytes w/o the leading zeros
-    /// (emulates bigint.bytes() in the kaspad golang ref)   
+    /// (emulates bigint.bytes() in the kaspad golang ref)
     fn write_blue_work(&mut self, work: BlueWorkType) -> &mut Self;
 
     /// Writes the number of bytes followed by the bytes themselves

--- a/consensus/core/src/utxo/utxo_collection.rs
+++ b/consensus/core/src/utxo/utxo_collection.rs
@@ -8,7 +8,7 @@ pub trait UtxoCollectionExtensions {
     fn contains_with_daa_score(&self, outpoint: &TransactionOutpoint, daa_score: u64) -> bool;
 
     /// Adds all entries from `other` to `self`.
-    /// Note that this means that values from `other` might override values of `self`.   
+    /// Note that this means that values from `other` might override values of `self`.
     fn add_many(&mut self, other: &Self);
 
     /// Removes all elements in `other` from `self`. Equivalent to `self - other` in set theory.

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -247,8 +247,8 @@ impl Consensus {
 }
 
 impl Service for Consensus {
-    fn ident(self: Arc<Consensus>) -> String {
-        "consensus".to_owned()
+    fn ident(self: Arc<Consensus>) -> &'static str {
+        "consensus"
     }
 
     fn start(self: Arc<Consensus>, core: Arc<Core>) -> Vec<JoinHandle<()>> {

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -140,8 +140,8 @@ impl TestConsensus {
 }
 
 impl Service for TestConsensus {
-    fn ident(self: Arc<TestConsensus>) -> String {
-        "test-consensus".to_owned()
+    fn ident(self: Arc<TestConsensus>) -> &'static str {
+        "test-consensus"
     }
 
     fn start(self: Arc<TestConsensus>, core: Arc<Core>) -> Vec<JoinHandle<()>> {

--- a/consensus/src/model/services/reachability.rs
+++ b/consensus/src/model/services/reachability.rs
@@ -50,7 +50,7 @@ impl<T: ReachabilityStoreReader + ?Sized> MTReachabilityService<T> {
     /// To skip `from_ancestor` simply apply `skip(1)`.
     ///
     /// The caller is expected to verify that `from_ancestor` is indeed a chain ancestor of
-    /// `to_descendant`, otherwise an error will be returned.  
+    /// `to_descendant`, otherwise an error will be returned.
     pub fn forward_chain_iterator(
         &self, from_ancestor: Hash, to_descendant: Hash, inclusive: bool,
     ) -> impl Iterator<Item = Result<Hash>> {
@@ -63,7 +63,7 @@ impl<T: ReachabilityStoreReader + ?Sized> MTReachabilityService<T> {
     /// To skip `from_descendant` simply apply `skip(1)`.
     ///
     /// The caller is expected to verify that `to_ancestor` is indeed a chain ancestor of
-    /// `from_descendant`, otherwise the iterator will eventually return an error.  
+    /// `from_descendant`, otherwise the iterator will eventually return an error.
     pub fn backward_chain_iterator(
         &self, from_descendant: Hash, to_ancestor: Hash, inclusive: bool,
     ) -> impl Iterator<Item = Result<Hash>> {

--- a/consensus/src/model/stores/daa.rs
+++ b/consensus/src/model/stores/daa.rs
@@ -28,19 +28,12 @@ impl DbDaaStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
         Self {
             raw_db: Arc::clone(&db),
-            cached_daa_added_blocks_access: CachedDbAccess::new(Arc::clone(&db), cache_size, ADDED_BLOCKS_STORE_PREFIX),
+            cached_daa_added_blocks_access: CachedDbAccess::new(db, cache_size, ADDED_BLOCKS_STORE_PREFIX),
         }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_daa_added_blocks_access: CachedDbAccess::new(
-                Arc::clone(&self.raw_db),
-                cache_size,
-                ADDED_BLOCKS_STORE_PREFIX,
-            ),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 
     pub fn insert_batch(

--- a/consensus/src/model/stores/depth.rs
+++ b/consensus/src/model/stores/depth.rs
@@ -33,17 +33,11 @@ pub struct DbDepthStore {
 
 impl DbDepthStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&db),
-            cached_access: CachedDbAccessForCopy::new(Arc::clone(&db), cache_size, STORE_PREFIX),
-        }
+        Self { raw_db: Arc::clone(&db), cached_access: CachedDbAccessForCopy::new(db, cache_size, STORE_PREFIX) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_access: CachedDbAccessForCopy::new(Arc::clone(&self.raw_db), cache_size, STORE_PREFIX),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 
     pub fn insert_batch(

--- a/consensus/src/model/stores/errors.rs
+++ b/consensus/src/model/stores/errors.rs
@@ -36,10 +36,10 @@ pub trait StoreResultExtensions<T> {
 
 impl<T> StoreResultExtensions<T> for StoreResult<T> {
     fn unwrap_option(self) -> Option<T> {
-        if let Err(StoreError::KeyNotFound(_)) = self {
-            return None;
+        match self {
+            Ok(value) => Some(value),
+            Err(StoreError::KeyNotFound(_)) => None,
+            Err(err) => panic!("Unexpected store error: {:?}", err),
         }
-
-        Some(self.unwrap())
     }
 }

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -186,14 +186,11 @@ pub struct DbGhostdagStore {
 
 impl DbGhostdagStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { raw_db: Arc::clone(&db), cached_access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX) }
+        Self { raw_db: Arc::clone(&db), cached_access: CachedDbAccess::new(db, cache_size, STORE_PREFIX) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_access: CachedDbAccess::new(Arc::clone(&self.raw_db), cache_size, STORE_PREFIX),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 
     pub fn insert_batch(&self, batch: &mut WriteBatch, hash: Hash, data: &Arc<GhostdagData>) -> Result<(), StoreError> {

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -97,7 +97,7 @@ impl GhostdagData {
     }
 
     /// Returns an iterator to the mergeset with no specified order (excluding the selected parent)
-    pub fn unordered_mergeset_without_selected_parent<'a>(&'a self) -> impl Iterator<Item = Hash> + '_ {
+    pub fn unordered_mergeset_without_selected_parent(&self) -> impl Iterator<Item = Hash> + '_ {
         self.mergeset_blues
             .iter()
             .skip(1) // Skip the selected parent
@@ -106,7 +106,7 @@ impl GhostdagData {
     }
 
     /// Returns an iterator to the mergeset with no specified order (including the selected parent)
-    pub fn unordered_mergeset<'a>(&'a self) -> impl Iterator<Item = Hash> + '_ {
+    pub fn unordered_mergeset(&self) -> impl Iterator<Item = Hash> + '_ {
         self.mergeset_blues
             .iter()
             .cloned()

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -24,7 +24,7 @@ pub trait HeaderStore: HeaderStoreReader {
 }
 
 const HEADERS_STORE_PREFIX: &[u8] = b"headers";
-const COPMACT_HEADER_DATA_STORE_PREFIX: &[u8] = b"compact-header-data";
+const COMPACT_HEADER_DATA_STORE_PREFIX: &[u8] = b"compact-header-data";
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct CompactHeaderData {
@@ -49,22 +49,14 @@ impl DbHeadersStore {
             cached_compact_headers_access: CachedDbAccessForCopy::new(
                 Arc::clone(&db),
                 cache_size,
-                COPMACT_HEADER_DATA_STORE_PREFIX,
+                COMPACT_HEADER_DATA_STORE_PREFIX,
             ),
-            cached_headers_access: CachedDbAccess::new(Arc::clone(&db), cache_size, HEADERS_STORE_PREFIX),
+            cached_headers_access: CachedDbAccess::new(db, cache_size, HEADERS_STORE_PREFIX),
         }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_compact_headers_access: CachedDbAccessForCopy::new(
-                Arc::clone(&self.raw_db),
-                cache_size,
-                COPMACT_HEADER_DATA_STORE_PREFIX,
-            ),
-            cached_headers_access: CachedDbAccess::new(Arc::clone(&self.raw_db), cache_size, HEADERS_STORE_PREFIX),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 
     pub fn insert_batch(&self, batch: &mut WriteBatch, hash: Hash, header: Arc<Header>) -> Result<(), StoreError> {

--- a/consensus/src/model/stores/pruning.rs
+++ b/consensus/src/model/stores/pruning.rs
@@ -29,10 +29,7 @@ impl DbPruningStore {
     }
 
     pub fn clone_with_new_cache(&self) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            pruning_point: CachedDbItem::new(Arc::clone(&self.raw_db), PRUNING_POINT_KEY),
-        }
+        Self::new(Arc::clone(&self.raw_db))
     }
 }
 

--- a/consensus/src/model/stores/reachability.rs
+++ b/consensus/src/model/stores/reachability.rs
@@ -71,11 +71,7 @@ impl DbReachabilityStore {
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_access: CachedDbAccess::new(Arc::clone(&self.raw_db), cache_size, STORE_PREFIX),
-            reindex_root: CachedDbItem::new(Arc::clone(&self.raw_db), REINDEX_ROOT_KEY),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 }
 

--- a/consensus/src/model/stores/reachability.rs
+++ b/consensus/src/model/stores/reachability.rs
@@ -36,7 +36,7 @@ pub trait ReachabilityStoreReader {
 }
 
 /// Write API for `ReachabilityStore`. All write functions are deliberately `mut`
-/// since reachability writes are not append-only and thus need to be guarded.  
+/// since reachability writes are not append-only and thus need to be guarded.
 pub trait ReachabilityStore: ReachabilityStoreReader {
     fn init(&mut self, origin: Hash, capacity: Interval) -> Result<(), StoreError>;
     fn insert(&mut self, hash: Hash, parent: Hash, interval: Interval, height: u64) -> Result<(), StoreError>;

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -220,7 +220,7 @@ mod tests {
         let parents = [(1, vec![]), (2, vec![1]), (3, vec![1]), (4, vec![2, 3]), (5, vec![1, 4])];
         for (i, vec) in parents.iter().cloned() {
             store
-                .insert(i.into(), BlockHashes::new(vec.iter().cloned().map(|j| j.into()).collect()))
+                .insert(i.into(), BlockHashes::new(vec.iter().copied().map(Hash::from).collect()))
                 .unwrap();
         }
 
@@ -230,8 +230,8 @@ mod tests {
                 .get_children(i.into())
                 .unwrap()
                 .iter()
-                .cloned()
-                .eq(vec.iter().cloned().map(|j| j.into())));
+                .copied()
+                .eq(vec.iter().copied().map(Hash::from)));
         }
 
         for (i, vec) in parents {
@@ -239,8 +239,8 @@ mod tests {
                 .get_parents(i.into())
                 .unwrap()
                 .iter()
-                .cloned()
-                .eq(vec.iter().cloned().map(|j| j.into())));
+                .copied()
+                .eq(vec.iter().copied().map(Hash::from)));
         }
     }
 }

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -17,9 +17,9 @@ pub trait RelationsStoreReader {
 
 /// Write API for `RelationsStore`. The insert function is deliberately `mut`
 /// since it modifies the children arrays for previously added parents which is
-/// non-append-only and thus needs to be guarded.  
+/// non-append-only and thus needs to be guarded.
 pub trait RelationsStore: RelationsStoreReader {
-    /// Inserts `parents` into a new store entry for `hash`, and for each `parent ∈ parents` adds `hash` to `parent.children`  
+    /// Inserts `parents` into a new store entry for `hash`, and for each `parent ∈ parents` adds `hash` to `parent.children`
     fn insert(&mut self, hash: Hash, parents: BlockHashes) -> Result<(), StoreError>;
 }
 

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -40,16 +40,12 @@ impl DbRelationsStore {
         Self {
             raw_db: Arc::clone(&db),
             parents_access: CachedDbAccess::new(Arc::clone(&db), cache_size, PARENTS_PREFIX),
-            children_access: CachedDbAccess::new(Arc::clone(&db), cache_size, CHILDREN_PREFIX),
+            children_access: CachedDbAccess::new(db, cache_size, CHILDREN_PREFIX),
         }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            parents_access: CachedDbAccess::new(Arc::clone(&self.raw_db), cache_size, PARENTS_PREFIX),
-            children_access: CachedDbAccess::new(Arc::clone(&self.raw_db), cache_size, CHILDREN_PREFIX),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 
     // Should be kept private and used only through `RelationsStoreBatchExtensions.insert_batch`

--- a/consensus/src/model/stores/statuses.rs
+++ b/consensus/src/model/stores/statuses.rs
@@ -11,10 +11,9 @@ use super::{
 use hashes::Hash;
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
-#[repr(u8)]
 pub enum BlockStatus {
     /// StatusInvalid indicates that the block is invalid.
-    StatusInvalid = 0,
+    StatusInvalid,
 
     /// StatusUTXOValid indicates the block is valid from any UTXO related aspects and has passed all the other validations as well.
     StatusUTXOValid,

--- a/consensus/src/model/stores/statuses.rs
+++ b/consensus/src/model/stores/statuses.rs
@@ -58,10 +58,7 @@ impl DbStatusesStore {
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {
-        Self {
-            raw_db: Arc::clone(&self.raw_db),
-            cached_access: CachedDbAccessForCopy::new(Arc::clone(&self.raw_db), cache_size, STORE_PREFIX),
-        }
+        Self::new(Arc::clone(&self.raw_db), cache_size)
     }
 }
 

--- a/consensus/src/processes/Parallel Processing.md
+++ b/consensus/src/processes/Parallel Processing.md
@@ -8,7 +8,7 @@ A design document intended to guide the new concurrent implementation of header 
 
 Below we detail the current state of affairs in *go-kaspad* and discuss future parallelism opportunities. Processing dependencies between various stages are detailed in square brackets [***deps; type***].
 
-### Header processing 
+### Header processing
 
 * Pre pow (aka "*header in isolation*" -- no DB writes to avoid spamming):
     * block version
@@ -25,7 +25,7 @@ Below we detail the current state of affairs in *go-kaspad* and discuss future p
     * check difficulty and blue work
         * run GHOSTDAG and stage [***reachability; read*** | ***ghostdag; write***]
         * calculate DAA window and stage; compute difficulty from window; [***windows; read | write***]
-        * verify bits from calculated difficulty 
+        * verify bits from calculated difficulty
 * Post pow (aka "*header in context*"):
     * validate median time (uses median time window) [***windows; read***]
     * check mergeset size limit (could be done following GHOSTDAG)
@@ -49,7 +49,7 @@ Below we detail the current state of affairs in *go-kaspad* and discuss future p
     * check txs are ordered by subnet ID
     * for each tx, validate tx in isolation (includes anything that can be checked w/o context)
     * check block mass
-    * check if duplicate txs 
+    * check if duplicate txs
     * check double spends
     * validate gas limit
 
@@ -65,36 +65,36 @@ Below we detail the current state of affairs in *go-kaspad* and discuss future p
 
 * (*roughly*)
 * build the utxo state for selected parent through utxo diffs from virtual
-* build the utxo state for current block based on selected parent state and tx data from the mergeset 
+* build the utxo state for current block based on selected parent state and tx data from the mergeset
 * stage acceptance data
-* update diff paths to virtual 
+* update diff paths to virtual
 * update virtual state
 
 ## Parallel processing -- Discussion
 
-There are two levels of possible concurrency to support: (i) process the various stages concurrently in a *pipeline*, i.e., when a block moves to body processing, other headers can enter the header processing stage, and so on; (ii) *parallelism* within each processing "station" of the pipeline, i.e., within header processing, allow *n* independent blocks to be processed in parallel. 
+There are two levels of possible concurrency to support: (i) process the various stages concurrently in a *pipeline*, i.e., when a block moves to body processing, other headers can enter the header processing stage, and so on; (ii) *parallelism* within each processing "station" of the pipeline, i.e., within header processing, allow *n* independent blocks to be processed in parallel.
 
 ### Pipeline concurrency
 
-The current code design (*go-kaspad*) already logically supports this since the various processing stages were already decoupled for supporting efficient IBD. 
+The current code design (*go-kaspad*) already logically supports this since the various processing stages were already decoupled for supporting efficient IBD.
 
 ### Header processing parallelism
 
-If you analyze the dependency graph above you can see this is the most challenging part. For instance, we cannot easily create multiple staging areas in parallel, since committing them with out synchronization will introduce logical write conflicts. 
+If you analyze the dependency graph above you can see this is the most challenging part. For instance, we cannot easily create multiple staging areas in parallel, since committing them with out synchronization will introduce logical write conflicts.
 
 #### **Natural DAG parallelism**
 
-Throughout header processing, the computation naturally depends on previous output from parents and ancestors of the currently processed header. This means we cannot concurrently process a block with its ancestors, however we can concurrently process blocks which are parallel to each other in the DAG structure (i.e. blocks which are in the anticone of each other). As we increase block rate, more blocks will be mined in parallel -- thus creating more parallelism opportunities as well. 
+Throughout header processing, the computation naturally depends on previous output from parents and ancestors of the currently processed header. This means we cannot concurrently process a block with its ancestors, however we can concurrently process blocks which are parallel to each other in the DAG structure (i.e. blocks which are in the anticone of each other). As we increase block rate, more blocks will be mined in parallel -- thus creating more parallelism opportunities as well.
 
 This logic is already implement in `pipeline::HeaderProcessor` struct. The code uses a simple DAG-dependency mechanism to delay processing tasks until all depending tasks are completed. If there are no dependencies, a `rayon::spawn` assigns a thread-pool worker to the ready-to-be processed header.
 
 #### **Managing store writes**
 
-Most of DB writes during header processing are append-only. That is, a new item is inserted to the store for the new header, and it is never modified in the future. This semantic means that no lock is needed in order to write to such a store as long as we verify that only a single worker thread "owns" each header (`DbGhostdagStore` is an example; note that the DB and cache instances used therein already support concurrency). 
+Most of DB writes during header processing are append-only. That is, a new item is inserted to the store for the new header, and it is never modified in the future. This semantic means that no lock is needed in order to write to such a store as long as we verify that only a single worker thread "owns" each header (`DbGhostdagStore` is an example; note that the DB and cache instances used therein already support concurrency).
 
-There are two exceptions to this: reachability and relations stores are both non-append-only. We currently assume that their processing time is negligible compared to overall header processing and thus use serialized upgradable-read/write locks in order to manage this part. See `pipeline::HeaderProcessor::commit_header`. 
+There are two exceptions to this: reachability and relations stores are both non-append-only. We currently assume that their processing time is negligible compared to overall header processing and thus use serialized upgradable-read/write locks in order to manage this part. See `pipeline::HeaderProcessor::commit_header`.
 
-Current design should be benchmarked when header processing is fully implemented. If the reachability algorithms are a bottleneck, we can consider moving reachability and relations writes to a new processing unit named "Header DAG processing". This unit will support adding multiple blocks at one call to the reachability tree by performing a single reindexing for all (can be easily supported by current algos). 
+Current design should be benchmarked when header processing is fully implemented. If the reachability algorithms are a bottleneck, we can consider moving reachability and relations writes to a new processing unit named "Header DAG processing". This unit will support adding multiple blocks at one call to the reachability tree by performing a single reindexing for all (can be easily supported by current algos).
 
 
 ### Block processing parallelism
@@ -106,5 +106,5 @@ Seems straightforward.
 
 * Process each chain block + mergeset sequentially.
 * Within each such step:
-    * txs within each block can be validated against the utxo set in parallel 
+    * txs within each block can be validated against the utxo set in parallel
     * blocks in the mergeset and txs within can be processed in parallel based on the consensus-agreed topological mergeset ordering -- however conflicts might arise and need to be taken care of according to said order.

--- a/consensus/src/processes/ghostdag/mergeset.rs
+++ b/consensus/src/processes/ghostdag/mergeset.rs
@@ -9,13 +9,13 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
     GhostdagManager<T, S, U, V>
 {
     pub fn ordered_mergeset_without_selected_parent(&self, selected_parent: Hash, parents: &[Hash]) -> Vec<Hash> {
-        let mut queue: VecDeque<Hash> = parents
+        let mut queue: VecDeque<_> = parents
             .iter()
-            .cloned()
-            .filter(|p| *p != selected_parent)
+            .copied()
+            .filter(|p| p != &selected_parent)
             .collect();
-        let mut mergeset = HashSet::<Hash>::from_iter(queue.iter().cloned());
-        let mut selected_parent_past: HashSet<Hash> = HashSet::new();
+        let mut mergeset: HashSet<_> = queue.iter().copied().collect();
+        let mut selected_parent_past = HashSet::new();
 
         while let Some(current) = queue.pop_front() {
             let current_parents = self.relations_store.get_parents(current).unwrap();

--- a/consensus/src/processes/ghostdag/ordering.rs
+++ b/consensus/src/processes/ghostdag/ordering.rs
@@ -36,11 +36,9 @@ impl PartialOrd for SortableBlock {
 
 impl Ord for SortableBlock {
     fn cmp(&self, other: &Self) -> Ordering {
-        let res = self.blue_work.cmp(&other.blue_work);
-        match res {
-            Ordering::Equal => self.hash.cmp(&other.hash),
-            _ => res,
-        }
+        self.blue_work
+            .cmp(&other.blue_work)
+            .then_with(|| self.hash.cmp(&other.hash))
     }
 }
 

--- a/consensus/src/processes/ghostdag/ordering.rs
+++ b/consensus/src/processes/ghostdag/ordering.rs
@@ -46,7 +46,7 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
     GhostdagManager<T, S, U, V>
 {
     pub fn sort_blocks(&self, blocks: HashSet<Hash>) -> Vec<Hash> {
-        let mut sorted_blocks: Vec<Hash> = Vec::from_iter(blocks.iter().cloned());
+        let mut sorted_blocks: Vec<Hash> = blocks.into_iter().collect();
         sorted_blocks.sort_by_cached_key(|block| SortableBlock {
             hash: *block,
             blue_work: self.ghostdag_store.get_blue_work(*block).unwrap(),

--- a/consensus/src/processes/ghostdag/protocol.rs
+++ b/consensus/src/processes/ghostdag/protocol.rs
@@ -147,7 +147,7 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
             }
         }
 
-        for block in chain_block.data.mergeset_blues.iter().cloned() {
+        for &block in chain_block.data.mergeset_blues.iter() {
             // Skip blocks that exist in the past of blue_candidate.
             if self
                 .reachability_service

--- a/consensus/src/processes/reachability/interval.rs
+++ b/consensus/src/processes/reachability/interval.rs
@@ -93,13 +93,15 @@ impl Interval {
     /// equal to the interval's size.
     pub fn split_exact(&self, sizes: &[u64]) -> Vec<Self> {
         assert_eq!(sizes.iter().sum::<u64>(), self.size(), "sum of sizes must be equal to the interval's size");
-        let mut intervals = Vec::<Self>::with_capacity(sizes.len());
         let mut start = self.start;
-        for size in sizes {
-            intervals.push(Self::new(start, start + size - 1));
-            start += size;
-        }
-        intervals
+        sizes
+            .iter()
+            .map(|size| {
+                let interval = Self::new(start, start + size - 1);
+                start += size;
+                interval
+            })
+            .collect()
     }
 
     /// Splits this interval to |sizes| parts
@@ -162,7 +164,7 @@ impl Interval {
 /// result in loss of float precision. This is not a problem - all
 /// numbers close to 0 bear effectively the same weight.
 fn exponential_fractions(sizes: &[u64]) -> Vec<f64> {
-    let max_size = sizes.iter().cloned().max().unwrap_or_default();
+    let max_size = sizes.iter().copied().max().unwrap_or_default();
 
     let mut fractions = sizes
         .iter()

--- a/consensus/src/processes/reachability/reindex.rs
+++ b/consensus/src/processes/reachability/reindex.rs
@@ -180,7 +180,7 @@ impl<'a, T: ReachabilityStore + ?Sized> ReindexOperationContext<'a, T> {
                     .collect();
                 let interval = self.store.interval_children_capacity(current)?;
                 let intervals = interval.split_exponential(&sizes);
-                for (c, ci) in children.iter().cloned().zip(intervals) {
+                for (c, ci) in children.iter().copied().zip(intervals) {
                     self.store.set_interval(c, ci)?;
                 }
                 queue.extend(children.iter());

--- a/consensus/src/processes/reachability/reindex.rs
+++ b/consensus/src/processes/reachability/reindex.rs
@@ -46,8 +46,8 @@ impl<'a, T: ReachabilityStore + ?Sized> ReindexOperationContext<'a, T> {
                 // than 2^64 blocks, which shouldn't ever happen.
                 return Err(ReachabilityError::DataOverflow(
                     "missing tree
-                        parent during reindexing. Theoretically, this 
-                        should only ever happen if there are more 
+                        parent during reindexing. Theoretically, this
+                        should only ever happen if there are more
                         than 2^64 blocks in the DAG."
                         .to_string(),
                 ));
@@ -59,7 +59,7 @@ impl<'a, T: ReachabilityStore + ?Sized> ReindexOperationContext<'a, T> {
                 // even if block rate per second is above 100. The calculation follows from the allocation of
                 // 2^12 (which equals 2^64/2^52) for slack per chain block below the reindex root.
                 return Err(ReachabilityError::DataOverflow(format!(
-                    "unexpected behavior: reindex root {} is out of capacity during reindexing. 
+                    "unexpected behavior: reindex root {} is out of capacity during reindexing.
                     Theoretically, this should only ever happen if there are more than ~2^52 blocks in the DAG.",
                     reindex_root
                 )));

--- a/consensus/src/processes/reachability/tests.rs
+++ b/consensus/src/processes/reachability/tests.rs
@@ -142,8 +142,7 @@ impl<'a, T: ReachabilityStore + ?Sized> DagBuilder<'a, T> {
                 queue.push_back(*parent);
             }
         }
-
-        Vec::<Hash>::from_iter(mergeset.iter().cloned())
+        mergeset.into_iter().collect()
     }
 
     pub fn store(&self) -> &&'a mut T {

--- a/consensus/src/processes/reachability/tests.rs
+++ b/consensus/src/processes/reachability/tests.rs
@@ -121,10 +121,10 @@ impl<'a, T: ReachabilityStore + ?Sized> DagBuilder<'a, T> {
         let mut queue: VecDeque<Hash> = block
             .parents
             .iter()
-            .cloned()
+            .copied()
             .filter(|p| *p != selected_parent)
             .collect();
-        let mut mergeset = HashSet::<Hash>::from_iter(queue.iter().cloned());
+        let mut mergeset: HashSet<_> = queue.iter().copied().collect();
         let mut past: HashSet<Hash> = HashSet::new();
 
         while let Some(current) = queue.pop_front() {

--- a/consensus/tests/integration_tests.rs
+++ b/consensus/tests/integration_tests.rs
@@ -26,7 +26,6 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::{self, BufRead, BufReader},
-    path::Path,
     str::{from_utf8, FromStr},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -63,10 +62,8 @@ fn reachability_stretch_test(use_attack_json: bool) {
         if use_attack_json { "" } else { "no" },
         NUM_BLOCKS_EXPONENT
     );
-    let path = Path::new(&path_str);
-    let file = File::open(path).unwrap();
-    let reader = BufReader::new(file);
-    let decoder = GzDecoder::new(reader);
+    let file = File::open(path_str).unwrap();
+    let decoder = GzDecoder::new(file);
     let json_blocks: Vec<JsonBlock> = serde_json::from_reader(decoder).unwrap();
 
     let root = blockhash::ORIGIN;
@@ -215,8 +212,7 @@ async fn ghostdag_test() {
 
     for path_string in path_strings.iter() {
         println!("Running test {}", path_string);
-        let path = Path::new(&path_string);
-        let file = File::open(path).unwrap();
+        let file = File::open(path_string).unwrap();
         let reader = BufReader::new(file);
         let test: GhostdagTestDag = serde_json::from_reader(reader).unwrap();
 
@@ -737,9 +733,8 @@ struct RPCBlockVerboseData {
 #[tokio::test]
 async fn json_test() {
     let file = File::open("tests/testdata/json_test.json.gz").unwrap();
-    let reader = BufReader::new(file);
-    let decoder = GzDecoder::new(reader);
-    let mut lines = io::BufReader::new(decoder).lines();
+    let decoder = GzDecoder::new(file);
+    let mut lines = BufReader::new(decoder).lines();
     let first_line = lines.next().unwrap();
     let genesis = json_line_to_block(first_line.unwrap());
     let mut params = MAINNET_PARAMS;
@@ -776,8 +771,7 @@ async fn json_test() {
 #[tokio::test]
 async fn json_concurrency_test() {
     let file = File::open("tests/testdata/json_test.json.gz").unwrap();
-    let reader = BufReader::new(file);
-    let decoder = GzDecoder::new(reader);
+    let decoder = GzDecoder::new(file);
     let mut lines = io::BufReader::new(decoder).lines();
     let first_line = lines.next().unwrap();
     let genesis = json_line_to_block(first_line.unwrap());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,4 +5,3 @@ pub mod core;
 pub mod log;
 pub mod service;
 pub mod signals;
-pub mod utils;

--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -3,7 +3,7 @@ use intertrait::CastFromSync;
 use std::{sync::Arc, thread::JoinHandle};
 
 pub trait Service: CastFromSync {
-    fn ident(self: Arc<Self>) -> String;
+    fn ident(self: Arc<Self>) -> &'static str;
     fn start(self: Arc<Self>, core: Arc<Core>) -> Vec<JoinHandle<()>>;
     fn stop(self: Arc<Self>);
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,9 +1,0 @@
-#[macro_export]
-macro_rules! extract_enum_value {
-    ($value:expr, $pattern:pat => $extracted_value:expr) => {
-        match $value {
-            $pattern => $extracted_value,
-            _ => panic!("Pattern doesn't match!"),
-        }
-    };
-}

--- a/crypto/addresses/Cargo.toml
+++ b/crypto/addresses/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 
 [dev-dependencies]
-criterion = "0.3"
-#rand = "0.8"
+criterion = { version = "0.4", default-features = false }
+
 [[bench]]
 name = "bench"
 harness = false

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -22,7 +22,7 @@ keccak = "0.1"
 
 [dev-dependencies]
 sha3 = "0.10"
-criterion = "0.3"
+criterion = { version = "0.4", default-features = false }
 rand = "0.8"
 
 [build-dependencies]

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -11,8 +11,9 @@ hashes = { path = "../hashes" }
 
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.4", default-features = false }
 rand = "0.8"
+
 [[bench]]
 name = "bench"
 harness = false

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -105,8 +105,8 @@ impl RandomBlockEmitter {
 }
 
 impl Service for RandomBlockEmitter {
-    fn ident(self: Arc<RandomBlockEmitter>) -> String {
-        "block-emitter".into()
+    fn ident(self: Arc<RandomBlockEmitter>) -> &'static str {
+        "block-emitter"
     }
 
     fn start(self: Arc<RandomBlockEmitter>, core: Arc<Core>) -> Vec<JoinHandle<()>> {
@@ -175,8 +175,8 @@ impl ConsensusMonitor {
 
 // service trait implementation for Monitor
 impl Service for ConsensusMonitor {
-    fn ident(self: Arc<ConsensusMonitor>) -> String {
-        "consensus-monitor".into()
+    fn ident(self: Arc<ConsensusMonitor>) -> &'static str {
+        "consensus-monitor"
     }
 
     fn start(self: Arc<ConsensusMonitor>, _core: Arc<Core>) -> Vec<JoinHandle<()>> {


### PR DESCRIPTION
1. Removed trailing spaces (my editor does this automatically, and also it's quite annoying to see in vim)
2. Replaced some `push` lops with `collect`, and removed an unnecessary macro for enums by built in functions.
3. Replaced creating new vectors by copying an iterator with collecting from the objects directly (this removes an allocation + copy).
4. Removed unnecessary buffers from the json tests (the Gz decoder we use already buffers, so we overall had too many indirection buffers that only degrade performance) .
5. Made the identifier in `Service` a `&'static str` as it makes more sense and also requires 0 allocations or copies