### PR TITLE
Override Hasher on BlockHashMap and BlockHashSet

### DIFF
--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasher, Hasher};
 
 use hashes::Hash;
 
@@ -14,14 +15,95 @@ pub mod utxo;
 
 /// Integer type for accumulated PoW of blue blocks. We expect no more than
 /// 2^128 work in a single block (btc has ~2^80), and no more than 2^64
-/// overall blocks, so 2^192 is definitely a justified upper-bound.  
+/// overall blocks, so 2^192 is definitely a justified upper-bound.
 pub type BlueWorkType = math::Uint192;
 
-/// Defined in order to make it easy to experiment with various hashers
-pub type BlockHashSet = HashSet<Hash>;
+/// This HashMap skips the hashing of the key and uses the key directly as the hash.
+/// Should only be used for block hashes that has correct DAA,
+/// otherwise it is susceptible to DOS attacks via hash collisions.
+pub type BlockHashMap<V> = HashMap<Hash, V, BlockHasher>;
 
-/// Defined in order to make it easy to experiment with various hashers
-pub type BlockHashMap<T> = HashMap<Hash, T>;
+/// Same as `BlockHashMap` but a `HashSet`.
+pub type BlockHashSet = HashSet<Hash, BlockHasher>;
 
 // TODO: if custom hashers are used for BlockHashMap, make sure that store caches
 // which are keyed by Hash use them as well.
