### PR TITLE
Handle recovery of pruning workflows on process crashes

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -443,10 +443,10 @@ impl ConsensusApi for Consensus {
         if self.pruning_point_store.read().pruning_point().unwrap() != expected_pruning_point {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
-        let pruning_point_utxoset_read = self.pruning_point_utxo_set_store.read();
-        let iter = pruning_point_utxoset_read.seek_iterator(from_outpoint, chunk_size, skip_first);
+        let pruning_utxoset_read = self.pruning_utxoset_stores.read();
+        let iter = pruning_utxoset_read.utxo_set.seek_iterator(from_outpoint, chunk_size, skip_first);
         let utxos = iter.map(|item| item.unwrap()).collect();
-        drop(pruning_point_utxoset_read);
+        drop(pruning_utxoset_read);
 
         // We recheck the expected pruning point in case it was switched just before the utxo set read.
         // NOTE: we rely on order of operations by pruning processor. See extended comment therein.
@@ -477,8 +477,8 @@ impl ConsensusApi for Consensus {
         // TODO: Check if a db tx is needed. We probably need some kind of a flag that is set on this function to true, and then
         // is set to false on the end of import_pruning_point_utxo_set. On any failure on any of those functions (and also if the
         // node starts when the flag is true) the related data will be deleted and the flag will be set to false.
-        let mut pruning_point_utxo_set = self.pruning_point_utxo_set_store.write();
-        pruning_point_utxo_set.write_many(utxoset_chunk).unwrap();
+        let mut pruning_utxoset_write = self.pruning_utxoset_stores.write();
+        pruning_utxoset_write.utxo_set.write_many(utxoset_chunk).unwrap();
         for (outpoint, entry) in utxoset_chunk {
             current_multiset.add_utxo(outpoint, entry);
         }

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -12,6 +12,7 @@ use crate::{
         headers_selected_tip::DbHeadersSelectedTipStore,
         past_pruning_points::DbPastPruningPointsStore,
         pruning::DbPruningStore,
+        pruning_utxoset::PruningUtxosetStores,
         reachability::DbReachabilityStore,
         relations::DbRelationsStore,
         selected_chain::DbSelectedChainStore,
@@ -43,7 +44,7 @@ pub struct ConsensusStorage {
     pub pruning_point_store: Arc<RwLock<DbPruningStore>>,
     pub headers_selected_tip_store: Arc<RwLock<DbHeadersSelectedTipStore>>,
     pub body_tips_store: Arc<RwLock<DbTipsStore>>,
-    pub pruning_point_utxo_set_store: Arc<RwLock<DbUtxoSetStore>>,
+    pub pruning_utxoset_stores: Arc<RwLock<PruningUtxosetStores>>,
     pub virtual_stores: Arc<RwLock<VirtualStores>>,
     pub selected_chain_store: Arc<RwLock<DbSelectedChainStore>>,
 
@@ -110,9 +111,9 @@ impl ConsensusStorage {
         // Pruning
         let pruning_point_store = Arc::new(RwLock::new(DbPruningStore::new(db.clone())));
         let past_pruning_points_store = Arc::new(DbPastPruningPointsStore::new(db.clone(), 4));
-        let pruning_point_utxo_set_store =
-            Arc::new(RwLock::new(DbUtxoSetStore::new(db.clone(), perf_params.utxo_set_cache_size, store_names::PRUNING_UTXO_SET)));
+        let pruning_utxoset_stores = Arc::new(RwLock::new(PruningUtxosetStores::new(db.clone(), perf_params.utxo_set_cache_size)));
 
+        // Txs
         let block_transactions_store = Arc::new(DbBlockTransactionsStore::new(db.clone(), perf_params.block_data_cache_size));
         let utxo_diffs_store = Arc::new(DbUtxoDiffsStore::new(db.clone(), perf_params.block_data_cache_size));
         let utxo_multisets_store = Arc::new(DbUtxoMultisetsStore::new(db.clone(), perf_params.block_data_cache_size));
@@ -149,7 +150,7 @@ impl ConsensusStorage {
             body_tips_store,
             headers_store,
             block_transactions_store,
-            pruning_point_utxo_set_store,
+            pruning_utxoset_stores,
             virtual_stores,
             selected_chain_store,
             acceptance_data_store,

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -1,28 +1,12 @@
 use crate::{
     config::Config,
-    constants::store_names,
     model::stores::{
-        acceptance_data::DbAcceptanceDataStore,
-        block_transactions::DbBlockTransactionsStore,
-        block_window_cache::BlockWindowCacheStore,
-        daa::DbDaaStore,
-        depth::DbDepthStore,
-        ghostdag::DbGhostdagStore,
-        headers::DbHeadersStore,
-        headers_selected_tip::DbHeadersSelectedTipStore,
-        past_pruning_points::DbPastPruningPointsStore,
-        pruning::DbPruningStore,
-        pruning_utxoset::PruningUtxosetStores,
-        reachability::DbReachabilityStore,
-        relations::DbRelationsStore,
-        selected_chain::DbSelectedChainStore,
-        statuses::DbStatusesStore,
-        tips::DbTipsStore,
-        utxo_diffs::DbUtxoDiffsStore,
-        utxo_multisets::DbUtxoMultisetsStore,
-        utxo_set::DbUtxoSetStore,
-        virtual_state::{DbVirtualStateStore, VirtualStores},
-        DB,
+        acceptance_data::DbAcceptanceDataStore, block_transactions::DbBlockTransactionsStore,
+        block_window_cache::BlockWindowCacheStore, daa::DbDaaStore, depth::DbDepthStore, ghostdag::DbGhostdagStore,
+        headers::DbHeadersStore, headers_selected_tip::DbHeadersSelectedTipStore, past_pruning_points::DbPastPruningPointsStore,
+        pruning::DbPruningStore, pruning_utxoset::PruningUtxosetStores, reachability::DbReachabilityStore,
+        relations::DbRelationsStore, selected_chain::DbSelectedChainStore, statuses::DbStatusesStore, tips::DbTipsStore,
+        utxo_diffs::DbUtxoDiffsStore, utxo_multisets::DbUtxoMultisetsStore, virtual_state::VirtualStores, DB,
     },
     processes::{reachability::inquirer as reachability, relations},
 };
@@ -31,6 +15,8 @@ use itertools::Itertools;
 
 use parking_lot::RwLock;
 use std::{cmp::max, ops::DerefMut, sync::Arc};
+
+const REACHABILITY_RELATIONS_PREFIX: &[u8] = b"reachability-";
 
 pub struct ConsensusStorage {
     // DB
@@ -88,11 +74,8 @@ impl ConsensusStorage {
         ));
         let reachability_store = Arc::new(RwLock::new(DbReachabilityStore::new(db.clone(), extended_pruning_size_for_caches)));
         // Reachability relations are only read during pruning, so finality depth is sufficient for cache size
-        let reachability_relations_store = Arc::new(RwLock::new(DbRelationsStore::with_prefix(
-            db.clone(),
-            store_names::REACHABILITY_RELATIONS_PREFIX,
-            config.finality_depth,
-        )));
+        let reachability_relations_store =
+            Arc::new(RwLock::new(DbRelationsStore::with_prefix(db.clone(), REACHABILITY_RELATIONS_PREFIX, config.finality_depth)));
         let ghostdag_stores = Arc::new(
             (0..=params.max_block_level)
                 .map(|level| {
@@ -128,10 +111,7 @@ impl ConsensusStorage {
         let block_window_cache_for_past_median_time = Arc::new(BlockWindowCacheStore::new(perf_params.block_window_cache_size));
 
         // Virtual stores
-        let virtual_stores = Arc::new(RwLock::new(VirtualStores::new(
-            DbVirtualStateStore::new(db.clone()),
-            DbUtxoSetStore::new(db.clone(), perf_params.utxo_set_cache_size, store_names::VIRTUAL_UTXO_SET),
-        )));
+        let virtual_stores = Arc::new(RwLock::new(VirtualStores::new(db.clone(), perf_params.utxo_set_cache_size)));
 
         // Ensure that reachability stores are initialized
         reachability::init(reachability_store.write().deref_mut()).unwrap();

--- a/consensus/src/constants/mod.rs
+++ b/consensus/src/constants/mod.rs
@@ -1,8 +1,3 @@
-pub mod store_names {
-    pub const VIRTUAL_UTXO_SET: &[u8] = b"virtual-utxo-set";
-    pub const REACHABILITY_RELATIONS_PREFIX: &[u8] = b"reachability-";
-}
-
 // Re-exports constants from consensus core for internal crate usage
 pub use kaspa_consensus_core::config::constants::*;
 pub(crate) use kaspa_consensus_core::constants::*;

--- a/consensus/src/constants/mod.rs
+++ b/consensus/src/constants/mod.rs
@@ -1,6 +1,5 @@
 pub mod store_names {
     pub const VIRTUAL_UTXO_SET: &[u8] = b"virtual-utxo-set";
-    pub const PRUNING_UTXO_SET: &[u8] = b"pruning-utxo-set";
     pub const REACHABILITY_RELATIONS_PREFIX: &[u8] = b"reachability-";
 }
 

--- a/consensus/src/model/stores/mod.rs
+++ b/consensus/src/model/stores/mod.rs
@@ -12,6 +12,7 @@ pub mod headers;
 pub mod headers_selected_tip;
 pub mod past_pruning_points;
 pub mod pruning;
+pub mod pruning_utxoset;
 pub mod reachability;
 pub mod relations;
 pub mod statuses;

--- a/consensus/src/model/stores/pruning.rs
+++ b/consensus/src/model/stores/pruning.rs
@@ -33,7 +33,14 @@ pub trait PruningStoreReader {
     fn pruning_point(&self) -> StoreResult<Hash>;
     fn pruning_point_candidate(&self) -> StoreResult<Hash>;
     fn pruning_point_index(&self) -> StoreResult<u64>;
+
+    /// Returns full pruning point info, including its index and the next pruning point candidate
     fn get(&self) -> StoreResult<PruningPointInfo>;
+
+    /// Represent the point at which data prior to it was successfully pruned. This is usually the
+    /// pruning point itself, though it might lag a bit behind (and for archival nodes it will remain
+    /// the initial syncing point or the last pruning point before turning to an archive)
+    fn data_pruned_point(&self) -> StoreResult<Hash>;
 }
 
 pub trait PruningStore: PruningStoreReader {
@@ -45,13 +52,19 @@ pub trait PruningStore: PruningStoreReader {
 pub struct DbPruningStore {
     db: Arc<DB>,
     access: CachedDbItem<PruningPointInfo>,
+    data_pruned_point_access: CachedDbItem<Hash>,
 }
 
 const PRUNING_POINT_KEY: &[u8] = b"pruning-point";
+const DATA_PRUNED_POINT_KEY: &[u8] = b"data-pruned-point";
 
 impl DbPruningStore {
     pub fn new(db: Arc<DB>) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbItem::new(db.clone(), PRUNING_POINT_KEY.to_vec()) }
+        Self {
+            db: Arc::clone(&db),
+            access: CachedDbItem::new(db.clone(), PRUNING_POINT_KEY.to_vec()),
+            data_pruned_point_access: CachedDbItem::new(db.clone(), DATA_PRUNED_POINT_KEY.to_vec()),
+        }
     }
 
     pub fn clone_with_new_cache(&self) -> Self {
@@ -60,6 +73,10 @@ impl DbPruningStore {
 
     pub fn set_batch(&mut self, batch: &mut WriteBatch, pruning_point: Hash, candidate: Hash, index: u64) -> StoreResult<()> {
         self.access.write(BatchDbWriter::new(batch), &PruningPointInfo { pruning_point, candidate, index })
+    }
+
+    pub fn set_data_pruned_point(&mut self, batch: &mut WriteBatch, data_pruned_point: Hash) -> StoreResult<()> {
+        self.data_pruned_point_access.write(BatchDbWriter::new(batch), &data_pruned_point)
     }
 }
 
@@ -78,6 +95,10 @@ impl PruningStoreReader for DbPruningStore {
 
     fn get(&self) -> StoreResult<PruningPointInfo> {
         self.access.read()
+    }
+
+    fn data_pruned_point(&self) -> StoreResult<Hash> {
+        self.data_pruned_point_access.read()
     }
 }
 

--- a/consensus/src/model/stores/pruning_utxoset.rs
+++ b/consensus/src/model/stores/pruning_utxoset.rs
@@ -8,7 +8,7 @@ use rocksdb::WriteBatch;
 
 use super::utxo_set::DbUtxoSetStore;
 
-pub const PRUNING_UTXO_SET: &[u8] = b"pruning-utxo-set";
+const PRUNING_UTXO_SET: &[u8] = b"pruning-utxo-set";
 const PRUNING_UTXOSET_POSITION_KEY: &[u8] = b"pruning-utxoset-position";
 
 /// Used in order to group stores related to the pruning point utxoset under a single lock

--- a/consensus/src/model/stores/pruning_utxoset.rs
+++ b/consensus/src/model/stores/pruning_utxoset.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use kaspa_database::prelude::StoreResult;
+use kaspa_database::prelude::DB;
+use kaspa_database::prelude::{BatchDbWriter, CachedDbItem};
+use kaspa_hashes::Hash;
+use rocksdb::WriteBatch;
+
+use super::utxo_set::DbUtxoSetStore;
+
+pub const PRUNING_UTXO_SET: &[u8] = b"pruning-utxo-set";
+const PRUNING_UTXOSET_POSITION_KEY: &[u8] = b"pruning-utxoset-position";
+
+/// Used in order to group stores related to the pruning point utxoset under a single lock
+pub struct PruningUtxosetStores {
+    pub utxo_set: DbUtxoSetStore,
+    utxoset_position_access: CachedDbItem<Hash>,
+}
+
+impl PruningUtxosetStores {
+    pub fn new(db: Arc<DB>, utxoset_cache_size: u64) -> Self {
+        Self {
+            utxo_set: DbUtxoSetStore::new(db.clone(), utxoset_cache_size, PRUNING_UTXO_SET),
+            utxoset_position_access: CachedDbItem::new(db, PRUNING_UTXOSET_POSITION_KEY.to_vec()),
+        }
+    }
+
+    /// Represents the exact point of the current pruning point utxoset. Used it order to safely
+    /// progress the pruning point utxoset in batches and to allow recovery if the process crashes
+    /// during the pruning point utxoset movement
+    pub fn utxoset_position(&self) -> StoreResult<Hash> {
+        self.utxoset_position_access.read()
+    }
+
+    pub fn set_utxoset_position(&mut self, batch: &mut WriteBatch, pruning_utxoset_position: Hash) -> StoreResult<()> {
+        self.utxoset_position_access.write(BatchDbWriter::new(batch), &pruning_utxoset_position)
+    }
+}

--- a/consensus/src/model/stores/virtual_state.rs
+++ b/consensus/src/model/stores/virtual_state.rs
@@ -72,6 +72,8 @@ impl VirtualState {
     }
 }
 
+const VIRTUAL_UTXO_SET: &[u8] = b"virtual-utxo-set";
+
 /// Used in order to group virtual related stores under a single lock
 pub struct VirtualStores {
     pub state: DbVirtualStateStore,
@@ -79,8 +81,8 @@ pub struct VirtualStores {
 }
 
 impl VirtualStores {
-    pub fn new(state: DbVirtualStateStore, utxo_set: DbUtxoSetStore) -> Self {
-        Self { state, utxo_set }
+    pub fn new(db: Arc<DB>, utxoset_cache_size: u64) -> Self {
+        Self { state: DbVirtualStateStore::new(db.clone()), utxo_set: DbUtxoSetStore::new(db, utxoset_cache_size, VIRTUAL_UTXO_SET) }
     }
 }
 

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -112,7 +112,7 @@ impl PruningProcessor {
 
         // On start-up, check if any pruning workflows require recovery. We wait for the first processing message to arrive
         // in order to make sure the node is already connected and receiving blocks before we start background recovery operations
-        self.check_if_pruning_workflows_need_recovery();
+        self.recover_pruning_workflows_if_needed();
         self.advance_pruning_point_and_candidate_if_possible(sink_ghostdag_data);
 
         while let Ok(PruningProcessingMessage::Process { sink_ghostdag_data }) = self.receiver.recv() {
@@ -120,7 +120,7 @@ impl PruningProcessor {
         }
     }
 
-    fn check_if_pruning_workflows_need_recovery(&self) {
+    fn recover_pruning_workflows_if_needed(&self) {
         let pruning_point_read = self.pruning_point_store.read();
         let pruning_point = pruning_point_read.pruning_point().unwrap();
         let history_root = pruning_point_read.history_root().unwrap_option();

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -34,7 +34,7 @@ use kaspa_consensus_core::{
     BlockHashSet,
 };
 use kaspa_consensusmanager::SessionLock;
-use kaspa_core::{info, warn};
+use kaspa_core::{debug, info, warn};
 use kaspa_database::prelude::{BatchDbWriter, MemoryWriter, StoreResultExtensions, DB};
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
@@ -127,9 +127,15 @@ impl PruningProcessor {
         let pruning_utxoset_position = self.pruning_utxoset_stores.read().utxoset_position().unwrap_option();
         drop(pruning_point_read);
 
+        debug!(
+            "[PRUNING PROCESSOR] recovery check: current pruning point: {}, data pruned point: {:?}, pruning utxoset position: {:?}",
+            pruning_point, data_pruned_point, pruning_utxoset_position
+        );
+
         if let Some(pruning_utxoset_position) = pruning_utxoset_position {
             // This indicates the node crashed during a former pruning point move and we need to recover
             if pruning_utxoset_position != pruning_point {
+                info!("Recovering pruning utxo-set from {} to the pruning point {}", pruning_utxoset_position, pruning_point);
                 self.advance_pruning_utxoset(pruning_utxoset_position, pruning_point);
             }
         }

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -19,15 +19,15 @@ use crate::{
             daa::DbDaaStore,
             ghostdag::{DbGhostdagStore, GhostdagData, GhostdagStoreReader},
             headers::{DbHeadersStore, HeaderStoreReader},
-            past_pruning_points::{DbPastPruningPointsStore, PastPruningPointsStore},
-            pruning::{DbPruningStore, PruningStore, PruningStoreReader},
+            past_pruning_points::DbPastPruningPointsStore,
+            pruning::{DbPruningStore, PruningStoreReader},
+            pruning_utxoset::PruningUtxosetStores,
             reachability::DbReachabilityStore,
             relations::{DbRelationsStore, RelationsStoreReader},
             statuses::{DbStatusesStore, StatusesStore, StatusesStoreBatchExtensions, StatusesStoreReader},
             tips::{DbTipsStore, TipsStoreReader},
             utxo_diffs::{DbUtxoDiffsStore, UtxoDiffsStoreReader},
             utxo_multisets::{DbUtxoMultisetsStore, UtxoMultisetsStoreReader},
-            utxo_set::DbUtxoSetStore,
             virtual_state::{VirtualState, VirtualStateStore, VirtualStateStoreReader, VirtualStores},
             DB,
         },
@@ -121,7 +121,7 @@ pub struct VirtualStateProcessor {
     pub(super) utxo_multisets_store: Arc<DbUtxoMultisetsStore>,
     pub(super) acceptance_data_store: Arc<DbAcceptanceDataStore>,
     pub(super) virtual_stores: Arc<RwLock<VirtualStores>>,
-    pub(super) pruning_point_utxo_set_store: Arc<RwLock<DbUtxoSetStore>>,
+    pub(super) pruning_utxoset_stores: Arc<RwLock<PruningUtxosetStores>>,
 
     // Managers and services
     pub(super) ghostdag_manager: DbGhostdagManager,
@@ -186,7 +186,7 @@ impl VirtualStateProcessor {
             utxo_multisets_store: storage.utxo_multisets_store.clone(),
             acceptance_data_store: storage.acceptance_data_store.clone(),
             virtual_stores: storage.virtual_stores.clone(),
-            pruning_point_utxo_set_store: storage.pruning_point_utxo_set_store.clone(),
+            pruning_utxoset_stores: storage.pruning_utxoset_stores.clone(),
 
             ghostdag_manager: services.ghostdag_primary_manager.clone(),
             reachability_service: services.reachability_service.clone(),
@@ -730,30 +730,37 @@ impl VirtualStateProcessor {
         Ok(BlockTemplate::new(MutableBlock::new(header, txs), miner_data, coinbase.has_red_reward, selected_parent_timestamp))
     }
 
+    /// Make sure pruning point-related stores are initialized
     pub fn init(self: &Arc<Self>) {
-        let pp_read_guard = self.pruning_point_store.upgradable_read();
-
-        // Ensure that some pruning point is registered
-        if pp_read_guard.pruning_point().unwrap_option().is_none() {
-            self.past_pruning_points_store.insert(0, self.genesis.hash).unwrap_or_exists();
-            RwLockUpgradableReadGuard::upgrade(pp_read_guard).set(self.genesis.hash, self.genesis.hash, 0).unwrap();
+        let pruning_point_read = self.pruning_point_store.upgradable_read();
+        if pruning_point_read.pruning_point().unwrap_option().is_none() {
+            let mut pruning_point_write = RwLockUpgradableReadGuard::upgrade(pruning_point_read);
+            let mut pruning_utxoset_write = self.pruning_utxoset_stores.write();
+            let mut batch = WriteBatch::default();
+            self.past_pruning_points_store.insert_batch(&mut batch, 0, self.genesis.hash).unwrap_or_exists();
+            pruning_point_write.set_batch(&mut batch, self.genesis.hash, self.genesis.hash, 0).unwrap();
+            pruning_point_write.set_data_pruned_point(&mut batch, self.genesis.hash).unwrap();
+            pruning_utxoset_write.set_utxoset_position(&mut batch, self.genesis.hash).unwrap();
+            self.db.write(batch).unwrap();
+            drop(pruning_point_write);
+            drop(pruning_utxoset_write);
         }
     }
 
+    /// Initializes UTXO state of genesis and points virtual at genesis.
+    /// Note that pruning point-related stores are initialized by `init`
     pub fn process_genesis(self: &Arc<Self>) {
-        // Init virtual and pruning stores
+        // Write the UTXO state of genesis
+        self.commit_utxo_state(self.genesis.hash, UtxoDiff::default(), MuHash::new(), AcceptanceData::default());
+        // Init virtual stores
         self.virtual_stores
             .write()
             .state
             .set(Arc::new(VirtualState::from_genesis(&self.genesis, self.ghostdag_manager.ghostdag(&[self.genesis.hash]))))
             .unwrap();
-        self.past_pruning_points_store.insert(0, self.genesis.hash).unwrap_or_exists();
-        self.pruning_point_store.write().set(self.genesis.hash, self.genesis.hash, 0).unwrap();
-
-        // Write the UTXO state of genesis
-        self.commit_utxo_state(self.genesis.hash, UtxoDiff::default(), MuHash::new(), AcceptanceData::default());
     }
 
+    // TODO: rename to reflect finalizing pruning point utxoset state and importing *to* virtual utxoset
     pub fn import_pruning_point_utxo_set(
         &self,
         new_pruning_point: Hash,
@@ -770,12 +777,21 @@ impl VirtualStateProcessor {
         }
 
         {
+            // Set the pruning point utxoset position to the new point we just verified
+            let mut batch = WriteBatch::default();
+            let mut pruning_utxoset_write = self.pruning_utxoset_stores.write();
+            pruning_utxoset_write.set_utxoset_position(&mut batch, new_pruning_point).unwrap();
+            self.db.write(batch).unwrap();
+            drop(pruning_utxoset_write);
+        }
+
+        {
             // Copy the pruning-point UTXO set into virtual's UTXO set
-            let pruning_point_utxo_set = self.pruning_point_utxo_set_store.read();
+            let pruning_utxoset_read = self.pruning_utxoset_stores.read();
             let mut virtual_write = self.virtual_stores.write();
 
             virtual_write.utxo_set.clear().unwrap();
-            for chunk in &pruning_point_utxo_set.iterator().map(|iter_result| iter_result.unwrap()).chunks(1000) {
+            for chunk in &pruning_utxoset_read.utxo_set.iterator().map(|iter_result| iter_result.unwrap()).chunks(1000) {
                 virtual_write.utxo_set.write_from_iterator_without_cache(chunk).unwrap();
             }
         }

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -739,7 +739,7 @@ impl VirtualStateProcessor {
             let mut batch = WriteBatch::default();
             self.past_pruning_points_store.insert_batch(&mut batch, 0, self.genesis.hash).unwrap_or_exists();
             pruning_point_write.set_batch(&mut batch, self.genesis.hash, self.genesis.hash, 0).unwrap();
-            pruning_point_write.set_data_pruned_point(&mut batch, self.genesis.hash).unwrap();
+            pruning_point_write.set_history_root(&mut batch, self.genesis.hash).unwrap();
             pruning_utxoset_write.set_utxoset_position(&mut batch, self.genesis.hash).unwrap();
             self.db.write(batch).unwrap();
             drop(pruning_point_write);

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -168,7 +168,7 @@ impl PruningProofManager {
         let mut pruning_point_write = self.pruning_point_store.write();
         let mut batch = WriteBatch::default();
         pruning_point_write.set_batch(&mut batch, new_pruning_point, new_pruning_point, (pruning_points.len() - 1) as u64).unwrap();
-        pruning_point_write.set_data_pruned_point(&mut batch, new_pruning_point).unwrap();
+        pruning_point_write.set_history_root(&mut batch, new_pruning_point).unwrap();
         self.db.write(batch).unwrap();
         drop(pruning_point_write);
     }

--- a/database/src/errors.rs
+++ b/database/src/errors.rs
@@ -15,6 +15,9 @@ pub enum StoreError {
     #[error("hash {0} already exists in store")]
     HashAlreadyExists(Hash),
 
+    #[error("data inconsistency: {0}")]
+    DataInconsistency(String),
+
     #[error("rocksdb error {0}")]
     DbError(#[from] rocksdb::Error),
 

--- a/mining/src/block_template/builder.rs
+++ b/mining/src/block_template/builder.rs
@@ -3,8 +3,7 @@ use crate::{block_template::selector::TransactionsSelector, model::candidate_tx:
 use kaspa_consensus_core::{
     api::ConsensusApi, block::BlockTemplate, coinbase::MinerData, merkle::calc_hash_merkle_root, tx::COINBASE_TRANSACTION_INDEX,
 };
-use kaspa_core::debug;
-use std::time::{SystemTime, UNIX_EPOCH};
+use kaspa_core::{debug, time::unix_now};
 
 pub(crate) struct BlockTemplateBuilder {
     policy: Policy,
@@ -110,7 +109,7 @@ impl BlockTemplateBuilder {
         }
         // Update the hash merkle root according to the modified transactions
         block_template.block.header.hash_merkle_root = calc_hash_merkle_root(block_template.block.transactions.iter());
-        let new_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        let new_timestamp = unix_now();
         if new_timestamp > block_template.block.header.timestamp {
             // Only if new time stamp is later than current, update the header. Otherwise,
             // we keep the previous time as built by internal consensus median time logic

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -15,7 +15,6 @@ use kaspa_core::{debug, time::unix_now, warn};
 use std::{
     collections::{hash_map::Keys, hash_set::Iter},
     sync::Arc,
-    time::SystemTime,
 };
 
 use super::pool::TransactionsEdges;
@@ -68,7 +67,7 @@ impl TransactionsPool {
             parent_transactions: TransactionsEdges::default(),
             chained_transactions: TransactionsEdges::default(),
             last_expire_scan_daa_score: 0,
-            last_expire_scan_time: SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as u64,
+            last_expire_scan_time: unix_now(),
             utxo_set: MempoolUtxoSet::new(),
         }
     }

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -15,10 +15,11 @@ use kaspa_consensus_core::{
     tx::{MutableTransaction, Transaction, TransactionId, TransactionOutpoint, UtxoEntry},
     utxo::utxo_collection::UtxoCollection,
 };
+use kaspa_core::time::unix_now;
 use kaspa_hashes::ZERO_HASH;
 
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::SystemTime};
+use std::{collections::HashMap, sync::Arc};
 
 pub(crate) struct ConsensusMock {
     transactions: RwLock<HashMap<TransactionId, Arc<Transaction>>>,
@@ -75,7 +76,7 @@ impl ConsensusApi for ConsensusMock {
         let coinbase_manager = CoinbaseManagerMock::new();
         let coinbase = coinbase_manager.expected_coinbase_transaction(miner_data.clone());
         txs.insert(0, coinbase.tx);
-        let now = SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as u64;
+        let now = unix_now();
         let hash_merkle_root = calc_hash_merkle_root(txs.iter());
         let header = Header::new(
             BLOCK_VERSION,

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -460,9 +460,6 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
                 return Err(ProtocolError::OtherOwned(format!("sent header of {} where expected block with body", block.hash())));
             }
             current_daa_score = block.header.daa_score;
-            // TODO: decide if we resolve virtual separately on long IBD
-            // TODO: handle peer banning
-            // TODO: call self.ctx.on_new_block for every inserted block
             jobs.push(consensus.validate_and_insert_block(block));
         }
 

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -68,6 +68,8 @@ pub enum IbdType {
     DownloadHeadersProof,
 }
 
+// TODO: define a peer banning strategy
+
 impl IbdFlow {
     pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, relay_receiver: Receiver<Block>) -> Self {
         Self { ctx, router, incoming_route, relay_receiver }

--- a/testing/integration/src/integration_tests.rs
+++ b/testing/integration/src/integration_tests.rs
@@ -34,6 +34,7 @@ use kaspa_consensus_core::{blockhash, hashing, BlockHashMap, BlueWorkType};
 use kaspa_consensus_notify::root::ConsensusNotificationRoot;
 use kaspa_consensus_notify::service::NotifyService;
 use kaspa_consensusmanager::ConsensusManager;
+use kaspa_core::time::unix_now;
 use kaspa_database::utils::{create_temp_db, get_kaspa_tempdir};
 use kaspa_hashes::Hash;
 
@@ -60,7 +61,6 @@ use std::{
     future::Future,
     io::{BufRead, BufReader},
     str::{from_utf8, FromStr},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use crate::common;
@@ -397,7 +397,7 @@ async fn header_in_isolation_validation_test() {
         let mut block = block.clone();
         block.header.hash = 2.into();
 
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        let now = unix_now();
         let block_ts = now + config.timestamp_deviation_tolerance * config.target_time_per_block + 2000;
         block.header.timestamp = block_ts;
         match consensus.validate_and_insert_block(block.to_immutable()).await {

--- a/utils/src/sync/semaphore.rs
+++ b/utils/src/sync/semaphore.rs
@@ -6,8 +6,11 @@ use std::{
 
 /// A low-level non-fair semaphore. The semaphore is non-fair in the sense that clients acquiring
 /// a lower number of permits might get their allocation before earlier clients which requested more
-/// permits -- if the semaphore can provide the lower allocation but not the larger. This is especially
-/// useful for implementing a readers-preferred reader-writer lock
+/// permits -- if the semaphore can provide the lower allocation but not the larger. This non-fairness
+/// is especially useful for implementing a strict readers-preferred reader-writer lock. See [`RfRwLock`].
+/// Additionally it is possible that a new client immediately acquires if it happens to arrive right after
+/// a release and before others were awaked. Otherwise the semaphore is usually fair in the sense that
+/// waiters are awaked in the order they arrived at.
 #[derive(Debug)]
 pub(crate) struct Semaphore {
     counter: AtomicUsize,

--- a/utils/src/sync/semaphore.rs
+++ b/utils/src/sync/semaphore.rs
@@ -6,7 +6,7 @@ use std::{
 
 /// A low-level non-fair semaphore. The semaphore is non-fair in the sense that clients acquiring
 /// a lower number of permits might get their allocation before earlier clients which requested more
-/// permits, if the semaphore can provide the lower allocation but not the larger. This is especially
+/// permits -- if the semaphore can provide the lower allocation but not the larger. This is especially
 /// useful for implementing a readers-preferred reader-writer lock
 #[derive(Debug)]
 pub(crate) struct Semaphore {


### PR DESCRIPTION
Adds support for batching and recovery for pruning operations in order to ensure coherent state also on system crashes. 
Namely:

1. Performs pruning point utxo-set update in DB batches which include the current position
2. Uses the above position to recover the process on system restart
3. Saves the last data pruned point in the DB
4. Uses this point to trigger data prune on system restart if a former operation was uncompleted
5. This point also marks the beginning of full history for archival nodes 