### PR TITLE
Ser-de opcode fixes (better api) and some opcode tests

### DIFF
--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -85,10 +85,7 @@ pub struct TxScriptEngine<'a, T: VerifiableTransaction> {
 fn parse_script<T: VerifiableTransaction>(
     script: &[u8],
 ) -> impl Iterator<Item = Result<Box<dyn OpCodeImplementation<T>>, TxScriptError>> + '_ {
-    script.iter().batching(|it| {
-        // reads the opcode num item here and then match to opcode
-        it.next().map(|code| deserialize_opcode_data(*code, it))
-    })
+    script.iter().batching(|it| deserialize_opcode_data(it))
 }
 
 pub fn get_sig_op_count<T: VerifiableTransaction>(signature_script: &[u8], prev_script_public_key: &ScriptPublicKey) -> u64 {
@@ -531,7 +528,7 @@ mod tests {
         }
     }
 
-    fn test_script_cases(test_cases: Vec<ScriptTestCase>) {
+    fn run_test_script_cases(test_cases: Vec<ScriptTestCase>) {
         let sig_cache = Cache::new(10_000);
         let mut reused_values = SigHashReusedValues::new();
 
@@ -583,7 +580,7 @@ mod tests {
             },
         ];
 
-        test_script_cases(test_cases)
+        run_test_script_cases(test_cases)
     }
 
     #[test]
@@ -615,7 +612,7 @@ mod tests {
             },
         ];
 
-        test_script_cases(test_cases)
+        run_test_script_cases(test_cases)
     }
 
     #[test]

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -10,7 +10,7 @@ pub mod standard;
 
 use crate::caches::Cache;
 use crate::data_stack::{DataStack, Stack};
-use crate::opcodes::{deserialize_opcode_data, OpCodeImplementation};
+use crate::opcodes::{deserialize_next_opcode, OpCodeImplementation};
 use itertools::Itertools;
 use kaspa_consensus_core::hashing::sighash::{calc_ecdsa_signature_hash, calc_schnorr_signature_hash, SigHashReusedValues};
 use kaspa_consensus_core::hashing::sighash_type::SigHashType;
@@ -85,7 +85,7 @@ pub struct TxScriptEngine<'a, T: VerifiableTransaction> {
 fn parse_script<T: VerifiableTransaction>(
     script: &[u8],
 ) -> impl Iterator<Item = Result<Box<dyn OpCodeImplementation<T>>, TxScriptError>> + '_ {
-    script.iter().batching(|it| deserialize_opcode_data(it))
+    script.iter().batching(|it| deserialize_next_opcode(it))
 }
 
 pub fn get_sig_op_count<T: VerifiableTransaction>(signature_script: &[u8], prev_script_public_key: &ScriptPublicKey) -> u64 {

--- a/crypto/txscript/src/opcodes/macros.rs
+++ b/crypto/txscript/src/opcodes/macros.rs
@@ -111,7 +111,7 @@ macro_rules! opcode_list {
             )?
         )*
 
