### PR TITLE
Mempool & txscript

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -78,6 +78,17 @@ impl Params {
     }
 }
 
+impl From<NetworkType> for Params {
+    fn from(value: NetworkType) -> Self {
+        match value {
+            NetworkType::Mainnet => MAINNET_PARAMS,
+            NetworkType::Testnet => TESTNET_PARAMS,
+            NetworkType::Devnet => DEVNET_PARAMS,
+            NetworkType::Simnet => SIMNET_PARAMS,
+        }
+    }
+}
+
 /// Highest proof of work difficulty value a Kaspa block can have for each network.
 /// It is the value 2^255 - 1.
 ///

--- a/consensus/core/src/networktype.rs
+++ b/consensus/core/src/networktype.rs
@@ -45,6 +45,12 @@ impl NetworkType {
             format!("kaspa-{}", self)
         }
     }
+
+    pub fn iter() -> impl Iterator<Item = Self> {
+        static NETWORK_TYPES: [NetworkType; 4] =
+            [NetworkType::Mainnet, NetworkType::Testnet, NetworkType::Devnet, NetworkType::Simnet];
+        NETWORK_TYPES.iter().copied()
+    }
 }
 
 impl TryFrom<Prefix> for NetworkType {

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -28,7 +28,6 @@ use args::{Args, Defaults};
 
 use crate::monitor::ConsensusMonitor;
 use kaspa_consensus::config::ConfigBuilder;
-use kaspa_consensus::params::{DEVNET_PARAMS, MAINNET_PARAMS, SIMNET_PARAMS, TESTNET_PARAMS};
 use kaspa_utxoindex::UtxoIndex;
 
 use async_channel::unbounded;
@@ -45,8 +44,6 @@ const CONSENSUS_DB: &str = "consensus";
 const UTXOINDEX_DB: &str = "utxoindex";
 const META_DB: &str = "meta";
 
-// TODO: add a Config
-// TODO: apply Args to Config
 // TODO: log to file
 // TODO: refactor the shutdown sequence into a predefined controlled sequence
 
@@ -145,16 +142,7 @@ pub fn main() {
         _ => panic!("only a single net should be activated"),
     };
 
-    let config = Arc::new(
-        match network_type {
-            NetworkType::Mainnet => ConfigBuilder::new(MAINNET_PARAMS),
-            NetworkType::Testnet => ConfigBuilder::new(TESTNET_PARAMS),
-            NetworkType::Devnet => ConfigBuilder::new(DEVNET_PARAMS),
-            NetworkType::Simnet => ConfigBuilder::new(SIMNET_PARAMS),
-        }
-        .apply_args(|config| args.apply_to_config(config))
-        .build(),
-    );
+    let config = Arc::new(ConfigBuilder::new(network_type.into()).apply_args(|config| args.apply_to_config(config)).build());
 
     // TODO: Refactor all this quick-and-dirty code
     let app_dir = args

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         model::candidate_tx::CandidateTransaction,
         testutils::consensus_mock::ConsensusMock,
     };
-    use kaspa_addresses::Prefix;
+    use kaspa_addresses::{Address, Prefix, Version};
     use kaspa_consensus_core::{
         api::ConsensusApi,
         coinbase::MinerData,
@@ -21,13 +21,13 @@ mod tests {
         mass::transaction_estimated_serialized_size,
         subnets::SUBNETWORK_ID_NATIVE,
         tx::{
-            scriptvec, MutableTransaction, ScriptPublicKey, ScriptVec, Transaction, TransactionId, TransactionInput,
-            TransactionOutpoint, TransactionOutput, UtxoEntry,
+            scriptvec, MutableTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
+            TransactionOutput, UtxoEntry,
         },
     };
     use kaspa_hashes::Hash;
     use kaspa_txscript::{
-        pay_to_script_hash_signature_script,
+        pay_to_address_script, pay_to_script_hash_signature_script,
         test_helpers::{create_transaction, op_true_script},
     };
     use std::sync::Arc;
@@ -936,15 +936,12 @@ mod tests {
         block_transactions
     }
 
-    fn get_miner_data(_address_prefix: Prefix) -> MinerData {
+    fn get_miner_data(prefix: Prefix) -> MinerData {
         let secp = secp256k1::Secp256k1::new();
         let mut rng = rand::thread_rng();
         let (_sk, pk) = secp.generate_keypair(&mut rng);
-
-        //let addr = Address { prefix: address_prefix, payload: Vec::from(pk.serialize()), version: 0};
-        // TODO: call txscript.PayToAddrScript(addr) instead of this:
-        let script = ScriptVec::from_slice(&pk.serialize());
-
-        MinerData::new(ScriptPublicKey::new(0, script), vec![])
+        let address = Address::new(prefix, Version::PubKeyECDSA, &pk.serialize());
+        let script = pay_to_address_script(&address);
+        MinerData::new(script, vec![])
     }
 }


### PR DESCRIPTION
Add iterating over the network parameters of all available network types.
Address some remaining TODOs asking Mempool to make use of txscript.
Add txscript `is_unspendable` function.