### PR TITLE
Optimize database key sizes to be mostly constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "serde",
+ "smallvec",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "enum-primitive-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,11 +1723,13 @@ name = "kaspa-database"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "enum-primitive-derive",
  "faster-hex",
  "indexmap",
  "itertools 0.10.5",
  "kaspa-hashes",
  "kaspa-utils",
+ "num-traits",
  "num_cpus",
  "parking_lot",
  "rand 0.8.5",

--- a/components/addressmanager/src/stores/address_store.rs
+++ b/components/addressmanager/src/stores/address_store.rs
@@ -2,16 +2,14 @@ use kaspa_database::{
     prelude::DB,
     prelude::{CachedDbAccess, DirectDbWriter},
     prelude::{StoreError, StoreResult},
+    registry::DatabaseStorePrefixes,
 };
 use serde::{Deserialize, Serialize};
 use std::net::Ipv6Addr;
 use std::{error::Error, fmt::Display, sync::Arc};
 
-use crate::NetAddress;
-
 use super::AddressKey;
-
-const STORE_PREFIX_CONNECTION_FAILED_COUNT: &[u8] = b"not-banned-addresses-connection";
+use crate::NetAddress;
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct Entry {
@@ -77,10 +75,7 @@ pub struct DbAddressesStore {
 
 impl DbAddressesStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self {
-            db: Arc::clone(&db),
-            access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX_CONNECTION_FAILED_COUNT.to_vec()),
-        }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::Addresses.into()) }
     }
 
     pub fn iterator(&self) -> impl Iterator<Item = Result<(AddressKey, Entry), Box<dyn Error>>> + '_ {

--- a/components/addressmanager/src/stores/banned_address_store.rs
+++ b/components/addressmanager/src/stores/banned_address_store.rs
@@ -1,12 +1,11 @@
 use kaspa_database::{
     prelude::{CachedDbAccess, DirectDbWriter, DB},
     prelude::{StoreError, StoreResult},
+    registry::DatabaseStorePrefixes,
 };
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv6Addr};
 use std::{error::Error, fmt::Display, sync::Arc};
