### PR TITLE
Use malachite for modular inverse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
  "futures-util",
  "hashes",
  "indexmap",
- "itertools",
+ "itertools 0.10.5",
  "kaspa-core",
  "kaspa-utils",
  "log",
@@ -777,7 +777,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -796,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -960,6 +960,18 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "embed-doc-image"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af36f591236d9d822425cb6896595658fa558fcebf5ee8accac1d4b92c47166e"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -1260,7 +1272,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
 ]
 
 [[package]]
@@ -1471,6 +1483,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1736,6 +1757,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite-base"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6966380e35149e65ed5182d1ba34dddacdfd012617558a94e8ee3a2795e34d3a"
+dependencies = [
+ "itertools 0.9.0",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "ryu",
+ "sha3 0.9.1",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c492f43fabcea46b1869f0a000db5140c347205892d497db6aaa9844901d444c"
+dependencies = [
+ "embed-doc-image",
+ "itertools 0.9.0",
+ "malachite-base",
+]
+
+[[package]]
 name = "manual_future"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1802,8 @@ dependencies = [
  "borsh",
  "criterion",
  "faster-hex",
+ "malachite-base",
+ "malachite-nz",
  "rand_chacha 0.3.1",
  "serde",
 ]
@@ -2158,7 +2205,7 @@ checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2179,7 +2226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -2568,6 +2615,18 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
@@ -2593,7 +2652,7 @@ dependencies = [
  "futures-util",
  "hashes",
  "indexmap",
- "itertools",
+ "itertools 0.10.5",
  "kaspa-core",
  "rand 0.8.5",
  "rand_distr",
@@ -2706,7 +2765,7 @@ dependencies = [
  "console_log",
  "curve25519-dalek",
  "getrandom 0.2.8",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "libc",
@@ -2725,7 +2784,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",

--- a/crypto/muhash/benches/bench.rs
+++ b/crypto/muhash/benches/bench.rs
@@ -8,12 +8,16 @@ use muhash::MuHash;
 
 fn bench_muhash(c: &mut Criterion) {
     let mut rng = ChaCha8Rng::from_seed([42u8; 32]);
+    let mut rand_set = MuHash::new();
 
     let mut data = [0u8; 100];
+    // Set the numerator and denominators.
     rng.fill_bytes(&mut data);
-    let mut rand_set_serialized = [0u8; 384];
-    rng.fill_bytes(&mut rand_set_serialized);
-    let mut rand_set = MuHash::deserialize(rand_set_serialized).unwrap();
+    rand_set.add_element(&data);
+    rng.fill_bytes(&mut data);
+    rand_set.remove_element(&data);
+
+    rng.fill_bytes(&mut data);
 
     c.bench_function("MuHash::add_element", |b| {
         let mut muhash = MuHash::new();
@@ -62,14 +66,10 @@ fn bench_muhash(c: &mut Criterion) {
         b.iter(|| black_box(muhash.clone()).serialize())
     });
 
-    c.bench_function("MuHash::serialize rand", |b| {
-        let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
-        b.iter(|| black_box(muhash.clone()).serialize())
-    });
+    c.bench_function("MuHash::serialize rand", |b| b.iter(|| black_box(rand_set.clone()).serialize()));
 
     c.bench_function("MuHash::finalize", |b| {
-        let muhash = MuHash::deserialize(rand_set_serialized).unwrap();
-        b.iter(|| black_box(muhash.clone()).finalize());
+        b.iter(|| black_box(rand_set.clone()).finalize());
     });
 }
 

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -147,7 +147,10 @@ impl U3072 {
             a.full_reduce();
         }
         // The only value that doesn't have a multiplicative inverse is 0, and 0/x is 0.
-        let inv = Self { limbs: Uint3072(a.limbs).mod_inverse(Self::UINT_PRIME).unwrap_or_default().0 };
+        if a == Self::zero() {
+            return a;
+        }
+        let inv = Self { limbs: Uint3072(a.limbs).mod_inverse(Self::UINT_PRIME).expect("Cannot fail, 0 < a < prime").0 };
         if cfg!(debug_assertions) {
             let mut one = inv;
             one *= a;

--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -147,8 +147,13 @@ impl U3072 {
             a.full_reduce();
         }
         // The only value that doesn't have a multiplicative inverse is 0, and 0/x is 0.
-        let inv = Uint3072(a.limbs).mod_inverse(Self::UINT_PRIME).unwrap_or_default();
-        Self { limbs: inv.0 }
+        let inv = Self { limbs: Uint3072(a.limbs).mod_inverse(Self::UINT_PRIME).unwrap_or_default().0 };
+        if cfg!(debug_assertions) {
+            let mut one = inv;
+            one *= a;
+            assert_eq!(one, Self::one());
+        }
+        inv
     }
 
     fn div(&mut self, other: &Self) {

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace = true
 serde.workspace = true
 faster-hex.workspace = true
 borsh.workspace = true
+malachite-nz = "0.3"
+malachite-base = "0.3"
 
 [dev-dependencies]
 rand_chacha.workspace = true

--- a/math/fuzz/fuzz_targets/u192.rs
+++ b/math/fuzz/fuzz_targets/u192.rs
@@ -133,10 +133,11 @@ fuzz_target!(|data: &[u8]| {
     // mod_inv
     {
         // the modular inverse of 1 in Z/1Z is weird, should it be 1 or 0?
+        // Also, 0 never has a mod_inverse
         let ((lib1, native1), (lib2, native2)) = loop {
             let (lib1, native1) = try_opt!(generate_ints(&mut data));
             let (lib2, native2) = try_opt!(generate_ints(&mut data));
-            if lib1 != 1u64 || lib2 != 1u64 {
+            if lib1 < lib2 && lib1 != 0u64 {
                 break ((lib1, native1), (lib2, native2));
             }
         };

--- a/math/fuzz/fuzz_targets/u256.rs
+++ b/math/fuzz/fuzz_targets/u256.rs
@@ -135,7 +135,7 @@ fuzz_target!(|data: &[u8]| {
         let ((lib1, native1), (lib2, native2)) = loop {
             let (lib1, native1) = try_opt!(generate_ints(&mut data));
             let (lib2, native2) = try_opt!(generate_ints(&mut data));
-            if lib1 != 1u64 || lib2 != 1u64 {
+            if lib1 < lib2 && lib1 != 0u64 {
                 break ((lib1, native1), (lib2, native2));
             }
         };


### PR DESCRIPTION
This uses the new https://github.com/mhogrefe/malachite crate for computing modular inverses, in the future, we'd want to replace that with our own implementation of Lehmer's algorithm.
Benchmark before on my machine with turbo-boost off:
```
Uint3072/mod_inv Muhash prime
                        time:   [254.88 ms 257.58 ms 260.49 ms]
                        change: [+0.5522% +1.8513% +3.4027%] (p = 0.01 < 0.05)
                        Change within noise threshold.
```

After: 

```
Uint3072/mod_inv Muhash prime
                        time:   [1.5437 ms 1.5536 ms 1.5654 ms]
                        change: [-99.404% -99.396% -99.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
```

I will let the fuzzers run throughout the weekend

(Thanks @michaelsutton For pointing this library out and suggesting we'll use it here)