### PR TITLE
CLI Peers Management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "kaspa-p2p-flows",
  "kaspa-rpc-core",
  "kaspa-rpc-service",
+ "kaspa-utils",
  "kaspa-utxoindex",
  "kaspa-wrpc-server",
  "log",

--- a/components/connectionmanager/src/lib.rs
+++ b/components/connectionmanager/src/lib.rs
@@ -208,7 +208,7 @@ impl ConnectionManager {
             }
         }
 
-        if missing_connections > 0 {
+        if missing_connections > 0 && !self.dns_seeders.is_empty() {
             let cmgr = self.clone();
             // DNS lookup is a blocking i/o operation, so we spawn it as a blocking task
             let _ = tokio::task::spawn_blocking(move || {

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -39,6 +39,8 @@ pub struct Config {
     /// (this flag is mainly used for testing)
     // TODO: add and handle a matching kaspad command argument
     pub allow_submit_block_when_not_synced: bool,
+
+    pub user_agent_comments: Vec<String>,
 }
 
 impl Config {
@@ -50,6 +52,7 @@ impl Config {
             utxoindex: false,
             unsafe_rpc: false,
             allow_submit_block_when_not_synced: false,
+            user_agent_comments: Default::default(),
         }
     }
 

--- a/consensus/core/src/errors/config.rs
+++ b/consensus/core/src/errors/config.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+pub enum ConfigError {
+    #[error("Configuration: --addpeer and --connect cannot be used together")]
+    MixedConnectAndAddPeers,
+}
+
+pub type ConfigResult<T> = std::result::Result<T, ConfigError>;

--- a/consensus/core/src/errors/mod.rs
+++ b/consensus/core/src/errors/mod.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod coinbase;
+pub mod config;
 pub mod consensus;
 pub mod difficulty;
 pub mod pruning;

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 kaspa-hashes.workspace = true
+kaspa-utils.workspace = true
 kaspa-core.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-consensus.workspace = true

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -53,6 +53,7 @@ pub struct Args {
     pub connect_peers: Vec<ContextualNetAddress>,
     pub add_peers: Vec<ContextualNetAddress>,
     pub listen: Option<ContextualNetAddress>,
+    pub user_agent_comments: Vec<String>,
     pub utxoindex: bool,
     pub reset_db: bool,
     pub outbound_target: usize,
@@ -172,6 +173,14 @@ pub fn cli(defaults: &Defaults) -> Command {
         .arg(arg!(--testnet "Use the test network"))
         .arg(arg!(--devnet "Use the development test network"))
         .arg(arg!(--simnet "Use the simulation test network"))
+        .arg(
+            Arg::new("user_agent_comments")
+                .long("uacomment")
+                .action(ArgAction::Append)
+                .num_args(0..=10)// TODO: define an upper bound
+                .require_equals(true)
+                .help("Comment to add to the user agent -- See BIP 14 for more information."),
+        )
 }
 
 impl Args {
@@ -196,12 +205,14 @@ impl Args {
             testnet: m.get_one::<bool>("testnet").cloned().unwrap_or(defaults.testnet),
             devnet: m.get_one::<bool>("devnet").cloned().unwrap_or(defaults.devnet),
             simnet: m.get_one::<bool>("simnet").cloned().unwrap_or(defaults.simnet),
+            user_agent_comments: m.get_many::<String>("user_agent_comments").unwrap_or_default().cloned().collect(),
         }
     }
 
     pub fn apply_to_config(&self, config: &mut Config) {
         config.utxoindex = self.utxoindex;
         config.unsafe_rpc = self.unsafe_rpc;
+        config.user_agent_comments = self.user_agent_comments.clone();
     }
 }
 

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -73,7 +73,6 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .short('t')
                 .long("async-threads")
                 .value_name("async_threads")
-                .num_args(0..=1)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(usize))
                 .help(format!("Specify number of async threads (default: {}).", defaults.async_threads)),
@@ -84,7 +83,6 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .long("loglevel")
                 .value_name("LEVEL")
                 .default_value("info")
-                .num_args(0..=1)
                 .require_equals(true)
                 .help("Logging level for all subsystems {off, error, warn, info, debug, trace}\n-- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems.".to_string()),
         )
@@ -92,7 +90,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("rpclisten")
                 .long("rpclisten")
                 .value_name("IP[:PORT]")
-                .num_args(0..=1)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
                 .help("Interface:port to listen for gRPC connections (default port: 16110, testnet: 16210)."),
@@ -101,7 +98,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("rpclisten-borsh")
                 .long("rpclisten-borsh")
                 .value_name("IP[:PORT]")
-                .num_args(0..=1)
                 .require_equals(true)
                 .default_missing_value(defaults.rpclisten_borsh)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
@@ -114,7 +110,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("rpclisten-json")
                 .long("rpclisten-json")
                 .value_name("IP[:PORT]")
-                .num_args(0..=1)
                 .require_equals(true)
                 .default_missing_value(defaults.rpclisten_json)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
@@ -126,7 +121,6 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .long("connect")
                 .value_name("IP[:PORT]")
                 .action(ArgAction::Append)
-                .num_args(0..=10) // TODO: define an upper bound
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
                 .help("Connect only to the specified peers at startup (maximum 10 peers)."),
@@ -136,7 +130,6 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .long("addpeer")
                 .value_name("IP[:PORT]")
                 .action(ArgAction::Append)
-                .num_args(0..=20)// TODO: define an upper bound
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
                 .help("Add peers to connect with at startup (maximum 20 peers)."),
@@ -145,7 +138,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("listen")
                 .long("listen")
                 .value_name("IP[:PORT]")
-                .num_args(0..=1)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
                 .help("Add an interface:port to listen for connections (default all interfaces port: 16111, testnet: 16211)."),
@@ -154,7 +146,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("outpeers")
                 .long("outpeers")
                 .value_name("outpeers")
-                .num_args(0..=1)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(usize))
                 .help("Target number of outbound peers (default: 8)."),
@@ -163,7 +154,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("maxinpeers")
                 .long("maxinpeers")
                 .value_name("maxinpeers")
-                .num_args(0..=1)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(usize))
                 .help("Max number of inbound peers (default: 128)."),
