### PR TITLE
Optimize multi-level parents builder

### DIFF
--- a/consensus/src/model/services/reachability.rs
+++ b/consensus/src/model/services/reachability.rs
@@ -14,6 +14,7 @@ pub trait ReachabilityService {
     fn is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> bool;
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool;
     fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool;
+    fn is_any_dag_ancestor_result(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool>;
     fn get_next_chain_ancestor(&self, descendant: Hash, ancestor: Hash) -> Hash;
 }
 
@@ -48,6 +49,16 @@ impl<T: ReachabilityStoreReader + ?Sized> ReachabilityService for MTReachability
     fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool {
         let read_guard = self.store.read();
         list.any(|hash| inquirer::is_dag_ancestor_of(read_guard.deref(), hash, queried).unwrap())
+    }
+
+    fn is_any_dag_ancestor_result(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool> {
+        let read_guard = self.store.read();
+        for hash in list {
+            if inquirer::is_dag_ancestor_of(read_guard.deref(), hash, queried)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool {

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -68,9 +68,11 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
 
             for parent in direct_parent_headers
                 .iter()
-                .filter(|h| block_level > h.block_level as usize) // We need to iterate parent's parents only if parent is not at block_level
+                // We need to iterate parent's parents only if parent is not at block_level
+                .filter(|h| block_level > h.block_level as usize)
                 .flat_map(|h| self.parents_at_level(&h.header, block_level as u8).iter().copied())
-                // We use IndexSet in order to preserve iteration order
+                // We use IndexSet in order to preserve iteration order and make sure we visit the parents of the first 
+                // parent first (since we verified it was in the pruning point's future)
                 .collect::<IndexSet<Hash, BlockHasher>>()
             {
                 let is_in_origin_children_future = self

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -72,10 +72,6 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
 
         for block_level in 0..self.max_block_level as usize {
             for direct_parent_header in direct_parent_headers.iter() {
-                // for (block_level, direct_parent_level_parents) in self.parents(&direct_parent_header.header).enumerate() {
-                // for block_level in 0..self.max_block_level as usize {
-                let is_empty_level = candidates_by_level_to_reference_blocks_map[block_level].is_empty();
-
                 for parent in self.parents_at_level(&direct_parent_header.header, block_level as u8).iter().copied() {
                     let mut is_in_future_origin_children = false;
                     for child in origin_children.iter().copied() {
@@ -119,7 +115,7 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
                         reference_blocks
                     };
 
-                    if is_empty_level {
+                    if candidates_by_level_to_reference_blocks_map[block_level].is_empty() {
                         candidates_by_level_to_reference_blocks_map[block_level].insert(parent, reference_blocks);
                         continue;
                     }

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -68,7 +68,8 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
 
             for parent in direct_parent_headers
                 .iter()
-                .flat_map(|header| self.parents_at_level(&header.header, block_level as u8).iter().copied())
+                .filter(|h| block_level > h.block_level as usize) // We need to iterate parent's parents only if parent is not at block_level
+                .flat_map(|h| self.parents_at_level(&h.header, block_level as u8).iter().copied())
                 // We use IndexSet in order to preserve iteration order
                 .collect::<IndexSet<Hash, BlockHasher>>()
             {

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -1,12 +1,8 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-
-use consensus_core::{blockhash::ORIGIN, header::Header};
+use consensus_core::{blockhash::ORIGIN, header::Header, BlockHashMap, BlockHashSet, HashMapCustomHasher};
 use hashes::Hash;
 use itertools::Itertools;
 use parking_lot::RwLock;
+use std::sync::Arc;
 
 use crate::{
     model::{
@@ -56,7 +52,7 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
             .expect("at least one of the parents is expected to be in the future of the pruning point");
         direct_parent_headers.swap(0, first_parent_in_future_of_pruning_point);
 
-        let mut candidates_by_level_to_reference_blocks_map = (0..self.max_block_level + 1).map(|_| HashMap::new()).collect_vec();
+        let mut candidates_by_level_to_reference_blocks_map = (0..self.max_block_level + 1).map(|_| BlockHashMap::new()).collect_vec();
         // Direct parents are guaranteed to be in one other's anticones so add them all to
         // all the block levels they occupy.
         for direct_parent_header in direct_parent_headers.iter() {
@@ -124,7 +120,7 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
                         continue;
                     }
 
-                    let mut to_remove = HashSet::new();
+                    let mut to_remove = BlockHashSet::new();
                     for (candidate, candidate_references) in candidates_by_level_to_reference_blocks_map[block_level].iter() {
                         if self.reachability_service.is_any_dag_ancestor(&mut candidate_references.iter().copied(), parent) {
                             to_remove.insert(*candidate);

--- a/consensus/src/processes/reachability/mod.rs
+++ b/consensus/src/processes/reachability/mod.rs
@@ -23,4 +23,24 @@ pub enum ReachabilityError {
     BadQuery,
 }
 
+impl ReachabilityError {
+    pub fn is_key_not_found(&self) -> bool {
+        matches!(self, ReachabilityError::StoreError(e) if matches!(e, StoreError::KeyNotFound(_)))
+    }
+}
+
 pub type Result<T> = std::result::Result<T, ReachabilityError>;
+
+pub trait ReachabilityResultExtensions<T> {
+    fn unwrap_option(self) -> Option<T>;
+}
+
+impl<T> ReachabilityResultExtensions<T> for Result<T> {
+    fn unwrap_option(self) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(err) if err.is_key_not_found() => None,
+            Err(err) => panic!("Unexpected reachability error: {:?}", err),
+        }
+    }
+}


### PR DESCRIPTION
Improves performance drastically (avoiding a quadratic `O(num_parents^2)` term) 