-
-const STORE_PREFIX: &[u8] = b"banned-addresses";
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct ConnectionBanTimestamp(pub u64);
@@ -72,7 +71,7 @@ pub struct DbBannedAddressesStore {
 
 impl DbBannedAddressesStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::BannedAddresses.into()) }
     }
 
     pub fn iterator(&self) -> impl Iterator<Item = Result<(IpAddr, ConnectionBanTimestamp), Box<dyn Error>>> + '_ {

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -13,10 +13,9 @@ use crate::{
 
 use itertools::Itertools;
 
+use kaspa_database::registry::DatabaseStorePrefixes;
 use parking_lot::RwLock;
 use std::{cmp::max, ops::DerefMut, sync::Arc};
-
-const REACHABILITY_RELATIONS_PREFIX: &[u8] = b"reachability-";
 
 pub struct ConsensusStorage {
     // DB
@@ -74,8 +73,11 @@ impl ConsensusStorage {
         ));
         let reachability_store = Arc::new(RwLock::new(DbReachabilityStore::new(db.clone(), extended_pruning_size_for_caches)));
         // Reachability relations are only read during pruning, so finality depth is sufficient for cache size
-        let reachability_relations_store =
-            Arc::new(RwLock::new(DbRelationsStore::with_prefix(db.clone(), REACHABILITY_RELATIONS_PREFIX, config.finality_depth)));
+        let reachability_relations_store = Arc::new(RwLock::new(DbRelationsStore::with_prefix(
+            db.clone(),
+            DatabaseStorePrefixes::ReachabilityRelations.as_ref(),
+            config.finality_depth,
+        )));
         let ghostdag_stores = Arc::new(
             (0..=params.max_block_level)
                 .map(|level| {

--- a/consensus/src/model/stores/acceptance_data.rs
+++ b/consensus/src/model/stores/acceptance_data.rs
@@ -3,6 +3,7 @@ use kaspa_consensus_core::BlockHasher;
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 use std::sync::Arc;
@@ -16,8 +17,6 @@ pub trait AcceptanceDataStore: AcceptanceDataStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"acceptance-data";
-
 /// A DB + cache implementation of `DbAcceptanceDataStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbAcceptanceDataStore {
@@ -27,7 +26,7 @@ pub struct DbAcceptanceDataStore {
 
 impl DbAcceptanceDataStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::AcceptanceData.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/block_transactions.rs
+++ b/consensus/src/model/stores/block_transactions.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{tx::Transaction, BlockHasher};
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -17,8 +18,6 @@ pub trait BlockTransactionsStore: BlockTransactionsStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"block-transactions";
-
 /// A DB + cache implementation of `BlockTransactionsStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbBlockTransactionsStore {
@@ -28,7 +27,7 @@ pub struct DbBlockTransactionsStore {
 
 impl DbBlockTransactionsStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::BlockTransactions.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/daa.rs
+++ b/consensus/src/model/stores/daa.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{BlockHashSet, BlockHasher};
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -17,8 +18,6 @@ pub trait DaaStore: DaaStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"mergeset_non_daa";
-
 /// A DB + cache implementation of `DaaStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbDaaStore {
@@ -28,7 +27,7 @@ pub struct DbDaaStore {
 
 impl DbDaaStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::NonDaaMergeset.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/depth.rs
+++ b/consensus/src/model/stores/depth.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::BlockHasher;
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -18,8 +19,6 @@ pub trait DepthStore: DepthStoreReader {
     fn insert(&self, hash: Hash, merge_depth_root: Hash, finality_point: Hash) -> Result<(), StoreError>;
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
-
-const STORE_PREFIX: &[u8] = b"block-at-depth";
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 struct BlockDepthInfo {
@@ -36,7 +35,7 @@ pub struct DbDepthStore {
 
 impl DbDepthStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::BlockDepth.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{BlockHashMap, BlockHasher, BlockLevel, HashMapCustomH
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DbKey};
-use kaspa_database::registry::DatabaseStorePrefixes;
+use kaspa_database::registry::{DatabaseStorePrefixes, SEPARATOR};
 use kaspa_hashes::Hash;
 
 use itertools::EitherOrBoth::{Both, Left, Right};
@@ -246,6 +246,7 @@ pub struct DbGhostdagStore {
 
 impl DbGhostdagStore {
     pub fn new(db: Arc<DB>, level: BlockLevel, cache_size: u64) -> Self {
+        assert_ne!(SEPARATOR, level, "level {} is reserved for the separator", level);
         let lvl_bytes = level.to_le_bytes();
         let prefix = DatabaseStorePrefixes::Ghostdag.into_iter().chain(lvl_bytes).collect_vec();
         let compact_prefix = DatabaseStorePrefixes::GhostdagCompact.into_iter().chain(lvl_bytes).collect_vec();

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -5,6 +5,7 @@ use kaspa_consensus_core::{BlockHashMap, BlockHasher, BlockLevel, HashMapCustomH
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DbKey};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 
 use itertools::EitherOrBoth::{Both, Left, Right};
@@ -234,9 +235,6 @@ pub trait GhostdagStore: GhostdagStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"block-ghostdag-data";
-const COMPACT_STORE_PREFIX: &[u8] = b"compact-block-ghostdag-data";
-
 /// A DB + cache implementation of `GhostdagStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbGhostdagStore {
@@ -249,8 +247,8 @@ pub struct DbGhostdagStore {
 impl DbGhostdagStore {
     pub fn new(db: Arc<DB>, level: BlockLevel, cache_size: u64) -> Self {
         let lvl_bytes = level.to_le_bytes();
-        let prefix = STORE_PREFIX.iter().copied().chain(lvl_bytes).collect_vec();
-        let compact_prefix = COMPACT_STORE_PREFIX.iter().copied().chain(lvl_bytes).collect_vec();
+        let prefix = DatabaseStorePrefixes::Ghostdag.into_iter().chain(lvl_bytes).collect_vec();
+        let compact_prefix = DatabaseStorePrefixes::GhostdagCompact.into_iter().chain(lvl_bytes).collect_vec();
         Self {
             db: Arc::clone(&db),
             level,
@@ -369,6 +367,10 @@ impl MemoryGhostdagStore {
             blues_anticone_sizes_map: RefCell::new(BlockHashMap::new()),
         }
     }
+
+    pub fn key_not_found_error(hash: Hash) -> StoreError {
+        StoreError::KeyNotFound(DbKey::new(DatabaseStorePrefixes::Ghostdag.as_ref(), hash))
+    }
 }
 
 impl Default for MemoryGhostdagStore {
@@ -406,48 +408,48 @@ impl GhostdagStoreReader for MemoryGhostdagStore {
     fn get_blue_score(&self, hash: Hash) -> Result<u64, StoreError> {
         match self.blue_score_map.borrow().get(&hash) {
             Some(blue_score) => Ok(*blue_score),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_blue_work(&self, hash: Hash) -> Result<BlueWorkType, StoreError> {
         match self.blue_work_map.borrow().get(&hash) {
             Some(blue_work) => Ok(*blue_work),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_selected_parent(&self, hash: Hash) -> Result<Hash, StoreError> {
         match self.selected_parent_map.borrow().get(&hash) {
             Some(selected_parent) => Ok(*selected_parent),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_mergeset_blues(&self, hash: Hash) -> Result<BlockHashes, StoreError> {
         match self.mergeset_blues_map.borrow().get(&hash) {
             Some(mergeset_blues) => Ok(BlockHashes::clone(mergeset_blues)),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_mergeset_reds(&self, hash: Hash) -> Result<BlockHashes, StoreError> {
         match self.mergeset_reds_map.borrow().get(&hash) {
             Some(mergeset_reds) => Ok(BlockHashes::clone(mergeset_reds)),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_blues_anticone_sizes(&self, hash: Hash) -> Result<HashKTypeMap, StoreError> {
         match self.blues_anticone_sizes_map.borrow().get(&hash) {
             Some(sizes) => Ok(HashKTypeMap::clone(sizes)),
-            None => Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash))),
+            None => Err(Self::key_not_found_error(hash)),
         }
     }
 
     fn get_data(&self, hash: Hash) -> Result<Arc<GhostdagData>, StoreError> {
         if !self.has(hash)? {
-            return Err(StoreError::KeyNotFound(DbKey::new(STORE_PREFIX, hash)));
+            return Err(Self::key_not_found_error(hash));
         }
         Ok(Arc::new(GhostdagData::new(
             self.blue_score_map.borrow()[&hash],

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{header::Header, BlockHasher, BlockLevel};
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess};
 use kaspa_database::prelude::{StoreError, StoreResult};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -29,9 +30,6 @@ pub trait HeaderStore: HeaderStoreReader {
     fn insert(&self, hash: Hash, header: Arc<Header>, block_level: BlockLevel) -> Result<(), StoreError>;
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
-
-const HEADERS_STORE_PREFIX: &[u8] = b"headers";
-const COMPACT_HEADER_DATA_STORE_PREFIX: &[u8] = b"compact-header-data";
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct CompactHeaderData {
@@ -59,8 +57,8 @@ impl DbHeadersStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
         Self {
             db: Arc::clone(&db),
-            compact_headers_access: CachedDbAccess::new(Arc::clone(&db), cache_size, COMPACT_HEADER_DATA_STORE_PREFIX.to_vec()),
-            headers_access: CachedDbAccess::new(db, cache_size, HEADERS_STORE_PREFIX.to_vec()),
+            compact_headers_access: CachedDbAccess::new(Arc::clone(&db), cache_size, DatabaseStorePrefixes::HeadersCompact.into()),
+            headers_access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::Headers.into()),
         }
     }
 

--- a/consensus/src/model/stores/headers_selected_tip.rs
+++ b/consensus/src/model/stores/headers_selected_tip.rs
@@ -2,6 +2,7 @@ use crate::processes::ghostdag::ordering::SortableBlock;
 use kaspa_database::prelude::StoreResult;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbItem, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use rocksdb::WriteBatch;
 use std::sync::Arc;
 
@@ -14,8 +15,6 @@ pub trait HeadersSelectedTipStore: HeadersSelectedTipStoreReader {
     fn set(&mut self, block: SortableBlock) -> StoreResult<()>;
 }
 
-pub const STORE_NAME: &[u8] = b"headers-selected-tip";
-
 /// A DB + cache implementation of `HeadersSelectedTipStore` trait
 #[derive(Clone)]
 pub struct DbHeadersSelectedTipStore {
@@ -25,7 +24,7 @@ pub struct DbHeadersSelectedTipStore {
 
 impl DbHeadersSelectedTipStore {
     pub fn new(db: Arc<DB>) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbItem::new(db.clone(), STORE_NAME.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbItem::new(db, DatabaseStorePrefixes::HeadersSelectedTip.into()) }
     }
 
     pub fn clone_with_new_cache(&self) -> Self {

--- a/consensus/src/model/stores/past_pruning_points.rs
+++ b/consensus/src/model/stores/past_pruning_points.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
 use kaspa_database::prelude::{StoreError, StoreResult};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -18,8 +19,6 @@ pub trait PastPruningPointsStore: PastPruningPointsStoreReader {
     fn set(&self, index: u64, pruning_point: Hash) -> StoreResult<()>;
 }
 
-const STORE_PREFIX: &[u8] = b"past-pruning-points";
-
 /// A DB + cache implementation of `PastPruningPointsStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbPastPruningPointsStore {
@@ -29,7 +28,7 @@ pub struct DbPastPruningPointsStore {
 
 impl DbPastPruningPointsStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::PastPruningPoints.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/pruning.rs
+++ b/consensus/src/model/stores/pruning.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use kaspa_database::prelude::StoreResult;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbItem, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
@@ -55,15 +56,12 @@ pub struct DbPruningStore {
     history_root_access: CachedDbItem<Hash>,
 }
 
-const PRUNING_POINT_KEY: &[u8] = b"pruning-point";
-const HISTORY_ROOT_KEY: &[u8] = b"history_root";
-
 impl DbPruningStore {
     pub fn new(db: Arc<DB>) -> Self {
         Self {
             db: Arc::clone(&db),
-            access: CachedDbItem::new(db.clone(), PRUNING_POINT_KEY.to_vec()),
-            history_root_access: CachedDbItem::new(db.clone(), HISTORY_ROOT_KEY.to_vec()),
+            access: CachedDbItem::new(db.clone(), DatabaseStorePrefixes::PruningPoint.into()),
+            history_root_access: CachedDbItem::new(db, DatabaseStorePrefixes::HistoryRoot.into()),
         }
     }
 

--- a/consensus/src/model/stores/pruning_utxoset.rs
+++ b/consensus/src/model/stores/pruning_utxoset.rs
@@ -3,13 +3,11 @@ use std::sync::Arc;
 use kaspa_database::prelude::StoreResult;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbItem};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
 use super::utxo_set::DbUtxoSetStore;
-
-const PRUNING_UTXO_SET: &[u8] = b"pruning-utxo-set";
-const PRUNING_UTXOSET_POSITION_KEY: &[u8] = b"pruning-utxoset-position";
 
 /// Used in order to group stores related to the pruning point utxoset under a single lock
 pub struct PruningUtxosetStores {
@@ -20,8 +18,8 @@ pub struct PruningUtxosetStores {
 impl PruningUtxosetStores {
     pub fn new(db: Arc<DB>, utxoset_cache_size: u64) -> Self {
         Self {
-            utxo_set: DbUtxoSetStore::new(db.clone(), utxoset_cache_size, PRUNING_UTXO_SET),
-            utxoset_position_access: CachedDbItem::new(db, PRUNING_UTXOSET_POSITION_KEY.to_vec()),
+            utxo_set: DbUtxoSetStore::new(db.clone(), utxoset_cache_size, DatabaseStorePrefixes::PruningUtxoset.into()),
+            utxoset_position_access: CachedDbItem::new(db, DatabaseStorePrefixes::PruningUtxosetPosition.into()),
         }
     }
 

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -6,7 +6,7 @@ use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, DbWriter};
 use kaspa_database::prelude::{CachedDbAccess, DbKey, DirectDbWriter};
-use kaspa_database::registry::DatabaseStorePrefixes;
+use kaspa_database::registry::{DatabaseStorePrefixes, SEPARATOR};
 use kaspa_hashes::Hash;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rocksdb::WriteBatch;
@@ -42,6 +42,7 @@ pub struct DbRelationsStore {
 
 impl DbRelationsStore {
     pub fn new(db: Arc<DB>, level: BlockLevel, cache_size: u64) -> Self {
+        assert_ne!(SEPARATOR, level, "level {} is reserved for the separator", level);
         let lvl_bytes = level.to_le_bytes();
         let parents_prefix = DatabaseStorePrefixes::RelationsParents.into_iter().chain(lvl_bytes).collect_vec();
         let children_prefix = DatabaseStorePrefixes::RelationsChildren.into_iter().chain(lvl_bytes).collect_vec();

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -6,6 +6,7 @@ use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, DbWriter};
 use kaspa_database::prelude::{CachedDbAccess, DbKey, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rocksdb::WriteBatch;
@@ -31,9 +32,6 @@ pub trait RelationsStore: RelationsStoreReader {
     fn delete_entries(&mut self, writer: impl DbWriter, hash: Hash) -> Result<(), StoreError>;
 }
 
-const PARENTS_PREFIX: &[u8] = b"block-parents";
-const CHILDREN_PREFIX: &[u8] = b"block-children";
-
 /// A DB + cache implementation of `RelationsStore` trait, with concurrent readers support.
 #[derive(Clone)]
 pub struct DbRelationsStore {
@@ -45,8 +43,8 @@ pub struct DbRelationsStore {
 impl DbRelationsStore {
     pub fn new(db: Arc<DB>, level: BlockLevel, cache_size: u64) -> Self {
         let lvl_bytes = level.to_le_bytes();
-        let parents_prefix = PARENTS_PREFIX.iter().copied().chain(lvl_bytes).collect_vec();
-        let children_prefix = CHILDREN_PREFIX.iter().copied().chain(lvl_bytes).collect_vec();
+        let parents_prefix = DatabaseStorePrefixes::RelationsParents.into_iter().chain(lvl_bytes).collect_vec();
+        let children_prefix = DatabaseStorePrefixes::RelationsChildren.into_iter().chain(lvl_bytes).collect_vec();
         Self {
             db: Arc::clone(&db),
             parents_access: CachedDbAccess::new(Arc::clone(&db), cache_size, parents_prefix),
@@ -55,8 +53,8 @@ impl DbRelationsStore {
     }
 
     pub fn with_prefix(db: Arc<DB>, prefix: &[u8], cache_size: u64) -> Self {
-        let parents_prefix = prefix.iter().copied().chain(PARENTS_PREFIX.iter().copied()).collect_vec();
-        let children_prefix = prefix.iter().copied().chain(CHILDREN_PREFIX.iter().copied()).collect_vec();
+        let parents_prefix = prefix.iter().copied().chain(DatabaseStorePrefixes::RelationsParents.into_iter()).collect_vec();
+        let children_prefix = prefix.iter().copied().chain(DatabaseStorePrefixes::RelationsChildren.into_iter()).collect_vec();
         Self {
             db: Arc::clone(&db),
             parents_access: CachedDbAccess::new(Arc::clone(&db), cache_size, parents_prefix),
@@ -247,14 +245,14 @@ impl RelationsStoreReader for MemoryRelationsStore {
     fn get_parents(&self, hash: Hash) -> Result<BlockHashes, StoreError> {
         match self.parents_map.get(&hash) {
             Some(parents) => Ok(BlockHashes::clone(parents)),
-            None => Err(StoreError::KeyNotFound(DbKey::new(PARENTS_PREFIX, hash))),
+            None => Err(StoreError::KeyNotFound(DbKey::new(DatabaseStorePrefixes::RelationsParents.as_ref(), hash))),
         }
     }
 
     fn get_children(&self, hash: Hash) -> Result<BlockHashes, StoreError> {
         match self.children_map.get(&hash) {
             Some(children) => Ok(BlockHashes::clone(children)),
-            None => Err(StoreError::KeyNotFound(DbKey::new(CHILDREN_PREFIX, hash))),
+            None => Err(StoreError::KeyNotFound(DbKey::new(DatabaseStorePrefixes::RelationsChildren.as_ref(), hash))),
         }
     }
 

--- a/consensus/src/model/stores/selected_chain.rs
+++ b/consensus/src/model/stores/selected_chain.rs
@@ -1,5 +1,6 @@
 use kaspa_consensus_core::blockstatus::BlockStatus;
 use kaspa_consensus_core::ChainPath;
+use kaspa_database::registry::DatabaseStorePrefixes;
 use parking_lot::RwLockWriteGuard;
 use rocksdb::WriteBatch;
 
@@ -26,10 +27,6 @@ pub trait SelectedChainStore: SelectedChainStoreReader {
     fn init_with_pruning_point(&mut self, batch: &mut WriteBatch, block: Hash) -> StoreResult<()>;
 }
 
-const STORE_PREFIX_HASH_BY_INDEX: &[u8] = b"selected-chain-hash-by-index";
-const STORE_PREFIX_INDEX_BY_HASH: &[u8] = b"selected-chain-index-by-hash";
-const STORE_PREFIX_HIGHEST_INDEX: &[u8] = b"selected-chain-highest-index";
-
 /// A DB + cache implementation of `SelectedChainStore` trait, with concurrent readers support.
 #[derive(Clone)]
 pub struct DbSelectedChainStore {
@@ -43,9 +40,9 @@ impl DbSelectedChainStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
         Self {
             db: Arc::clone(&db),
-            access_hash_by_index: CachedDbAccess::new(db.clone(), cache_size, STORE_PREFIX_HASH_BY_INDEX.to_vec()),
-            access_index_by_hash: CachedDbAccess::new(db.clone(), cache_size, STORE_PREFIX_INDEX_BY_HASH.to_vec()),
-            access_highest_index: CachedDbItem::new(db, STORE_PREFIX_HIGHEST_INDEX.to_vec()),
+            access_hash_by_index: CachedDbAccess::new(db.clone(), cache_size, DatabaseStorePrefixes::ChainHashByIndex.into()),
+            access_index_by_hash: CachedDbAccess::new(db.clone(), cache_size, DatabaseStorePrefixes::ChainIndexByHash.into()),
+            access_highest_index: CachedDbItem::new(db, DatabaseStorePrefixes::ChainHighestIndex.into()),
         }
     }
 

--- a/consensus/src/model/stores/statuses.rs
+++ b/consensus/src/model/stores/statuses.rs
@@ -1,4 +1,5 @@
 use kaspa_consensus_core::{blockstatus::BlockStatus, BlockHasher};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use rocksdb::WriteBatch;
 use std::sync::Arc;
@@ -22,8 +23,6 @@ pub trait StatusesStore: StatusesStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"block-statuses";
-
 /// A DB + cache implementation of `StatusesStore` trait, with concurrent readers support.
 #[derive(Clone)]
 pub struct DbStatusesStore {
@@ -33,7 +32,7 @@ pub struct DbStatusesStore {
 
 impl DbStatusesStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::Statuses.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/tips.rs
+++ b/consensus/src/model/stores/tips.rs
@@ -6,6 +6,7 @@ use kaspa_database::prelude::StoreResult;
 use kaspa_database::prelude::StoreResultExtensions;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbItem, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -31,8 +32,6 @@ pub trait TipsStore: TipsStoreReader {
     fn prune_tips_with_writer(&mut self, writer: impl DbWriter, pruned_tips: &[Hash]) -> StoreResult<()>;
 }
 
-pub const STORE_NAME: &[u8] = b"body-tips";
-
 /// A DB + cache implementation of `TipsStore` trait
 #[derive(Clone)]
 pub struct DbTipsStore {
@@ -42,7 +41,7 @@ pub struct DbTipsStore {
 
 impl DbTipsStore {
     pub fn new(db: Arc<DB>) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbItem::new(db.clone(), STORE_NAME.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbItem::new(db, DatabaseStorePrefixes::Tips.into()) }
     }
 
     pub fn clone_with_new_cache(&self) -> Self {

--- a/consensus/src/model/stores/utxo_diffs.rs
+++ b/consensus/src/model/stores/utxo_diffs.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{utxo::utxo_diff::UtxoDiff, BlockHasher};
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -22,8 +23,6 @@ pub trait UtxoDiffsStore: UtxoDiffsStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"utxo-diffs";
-
 /// A DB + cache implementation of `UtxoDifferencesStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbUtxoDiffsStore {
@@ -33,7 +32,7 @@ pub struct DbUtxoDiffsStore {
 
 impl DbUtxoDiffsStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::UtxoDiffs.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/utxo_multisets.rs
+++ b/consensus/src/model/stores/utxo_multisets.rs
@@ -2,6 +2,7 @@ use kaspa_consensus_core::BlockHasher;
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use kaspa_math::Uint3072;
 use kaspa_muhash::MuHash;
@@ -17,8 +18,6 @@ pub trait UtxoMultisetsStore: UtxoMultisetsStoreReader {
     fn delete(&self, hash: Hash) -> Result<(), StoreError>;
 }
 
-const STORE_PREFIX: &[u8] = b"utxo-multisets";
-
 /// A DB + cache implementation of `DbUtxoMultisetsStore` trait, with concurrency support.
 #[derive(Clone)]
 pub struct DbUtxoMultisetsStore {
@@ -28,7 +27,7 @@ pub struct DbUtxoMultisetsStore {
 
 impl DbUtxoMultisetsStore {
     pub fn new(db: Arc<DB>, cache_size: u64) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbAccess::new(Arc::clone(&db), cache_size, STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_size, DatabaseStorePrefixes::UtxoMultisets.into()) }
     }
 
     pub fn clone_with_new_cache(&self, cache_size: u64) -> Self {

--- a/consensus/src/model/stores/utxo_set.rs
+++ b/consensus/src/model/stores/utxo_set.rs
@@ -35,8 +35,8 @@ struct UtxoKey([u8; UTXO_KEY_SIZE]);
 
 impl AsRef<[u8]> for UtxoKey {
     fn as_ref(&self) -> &[u8] {
-        // In every practical case the index will need at most 2 bytes, so the overall DB key structure
-        // will be { prefix byte || prefix sep byte || TX ID (32 bytes) || TX INDEX (2) } = 36 bytes
+        // In every practical case a transaction output index needs at most 2 bytes, so the overall
+        // DB key structure will be { prefix byte || TX ID (32 bytes) || TX INDEX (2) } = 35 bytes
         // which fit on the smallvec without requiring heap allocation (see key.rs)
         let rposition = self.0[kaspa_hashes::HASH_SIZE..].iter().rposition(|&v| v != 0).unwrap_or(0);
         &self.0[..=kaspa_hashes::HASH_SIZE + rposition]
@@ -53,7 +53,8 @@ impl TryFrom<&[u8]> for UtxoKey {
         if slice.len() < kaspa_hashes::HASH_SIZE + 1 {
             return Err("src slice is too short");
         }
-        // If the slice is shorter than HASH len + u32 len then we pad with zeros, effectively implementing the reverse logic of `AsRef`.
+        // If the slice is shorter than HASH len + u32 len then we pad with zeros, effectively
+        // implementing the inverse logic of `AsRef`.
         let mut bytes = [0; UTXO_KEY_SIZE];
         bytes[..slice.len()].copy_from_slice(slice);
         Ok(Self(bytes))

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -368,13 +368,7 @@ impl PruningProofManager {
         let mut relations_stores =
             (0..=self.max_block_level).map(|level| DbRelationsStore::new(db.clone(), level, 2 * self.pruning_proof_m)).collect_vec();
         let reachability_stores = (0..=self.max_block_level)
-            .map(|level| {
-                Arc::new(RwLock::new(DbReachabilityStore::new_with_alternative_prefix_end(
-                    db.clone(),
-                    2 * self.pruning_proof_m,
-                    level,
-                )))
-            })
+            .map(|level| Arc::new(RwLock::new(DbReachabilityStore::with_block_level(db.clone(), 2 * self.pruning_proof_m, level))))
             .collect_vec();
 
         let reachability_services = (0..=self.max_block_level)

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -17,6 +17,7 @@ rand.workspace = true
 faster-hex.workspace = true
 kaspa-hashes.workspace = true
 kaspa-utils.workspace = true
+smallvec.workspace = true
 itertools.workspace = true
 num_cpus.workspace = true
 tempfile.workspace = true

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -21,3 +21,6 @@ smallvec.workspace = true
 itertools.workspace = true
 num_cpus.workspace = true
 tempfile.workspace = true
+
+enum-primitive-derive = "0.2.2"
+num-traits = "0.2.15"

--- a/database/src/cache.rs
+++ b/database/src/cache.rs
@@ -7,7 +7,7 @@ use std::{collections::hash_map::RandomState, hash::BuildHasher, sync::Arc};
 pub struct Cache<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync, S = RandomState> {
     // We use IndexMap and not HashMap, because it makes it cheaper to remove a random element when the cache is full.
     map: Arc<RwLock<IndexMap<TKey, TData, S>>>,
-    pub size: usize,
+    size: usize,
 }
 
 impl<TKey: Clone + std::hash::Hash + Eq + Send + Sync, TData: Clone + Send + Sync, S: BuildHasher + Default> Cache<TKey, TData, S> {

--- a/database/src/key.rs
+++ b/database/src/key.rs
@@ -3,12 +3,14 @@ use std::{
     str,
 };
 
+use smallvec::SmallVec;
+
 pub const SEP: u8 = b'/';
 pub const SEP_SIZE: usize = 1;
 
 #[derive(Clone)]
 pub struct DbKey {
-    path: Vec<u8>,
+    path: SmallVec<[u8; 36]>,
     prefix_len: usize,
 }
 
@@ -32,7 +34,7 @@ impl DbKey {
     where
         TBucket: Copy + AsRef<[u8]>,
     {
-        self.path.extend(bucket.as_ref().iter());
+        self.path.extend(bucket.as_ref().iter().copied());
         self.prefix_len += bucket.as_ref().len();
     }
 

--- a/database/src/key.rs
+++ b/database/src/key.rs
@@ -1,16 +1,10 @@
-use std::{
-    fmt::{Debug, Display},
-    str,
-};
-
+use crate::registry::{DatabaseStorePrefixes, SEPARATOR};
 use smallvec::SmallVec;
-
-pub const SEP: u8 = b'/';
-pub const SEP_SIZE: usize = 1;
+use std::fmt::{Debug, Display};
 
 #[derive(Clone)]
 pub struct DbKey {
-    path: SmallVec<[u8; 36]>,
+    path: SmallVec<[u8; 36]>, // Optimized for the common case of { prefix byte || HASH (32 bytes) }
     prefix_len: usize,
 }
 
@@ -19,10 +13,7 @@ impl DbKey {
     where
         TKey: Clone + AsRef<[u8]>,
     {
-        Self {
-            path: prefix.iter().chain(std::iter::once(&SEP)).chain(key.as_ref().iter()).copied().collect(),
-            prefix_len: prefix.len() + SEP_SIZE, // Include `SEP` as part of the prefix
-        }
+        Self { path: prefix.iter().chain(key.as_ref().iter()).copied().collect(), prefix_len: prefix.len() }
     }
 
     pub fn prefix_only(prefix: &[u8]) -> Self {
@@ -51,17 +42,39 @@ impl AsRef<[u8]> for DbKey {
 
 impl Display for DbKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (prefix, key) = self.path.split_at(self.prefix_len);
-        // We expect the prefix to be human readable
-        if let Ok(s) = str::from_utf8(prefix) {
-            f.write_str(s)?;
-        } else {
-            // Otherwise we fallback to hex parsing
-            f.write_str(&faster_hex::hex_string(&prefix[..prefix.len() - SEP_SIZE]))?; // Drop `SEP`
-            f.write_str("/")?;
+        use DatabaseStorePrefixes::*;
+        let mut pos = 0;
+
+        if self.prefix_len > 0 {
+            if let Ok(prefix) = DatabaseStorePrefixes::try_from(self.path[0]) {
+                prefix.fmt(f)?;
+                f.write_str("/")?;
+                pos += 1;
+                if self.prefix_len > 1 {
+                    match prefix {
+                        Ghostdag | GhostdagCompact | RelationsParents | RelationsChildren | Reachability => {
+                            if self.path[1] != SEPARATOR {
+                                // Expected to be a block level so we display as a number
+                                Display::fmt(&self.path[1], f)?;
+                                f.write_str("/")?;
+                            }
+                            pos += 1;
+                        }
+                        ReachabilityRelations => {
+                            if let Ok(next_prefix) = DatabaseStorePrefixes::try_from(self.path[1]) {
+                                next_prefix.fmt(f)?;
+                                f.write_str("/")?;
+                                pos += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
-        // We expect that key is usually more readable as hex
-        f.write_str(&faster_hex::hex_string(key))
+
+        // We expect that the key part is usually more readable as hex
+        f.write_str(&faster_hex::hex_string(&self.path[pos..]))
     }
 }
 
@@ -75,19 +88,28 @@ impl Debug for DbKey {
 mod tests {
     use super::*;
     use kaspa_hashes::{Hash, HASH_SIZE};
+    use DatabaseStorePrefixes::*;
 
     #[test]
     fn test_key_display() {
-        let key1 = DbKey::new(b"human-readable", Hash::from_u64_word(34567890));
-        let key2 = DbKey::new(&[0xC0, 0xC1, 0xF5, 0xF6], Hash::from_u64_word(345690)); // `0xC0, 0xC1, 0xF5, 0xF6` are invalid UTF-8 chars
-        let key3 = DbKey::new(b"human/readable", Hash::from_bytes([SEP; HASH_SIZE])); // Add many binary `/` to assert prefix is recognized
-        let key4 = DbKey::prefix_only(&[0xC0, 0xC1, 0xF5, 0xF6]);
-        let key5 = DbKey::prefix_only(b"direct-prefix");
+        let level = 37;
+        let key1 = DbKey::new(&[ReachabilityRelations.into(), RelationsParents.into()], Hash::from_u64_word(34567890));
+        let key2 = DbKey::new(&[Reachability.into(), Separator.into()], Hash::from_u64_word(345690));
+        let key3 = DbKey::new(&[Reachability.into(), level], Hash::from_u64_word(345690));
+        let key4 = DbKey::new(&[RelationsParents.into(), level], Hash::from_u64_word(345690));
 
-        assert!(key1.to_string().starts_with("human-readable/"));
-        assert!(key2.to_string().starts_with("c0c1f5f6/")); // Expecting hex since invalid UTF-8 was used
-        assert!(key3.to_string().starts_with("human/readable/"));
-        assert_eq!(key4.to_string(), "c0c1f5f6/");
-        assert_eq!(key5.to_string(), "direct-prefix/");
+        assert!(key1.to_string().starts_with(&format!("{:?}/{:?}/00", ReachabilityRelations, RelationsParents)));
+        assert!(key2.to_string().starts_with(&format!("{:?}/00", Reachability)));
+        assert!(key3.to_string().starts_with(&format!("{:?}/{}/00", Reachability, level)));
+        assert!(key4.to_string().starts_with(&format!("{:?}/{}/00", RelationsParents, level)));
+
+        let key5 = DbKey::new(b"human/readable", Hash::from_bytes([SEPARATOR; HASH_SIZE]));
+        let key6 = DbKey::prefix_only(&[0xC0, 0xC1, 0xF5, 0xF6]);
+        let key7 = DbKey::prefix_only(b"direct-prefix");
+
+        // Make sure display can handle arbitrary strings
+        let _ = key5.to_string();
+        let _ = key6.to_string();
+        let _ = key7.to_string();
     }
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -6,6 +6,7 @@ mod item;
 mod key;
 mod writer;
 
+pub mod registry;
 pub mod utils;
 
 pub mod prelude {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -15,7 +15,7 @@ pub mod prelude {
     pub use super::access::CachedDbAccess;
     pub use super::cache::Cache;
     pub use super::item::CachedDbItem;
-    pub use super::key::{DbKey, SEP, SEP_SIZE};
+    pub use super::key::DbKey;
     pub use super::writer::{BatchDbWriter, DbWriter, DirectDbWriter, MemoryWriter};
     pub use db::{delete_db, open_db, DB};
     pub use errors::{StoreError, StoreResult, StoreResultEmptyTuple, StoreResultExtensions};

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -37,6 +37,10 @@ pub enum DatabaseStorePrefixes {
     VirtualUtxoset = 27,
     VirtualState = 28,
 
+    // ---- Metadata ----
+    MultiConsensusMetadata = 124,
+    ConsensusEntries = 125,
+
     // ---- Components ----
     Addresses = 128,
     BannedAddresses = 129,
@@ -66,7 +70,7 @@ impl From<DatabaseStorePrefixes> for u8 {
 impl AsRef<[u8]> for DatabaseStorePrefixes {
     fn as_ref(&self) -> &[u8] {
         // SAFETY: enum has repr(u8)
-        std::slice::from_ref(unsafe { std::mem::transmute(self) })
+        std::slice::from_ref(unsafe { &*(self as *const Self as *const u8) })
     }
 }
 

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -1,0 +1,80 @@
+use std::{mem::transmute, slice::from_ref};
+
+#[repr(u8)]
+pub enum DatabaseStorePrefixes {
+    // ---- Consensus ----
+    AcceptanceData = 1,
+    BlockTransactions = 2,
+    NonDaaMergeset = 3,
+    BlockDepth = 4,
+    Ghostdag = 5,
+    GhostdagCompact = 6,
+    HeadersSelectedTip = 7,
+    Headers = 8,
+    HeadersCompact = 9,
+    PastPruningPoints = 10,
+    PruningUtxoset = 11,
+    PruningUtxosetPosition = 12,
+    PruningPoint = 13,
+    HistoryRoot = 14,
+    Reachability = 15,
+    ReachabilityReindexRoot = 16,
+    ReachabilityRelations = 17,
+    RelationsParents = 18,
+    RelationsChildren = 19,
+    ChainHashByIndex = 20,
+    ChainIndexByHash = 21,
+    ChainHighestIndex = 22,
+    Statuses = 23,
+    Tips = 24,
+    UtxoDiffs = 25,
+    UtxoMultisets = 26,
+    VirtualUtxoset = 27,
+    VirtualState = 28,
+
+    // ---- Components ----
+    Addresses = 128,
+    BannedAddresses = 129,
+
+    // ---- Indexes ----
+    UtxoIndex = 192,
+    UtxoIndexTips = 193,
+    CirculatingSupply = 194,
+}
+
+impl From<DatabaseStorePrefixes> for Vec<u8> {
+    fn from(value: DatabaseStorePrefixes) -> Self {
+        [value as u8].to_vec()
+    }
+}
+
+impl From<DatabaseStorePrefixes> for u8 {
+    fn from(value: DatabaseStorePrefixes) -> Self {
+        value as u8
+    }
+}
+
+impl AsRef<[u8]> for DatabaseStorePrefixes {
+    fn as_ref(&self) -> &[u8] {
+        from_ref(unsafe { transmute(self) })
+    }
+}
+
+impl IntoIterator for DatabaseStorePrefixes {
+    type Item = u8;
+    type IntoIter = <[u8; 1] as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        [self as u8].into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_ref() {
+        let prefix = DatabaseStorePrefixes::AcceptanceData;
+        assert_eq!([1u8], prefix.as_ref());
+    }
+}

--- a/indexes/utxoindex/src/index.rs
+++ b/indexes/utxoindex/src/index.rs
@@ -53,7 +53,7 @@ impl UtxoIndexApi for UtxoIndex {
     fn get_utxos_by_script_public_keys(&self, script_public_keys: ScriptPublicKeys) -> StoreResult<UtxoSetByScriptPublicKey> {
         trace!("[{0}] retrieving utxos from {1} script public keys", IDENT, script_public_keys.len());
 
-        self.store.get_utxos_by_script_public_key(&script_public_keys)
+        self.store.get_utxos_by_script_public_key(script_public_keys)
     }
 
     /// Retrieve the stored tips of the utxoindex.

--- a/indexes/utxoindex/src/stores/store_manager.rs
+++ b/indexes/utxoindex/src/stores/store_manager.rs
@@ -33,7 +33,7 @@ impl Store {
         }
     }
 
-    pub fn get_utxos_by_script_public_key(&self, script_public_keys: &ScriptPublicKeys) -> StoreResult<UtxoSetByScriptPublicKey> {
+    pub fn get_utxos_by_script_public_key(&self, script_public_keys: ScriptPublicKeys) -> StoreResult<UtxoSetByScriptPublicKey> {
         self.utxos_by_script_public_key_store.get_utxos_from_script_public_keys(script_public_keys)
     }
 

--- a/indexes/utxoindex/src/stores/supply.rs
+++ b/indexes/utxoindex/src/stores/supply.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use kaspa_database::prelude::{CachedDbItem, DirectDbWriter, StoreResult, DB};
+use kaspa_database::{
+    prelude::{CachedDbItem, DirectDbWriter, StoreResult, DB},
+    registry::DatabaseStorePrefixes,
+};
 
 use crate::model::CirculatingSupply;
 
@@ -11,13 +14,9 @@ pub trait CirculatingSupplyStoreReader {
 
 pub trait CirculatingSupplyStore: CirculatingSupplyStoreReader {
     fn update_circulating_supply(&mut self, to_add: CirculatingSupply) -> StoreResult<u64>;
-
     fn insert(&mut self, circulating_supply: u64) -> StoreResult<()>;
-
     fn remove(&mut self) -> StoreResult<()>;
 }
-
-pub const CIRCULATING_SUPPLY_STORE_PREFIX: &[u8] = b"circulating-supply";
 
 /// A DB + cache implementation of `UtxoIndexTipsStore` trait
 #[derive(Clone)]
@@ -28,7 +27,7 @@ pub struct DbCirculatingSupplyStore {
 
 impl DbCirculatingSupplyStore {
     pub fn new(db: Arc<DB>) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbItem::new(db, CIRCULATING_SUPPLY_STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbItem::new(db, DatabaseStorePrefixes::CirculatingSupply.into()) }
     }
 }
 

--- a/indexes/utxoindex/src/stores/tips.rs
+++ b/indexes/utxoindex/src/stores/tips.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use kaspa_database::prelude::{CachedDbItem, DirectDbWriter, StoreError, StoreResult, DB};
+use kaspa_database::{
+    prelude::{CachedDbItem, DirectDbWriter, StoreError, StoreResult, DB},
+    registry::DatabaseStorePrefixes,
+};
 
 use kaspa_consensus_core::BlockHashSet;
 
@@ -11,11 +14,8 @@ pub trait UtxoIndexTipsStoreReader {
 
 pub trait UtxoIndexTipsStore: UtxoIndexTipsStoreReader {
     fn set_tips(&mut self, new_tips: BlockHashSet) -> StoreResult<()>;
-
     fn remove(&mut self) -> Result<(), StoreError>;
 }
-
-pub const TIPS_STORE_PREFIX: &[u8] = b"tips";
 
 /// A DB + cache implementation of `UtxoIndexTipsStore` trait
 #[derive(Clone)]
@@ -26,7 +26,7 @@ pub struct DbUtxoIndexTipsStore {
 
 impl DbUtxoIndexTipsStore {
     pub fn new(db: Arc<DB>) -> Self {
-        Self { db: Arc::clone(&db), access: CachedDbItem::new(db.clone(), TIPS_STORE_PREFIX.to_vec()) }
+        Self { db: Arc::clone(&db), access: CachedDbItem::new(db.clone(), DatabaseStorePrefixes::UtxoIndexTips.into()) }
     }
 }
 

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -22,6 +22,7 @@ pub struct Defaults {
     pub simnet: bool,
     pub archival: bool,
     pub sanity: bool,
+    pub yes: bool,
 }
 
 impl Default for Defaults {
@@ -43,6 +44,7 @@ impl Default for Defaults {
             simnet: false,
             archival: false,
             sanity: false,
+            yes: false,
         }
     }
 }
@@ -74,6 +76,7 @@ pub struct Args {
     pub simnet: bool,
     pub archival: bool,
     pub sanity: bool,
+    pub yes: bool,
 }
 
 pub fn cli(defaults: &Defaults) -> Command {
@@ -181,6 +184,7 @@ pub fn cli(defaults: &Defaults) -> Command {
         .arg(arg!(--simnet "Use the simulation test network"))
         .arg(arg!(--archival "Run as an archival node: avoids deleting old block data when moving the pruning point (Warning: heavy disk usage)"))
         .arg(arg!(--sanity "Enable various sanity checks which might be compute-intensive (mostly performed during pruning)"))
+        .arg(arg!(--yes "Answer yes to all interactive console questions"))
         .arg(
             Arg::new("user_agent_comments")
                 .long("uacomment")
@@ -217,6 +221,7 @@ impl Args {
             simnet: m.get_one::<bool>("simnet").cloned().unwrap_or(defaults.simnet),
             archival: m.get_one::<bool>("archival").cloned().unwrap_or(defaults.archival),
             sanity: m.get_one::<bool>("sanity").cloned().unwrap_or(defaults.sanity),
+            yes: m.get_one::<bool>("yes").cloned().unwrap_or(defaults.yes),
             user_agent_comments: m.get_many::<String>("user_agent_comments").unwrap_or_default().cloned().collect(),
         }
     }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -180,7 +180,7 @@ impl IbdFlow {
         syncer_header_selected_tip: Hash,
         relay_block: &Block,
     ) -> Result<(), ProtocolError> {
-        info!("Starting IBD with headers proof");
+        info!("Starting IBD with headers proof with peer {}", self.router);
 
         let session = staging.session().await;
         let consensus = session.deref();

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -83,7 +83,7 @@ impl IbdFlow {
                 match self.ibd(relay_block).await {
                     Ok(_) => info!("IBD with peer {} completed successfully", self.router),
                     Err(e) => {
-                        info!("IBD with peer {} completed with error: {:?}", self.router, e);
+                        info!("IBD with peer {} completed with error: {}", self.router, e);
                         return Err(e);
                     }
                 }
@@ -215,6 +215,10 @@ impl IbdFlow {
 
         if pruning_points.is_empty() || pruning_points.last().unwrap().hash != proof_pruning_point {
             return Err(ProtocolError::Other("the proof pruning point is not equal to the last pruning point in the list"));
+        }
+
+        if pruning_points.first().unwrap().hash != self.ctx.config.genesis.hash {
+            return Err(ProtocolError::Other("the first pruning point in the list is expected to be genesis"));
         }
 
         // TODO: validate pruning points before importing

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -167,8 +167,9 @@ fn main() {
 }
 
 fn adjust_consensus_params(args: &Args, params: &mut Params) {
-    // We have no actual PoW in the simulation, so the true max is most reflective
-    params.max_block_level = BlockLevel::MAX;
+    // We have no actual PoW in the simulation, so the true max is most reflective,
+    // however we avoid the actual max since it is reserved for the DB prefix scheme
+    params.max_block_level = BlockLevel::MAX - 1;
     params.genesis.timestamp = 0;
     if args.bps * args.delay > 2.0 {
         let k = u64::max(calculate_ghostdag_k(2.0 * args.delay * args.bps, 0.05), params.ghostdag_k as u64);


### PR DESCRIPTION
Seems to have a nice positive impact on performance but does not reduce storage (expected).

Includes: 

- Display of DB key according to registry enum names
- Prompt the user about the new DB scheme 
- Add DB version info to metadata DB 