### PR TITLE
Update emulator to use systemtime, and bug fix for `check_block_timestamp_in_isolation` 

### DIFF
--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -49,7 +49,7 @@ impl HeaderProcessor {
     fn check_block_timestamp_in_isolation(self: &Arc<HeaderProcessor>, header: &Header) -> BlockProcessResult<()> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
         let max_block_time = now + self.timestamp_deviation_tolerance * self.target_time_per_block;
-        if header.timestamp > now {
+        if header.timestamp > max_block_time {
             return Err(RuleError::TimeTooFarIntoTheFuture(header.timestamp, now));
         }
         Ok(())

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -50,7 +50,7 @@ impl HeaderProcessor {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
         let max_block_time = now + self.timestamp_deviation_tolerance * self.target_time_per_block;
         if header.timestamp > max_block_time {
-            return Err(RuleError::TimeTooFarIntoTheFuture(header.timestamp, now));
+            return Err(RuleError::TimeTooFarIntoTheFuture(header.timestamp, max_block_time));
         }
         Ok(())
     }

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -13,7 +13,7 @@ use std::{
         Arc,
     },
     thread::{self, spawn, JoinHandle},
-    time::{Duration},
+    time::Duration,
 };
 
 /// Emits blocks randomly in the round-based model where number of

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -13,7 +13,7 @@ use std::{
         Arc,
     },
     thread::{self, spawn, JoinHandle},
-    time::{Duration, SystemTime},
+    time::{Duration},
 };
 
 /// Emits blocks randomly in the round-based model where number of
@@ -58,7 +58,7 @@ impl RandomBlockEmitter {
             timestamp += (self.delay as u64) * 1000;
             if v == 0 {
                 continue;
-            }         
+            }
 
             if self.terminate.load(Ordering::SeqCst) {
                 break;

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -51,12 +51,11 @@ impl RandomBlockEmitter {
 
         let mut tips = vec![self.genesis];
         let mut total = 0;
-        let generate_timestamp = || -> u64 {
-                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64
-        };
 
         while total < self.target_blocks {
             let v = min(self.max_block_parents, poi.sample(&mut thread_rng) as u64);
+
+            let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
 
             if self.terminate.load(Ordering::SeqCst) {
                 break;
@@ -70,7 +69,7 @@ impl RandomBlockEmitter {
             for i in 0..v {
                 // Create a new block referencing all tips from the previous round
                 let mut b = self.consensus.build_block_with_parents(Default::default(), tips.clone());
-                b.header.timestamp = generate_timestamp();
+                b.header.timestamp = timestamp;
                 b.header.nonce = i;
                 b.header.finalize();
                 new_tips.push(b.header.hash);

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -54,6 +54,9 @@ impl RandomBlockEmitter {
 
         while total < self.target_blocks {
             let v = min(self.max_block_parents, poi.sample(&mut thread_rng) as u64);
+            if v == 0 {
+                continue;
+            }
 
             let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
 

--- a/kaspad/src/emulator.rs
+++ b/kaspad/src/emulator.rs
@@ -51,14 +51,14 @@ impl RandomBlockEmitter {
 
         let mut tips = vec![self.genesis];
         let mut total = 0;
+        let mut timestamp = 0u64;
 
         while total < self.target_blocks {
             let v = min(self.max_block_parents, poi.sample(&mut thread_rng) as u64);
+            timestamp += (self.delay as u64) * 1000;
             if v == 0 {
                 continue;
-            }
-
-            let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+            }         
 
             if self.terminate.load(Ordering::SeqCst) {
                 break;

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -36,6 +36,7 @@ pub fn main() {
 
     let mut params = MAINNET_PARAMS.clone_with_skip_pow();
     params.genesis_hash = genesis;
+    params.genesis_timestamp = 0;
 
     // Make sure to create the DB first, so it cleans up last
     let consensus = Arc::new(TestConsensus::create_from_temp_db(&params));


### PR DESCRIPTION
Changes:
1) [Bug fix] - use `max_block_time` in check `check_block_timestamp_in_isolation`
2) [update emulator] -  use system time in `block.header.timestamp` and remove usage of the delay, in order to make emulator compatible with new validation logic