+
+pub trait HashMapCustomHasher {
+    fn new() -> Self;
+    fn with_capacity(capacity: usize) -> Self;
+}
+
+// HashMap::new and HashMap::with_capacity are only implemented on Hasher=RandomState
+// to avoid type inference problems, so we need to provide our own versions.
+impl<V> HashMapCustomHasher for BlockHashMap<V> {
+    #[inline(always)]
+    fn new() -> Self {
+        Self::with_hasher(BlockHasher::new())
+    }
+    #[inline(always)]
+    fn with_capacity(cap: usize) -> Self {
+        Self::with_capacity_and_hasher(cap, BlockHasher::new())
+    }
+}
+
+impl HashMapCustomHasher for BlockHashSet {
+    #[inline(always)]
+    fn new() -> Self {
+        Self::with_hasher(BlockHasher::new())
+    }
+    #[inline(always)]
+    fn with_capacity(cap: usize) -> Self {
+        Self::with_capacity_and_hasher(cap, BlockHasher::new())
+    }
+}
+
+/// `hashes::Hash` writes 4 u64s so we just use the last one as the hash here
+#[doc(hidden)]
+#[derive(Default, Clone, Copy)]
+pub struct BlockHasher(u64);
+
+impl BlockHasher {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self(0)
+    }
+}
+
+impl Hasher for BlockHasher {
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    #[inline(always)]
+    fn write_u64(&mut self, v: u64) {
+        self.0 = v;
+    }
+    #[cold]
+    fn write(&mut self, _: &[u8]) {
+        unimplemented!("use write_u64")
+    }
+}
+
+impl BuildHasher for BlockHasher {
+    type Hasher = Self;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        Self(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BlockHasher;
+    use hashes::Hash;
+    use std::hash::{Hash as _, Hasher as _};
+    #[test]
+    fn test_block_hasher() {
+        let hash = Hash::from_le_u64([1, 2, 3, 4]);
+        let mut hasher = BlockHasher::default();
+        hash.hash(&mut hasher);
+        assert_eq!(hasher.finish(), 4);
+    }
+}

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -26,9 +26,6 @@ pub type BlockHashMap<V> = HashMap<Hash, V, BlockHasher>;
 /// Same as `BlockHashMap` but a `HashSet`.
 pub type BlockHashSet = HashSet<Hash, BlockHasher>;
 
-// TODO: if custom hashers are used for BlockHashMap, make sure that store caches
-// which are keyed by Hash use them as well.
-
 pub trait HashMapCustomHasher {
     fn new() -> Self;
     fn with_capacity(capacity: usize) -> Self;
@@ -59,7 +56,6 @@ impl HashMapCustomHasher for BlockHashSet {
 }
 
 /// `hashes::Hash` writes 4 u64s so we just use the last one as the hash here
-#[doc(hidden)]
 #[derive(Default, Clone, Copy)]
 pub struct BlockHasher(u64);
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod utxo;
 pub type BlueWorkType = math::Uint192;
 
 /// This HashMap skips the hashing of the key and uses the key directly as the hash.
-/// Should only be used for block hashes that has correct DAA,
+/// Should only be used for block hashes that have correct DAA,
 /// otherwise it is susceptible to DOS attacks via hash collisions.
 pub type BlockHashMap<V> = HashMap<Hash, V, BlockHasher>;
 

--- a/consensus/src/model/stores/acceptance_data.rs
+++ b/consensus/src/model/stores/acceptance_data.rs
@@ -3,6 +3,7 @@ use super::{
     errors::StoreError,
     DB,
 };
+use consensus_core::BlockHasher;
 use hashes::Hash;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -27,7 +28,7 @@ const STORE_PREFIX: &[u8] = b"acceptance-data";
 #[derive(Clone)]
 pub struct DbAcceptanceDataStore {
     raw_db: Arc<DB>,
-    cached_access: CachedDbAccess<Hash, AcceptanceData>,
+    cached_access: CachedDbAccess<Hash, AcceptanceData, BlockHasher>,
 }
 
 impl DbAcceptanceDataStore {

--- a/consensus/src/model/stores/block_transactions.rs
+++ b/consensus/src/model/stores/block_transactions.rs
@@ -5,7 +5,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::tx::Transaction;
+use consensus_core::{tx::Transaction, BlockHasher};
 use hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -25,7 +25,7 @@ const STORE_PREFIX: &[u8] = b"block-transactions";
 pub struct DbBlockTransactionsStore {
     raw_db: Arc<DB>,
     // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    cached_access: CachedDbAccess<Hash, Vec<Transaction>>,
+    cached_access: CachedDbAccess<Hash, Vec<Transaction>, BlockHasher>,
 }
 
 impl DbBlockTransactionsStore {

--- a/consensus/src/model/stores/block_window_cache.rs
+++ b/consensus/src/model/stores/block_window_cache.rs
@@ -1,5 +1,6 @@
 use super::database::prelude::Cache;
 use crate::processes::ghostdag::ordering::SortableBlock;
+use consensus_core::BlockHasher;
 use hashes::Hash;
 use std::{cmp::Reverse, collections::BinaryHeap, sync::Arc};
 
@@ -10,7 +11,7 @@ pub trait BlockWindowCacheReader {
     fn get(&self, hash: &Hash) -> Option<Arc<BlockWindowHeap>>;
 }
 
-pub type BlockWindowCacheStore = Cache<Hash, Arc<BlockWindowHeap>>;
+pub type BlockWindowCacheStore = Cache<Hash, Arc<BlockWindowHeap>, BlockHasher>;
 
 impl BlockWindowCacheReader for BlockWindowCacheStore {
     #[inline(always)]

--- a/consensus/src/model/stores/daa.rs
+++ b/consensus/src/model/stores/daa.rs
@@ -5,7 +5,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::blockhash::BlockHashes;
+use consensus_core::{blockhash::BlockHashes, BlockHasher};
 use hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -25,7 +25,7 @@ const ADDED_BLOCKS_STORE_PREFIX: &[u8] = b"daa-added-blocks";
 pub struct DbDaaStore {
     raw_db: Arc<DB>,
     // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    cached_daa_added_blocks_access: CachedDbAccess<Hash, Vec<Hash>>,
+    cached_daa_added_blocks_access: CachedDbAccess<Hash, Vec<Hash>, BlockHasher>,
 }
 
 impl DbDaaStore {

--- a/consensus/src/model/stores/database/cache.rs
+++ b/consensus/src/model/stores/database/cache.rs
@@ -1,18 +1,18 @@
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use rand::Rng;
-use std::sync::Arc;
+use std::{collections::hash_map::RandomState, hash::BuildHasher, sync::Arc};
 
 #[derive(Clone)]
-pub struct Cache<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync> {
+pub struct Cache<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync, S = RandomState> {
     // We use IndexMap and not HashMap, because it makes it cheaper to remove a random element when the cache is full.
-    map: Arc<RwLock<IndexMap<TKey, TData>>>,
+    map: Arc<RwLock<IndexMap<TKey, TData, S>>>,
     size: usize,
 }
 
-impl<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync> Cache<TKey, TData> {
+impl<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync, S: BuildHasher + Default> Cache<TKey, TData, S> {
     pub fn new(size: u64) -> Self {
-        Self { map: Arc::new(RwLock::new(IndexMap::with_capacity(size as usize))), size: size as usize }
+        Self { map: Arc::new(RwLock::new(IndexMap::with_capacity_and_hasher(size as usize, S::default()))), size: size as usize }
     }
 
     pub fn get(&self, key: &TKey) -> Option<TData> {

--- a/consensus/src/model/stores/database/item.rs
+++ b/consensus/src/model/stores/database/item.rs
@@ -38,7 +38,7 @@ impl<T> CachedDbItem<T> {
         T: Clone + Serialize,
     {
         *self.cached_item.write() = Some(item.clone());
-        let bin_data = bincode::serialize(&item)?;
+        let bin_data = bincode::serialize(item)?;
         writer.put(self.key, bin_data)?;
         Ok(())
     }

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -1,10 +1,10 @@
-use crate::processes::ghostdag::ordering::SortableBlock;
-
 use super::database::prelude::{BatchDbWriter, CachedDbAccess, CachedDbAccessForCopy, DbKey, DirectDbWriter};
 use super::{errors::StoreError, DB};
-use consensus_core::BlockHashMap;
+use crate::processes::ghostdag::ordering::SortableBlock;
 use consensus_core::{blockhash::BlockHashes, BlueWorkType};
+use consensus_core::{BlockHashMap, HashMapCustomHasher};
 use hashes::Hash;
+
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 use rocksdb::WriteBatch;
@@ -123,7 +123,7 @@ impl GhostdagData {
 
     /// Returns an iterator to the mergeset in topological consensus order -- starting with the selected parent,
     /// and adding the mergeset in increasing blue work order. Note that this is a topological order even though
-    /// the selected parent has highest blue work by def -- since the mergeset is in its anticone.  
+    /// the selected parent has highest blue work by def -- since the mergeset is in its anticone.
     pub fn consensus_ordered_mergeset<'a>(
         &'a self,
         store: &'a (impl GhostdagStoreReader + ?Sized),
@@ -463,10 +463,10 @@ mod tests {
         assert_eq!(expected, data.descending_mergeset_without_selected_parent(&store).map(|b| b.hash).collect::<Vec<Hash>>());
 
         // Use sets since the below functions have no order guarantee
-        let expected = BlockHashSet::from([4.into(), 2.into(), 5.into(), 3.into(), 6.into()]);
+        let expected = BlockHashSet::from_iter([4.into(), 2.into(), 5.into(), 3.into(), 6.into()]);
         assert_eq!(expected, data.unordered_mergeset_without_selected_parent().collect::<BlockHashSet>());
 
-        let expected = BlockHashSet::from([1.into(), 4.into(), 2.into(), 5.into(), 3.into(), 6.into()]);
+        let expected = BlockHashSet::from_iter([1.into(), 4.into(), 2.into(), 5.into(), 3.into(), 6.into()]);
         assert_eq!(expected, data.unordered_mergeset().collect::<BlockHashSet>());
     }
 }

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -2,7 +2,7 @@ use super::database::prelude::{BatchDbWriter, CachedDbAccess, CachedDbAccessForC
 use super::{errors::StoreError, DB};
 use crate::processes::ghostdag::ordering::SortableBlock;
 use consensus_core::{blockhash::BlockHashes, BlueWorkType};
-use consensus_core::{BlockHashMap, HashMapCustomHasher};
+use consensus_core::{BlockHashMap, BlockHasher, HashMapCustomHasher};
 use hashes::Hash;
 
 use itertools::EitherOrBoth::{Both, Left, Right};
@@ -217,8 +217,8 @@ const COMPACT_STORE_PREFIX: &[u8] = b"compact-block-ghostdag-data";
 pub struct DbGhostdagStore {
     raw_db: Arc<DB>,
     // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    cached_access: CachedDbAccess<Hash, GhostdagData>,
-    compact_cached_access: CachedDbAccessForCopy<Hash, CompactGhostdagData>,
+    cached_access: CachedDbAccess<Hash, GhostdagData, BlockHasher>,
+    compact_cached_access: CachedDbAccessForCopy<Hash, CompactGhostdagData, BlockHasher>,
 }
 
 impl DbGhostdagStore {

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -5,7 +5,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::header::Header;
+use consensus_core::{header::Header, BlockHasher};
 use hashes::Hash;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -46,9 +46,8 @@ pub struct CompactHeaderData {
 #[derive(Clone)]
 pub struct DbHeadersStore {
     raw_db: Arc<DB>,
-    // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    cached_compact_headers_access: CachedDbAccessForCopy<Hash, CompactHeaderData>,
-    cached_headers_access: CachedDbAccess<Hash, HeaderWithBlockLevel>,
+    cached_compact_headers_access: CachedDbAccessForCopy<Hash, CompactHeaderData, BlockHasher>,
+    cached_headers_access: CachedDbAccess<Hash, HeaderWithBlockLevel, BlockHasher>,
 }
 
 impl DbHeadersStore {

--- a/consensus/src/model/stores/past_pruning_points.rs
+++ b/consensus/src/model/stores/past_pruning_points.rs
@@ -44,7 +44,6 @@ const STORE_PREFIX: &[u8] = b"past-pruning-points";
 #[derive(Clone)]
 pub struct DbPastPruningPointsStore {
     raw_db: Arc<DB>,
-    // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
     cached_access: CachedDbAccessForCopy<Key, Hash>,
 }
 

--- a/consensus/src/model/stores/reachability.rs
+++ b/consensus/src/model/stores/reachability.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::processes::reachability::interval::Interval;
 use consensus_core::{
     blockhash::{self, BlockHashes},
-    BlockHashMap, HashMapCustomHasher,
+    BlockHashMap, BlockHasher, HashMapCustomHasher,
 };
 use hashes::Hash;
 
@@ -60,8 +60,7 @@ const STORE_PREFIX: &[u8] = b"reachability-data";
 #[derive(Clone)]
 pub struct DbReachabilityStore {
     raw_db: Arc<DB>,
-    // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    cached_access: CachedDbAccess<Hash, ReachabilityData>,
+    cached_access: CachedDbAccess<Hash, ReachabilityData, BlockHasher>,
     reindex_root: CachedDbItem<Hash>,
 }
 

--- a/consensus/src/model/stores/reachability.rs
+++ b/consensus/src/model/stores/reachability.rs
@@ -1,19 +1,19 @@
-use consensus_core::{
-    blockhash::{self, BlockHashes},
-    BlockHashMap,
-};
-use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
-use rocksdb::WriteBatch;
-use serde::{Deserialize, Serialize};
-use std::{collections::hash_map::Entry::Vacant, sync::Arc};
-
 use super::{
     database::prelude::{BatchDbWriter, CachedDbAccess, CachedDbItem, DbKey, DirectDbWriter},
     errors::StoreError,
     DB,
 };
 use crate::processes::reachability::interval::Interval;
+use consensus_core::{
+    blockhash::{self, BlockHashes},
+    BlockHashMap, HashMapCustomHasher,
+};
 use hashes::Hash;
+
+use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
+use rocksdb::WriteBatch;
+use serde::{Deserialize, Serialize};
+use std::{collections::hash_map::Entry::Vacant, sync::Arc};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ReachabilityData {

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -3,7 +3,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::{blockhash::BlockHashes, BlockHashMap, HashMapCustomHasher};
+use consensus_core::{blockhash::BlockHashes, BlockHashMap, BlockHasher, HashMapCustomHasher};
 use hashes::Hash;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use rocksdb::WriteBatch;
@@ -31,9 +31,8 @@ const CHILDREN_PREFIX: &[u8] = b"block-children";
 #[derive(Clone)]
 pub struct DbRelationsStore {
     raw_db: Arc<DB>,
-    // `CachedDbAccess` is shallow cloned so no need to wrap with Arc
-    parents_access: CachedDbAccess<Hash, Vec<Hash>>,
-    children_access: CachedDbAccess<Hash, Vec<Hash>>,
+    parents_access: CachedDbAccess<Hash, Vec<Hash>, BlockHasher>,
+    children_access: CachedDbAccess<Hash, Vec<Hash>, BlockHasher>,
 }
 
 impl DbRelationsStore {

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -3,7 +3,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::{blockhash::BlockHashes, BlockHashMap};
+use consensus_core::{blockhash::BlockHashes, BlockHashMap, HashMapCustomHasher};
 use hashes::Hash;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use rocksdb::WriteBatch;

--- a/consensus/src/model/stores/statuses.rs
+++ b/consensus/src/model/stores/statuses.rs
@@ -1,3 +1,4 @@
+use consensus_core::BlockHasher;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -59,7 +60,7 @@ const STORE_PREFIX: &[u8] = b"block-statuses";
 #[derive(Clone)]
 pub struct DbStatusesStore {
     raw_db: Arc<DB>,
-    cached_access: CachedDbAccessForCopy<Hash, BlockStatus>,
+    cached_access: CachedDbAccessForCopy<Hash, BlockStatus, BlockHasher>,
 }
 
 impl DbStatusesStore {

--- a/consensus/src/model/stores/tips.rs
+++ b/consensus/src/model/stores/tips.rs
@@ -78,8 +78,8 @@ mod tests {
 
     #[test]
     fn test_update_tips() {
-        let mut tips = Arc::new(BlockHashSet::from([1.into(), 3.into(), 5.into()]));
+        let mut tips = Arc::new(BlockHashSet::from_iter([1.into(), 3.into(), 5.into()]));
         tips = update_tips(tips, &[3.into(), 5.into()], 7.into());
-        assert_eq!(Arc::try_unwrap(tips).unwrap(), BlockHashSet::from([1.into(), 7.into()]));
+        assert_eq!(Arc::try_unwrap(tips).unwrap(), BlockHashSet::from_iter([1.into(), 7.into()]));
     }
 }

--- a/consensus/src/model/stores/utxo_diffs.rs
+++ b/consensus/src/model/stores/utxo_diffs.rs
@@ -5,7 +5,7 @@ use super::{
     errors::StoreError,
     DB,
 };
-use consensus_core::utxo::utxo_diff::UtxoDiff;
+use consensus_core::{utxo::utxo_diff::UtxoDiff, BlockHasher};
 use hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -29,7 +29,7 @@ const STORE_PREFIX: &[u8] = b"utxo-diffs";
 #[derive(Clone)]
 pub struct DbUtxoDiffsStore {
     raw_db: Arc<DB>,
-    cached_access: CachedDbAccess<Hash, UtxoDiff>,
+    cached_access: CachedDbAccess<Hash, UtxoDiff, BlockHasher>,
 }
 
 impl DbUtxoDiffsStore {

--- a/consensus/src/model/stores/utxo_multisets.rs
+++ b/consensus/src/model/stores/utxo_multisets.rs
@@ -3,6 +3,7 @@ use super::{
     errors::StoreError,
     DB,
 };
+use consensus_core::BlockHasher;
 use hashes::Hash;
 use math::Uint3072;
 use muhash::MuHash;
@@ -23,7 +24,7 @@ const STORE_PREFIX: &[u8] = b"utxo-multisets";
 #[derive(Clone)]
 pub struct DbUtxoMultisetsStore {
     raw_db: Arc<DB>,
-    cached_access: CachedDbAccessForCopy<Hash, Uint3072>,
+    cached_access: CachedDbAccessForCopy<Hash, Uint3072, BlockHasher>,
 }
 
 impl DbUtxoMultisetsStore {

--- a/consensus/src/model/stores/utxo_set.rs
+++ b/consensus/src/model/stores/utxo_set.rs
@@ -108,15 +108,14 @@ impl UtxoSetStore for DbUtxoSetStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
 
     #[test]
     fn test_utxo_key_conversion() {
-        let outpoint = TransactionOutpoint::new(2345.into(), 300);
+        let id = 2345.into();
+        let outpoint = TransactionOutpoint::new(id, 300);
         let key: UtxoKey = outpoint.into();
         assert_eq!(outpoint, key.into());
-        assert_eq!(
-            key.0,
-            [41, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 1, 0, 0]
-        );
+        assert_eq!(key.0.to_vec(), id.as_bytes().iter().copied().chain([44, 1, 0, 0].iter().copied()).collect_vec());
     }
 }

--- a/consensus/src/pipeline/deps_manager.rs
+++ b/consensus/src/pipeline/deps_manager.rs
@@ -1,5 +1,5 @@
 use crate::{errors::BlockProcessResult, model::stores::statuses::BlockStatus};
-use consensus_core::{block::Block, BlockHashMap};
+use consensus_core::{block::Block, BlockHashMap, HashMapCustomHasher};
 use hashes::Hash;
 use parking_lot::{Condvar, Mutex};
 use std::collections::hash_map::Entry::Vacant;

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -14,7 +14,7 @@ use consensus_core::{
         utxo_diff::UtxoDiff,
         utxo_view::{UtxoView, UtxoViewComposition},
     },
-    BlockHashMap,
+    BlockHashMap, HashMapCustomHasher,
 };
 use hashes::Hash;
 use kaspa_core::trace;
@@ -154,9 +154,9 @@ impl VirtualStateProcessor {
     ) -> Vec<ValidatedTransaction<'a>> {
         self.thread_pool.install(|| {
             txs
-                .par_iter() // We can do this in parallel without complications since block body validation already ensured 
-                            // that all txs within each block are independent 
-                .skip(1) // Skip the coinbase tx. 
+                .par_iter() // We can do this in parallel without complications since block body validation already ensured
+                            // that all txs within each block are independent
+                .skip(1) // Skip the coinbase tx.
                 .filter_map(|tx| self.validate_transaction_in_utxo_context(tx, &utxo_view, pov_daa_score))
                 .collect()
         })

--- a/consensus/src/processes/ghostdag/mergeset.rs
+++ b/consensus/src/processes/ghostdag/mergeset.rs
@@ -2,7 +2,7 @@ use super::protocol::GhostdagManager;
 use crate::model::stores::ghostdag::GhostdagStoreReader;
 use crate::model::stores::relations::RelationsStoreReader;
 use crate::model::{services::reachability::ReachabilityService, stores::headers::HeaderStoreReader};
-use consensus_core::BlockHashSet;
+use consensus_core::{BlockHashSet, HashMapCustomHasher};
 use hashes::Hash;
 use std::collections::VecDeque;
 

--- a/consensus/src/processes/ghostdag/protocol.rs
+++ b/consensus/src/processes/ghostdag/protocol.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use consensus_core::{
     blockhash::{self, BlockHashes},
-    BlockHashMap, BlueWorkType,
+    BlockHashMap, BlueWorkType, HashMapCustomHasher,
 };
 use hashes::Hash;
 

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -478,16 +478,13 @@ mod tests {
         for test_block in test_blocks {
             let direct_parents = test_block.direct_parents.iter().map(|parent| Hash::from_u64_word(*parent)).collect_vec();
             let parents = parents_manager.calc_block_parents(pruning_point, &direct_parents[..]);
-            let parents_as_u64 = parents
+            let actual_parents = parents.iter().map(|parents| HashSet::<Hash>::from_iter(parents.iter().copied())).collect_vec();
+            let expected_parents = test_block
+                .expected_parents
                 .iter()
-                .map(|parents| HashSet::<u64>::from_iter(parents.iter().map(|parent| hash_to_u64(*parent))))
+                .map(|v| HashSet::from_iter(v.iter().copied().map(Hash::from_u64_word)))
                 .collect_vec();
-            let expected_parents = test_block.expected_parents.iter().cloned().map(HashSet::from_iter).collect_vec();
-            assert_eq!(expected_parents, parents_as_u64, "failed for block {}", test_block.id);
+            assert_eq!(expected_parents, actual_parents, "failed for block {}", test_block.id);
         }
-    }
-
-    fn hash_to_u64(hash: Hash) -> u64 {
-        hash.to_le_u64()[0]
     }
 }

--- a/consensus/src/processes/reachability/reindex.rs
+++ b/consensus/src/processes/reachability/reindex.rs
@@ -1,6 +1,6 @@
 use super::{extensions::ReachabilityStoreIntervalExtensions, inquirer::get_next_chain_ancestor_unchecked, interval::Interval, *};
 use crate::model::stores::reachability::ReachabilityStore;
-use consensus_core::{blockhash::BlockHashExtensions, BlockHashMap};
+use consensus_core::{blockhash::BlockHashExtensions, BlockHashMap, HashMapCustomHasher};
 use hashes::Hash;
 use std::collections::VecDeque;
 

--- a/consensus/src/processes/reachability/tests.rs
+++ b/consensus/src/processes/reachability/tests.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     processes::reachability::interval::Interval,
 };
-use consensus_core::{blockhash::BlockHashExtensions, BlockHashMap, BlockHashSet};
+use consensus_core::{blockhash::BlockHashExtensions, BlockHashMap, BlockHashSet, HashMapCustomHasher};
 use hashes::Hash;
 use std::collections::VecDeque;
 use thiserror::Error;

--- a/crypto/hashes/src/lib.rs
+++ b/crypto/hashes/src/lib.rs
@@ -53,7 +53,7 @@ impl Hash {
 
     #[inline(always)]
     pub fn from_u64_word(word: u64) -> Self {
-        Self::from_le_u64([word, 0, 0, 0])
+        Self::from_le_u64([0, 0, 0, word])
     }
 }
 


### PR DESCRIPTION
The BlockHash contains the PoW nonce, which means that trying to DOS the hashmap costs you in PoW so the PoW function actually behaves as DOS resistancy for HashMaps where the BlockHash is the key.
meaning that we don't need to pass it through `SipHash` instead we can just take the first/last 64 bits of the hash and use those as the hash for the hashmap.