-        pub fn deserialize_opcode_data<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(it: &mut I) -> Option<Result<Box<dyn OpCodeImplementation<T>>, TxScriptError>> {
+        pub fn deserialize_next_opcode<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(it: &mut I) -> Option<Result<Box<dyn OpCodeImplementation<T>>, TxScriptError>> {
             match it.next() {
                 Some(opcode_num) => match opcode_num {
                     $(

--- a/crypto/txscript/src/opcodes/macros.rs
+++ b/crypto/txscript/src/opcodes/macros.rs
@@ -3,7 +3,7 @@ macro_rules! opcode_serde {
         #[allow(dead_code)]
         fn serialize(&self) -> Vec<u8> {
             let length = self.data.len() as $type;
-            [length.to_le_bytes().as_slice(), self.data.as_slice()].concat()
+            [[self.value()].as_slice(), length.to_le_bytes().as_slice(), self.data.as_slice()].concat()
         }
 
         fn deserialize<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(
@@ -16,6 +16,8 @@ macro_rules! opcode_serde {
                     if data.len() != length {
                         return Err(TxScriptError::MalformedPush(length, data.len()));
                     }
+                    // Skipping the extra check - we already checked data length
+                    // fits
                     Ok(Box::new(Self { data }))
                 }
                 Err(vec) => {
@@ -27,7 +29,7 @@ macro_rules! opcode_serde {
     ($length: literal) => {
         #[allow(dead_code)]
         fn serialize(&self) -> Vec<u8> {
-            self.data.clone()
+            [[self.value()].as_slice(), self.data.clone().as_slice()].concat()
         }
 
         fn deserialize<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(
@@ -35,6 +37,22 @@ macro_rules! opcode_serde {
         ) -> Result<Box<dyn OpCodeImplementation<T>>, TxScriptError> {
             // Static length includes the opcode itself
             let data: Vec<u8> = it.take($length - 1).copied().collect();
+            Self::new(data)
+        }
+    };
+}
+
+macro_rules! opcode_init {
+    ($type:ty) => {
+        fn new(data: Vec<u8>) -> Result<Box<dyn OpCodeImplementation<T>>, TxScriptError> {
+            if data.len() > <$type>::MAX as usize {
+                return Err(TxScriptError::MalformedPush(<$type>::MAX as usize, data.len()));
+            }
+            Ok(Box::new(Self { data }))
+        }
+    };
+    ($length: literal) => {
+        fn new(data: Vec<u8>) -> Result<Box<dyn OpCodeImplementation<T>>, TxScriptError> {
             if data.len() != $length - 1 {
                 return Err(TxScriptError::MalformedPush($length - 1, data.len()));
             }
@@ -47,18 +65,16 @@ macro_rules! opcode_impl {
     ($name: ident, $num: literal, $length: tt, $code: expr, $self:ident, $vm:ident ) => {
         type $name = OpCode<$num>;
 
-        impl $name {
+        impl OpcodeSerialization for $name {
             opcode_serde!($length);
         }
 
         impl<T: VerifiableTransaction> OpCodeExecution<T> for $name {
-            fn empty() -> Box<dyn OpCodeImplementation<T>> {
-                return Box::new(Self{data: vec![]})
+            fn empty() -> Result<Box<dyn OpCodeImplementation<T>>, TxScriptError> {
+                Self::new(vec![])
             }
 
-            fn new(data: Vec<u8>) -> Box<dyn OpCodeImplementation<T>> {
-                return Box::new(Self{data})
-            }
+            opcode_init!($length);
 
             #[allow(unused_variables)]
             fn execute(&$self, $vm: &mut TxScriptEngine<T>) -> OpCodeResult {
@@ -88,13 +104,21 @@ macro_rules! opcode_list {
 
         $(
             opcode_impl!($name, $num, $length, $code, $self, $vm);
+
+            $(
+                #[allow(dead_code)]
+                type $alias = $name;
+            )?
         )*
 
-        pub fn deserialize_opcode_data<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(opcode_num: u8, it: &mut I) -> Result<Box<dyn OpCodeImplementation<T>>, TxScriptError> {
-            match opcode_num {
-                $(
-                    $num => $name::deserialize(it),
-                )*
+        pub fn deserialize_opcode_data<'i, I: Iterator<Item = &'i u8>, T: VerifiableTransaction>(it: &mut I) -> Option<Result<Box<dyn OpCodeImplementation<T>>, TxScriptError>> {
+            match it.next() {
+                Some(opcode_num) => match opcode_num {
+                    $(
+                        $num => Some($name::deserialize(it)),
+                    )*
+                },
+                _ => None
             }
         }
     };


### PR DESCRIPTION
Fixes toward https://github.com/kaspanet/rusty-kaspa/issues/122

1. Opcode serialization now include the code
2. Opcode deserialization parse code and data (`deserialize_next_opcode` renamed to `deserialize_next_opcode`, which now deseriarilze (and consumes) a whole opcode from an iterator)
3. Added tests for push data, push number and unary number opcodes