### PR TITLE
 Make Muhash always use 64 bits limbs

### DIFF
--- a/crypto/muhash/src/u3072.rs
+++ b/crypto/muhash/src/u3072.rs
@@ -2,15 +2,18 @@ use crate::ELEMENT_BYTE_SIZE;
 use math::Uint3072;
 use serde::{Deserialize, Serialize};
 use std::ops::{DivAssign, MulAssign};
-#[cfg(target_pointer_width = "64")]
+
+// TODO: Add u32 support for optimization on 32 bit machines.
+
+//#[cfg(target_pointer_width = "64")]
 pub(crate) type Limb = u64;
-#[cfg(target_pointer_width = "64")]
+//#[cfg(target_pointer_width = "64")]
 pub(crate) type DoubleLimb = u128;
 
-#[cfg(target_pointer_width = "32")]
-pub(crate) type Limb = u32;
-#[cfg(target_pointer_width = "32")]
-pub(crate) type DoubleLimb = u64;
+//#[cfg(target_pointer_width = "32")]
+//pub(crate) type Limb = u32;
+//#[cfg(target_pointer_width = "32")]
+//pub(crate) type DoubleLimb = u64;
 
 const LIMB_SIZE_BYTES: usize = std::mem::size_of::<Limb>();
 const LIMB_SIZE: usize = std::mem::size_of::<Limb>() * 8;

--- a/math/src/uint.rs
+++ b/math/src/uint.rs
@@ -1,6 +1,8 @@
 #[doc(hidden)]
 pub use {faster_hex, malachite_base, malachite_nz, serde};
 
+// TODO: Add u32 support for optimization on 32 bit machines.
+
 #[macro_export]
 macro_rules! construct_uint {
     ($name:ident, $n_words:literal $(, $derive_trait:ty)*) => {


### PR DESCRIPTION
The tests anyway don't pass for the 32 bits right now even though the code is correct.
`Uint` is using u64's and because we use that for the modular inverse they need to either have the same kind of limbs, or be converted, so for now I made MuHash always use 64bit limbs, at the cost of a performance penalty for 32 bit machines. but at least it'll compile and work properly.

The `math` crate seems to build now under wasm (`cargo b --target wasm32-unknown-unknown`)