### PR TITLE
Deploy Linux executables with some statically linked libraries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,8 +162,9 @@ jobs:
         run: sudo apt install -y protobuf-compiler
 
       - name: Get llvm install script
-        run: wget https://apt.llvm.org/llvm.sh
-      - run: chmod +x llvm.sh
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
 
       - name: Install llvm
         id: install_llvm
@@ -210,8 +211,9 @@ jobs:
         run: sudo apt install -y protobuf-compiler
 
       - name: Get llvm install script
-        run: wget https://apt.llvm.org/llvm.sh
-      - run: chmod +x llvm.sh
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
 
       - name: Install llvm
         id: install_llvm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,17 +159,29 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install protoc
-        run: sudo apt install -y protobuf-compiler
-
-      - name: Get llvm install script
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
+          sudo apt update -y
+          sudo apt install -y protobuf-compiler
 
       - name: Install llvm
         id: install_llvm
         continue-on-error: true
-        run: sudo ./llvm.sh all || true
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-get install -y clang-15 lldb-15 lld-15 clangd-15 clang-tidy-15 clang-format-15 clang-tools-15 llvm-15-dev lld-15 lldb-15 llvm-15-tools libomp-15-dev libc++-15-dev libc++abi-15-dev libclang-common-15-dev libclang-15-dev libclang-cpp15-dev libunwind-15-dev
+          # Make Clang 15 default
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-15/bin/clang++ 100
+          sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-15/bin/clang 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-15/bin/clang-format 100
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-15/bin/clang-tidy 100
+          sudo update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/lib/llvm-15/bin/run-clang-tidy 100
+          # Alias cc to clang
+          sudo update-alternatives --install /usr/bin/cc cc /usr/lib/llvm-15/bin/clang 0
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/lib/llvm-15/bin/clang++ 0
+
+      - name: Install gcc-multilib
+        # gcc-multilib allows clang to find gnu libraries properly
+        run: sudo apt install -y gcc-multilib
 
       - name: Install stable toolchain
         if: steps.install_llvm.outcome == 'success' && steps.install_llvm.conclusion == 'success'
@@ -208,17 +220,29 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install protoc
-        run: sudo apt install -y protobuf-compiler
-
-      - name: Get llvm install script
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
+          sudo apt update -y
+          sudo apt install -y protobuf-compiler
 
       - name: Install llvm
         id: install_llvm
         continue-on-error: true
-        run: sudo ./llvm.sh all || true
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-get install -y clang-15 lldb-15 lld-15 clangd-15 clang-tidy-15 clang-format-15 clang-tools-15 llvm-15-dev lld-15 lldb-15 llvm-15-tools libomp-15-dev libc++-15-dev libc++abi-15-dev libclang-common-15-dev libclang-15-dev libclang-cpp15-dev libunwind-15-dev
+          # Make Clang 15 default
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-15/bin/clang++ 100
+          sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-15/bin/clang 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-15/bin/clang-format 100
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-15/bin/clang-tidy 100
+          sudo update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/lib/llvm-15/bin/run-clang-tidy 100
+          # Alias cc to clang
+          sudo update-alternatives --install /usr/bin/cc cc /usr/lib/llvm-15/bin/clang 0
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/lib/llvm-15/bin/clang++ 0
+
+      - name: Install gcc-multilib
+        # gcc-multilib allows clang to find gnu libraries properly
+        run: sudo apt install -y gcc-multilib
 
       - name: Install stable toolchain
         if: steps.install_llvm.outcome == 'success' && steps.install_llvm.conclusion == 'success'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Build gnu-linux on ubuntu-18.04 and musl on ubuntu latest
         # os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
-        os: [ ubuntu-18.04, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     name: Building, ${{ matrix.os }}
     steps:
       - name: Fix CRLF on Windows
@@ -40,36 +40,24 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build on Linux GNU
-        if: matrix.os == 'ubuntu-18.04'
+      - name: Install zig on linux
+        if: runner.os == 'Linux'
+        uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
+
+      - name: Build on Linux
+        if: runner.os == 'Linux'
         # We're using musl to make the binaries statically linked and portable
         run: |
-          cargo build --target=x86_64-unknown-linux-gnu --bin kaspad --release
-          cargo build --target=x86_64-unknown-linux-gnu --bin simpa --release
+          cargo install cargo-zigbuild
+          cargo --verbose zigbuild --bin kaspad --bin simpa --release --target x86_64-unknown-linux-gnu.2.27 # Use an older glibc version
           mkdir bin || true
-          cp target/release/kaspad bin/
-          cp target/release/simpa bin/
+          cp target/x86_64-unknown-linux-gnu/release/kaspad bin/
+          cp target/x86_64-unknown-linux-gnu/release/simpa bin/
           archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
           asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
           zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
-
-      # - name: Build on Linux musl
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
-      #     sudo apt-get install -y musl-tools
-      #     rustup target add x86_64-unknown-linux-musl
-      #     cargo build --target=x86_64-unknown-linux-musl --bin kaspad --release
-      #     cargo build --target=x86_64-unknown-linux-musl --bin simpa --release
-      #     mkdir bin || true
-      #     cp target/release/kaspad bin/
-      #     cp target/release/simpa bin/
-      #     archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
-      #     asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
-      #     zip -r "${archive}" ./bin/*
-      #     echo "archive=${archive}" >> $GITHUB_ENV
-      #     echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
       - name: Build on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        # Build gnu-linux on ubuntu-18.04 and musl on ubuntu latest
+        # os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-18.04, windows-latest, macos-latest ]
     name: Building, ${{ matrix.os }}
     steps:
       - name: Fix CRLF on Windows
@@ -38,19 +40,36 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build on Linux
-        if: runner.os == 'Linux'
+      - name: Build on Linux GNU
+        if: matrix.os == 'ubuntu-18.04'
+        # We're using musl to make the binaries statically linked and portable
         run: |
-          cargo build --bin kaspad --release
-          cargo build --bin simpa --release
+          cargo build --target=x86_64-unknown-linux-gnu --bin kaspad --release
+          cargo build --target=x86_64-unknown-linux-gnu --bin simpa --release
           mkdir bin || true
           cp target/release/kaspad bin/
           cp target/release/simpa bin/
-          archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux.zip"
-          asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux.zip"
+          archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
+          asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
           zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
+
+      # - name: Build on Linux musl
+      #   if: matrix.os == 'ubuntu-latest'
+      #   run: |
+      #     sudo apt-get install -y musl-tools
+      #     rustup target add x86_64-unknown-linux-musl
+      #     cargo build --target=x86_64-unknown-linux-musl --bin kaspad --release
+      #     cargo build --target=x86_64-unknown-linux-musl --bin simpa --release
+      #     mkdir bin || true
+      #     cp target/release/kaspad bin/
+      #     cp target/release/simpa bin/
+      #     archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
+      #     asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
+      #     zip -r "${archive}" ./bin/*
+      #     echo "archive=${archive}" >> $GITHUB_ENV
+      #     echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
       - name: Build on Windows
         if: runner.os == 'Windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,3 +171,6 @@ workflow-terminal = { version = "0.3.10" }
 # workflow-rpc = { path = "../workflow-rs/rpc" }
 # workflow-terminal = { path = "../workflow-rs/terminal" }
 
+[profile.release]
+lto = "thin"
+strip = true


### PR DESCRIPTION
In the downloadable Linux bundle, remove the dependencies of the executables to the libraries `libstdc++`, `libgcc_s` and `librt` by statically linking those.