### PR TITLE
gRPC server complement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "triggered",
+ "uuid 1.3.0",
  "wasm-bindgen",
  "workflow-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ convert_case = "0.5.0"
 wasm-bindgen-futures="0.4.33"
 js-sys = "0.3.56"
 getrandom = { version = "0.2.8", features = ["js"] }
+uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 
 # bip32 dependencies
 rand_core = { version = "0.6", features = ["std"] }

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -53,6 +53,14 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
+    fn get_virtual_bits(&self) -> u32 {
+        unimplemented!()
+    }
+
+    fn get_virtual_past_median_time(&self) -> u64 {
+        unimplemented!()
+    }
+
     fn get_virtual_merge_depth_root(&self) -> Option<Hash> {
         unimplemented!()
     }
@@ -90,6 +98,10 @@ pub trait ConsensusApi: Send + Sync {
         chunk_size: usize,
         skip_first: bool,
     ) -> Vec<(TransactionOutpoint, UtxoEntry)> {
+        unimplemented!()
+    }
+
+    fn get_tips(&self) -> Vec<Hash> {
         unimplemented!()
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -671,6 +671,14 @@ impl ConsensusApi for Consensus {
         self.virtual_processor.virtual_stores.read().state.get().unwrap().daa_score
     }
 
+    fn get_virtual_bits(&self) -> u32 {
+        self.virtual_processor.virtual_stores.read().state.get().unwrap().bits
+    }
+
+    fn get_virtual_past_median_time(&self) -> u64 {
+        self.virtual_processor.virtual_stores.read().state.get().unwrap().past_median_time
+    }
+
     fn get_virtual_merge_depth_root(&self) -> Option<Hash> {
         // TODO: consider saving the merge depth root as part of virtual state
         // TODO: unwrap on pruning_point and virtual state reads when staging consensus is implemented
@@ -713,11 +721,7 @@ impl ConsensusApi for Consensus {
     }
 
     fn get_virtual_parents(&self) -> BlockHashSet {
-        // TODO: unwrap on virtual state read when staging consensus is implemented
-        match self.virtual_processor.virtual_stores.read().state.get().unwrap_option() {
-            Some(s) => s.parents.iter().copied().collect(),
-            None => Default::default(),
-        }
+        self.virtual_processor.virtual_stores.read().state.get().unwrap().parents.iter().copied().collect()
     }
 
     fn get_virtual_utxos(
@@ -729,6 +733,10 @@ impl ConsensusApi for Consensus {
         let virtual_stores = self.virtual_processor.virtual_stores.read();
         let iter = virtual_stores.utxo_set.seek_iterator(from_outpoint, chunk_size, skip_first);
         iter.map(|item| item.unwrap()).collect()
+    }
+
+    fn get_tips(&self) -> Vec<Hash> {
+        self.body_tips().iter().copied().collect_vec()
     }
 
     fn get_pruning_point_utxos(

--- a/protocol/p2p/Cargo.toml
+++ b/protocol/p2p/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
 itertools.workspace = true
+uuid.workspace = true
 
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 prost = "0.11"
@@ -40,7 +41,6 @@ tokio = { version = "1.21.2", features = [
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tonic = { version = "0.9.1", features = ["tls", "gzip"] }
 h2 = "0.3"
-uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 
 [build-dependencies]
 tonic-build = { version = "0.9.1", features = ["prost"] }

--- a/rpc/core/Cargo.toml
+++ b/rpc/core/Cargo.toml
@@ -37,3 +37,4 @@ rand = "0.8"
 triggered = "0.1"
 workflow-core.workspace = true
 paste.workspace = true
+uuid.workspace = true

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -157,12 +157,12 @@ pub struct GetPeerAddressesRequest {}
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPeerAddressesResponse {
-    pub known_addresses: Vec<RpcAddress>,
-    pub banned_addresses: Vec<RpcAddress>,
+    pub known_addresses: Vec<RpcPeerAddress>,
+    pub banned_addresses: Vec<RpcPeerAddress>,
 }
 
 impl GetPeerAddressesResponse {
-    pub fn new(known_addresses: Vec<RpcAddress>, banned_addresses: Vec<RpcAddress>) -> Self {
+    pub fn new(known_addresses: Vec<RpcPeerAddress>, banned_addresses: Vec<RpcPeerAddress>) -> Self {
         Self { known_addresses, banned_addresses }
     }
 }
@@ -683,8 +683,8 @@ pub struct GetProcessMetricsResponse {
     pub uptime: u64,
     pub memory_used: Vec<u64>,
     pub storage_used: Vec<u64>,
-    pub grpc_connections: Vec<u32>,
-    pub wrpc_connections: Vec<u32>,
+    pub grpc_connections: Vec<u64>,
+    pub wrpc_connections: Vec<u64>,
     // TBD:
     //  - approx bandwidth consumption
     //  - other connection metrics
@@ -696,8 +696,8 @@ impl GetProcessMetricsResponse {
         uptime: u64,
         memory_used: Vec<u64>,
         storage_used: Vec<u64>,
-        grpc_connections: Vec<u32>,
-        wrpc_connections: Vec<u32>,
+        grpc_connections: Vec<u64>,
+        wrpc_connections: Vec<u64>,
     ) -> Self {
         Self { uptime, memory_used, storage_used, grpc_connections, wrpc_connections }
     }

--- a/rpc/core/src/model/peer.rs
+++ b/rpc/core/src/model/peer.rs
@@ -10,15 +10,15 @@ pub struct RpcPeerAddress {
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct RpcPeerInfo {
     // TODO: fix the type (gRPC has a string)
-    id: u64,
-    address: RpcPeerAddress,
-    last_ping_duration: u64, // NOTE: i64 in gRPC protowire
+    pub id: u64,
+    pub address: RpcPeerAddress,
+    pub last_ping_duration: u64, // NOTE: i64 in gRPC protowire
 
-    is_outbound: bool,
-    time_offset: u64,
-    user_agent: String,
+    pub is_outbound: bool,
+    pub time_offset: u64,
+    pub user_agent: String,
 
-    advertised_protocol_version: u32,
-    time_connected: u64, // NOTE: i64 in gRPC protowire
-    is_ibd_peer: bool,
+    pub advertised_protocol_version: u32,
+    pub time_connected: u64, // NOTE: i64 in gRPC protowire
+    pub is_ibd_peer: bool,
 }

--- a/rpc/grpc/core/src/convert/address.rs
+++ b/rpc/grpc/core/src/convert/address.rs
@@ -1,0 +1,22 @@
+use crate::protowire;
+use crate::{from, try_from};
+use kaspa_rpc_core::RpcError;
+
+// ----------------------------------------------------------------------------
+// rpc_core to protowire
+// ----------------------------------------------------------------------------
+
+from!(item: &kaspa_rpc_core::RpcBalancesByAddressesEntry, protowire::RpcBalancesByAddressesEntry, {
+    // TODO: Add an error if the balance is None
+    let error = Some(protowire::RpcError { message: "address has no balance".to_string() });
+    Self { address: (&item.address).into(), balance: item.balance.unwrap_or_default(), error }
+});
+
+// ----------------------------------------------------------------------------
+// protowire to rpc_core
+// ----------------------------------------------------------------------------
+
+try_from!(item: &protowire::RpcBalancesByAddressesEntry, kaspa_rpc_core::RpcBalancesByAddressesEntry, {
+    let balance = if item.error.is_some() { None } else { Some(item.balance) };
+    Self { address: item.address.as_str().try_into()?, balance }
+});

--- a/rpc/grpc/core/src/convert/address.rs
+++ b/rpc/grpc/core/src/convert/address.rs
@@ -7,9 +7,7 @@ use kaspa_rpc_core::RpcError;
 // ----------------------------------------------------------------------------
 
 from!(item: &kaspa_rpc_core::RpcBalancesByAddressesEntry, protowire::RpcBalancesByAddressesEntry, {
-    // TODO: Add an error if the balance is None
-    let error = Some(protowire::RpcError { message: "address has no balance".to_string() });
-    Self { address: (&item.address).into(), balance: item.balance.unwrap_or_default(), error }
+    Self { address: (&item.address).into(), balance: item.balance.unwrap_or_default(), error: None }
 });
 
 // ----------------------------------------------------------------------------

--- a/rpc/grpc/core/src/convert/mod.rs
+++ b/rpc/grpc/core/src/convert/mod.rs
@@ -1,3 +1,4 @@
+pub mod address;
 pub mod block;
 pub mod error;
 pub mod header;
@@ -5,4 +6,5 @@ pub mod kaspad;
 pub mod mempool;
 pub mod message;
 pub mod notification;
+pub mod peer;
 pub mod tx;

--- a/rpc/grpc/core/src/convert/peer.rs
+++ b/rpc/grpc/core/src/convert/peer.rs
@@ -1,0 +1,45 @@
+use crate::protowire;
+use crate::{from, try_from};
+use kaspa_rpc_core::{RpcError, RpcPeerAddress};
+
+// ----------------------------------------------------------------------------
+// rpc_core to protowire
+// ----------------------------------------------------------------------------
+
+from!(item: &kaspa_rpc_core::RpcPeerInfo, protowire::GetConnectedPeerInfoMessage, {
+    Self {
+        id: item.id.to_string(),               // TODO
+        address: item.address.address.clone(), // TODO
+        last_ping_duration: item.last_ping_duration as i64,
+        is_outbound: item.is_outbound,
+        time_offset: item.time_offset as i64,
+        user_agent: item.user_agent.clone(),
+        advertised_protocol_version: item.advertised_protocol_version,
+        time_connected: item.time_connected as i64,
+        is_ibd_peer: item.is_ibd_peer,
+    }
+});
+
+from!(item: &kaspa_rpc_core::RpcPeerAddress, protowire::GetPeerAddressesKnownAddressMessage, { Self { addr: item.address.clone() } });
+
+// ----------------------------------------------------------------------------
+// protowire to rpc_core
+// ----------------------------------------------------------------------------
+
+try_from!(item: &protowire::GetConnectedPeerInfoMessage, kaspa_rpc_core::RpcPeerInfo, {
+    Self {
+        id: 0, // TODO
+        address: RpcPeerAddress { address: item.address.clone() },
+        last_ping_duration: item.last_ping_duration as u64,
+        is_outbound: item.is_outbound,
+        time_offset: item.time_offset as u64,
+        user_agent: item.user_agent.clone(),
+        advertised_protocol_version: item.advertised_protocol_version,
+        time_connected: item.time_connected as u64,
+        is_ibd_peer: item.is_ibd_peer,
+    }
+});
+
+try_from!(item: &protowire::GetPeerAddressesKnownAddressMessage, kaspa_rpc_core::RpcPeerAddress, {
+    Self { address: item.addr.clone() }
+});

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -219,11 +219,15 @@ impl RpcApi<ChannelConnection> for RpcCoreService {
         // TODO: test
         let consensus = self.consensus_manager.consensus();
         let session = consensus.session().await;
-        let mut block = session.get_block_even_if_header_only(request.hash)?;
-        if !request.include_transactions {
-            block.transactions = Arc::new(vec![]);
-        }
-        Ok(GetBlockResponse { block: self.consensus_converter.get_block(session.deref(), &block, request.include_transactions)? })
+        let block = session.get_block_even_if_header_only(request.hash)?;
+        Ok(GetBlockResponse {
+            block: self.consensus_converter.get_block(
+                session.deref(),
+                &block,
+                request.include_transactions,
+                request.include_transactions,
+            )?,
+        })
     }
 
     async fn get_blocks_call(&self, request: GetBlocksRequest) -> RpcResult<GetBlocksResponse> {
@@ -264,11 +268,13 @@ impl RpcApi<ChannelConnection> for RpcCoreService {
                 .iter()
                 .cloned()
                 .map(|hash| {
-                    let mut block = session.get_block_even_if_header_only(hash)?;
-                    if !request.include_transactions {
-                        block.transactions = Arc::new(vec![]);
-                    }
-                    self.consensus_converter.get_block(session.deref(), &block, request.include_transactions)
+                    let block = session.get_block_even_if_header_only(hash)?;
+                    self.consensus_converter.get_block(
+                        session.deref(),
+                        &block,
+                        request.include_transactions,
+                        request.include_transactions,
+                    )
                 })
                 .collect::<RpcResult<Vec<_>>>()
         } else {

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -453,6 +453,23 @@ impl RpcApi<ChannelConnection> for RpcCoreService {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_block_dag_info_call(&self, _: GetBlockDagInfoRequest) -> RpcResult<GetBlockDagInfoResponse> {
+        let consensus = self.consensus_manager.consensus();
+        let session = consensus.session().await;
+        let sync_info = session.get_sync_info();
+        Ok(GetBlockDagInfoResponse::new(
+            self.config.net,
+            sync_info.block_count,
+            sync_info.header_count,
+            session.get_tips(),
+            self.consensus_converter.get_difficulty_ratio(session.get_virtual_bits()),
+            session.get_virtual_past_median_time(),
+            session.get_virtual_parents().iter().copied().collect::<Vec<_>>(),
+            session.pruning_point().unwrap_or_default(),
+            session.get_virtual_daa_score(),
+        ))
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // UNIMPLEMENTED METHODS
 
@@ -465,10 +482,6 @@ impl RpcApi<ChannelConnection> for RpcCoreService {
     }
 
     async fn add_peer_call(&self, _request: AddPeerRequest) -> RpcResult<AddPeerResponse> {
-        Err(RpcError::NotImplemented)
-    }
-
-    async fn get_block_dag_info_call(&self, _request: GetBlockDagInfoRequest) -> RpcResult<GetBlockDagInfoResponse> {
         Err(RpcError::NotImplemented)
     }
 

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -451,49 +451,49 @@ impl RpcApi<ChannelConnection> for RpcCoreService {
     // UNIMPLEMENTED METHODS
 
     async fn get_peer_addresses_call(&self, _request: GetPeerAddressesRequest) -> RpcResult<GetPeerAddressesResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn get_connected_peer_info_call(&self, _request: GetConnectedPeerInfoRequest) -> RpcResult<GetConnectedPeerInfoResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn add_peer_call(&self, _request: AddPeerRequest) -> RpcResult<AddPeerResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn get_block_dag_info_call(&self, _request: GetBlockDagInfoRequest) -> RpcResult<GetBlockDagInfoResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn resolve_finality_conflict_call(
         &self,
         _request: ResolveFinalityConflictRequest,
     ) -> RpcResult<ResolveFinalityConflictResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn shutdown_call(&self, _request: ShutdownRequest) -> RpcResult<ShutdownResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn ban_call(&self, _request: BanRequest) -> RpcResult<BanResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn unban_call(&self, _request: UnbanRequest) -> RpcResult<UnbanResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn estimate_network_hashes_per_second_call(
         &self,
         _request: EstimateNetworkHashesPerSecondRequest,
     ) -> RpcResult<EstimateNetworkHashesPerSecondResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     async fn get_process_metrics_call(&self, _request: GetProcessMetricsRequest) -> RpcResult<GetProcessMetricsResponse> {
-        unimplemented!();
+        Err(RpcError::NotImplemented)
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Enable all RPC API methods in the gRPC server.

For some methods, the response is a "Not implemented" error if `kaspa-rpc-core` has no implementation yet but both the gRPC server and the `kaspa-rpc-core` service do support all request types.