### PR TITLE
math: Add as_f64 function to Uint*

### DIFF
--- a/math/fuzz/Cargo.toml
+++ b/math/fuzz/Cargo.toml
@@ -14,8 +14,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
 
-
-[dependencies.math]
+[dependencies.kaspa-math]
 path = ".."
 
 # Prevent this from interfering with workspaces

--- a/math/fuzz/fuzz_targets/u128.rs
+++ b/math/fuzz/fuzz_targets/u128.rs
@@ -2,8 +2,8 @@
 mod utils;
 
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem};
-use libfuzzer_sys::fuzz_target;
 use kaspa_math::construct_uint;
+use libfuzzer_sys::fuzz_target;
 use std::convert::TryInto;
 use utils::{consume, try_opt};
 
@@ -106,6 +106,11 @@ fuzz_target!(|data: &[u8]| {
         let (lib, native) = try_opt!(generate_ints(&mut data));
         assert_eq!(lib.as_u128(), native as u128, "native: {native}");
     }
+    // as f64
+    {
+        let (lib, native) = try_opt!(generate_ints(&mut data));
+        assert_eq!(lib.as_f64(), native as f64, "native: {native}");
+    }
     // to_le_bytes
     {
         let (lib, native) = try_opt!(generate_ints(&mut data));
@@ -129,7 +134,7 @@ fuzz_target!(|data: &[u8]| {
     // mod_inv
     {
         // the modular inverse of 1 in Z/1Z is weird, should it be 1 or 0?
-          // Also, 0 never has a mod_inverse
+        // Also, 0 never has a mod_inverse
         let ((lib1, native1), (lib2, native2)) = loop {
             let (lib1, native1) = try_opt!(generate_ints_top_bit_cleared(&mut data));
             let (lib2, native2) = try_opt!(generate_ints_top_bit_cleared(&mut data));
@@ -145,7 +150,6 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 });
-
 
 fn naive_mod_inv(x: u128, p: u128) -> Option<u128> {
     let mut t = 0;

--- a/math/fuzz/fuzz_targets/u192.rs
+++ b/math/fuzz/fuzz_targets/u192.rs
@@ -2,8 +2,8 @@
 mod utils;
 
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem};
-use libfuzzer_sys::fuzz_target;
 use kaspa_math::construct_uint;
+use libfuzzer_sys::fuzz_target;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::{Signed, Zero};

--- a/math/fuzz/fuzz_targets/u256.rs
+++ b/math/fuzz/fuzz_targets/u256.rs
@@ -2,8 +2,8 @@
 mod utils;
 
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem};
-use libfuzzer_sys::fuzz_target;
 use kaspa_math::construct_uint;
+use libfuzzer_sys::fuzz_target;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::{Signed, Zero};


### PR DESCRIPTION
This uses the algorithm from https://blog.m-ou.se/floats/ to convert any Uint* struct into an `f64` according to the IEEE754 spec (rounding to the closest f64).

Also used rust-bitcoin's code as another reference: https://github.com/rust-bitcoin/rust-bitcoin/blob/e83a2d34222a36d7c7c3c572f6fc8ba20b380178/bitcoin/src/pow.rs#L650

Note that I did deviate a bit from the algorithm by keeping the highest dropped bit as bool and ORing together the rest of the dropped bits into a u64 and not squashing them together into a single u64 as that is quite harder with more limbs.

But it seems that this approach might even be faster somehow?(https://godbolt.org/z/W1hvs5jKv) I'll need to write a benchmark to be sure.

I'm currently running the fuzzer on `u128` in my laptop