### PR TITLE
Virtual processor part 2 -- virtual parents selection rules

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -287,7 +287,7 @@ impl Consensus {
             past_median_time_manager.clone(),
             dag_traversal_manager.clone(),
             difficulty_manager.clone(),
-            depth_manager,
+            depth_manager.clone(),
             pruning_manager.clone(),
             parents_manager.clone(),
             counters.clone(),
@@ -340,6 +340,7 @@ impl Consensus {
             past_median_time_manager.clone(),
             pruning_manager.clone(),
             parents_manager,
+            depth_manager,
         ));
 
         Self {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -95,8 +95,8 @@ pub struct Consensus {
     pub ghostdag_store: Arc<DbGhostdagStore>,
 
     // Services and managers
-    statuses_service: Arc<MTStatusesService<DbStatusesStore>>,
-    relations_service: Arc<MTRelationsService<DbRelationsStore>>,
+    statuses_service: MTStatusesService<DbStatusesStore>,
+    relations_service: MTRelationsService<DbRelationsStore>,
     reachability_service: MTReachabilityService<DbReachabilityStore>,
     pub(super) difficulty_manager: DifficultyManager<DbHeadersStore>,
     pub(super) dag_traversal_manager: DagTraversalManager<DbGhostdagStore, BlockWindowCacheStore>,
@@ -154,8 +154,8 @@ impl Consensus {
         // Services and managers
         //
 
-        let statuses_service = Arc::new(MTStatusesService::new(statuses_store.clone()));
-        let relations_service = Arc::new(MTRelationsService::new(relations_store.clone()));
+        let statuses_service = MTStatusesService::new(statuses_store.clone());
+        let relations_service = MTRelationsService::new(relations_store.clone());
         let reachability_service = MTReachabilityService::new(reachability_store.clone());
         let dag_traversal_manager = DagTraversalManager::new(
             params.genesis_hash,
@@ -332,6 +332,7 @@ impl Consensus {
             virtual_state_store,
             ghostdag_manager.clone(),
             reachability_service.clone(),
+            relations_service.clone(),
             dag_traversal_manager.clone(),
             difficulty_manager.clone(),
             coinbase_manager.clone(),

--- a/consensus/src/model/services/statuses.rs
+++ b/consensus/src/model/services/statuses.rs
@@ -5,6 +5,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 /// Multi-threaded block-statuses service imp
+#[derive(Clone)]
 pub struct MTStatusesService<T: StatusesStoreReader> {
     store: Arc<RwLock<T>>,
 }

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -103,15 +103,18 @@ impl HeaderProcessor {
         let gd_data = ctx.ghostdag_data.as_ref().unwrap();
         let merge_depth_root = self.depth_manager.calc_merge_depth_root(gd_data, ctx.pruning_point());
         let finality_point = self.depth_manager.calc_finality_point(gd_data, ctx.pruning_point());
-        let non_bounded_merge_depth_violating_blues: Vec<Hash> =
-            self.depth_manager.non_bounded_merge_depth_violating_blues(gd_data, merge_depth_root).collect();
+        let mut kosherizing_blues: Option<Vec<Hash>> = None;
 
         for red in gd_data.mergeset_reds.iter().cloned() {
             if self.reachability_service.is_dag_ancestor_of(merge_depth_root, red) {
                 continue;
             }
-
-            if !non_bounded_merge_depth_violating_blues.iter().any(|blue| self.reachability_service.is_dag_ancestor_of(red, *blue)) {
+            // Lazy load the kosherizing blocks since this case is extremely rare
+            if kosherizing_blues.is_none() {
+                kosherizing_blues =
+                    Some(self.depth_manager.non_bounded_merge_depth_violating_blues(gd_data, merge_depth_root).collect());
+            }
+            if !self.reachability_service.is_dag_ancestor_of_any(red, &mut kosherizing_blues.as_ref().unwrap().iter().copied()) {
                 return Err(RuleError::ViolatingBoundedMergeDepth);
             }
         }

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -105,14 +105,13 @@ impl HeaderProcessor {
         let finality_point = self.depth_manager.calc_finality_point(gd_data, ctx.pruning_point());
         let mut kosherizing_blues: Option<Vec<Hash>> = None;
 
-        for red in gd_data.mergeset_reds.iter().cloned() {
+        for red in gd_data.mergeset_reds.iter().copied() {
             if self.reachability_service.is_dag_ancestor_of(merge_depth_root, red) {
                 continue;
             }
             // Lazy load the kosherizing blocks since this case is extremely rare
             if kosherizing_blues.is_none() {
-                kosherizing_blues =
-                    Some(self.depth_manager.non_bounded_merge_depth_violating_blues(gd_data, merge_depth_root).collect());
+                kosherizing_blues = Some(self.depth_manager.kosherizing_blues(gd_data, merge_depth_root).collect());
             }
             if !self.reachability_service.is_dag_ancestor_of_any(red, &mut kosherizing_blues.as_ref().unwrap().iter().copied()) {
                 return Err(RuleError::ViolatingBoundedMergeDepth);

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -175,7 +175,7 @@ impl HeaderProcessor {
         block_window_cache_for_difficulty: Arc<BlockWindowCacheStore>,
         block_window_cache_for_past_median_time: Arc<BlockWindowCacheStore>,
         reachability_service: MTReachabilityService<DbReachabilityStore>,
-        relations_service: Arc<MTRelationsService<DbRelationsStore>>,
+        relations_service: MTRelationsService<DbRelationsStore>,
         past_median_time_manager: PastMedianTimeManager<DbHeadersStore, DbGhostdagStore, BlockWindowCacheStore>,
         dag_traversal_manager: DagTraversalManager<DbGhostdagStore, BlockWindowCacheStore>,
         difficulty_manager: DifficultyManager<DbHeadersStore>,

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -391,7 +391,7 @@ impl HeaderProcessor {
         header.timestamp = self.genesis_timestamp;
         let header = Arc::new(header);
         let mut ctx = HeaderProcessingContext::new(self.genesis_hash, &header, PruningPointInfo::from_genesis(self.genesis_hash));
-        ctx.ghostdag_data = Some(self.ghostdag_manager.genesis_ghostdag_data());
+        ctx.ghostdag_data = Some(Arc::new(self.ghostdag_manager.genesis_ghostdag_data()));
         ctx.block_window_for_difficulty = Some(Default::default());
         ctx.block_window_for_past_median_time = Some(Default::default());
         ctx.mergeset_non_daa = Some(Default::default());

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -322,7 +322,7 @@ impl VirtualStateProcessor {
         }
 
         // TODO: Make a separate pruning processor and send to its channel here
-        self.maybe_update_pruning_point_and_candidate()
+        self.advance_pruning_point_and_candidate_if_possible()
     }
 
     fn commit_utxo_state(self: &Arc<Self>, current: Hash, mergeset_diff: UtxoDiff, multiset: MuHash, acceptance_data: AcceptanceData) {
@@ -401,7 +401,7 @@ impl VirtualStateProcessor {
         BlockTemplate::new(MutableBlock::new(header, txs), miner_data, coinbase.has_red_reward, selected_parent_timestamp)
     }
 
-    fn maybe_update_pruning_point_and_candidate(self: &Arc<Self>) {
+    fn advance_pruning_point_and_candidate_if_possible(self: &Arc<Self>) {
         let virtual_sp = self.virtual_state_store.read().get().unwrap().ghostdag_data.selected_parent;
         if virtual_sp == self.genesis_hash {
             return;

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -497,7 +497,7 @@ impl VirtualStateProcessor {
         txs.insert(0, coinbase.tx);
         let version = BLOCK_VERSION;
         let parents_by_level = self.parents_manager.calc_block_parents(pruning_point, &virtual_state.parents);
-        let hash_merkle_root = calc_hash_merkle_root(&mut txs.iter());
+        let hash_merkle_root = calc_hash_merkle_root(txs.iter());
         let accepted_id_merkle_root = merkle::calc_merkle_root(virtual_state.accepted_tx_ids.iter().copied());
         let utxo_commitment = virtual_state.multiset.clone().finalize();
         // Past median time is the exclusive lower bound for valid block time, so we increase by 1 to get the valid min

--- a/consensus/src/processes/block_depth.rs
+++ b/consensus/src/processes/block_depth.rs
@@ -80,7 +80,9 @@ impl<S: DepthStoreReader, U: ReachabilityStoreReader, V: GhostdagStoreReader> Bl
         current
     }
 
-    pub fn non_bounded_merge_depth_violating_blues<'a>(
+    /// Returns the set of blues which are eligible for "kosherizing" merge bound violating blocks.
+    /// By prunality rules, these blocks must have `merge_depth_root` on their selected chain.  
+    pub fn kosherizing_blues<'a>(
         &'a self,
         ghostdag_data: &'a GhostdagData,
         merge_depth_root: Hash,

--- a/consensus/src/processes/ghostdag/protocol.rs
+++ b/consensus/src/processes/ghostdag/protocol.rs
@@ -43,15 +43,15 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
         Self { genesis_hash, k, ghostdag_store, relations_store, reachability_service, headers_store }
     }
 
-    pub fn genesis_ghostdag_data(&self) -> Arc<GhostdagData> {
-        Arc::new(GhostdagData::new(
+    pub fn genesis_ghostdag_data(&self) -> GhostdagData {
+        GhostdagData::new(
             0,
             Default::default(), // TODO: take blue score and work from actual genesis
             blockhash::ORIGIN,
             BlockHashes::new(Vec::new()),
             BlockHashes::new(Vec::new()),
             HashKTypeMap::new(BlockHashMap::new()),
-        ))
+        )
     }
 
     pub fn find_selected_parent(&self, parents: &mut impl Iterator<Item = Hash>) -> Hash {
@@ -177,7 +177,6 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
             }
 
             current_blues_anticone_sizes = self.ghostdag_store.get_blues_anticone_sizes(current_selected_parent).unwrap();
-
             current_selected_parent = self.ghostdag_store.get_selected_parent(current_selected_parent).unwrap();
         }
     }
@@ -190,13 +189,11 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
         }
 
         let mut candidate_blues_anticone_sizes: BlockHashMap<KType> = BlockHashMap::with_capacity(self.k as usize);
-
         // Iterate over all blocks in the blue past of the new block that are not in the past
         // of blue_candidate, and check for each one of them if blue_candidate potentially
         // enlarges their blue anticone to be over K, or that they enlarge the blue anticone
         // of blue_candidate to be over K.
         let mut chain_block = ChainBlock { hash: None, data: new_block_data.into() };
-
         let mut candidate_blue_anticone_size: KType = 0;
 
         loop {

--- a/consensus/src/processes/ghostdag/protocol.rs
+++ b/consensus/src/processes/ghostdag/protocol.rs
@@ -26,7 +26,7 @@ pub struct GhostdagManager<T: GhostdagStoreReader, S: RelationsStoreReader, U: R
     genesis_hash: Hash,
     pub(super) k: KType,
     pub(super) ghostdag_store: Arc<T>,
-    pub(super) relations_store: Arc<S>,
+    pub(super) relations_store: S,
     pub(super) headers_store: Arc<V>,
     pub(super) reachability_service: U,
 }
@@ -36,7 +36,7 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
         genesis_hash: Hash,
         k: KType,
         ghostdag_store: Arc<T>,
-        relations_store: Arc<S>,
+        relations_store: S,
         headers_store: Arc<V>,
         reachability_service: U,
     ) -> Self {

--- a/consensus/src/processes/reachability/mod.rs
+++ b/consensus/src/processes/reachability/mod.rs
@@ -32,6 +32,7 @@ impl ReachabilityError {
 pub type Result<T> = std::result::Result<T, ReachabilityError>;
 
 pub trait ReachabilityResultExtensions<T> {
+    /// Unwraps the error into `None` if the internal error is `StoreError::KeyNotFound` or panics otherwise
     fn unwrap_option(self) -> Option<T>;
 }
 


### PR DESCRIPTION
Implements virtual parent selection algorithms which enforce the following mining rules:

1. Max number of direct parents
2. Mergeset size limit 
3. Bounded merge depth 

The following components of virtual processing are yet to be implemented:

- Search for alternative virtual selected parent if the current one turns out to be disqualified from chain or violates finality.
- Refactor all functions and algorithms to proper files/structs/methods 