@@ -177,7 +167,6 @@ pub fn cli(defaults: &Defaults) -> Command {
             Arg::new("user_agent_comments")
                 .long("uacomment")
                 .action(ArgAction::Append)
-                .num_args(0..=10)// TODO: define an upper bound
                 .require_equals(true)
                 .help("Comment to add to the user agent -- See BIP 14 for more information."),
         )

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -123,7 +123,7 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .action(ArgAction::Append)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
-                .help("Connect only to the specified peers at startup (maximum 10 peers)."),
+                .help("Connect only to the specified peers at startup."),
         )
         .arg(
             Arg::new("add-peers")
@@ -132,7 +132,7 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .action(ArgAction::Append)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
-                .help("Add peers to connect with at startup (maximum 20 peers)."),
+                .help("Add peers to connect with at startup."),
         )
         .arg(
             Arg::new("listen")

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -18,6 +18,7 @@ use kaspa_index_processor::service::IndexService;
 use kaspa_mining::manager::MiningManager;
 use kaspa_p2p_flows::flow_context::FlowContext;
 use kaspa_rpc_service::RpcCoreServer;
+use kaspa_utils::networking::ContextualNetAddress;
 
 use std::fs;
 use std::path::PathBuf;
@@ -193,12 +194,12 @@ pub fn main() {
 
     let connect_peers = args.connect_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect::<Vec<_>>();
     let add_peers = args.add_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect();
-    let p2p_server_addr = args.listen.unwrap_or_default().normalize(config.default_p2p_port());
+    let p2p_server_addr = args.listen.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_p2p_port());
     // connect_peers means no DNS seeding and no outbound peers
     let outbound_target = if connect_peers.is_empty() { args.outbound_target } else { 0 };
     let dns_seeders = if connect_peers.is_empty() { config.dns_seeders } else { &[] };
 
-    let grpc_server_addr = args.rpclisten.unwrap_or_default().normalize(config.default_rpc_port());
+    let grpc_server_addr = args.rpclisten.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_rpc_port());
 
     let core = Arc::new(Core::new());
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -322,7 +322,7 @@ impl ConnectionInitializer for FlowContext {
         // Build the local version message
         // Subnets are not currently supported
         let mut self_version_message = Version::new(None, self.node_id, network_name.clone(), None, PROTOCOL_VERSION);
-        self_version_message.add_user_agent(name(), version(), &[]);
+        self_version_message.add_user_agent(name(), version(), &self.config.user_agent_comments);
         // TODO: full and accurate version info
         // TODO: get number of live services
         // TODO: disable_relay_tx from config/cmd

--- a/protocol/flows/src/service.rs
+++ b/protocol/flows/src/service.rs
@@ -75,11 +75,8 @@ impl AsyncService for P2pService {
 
         // Launch the service and wait for a shutdown signal
         Box::pin(async move {
-            for peer_address in self.connect_peers.iter().cloned() {
+            for peer_address in self.connect_peers.iter().cloned().chain(self.add_peers.iter().cloned()) {
                 connection_manager.add_connection_request(peer_address.into(), true).await;
-            }
-            for peer_address in self.add_peers.iter().cloned() {
-                connection_manager.add_connection_request(peer_address.into(), false).await;
             }
 
             // Keep the P2P server running until a service shutdown signal is received

--- a/protocol/flows/src/service.rs
+++ b/protocol/flows/src/service.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use kaspa_addressmanager::NetAddress;
 use kaspa_connectionmanager::ConnectionManager;
 use kaspa_core::{
     task::service::{AsyncService, AsyncServiceFuture},
@@ -5,7 +8,6 @@ use kaspa_core::{
 };
 use kaspa_p2p_lib::Adaptor;
 use kaspa_utils::triggers::SingleTrigger;
-use std::{net::ToSocketAddrs, sync::Arc};
 
 use crate::flow_context::FlowContext;
 
@@ -13,8 +15,9 @@ const P2P_CORE_SERVICE: &str = "p2p-service";
 
 pub struct P2pService {
     flow_context: Arc<FlowContext>,
-    connect: Option<String>, // TEMP: optional connect peer
-    listen: Option<String>,
+    connect_peers: Vec<NetAddress>,
+    add_peers: Vec<NetAddress>,
+    listen: NetAddress,
     outbound_target: usize,
     inbound_limit: usize,
     dns_seeders: &'static [&'static str],
@@ -25,8 +28,9 @@ pub struct P2pService {
 impl P2pService {
     pub fn new(
         flow_context: Arc<FlowContext>,
-        connect: Option<String>,
-        listen: Option<String>,
+        connect_peers: Vec<NetAddress>,
+        add_peers: Vec<NetAddress>,
+        listen: NetAddress,
         outbound_target: usize,
         inbound_limit: usize,
         dns_seeders: &'static [&'static str],
@@ -34,7 +38,8 @@ impl P2pService {
     ) -> Self {
         Self {
             flow_context,
-            connect,
+            connect_peers,
+            add_peers,
             shutdown: SingleTrigger::default(),
             listen,
             outbound_target,
@@ -56,8 +61,7 @@ impl AsyncService for P2pService {
         // Prepare a shutdown signal receiver
         let shutdown_signal = self.shutdown.listener.clone();
 
-        let server_address = self.listen.clone().unwrap_or(format!("0.0.0.0:{}", self.default_port));
-        let p2p_adaptor = Adaptor::bidirectional(server_address, self.flow_context.hub().clone(), self.flow_context.clone()).unwrap();
+        let p2p_adaptor = Adaptor::bidirectional(self.listen, self.flow_context.hub().clone(), self.flow_context.clone()).unwrap();
         let connection_manager = ConnectionManager::new(
             p2p_adaptor.clone(),
             self.outbound_target,
@@ -71,8 +75,11 @@ impl AsyncService for P2pService {
 
         // Launch the service and wait for a shutdown signal
         Box::pin(async move {
-            if let Some(peer_address) = self.connect.clone() {
-                connection_manager.add_connection_request(peer_address.to_socket_addrs().unwrap().next().unwrap(), true).await;
+            for peer_address in self.connect_peers.iter().cloned() {
+                connection_manager.add_connection_request(peer_address.into(), true).await;
+            }
+            for peer_address in self.add_peers.iter().cloned() {
+                connection_manager.add_connection_request(peer_address.into(), false).await;
             }
 
             // Keep the P2P server running until a service shutdown signal is received

--- a/protocol/p2p/src/bin/server.rs
+++ b/protocol/p2p/src/bin/server.rs
@@ -1,13 +1,14 @@
 use kaspa_core::debug;
 use kaspa_p2p_lib::echo::EchoFlowInitializer;
-use std::{sync::Arc, time::Duration};
+use kaspa_utils::networking::NetAddress;
+use std::{str::FromStr, sync::Arc, time::Duration};
 
 #[tokio::main]
 async fn main() {
     // [-] - init logger
     kaspa_core::log::init_logger("debug");
     // [0] - init p2p-adaptor - server side
-    let ip_port = String::from("[::1]:50051");
+    let ip_port = NetAddress::from_str("[::1]:50051").unwrap();
     let initializer = Arc::new(EchoFlowInitializer::new());
     let adaptor = kaspa_p2p_lib::Adaptor::bidirectional(ip_port, kaspa_p2p_lib::Hub::new(), initializer).unwrap();
     // [1] - connect to a few peers

--- a/protocol/p2p/src/core/adaptor.rs
+++ b/protocol/p2p/src/core/adaptor.rs
@@ -2,6 +2,7 @@ use crate::common::ProtocolError;
 use crate::core::hub::Hub;
 use crate::ConnectionError;
 use crate::{core::connection_handler::ConnectionHandler, Router};
+use kaspa_utils::networking::NetAddress;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -54,7 +55,7 @@ impl Adaptor {
 
     /// Creates a bidirectional P2P adaptor with a server serving at `serve_address` and with client support
     pub fn bidirectional(
-        serve_address: String,
+        serve_address: NetAddress,
         hub: Hub,
         initializer: Arc<dyn ConnectionInitializer>,
     ) -> Result<Arc<Self>, ConnectionError> {

--- a/protocol/p2p/src/echo.rs
+++ b/protocol/p2p/src/echo.rs
@@ -145,21 +145,22 @@ impl ConnectionInitializer for EchoFlowInitializer {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{str::FromStr, time::Duration};
 
     use super::*;
     use crate::{Adaptor, Hub};
     use kaspa_core::debug;
+    use kaspa_utils::networking::NetAddress;
 
     #[tokio::test]
     async fn test_handshake() {
         kaspa_core::log::try_init_logger("debug");
 
-        let address1 = String::from("[::1]:50053");
-        let adaptor1 = Adaptor::bidirectional(address1.clone(), Hub::new(), Arc::new(EchoFlowInitializer::new())).unwrap();
+        let address1 = NetAddress::from_str("[::1]:50053").unwrap();
+        let adaptor1 = Adaptor::bidirectional(address1, Hub::new(), Arc::new(EchoFlowInitializer::new())).unwrap();
 
-        let address2 = String::from("[::1]:50054");
-        let adaptor2 = Adaptor::bidirectional(address2.clone(), Hub::new(), Arc::new(EchoFlowInitializer::new())).unwrap();
+        let address2 = NetAddress::from_str("[::1]:50054").unwrap();
+        let adaptor2 = Adaptor::bidirectional(address2, Hub::new(), Arc::new(EchoFlowInitializer::new())).unwrap();
 
         // Initiate the connection from `adaptor1` (outbound) to `adaptor2` (inbound)
         let peer2_id = adaptor1

--- a/rpc/core/src/model/peer.rs
+++ b/rpc/core/src/model/peer.rs
@@ -1,60 +1,11 @@
-use std::{
-    net::{AddrParseError, SocketAddr},
-    str::FromStr,
-};
-
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use kaspa_utils::networking::{IpAddress, NetAddress, PeerId};
+use kaspa_utils::networking::{ContextualNetAddress, IpAddress, NetAddress, PeerId};
 use serde::{Deserialize, Serialize};
 
 pub type RpcNodeId = PeerId;
 pub type RpcIpAddress = IpAddress;
 pub type RpcPeerAddress = NetAddress;
-
-/// A peer address possibly without explicit port
-///
-/// Use `normalize` to get a fully determined address.
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
-pub struct RpcContextualPeerAddress {
-    ip: IpAddress,
-    port: Option<u16>,
-}
-
-impl RpcContextualPeerAddress {
-    fn new(ip: IpAddress, port: Option<u16>) -> Self {
-        Self { ip, port }
-    }
-
-    pub fn normalize(&self, default_port: u16) -> RpcPeerAddress {
-        RpcPeerAddress::new(self.ip, self.port.unwrap_or(default_port))
-    }
-}
-
-impl From<RpcPeerAddress> for RpcContextualPeerAddress {
-    fn from(value: RpcPeerAddress) -> Self {
-        Self::new(value.ip, Some(value.port))
-    }
-}
-
-impl FromStr for RpcContextualPeerAddress {
-    type Err = AddrParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match SocketAddr::from_str(s) {
-            Ok(socket) => Ok(Self::new(socket.ip().into(), Some(socket.port()))),
-            Err(_) => Ok(Self::new(IpAddress::from_str(s)?, None)),
-        }
-    }
-}
-
-impl ToString for RpcContextualPeerAddress {
-    fn to_string(&self) -> String {
-        match self.port {
-            Some(port) => SocketAddr::new(self.ip.into(), port).to_string(),
-            None => self.ip.to_string(),
-        }
-    }
-}
+pub type RpcContextualPeerAddress = ContextualNetAddress;
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct RpcPeerInfo {

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -148,17 +148,17 @@ impl From<NetAddress> for SocketAddr {
     }
 }
 
-impl ToString for NetAddress {
-    fn to_string(&self) -> String {
-        SocketAddr::from(self.to_owned()).to_string()
-    }
-}
-
 impl FromStr for NetAddress {
     type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         SocketAddr::from_str(s).map(NetAddress::from)
+    }
+}
+
+impl Display for NetAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        SocketAddr::from(self.to_owned()).fmt(f)
     }
 }
 
@@ -181,6 +181,12 @@ impl ContextualNetAddress {
     }
 }
 
+impl Default for ContextualNetAddress {
+    fn default() -> Self {
+        Self { ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)).into(), port: None }
+    }
+}
+
 impl From<NetAddress> for ContextualNetAddress {
     fn from(value: NetAddress) -> Self {
         Self::new(value.ip, Some(value.port))
@@ -198,15 +204,14 @@ impl FromStr for ContextualNetAddress {
     }
 }
 
-impl ToString for ContextualNetAddress {
-    fn to_string(&self) -> String {
+impl Display for ContextualNetAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.port {
-            Some(port) => SocketAddr::new(self.ip.into(), port).to_string(),
-            None => self.ip.to_string(),
+            Some(port) => SocketAddr::new(self.ip.into(), port).fmt(f),
+            None => self.ip.fmt(f),
         }
     }
 }
-
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, Default)]
 #[repr(transparent)]
 pub struct PeerId(pub Uuid);

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -179,11 +179,13 @@ impl ContextualNetAddress {
     pub fn normalize(&self, default_port: u16) -> NetAddress {
         NetAddress::new(self.ip, self.port.unwrap_or(default_port))
     }
-}
 
-impl Default for ContextualNetAddress {
-    fn default() -> Self {
+    pub fn unspecified() -> Self {
         Self { ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)).into(), port: None }
+    }
+
+    pub fn loopback() -> Self {
+        Self { ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).into(), port: None }
     }
 }
 


### PR DESCRIPTION
Enhance `kaspad` CLI with following repeatable arguments:
- `--connect=` and `--addpeer=` for peers management.
- `--uacomment=` for user-agent comments describing the launched node (see [BIP-014](https://en.bitcoin.it/wiki/BIP_0014) for more information)