### PR TITLE
Refactor block struct

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -1,33 +1,41 @@
 use std::sync::Arc;
 
-use crate::{header::Header, tx::Transaction, BlueWorkType};
+use crate::{header::Header, tx::Transaction};
 use hashes::Hash;
 
 #[derive(Debug, Clone)]
-pub struct Block {
+pub struct MutableBlock {
     pub header: Header,
+    pub transactions: Vec<Transaction>,
+}
+
+impl MutableBlock {
+    pub fn new(header: Header, txs: Vec<Transaction>) -> Self {
+        Self { header, transactions: txs }
+    }
+
+    pub fn from_header(header: Header) -> Self {
+        Self::new(header, vec![])
+    }
+
+    pub fn to_immutable(self) -> Block {
+        Block::new(self.header, self.transactions)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Block {
+    pub header: Arc<Header>,
     pub transactions: Arc<Vec<Transaction>>,
 }
 
 impl Block {
-    pub fn new(
-        version: u16,
-        parents: Vec<Hash>,
-        timestamp: u64,
-        bits: u32,
-        nonce: u64,
-        daa_score: u64,
-        blue_work: BlueWorkType,
-        blue_score: u64,
-    ) -> Self {
-        Self {
-            header: Header::new(version, parents, Default::default(), timestamp, bits, nonce, daa_score, blue_work, blue_score),
-            transactions: Arc::new(Vec::new()),
-        }
+    pub fn new(header: Header, txs: Vec<Transaction>) -> Self {
+        Self { header: Arc::new(header), transactions: Arc::new(txs) }
     }
 
     pub fn from_header(header: Header) -> Self {
-        Self { header, transactions: Arc::new(Vec::new()) }
+        Self { header: Arc::new(header), transactions: Arc::new(Vec::new()) }
     }
 
     pub fn is_header_only(&self) -> bool {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{header::Header, tx::Transaction};
 use hashes::Hash;
 
+/// A mutable block structure where header and transactions within can still be mutated.
 #[derive(Debug, Clone)]
 pub struct MutableBlock {
     pub header: Header,
@@ -23,6 +24,9 @@ impl MutableBlock {
     }
 }
 
+/// A block structure where the inner header and transactions are wrapped by Arcs for
+/// cheap cloning and for cross-thread safety and immutability. Note: no need to wrap
+/// this struct with an additional Arc.
 #[derive(Debug, Clone)]
 pub struct Block {
     pub header: Arc<Header>,

--- a/consensus/core/src/header.rs
+++ b/consensus/core/src/header.rs
@@ -50,6 +50,7 @@ impl Header {
         header
     }
 
+    /// Finalizes the header and recomputes the header hash
     pub fn finalize(&mut self) {
         self.hash = hashing::header::hash(self);
     }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -334,7 +334,7 @@ impl Consensus {
         ]
     }
 
-    pub fn validate_and_insert_block(&self, block: Arc<Block>) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
+    pub fn validate_and_insert_block(&self, block: Block) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
         let (tx, rx): (BlockResultSender, _) = oneshot::channel();
         self.block_sender.send(BlockTask::Process(block, vec![tx])).unwrap();
         async { rx.await.unwrap() }

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -426,7 +426,7 @@ mod tests {
             Err(RuleError::TxInIsolationValidationFailed(_, _))
         );
 
-        let mut block = example_block.clone();
+        let mut block = example_block;
         let txs = &mut block.transactions;
         Arc::make_mut(&mut txs[3].inputs[0]).previous_outpoint = TransactionOutpoint { transaction_id: txs[2].id(), index: 0 };
         block.header.hash_merkle_root = calc_hash_merkle_root(txs.iter());

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -77,7 +77,7 @@ impl RandomBlockEmitter {
                 b.header.finalize();
                 new_tips.push(b.header.hash);
                 // Submit to consensus
-                let f = self.consensus.validate_and_insert_block(Arc::new(b));
+                let f = self.consensus.validate_and_insert_block(b.to_immutable());
                 futures.push(f);
             }
             join_all(futures).await.into_iter().collect::<Result<Vec<BlockStatus>, RuleError>>().unwrap();


### PR DESCRIPTION
Created a `MutableBlock` struct which test consensus returns from build methods, and changed `Block` to have header through an Arc, making it immutable and easy to pass by cloning (w/o another Arc around). This also saves from a full header clone on header processor commit 