### PR TITLE
Graceful shutdown sequence

### DIFF
--- a/components/consensusmanager/src/lib.rs
+++ b/components/consensusmanager/src/lib.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use kaspa_consensus_core::api::{ConsensusApi, DynConsensus};
-use kaspa_core::{core::Core, service::Service, warn};
+use kaspa_core::{core::Core, debug, service::Service};
 use parking_lot::RwLock;
 use std::{collections::VecDeque, ops::Deref, sync::Arc, thread::JoinHandle};
 
@@ -141,7 +141,7 @@ impl ConsensusManager {
 
         // All consensus instances have been shutdown and we are exiting, so close the factory. Internally this closes
         // the notification root sender channel, leading to a graceful shutdown of the notification sub-system.
-        warn!("[Consensus manager] all consensus threads exited");
+        debug!("[Consensus manager] all consensus threads exited");
         self.factory.close();
     }
 }

--- a/consensus/notify/src/service.rs
+++ b/consensus/notify/src/service.rs
@@ -54,7 +54,7 @@ impl AsyncService for NotifyService {
 
             // Keep the notifier running until a service shutdown signal is received
             shutdown_signal.await;
-            match self.notifier.stop().await {
+            match self.notifier.join().await {
                 Ok(_) => Ok(()),
                 Err(err) => {
                     trace!("Error while stopping {}: {}", NOTIFY_SERVICE, err);

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -176,6 +176,8 @@ impl Factory {
 
 impl ConsensusFactory for Factory {
     fn new_active_consensus(&self) -> (ConsensusInstance, DynConsensusCtl) {
+        assert!(!self.notification_root.is_closed());
+
         let mut config = self.config.clone();
         let mut is_new_consensus = false;
         let entry = match self.management_store.write().active_consensus_entry().unwrap() {
@@ -212,6 +214,8 @@ impl ConsensusFactory for Factory {
     }
 
     fn new_staging_consensus(&self) -> (ConsensusInstance, DynConsensusCtl) {
+        assert!(!self.notification_root.is_closed());
+
         let entry = self.management_store.write().new_staging_consensus_entry().unwrap();
         let dir = self.db_root_dir.join(entry.directory_name);
         let db = kaspa_database::prelude::open_db(dir, true, self.db_parallelism);
@@ -226,5 +230,9 @@ impl ConsensusFactory for Factory {
         ));
 
         (ConsensusInstance::new(session_lock, consensus.clone()), Arc::new(Ctl::new(self.management_store.clone(), db, consensus)))
+    }
+
+    fn close(&self) {
+        self.notification_root.close();
     }
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -297,6 +297,10 @@ impl Consensus {
         self.statuses_store.read().get(hash).unwrap()
     }
 
+    pub fn session_lock(&self) -> SessionLock {
+        self.pruning_lock.clone()
+    }
+
     pub fn notification_root(&self) -> Arc<ConsensusNotificationRoot> {
         self.notification_root.clone()
     }

--- a/consensus/src/pipeline/body_processor/processor.rs
+++ b/consensus/src/pipeline/body_processor/processor.rs
@@ -205,8 +205,9 @@ impl BlockBodyProcessor {
         self.commit_body(block.hash(), block.header.direct_parents(), block.transactions.clone());
 
         // Send a BlockAdded notification
-        // TODO: handle notify errors
-        let _ = self.notification_root.notify(Notification::BlockAdded(BlockAddedNotification::new(block.to_owned())));
+        self.notification_root
+            .notify(Notification::BlockAdded(BlockAddedNotification::new(block.to_owned())))
+            .expect("expecting an open unbounded channel");
 
         // Report counters
         self.counters.body_counts.fetch_add(1, Ordering::Relaxed);

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -272,24 +272,26 @@ impl VirtualStateProcessor {
         // Emit notifications
         let accumulated_diff = Arc::new(accumulated_diff);
         let virtual_parents = Arc::new(new_virtual_state.parents.clone());
-        let _ = self
-            .notification_root
-            .notify(Notification::UtxosChanged(UtxosChangedNotification::new(accumulated_diff, virtual_parents)));
-        let _ = self
-            .notification_root
-            .notify(Notification::SinkBlueScoreChanged(SinkBlueScoreChangedNotification::new(sink_ghostdag_data.blue_score)));
-        let _ = self
-            .notification_root
-            .notify(Notification::VirtualDaaScoreChanged(VirtualDaaScoreChangedNotification::new(new_virtual_state.daa_score)));
+        self.notification_root
+            .notify(Notification::UtxosChanged(UtxosChangedNotification::new(accumulated_diff, virtual_parents)))
+            .expect("expecting an open unbounded channel");
+        self.notification_root
+            .notify(Notification::SinkBlueScoreChanged(SinkBlueScoreChangedNotification::new(sink_ghostdag_data.blue_score)))
+            .expect("expecting an open unbounded channel");
+        self.notification_root
+            .notify(Notification::VirtualDaaScoreChanged(VirtualDaaScoreChangedNotification::new(new_virtual_state.daa_score)))
+            .expect("expecting an open unbounded channel");
         let chain_path = self.dag_traversal_manager.calculate_chain_path(prev_sink, new_sink);
         // TODO: Fetch acceptance data only if there's a subscriber for the below notification.
         let added_chain_blocks_acceptance_data =
             chain_path.added.iter().copied().map(|added| self.acceptance_data_store.get(added).unwrap()).collect_vec();
-        let _ = self.notification_root.notify(Notification::VirtualChainChanged(VirtualChainChangedNotification::new(
-            chain_path.added.into(),
-            chain_path.removed.into(),
-            Arc::new(added_chain_blocks_acceptance_data),
-        )));
+        self.notification_root
+            .notify(Notification::VirtualChainChanged(VirtualChainChangedNotification::new(
+                chain_path.added.into(),
+                chain_path.removed.into(),
+                Arc::new(added_chain_blocks_acceptance_data),
+            )))
+            .expect("expecting an open unbounded channel");
     }
 
     fn virtual_finality_point(&self, virtual_ghostdag_data: &GhostdagData, pruning_point: Hash) -> Hash {

--- a/indexes/processor/src/processor.rs
+++ b/indexes/processor/src/processor.rs
@@ -78,7 +78,7 @@ impl Processor {
                                 }
                             },
                             Err(_) => {
-                                warn!("[Indexes Processor] notification stream ended");
+                                warn!("[{}] notification stream ended", std::any::type_name::<Self>());
                                 notifier.close();
                                 break;
                             }

--- a/indexes/processor/src/processor.rs
+++ b/indexes/processor/src/processor.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use kaspa_consensus_notify::{notification as consensus_notification, notification::Notification as ConsensusNotification};
-use kaspa_core::{trace, warn};
+use kaspa_core::{debug, trace};
 use kaspa_index_core::notification::{Notification, PruningPointUtxoSetOverrideNotification, UtxosChangedNotification};
 use kaspa_notify::{
     collector::{Collector, CollectorNotificationReceiver},
@@ -68,7 +68,7 @@ impl Processor {
                 }
             }
 
-            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
+            debug!("[{}] notification stream ended", std::any::type_name::<Self>());
             // Propagate channel closing
             notifier.close();
             self.collect_shutdown.trigger.trigger();

--- a/indexes/processor/src/service.rs
+++ b/indexes/processor/src/service.rs
@@ -73,7 +73,7 @@ impl AsyncService for IndexService {
 
             // Keep the notifier running until a service shutdown signal is received
             shutdown_signal.await;
-            match self.notifier.stop().await {
+            match self.notifier.join().await {
                 Ok(_) => Ok(()),
                 Err(err) => {
                     trace!("Error while stopping {}: {}", INDEX_SERVICE, err);

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -7,7 +7,7 @@ use async_channel::{Receiver, Sender};
 use core::fmt::Debug;
 use derive_more::Deref;
 use futures::{future::FutureExt, select};
-use kaspa_core::{trace, warn};
+use kaspa_core::{debug, trace};
 use std::{
     collections::HashMap,
     sync::{
@@ -188,7 +188,7 @@ where
                             purge.drain(..).for_each(|id| { plan[event].remove(&id); });
 
                         } else {
-                            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
+                            debug!("[{}] notification stream ended", std::any::type_name::<Self>());
                             let _ = self.shutdown.drain();
                             let _ = self.shutdown.try_send(());
                             break;

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -196,16 +196,6 @@ where
 
                         } else {
                             warn!("[Broadcaster] notification stream ended");
-                            // TODO: not sure about this
-                            plan.iter().for_each(|p| {
-                                p.0.values().for_each(|s| {
-                                    s.values().for_each(|m| {
-                                        m.values().for_each(|c| {
-                                            c.close();
-                                        })
-                                    })
-                                })
-                            });
                             let _ = self.shutdown.drain();
                             let _ = self.shutdown.try_send(());
                             break;

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -195,7 +195,7 @@ where
                             purge.drain(..).for_each(|id| { plan[event].remove(&id); });
 
                         } else {
-                            warn!("[Broadcaster] notification stream ended");
+                            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
                             let _ = self.shutdown.drain();
                             let _ = self.shutdown.try_send(());
                             break;

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -1,19 +1,12 @@
 extern crate derive_more;
 use super::{
-    connection::Connection,
-    error::{Error, Result},
-    events::EventArray,
-    listener::ListenerId,
-    notification::Notification,
+    connection::Connection, error::Result, events::EventArray, listener::ListenerId, notification::Notification,
     subscription::DynSubscription,
 };
 use async_channel::{Receiver, Sender};
 use core::fmt::Debug;
 use derive_more::Deref;
-use futures::{
-    future::FutureExt, // for `.fuse()`
-    select,
-};
+use futures::{future::FutureExt, select};
 use kaspa_core::{trace, warn};
 use std::{
     collections::HashMap,
@@ -222,16 +215,13 @@ where
         Ok(())
     }
 
-    async fn stop_notification_broadcasting_task(&self) -> Result<()> {
-        if self.started.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst).is_err() {
-            return Err(Error::AlreadyStoppedError);
-        }
+    async fn join_notification_broadcasting_task(&self) -> Result<()> {
         self.shutdown.recv().await?;
         Ok(())
     }
 
-    pub async fn stop(&self) -> Result<()> {
-        self.stop_notification_broadcasting_task().await
+    pub async fn join(&self) -> Result<()> {
+        self.join_notification_broadcasting_task().await
     }
 }
 
@@ -348,7 +338,7 @@ mod tests {
                 }
             }
             self.notification_sender.close();
-            assert!(self.broadcaster.stop().await.is_ok(), "broadcaster failed to stop");
+            assert!(self.broadcaster.join().await.is_ok(), "broadcaster failed to stop");
         }
     }
 

--- a/notify/src/collector.rs
+++ b/notify/src/collector.rs
@@ -100,7 +100,7 @@ where
                                 }
                             },
                             None => {
-                                warn!("[Collector] notification stream ended");
+                                warn!("[{}] notification stream ended", std::any::type_name::<Self>());
                                 notifier.close();
                                 break;
                             }

--- a/notify/src/collector.rs
+++ b/notify/src/collector.rs
@@ -1,13 +1,8 @@
-use super::{
-    error::{Error, Result},
-    notification::Notification,
-};
+use super::{error::Result, notification::Notification};
 use crate::{converter::Converter, notifier::DynNotify};
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
 use core::fmt::Debug;
-use futures::{future::FutureExt, pin_mut, select};
-use futures_util::stream::StreamExt;
 use kaspa_core::{trace, warn};
 use kaspa_utils::{channel::Channel, triggers::SingleTrigger};
 use std::sync::{
@@ -32,8 +27,9 @@ where
 {
     /// Start collecting notifications for `notifier`
     fn start(self: Arc<Self>, notifier: DynNotify<N>);
-    /// Stop collecting notifications
-    async fn stop(self: Arc<Self>) -> Result<()>;
+    /// Join notification collecting tasks. Assumes that the notification system is already
+    /// folding up by propagating channel closing from the notification root
+    async fn join(self: Arc<Self>) -> Result<()>;
 }
 
 pub type DynCollector<N> = Arc<dyn Collector<N>>;
@@ -52,6 +48,7 @@ where
     /// Has this collector been started?
     is_started: Arc<AtomicBool>,
 
+    /// Triggers when the collecting task exits
     collect_shutdown: Arc<SingleTrigger>,
 }
 
@@ -84,39 +81,24 @@ where
         workflow_core::task::spawn(async move {
             trace!("[Collector] collecting_task start");
 
-            let notifications = recv_channel.fuse();
-            pin_mut!(notifications);
-
-            loop {
-                select! {
-                    notification = notifications.next().fuse() => {
-                        match notification {
-                            Some(notification) => {
-                                match notifier.notify(converter.convert(notification).await) {
-                                    Ok(_) => (),
-                                    Err(err) => {
-                                        trace!("[Collector] notification sender error: {:?}", err);
-                                    },
-                                }
-                            },
-                            None => {
-                                warn!("[{}] notification stream ended", std::any::type_name::<Self>());
-                                notifier.close();
-                                break;
-                            }
-                        }
+            while let Ok(notification) = recv_channel.recv().await {
+                match notifier.notify(converter.convert(notification).await) {
+                    Ok(_) => (),
+                    Err(err) => {
+                        trace!("[{}] notification sender error: {}", std::any::type_name::<Self>(), err);
                     }
                 }
             }
+
+            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
+            // Propagate channel closing
+            notifier.close();
             collect_shutdown.trigger.trigger();
             trace!("[Collector] collecting_task end");
         });
     }
 
-    async fn stop_collecting_task(self: &Arc<Self>) -> Result<()> {
-        if self.is_started.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst).is_err() {
-            return Err(Error::AlreadyStoppedError);
-        }
+    async fn join_collecting_task(self: &Arc<Self>) -> Result<()> {
         self.collect_shutdown.listener.clone().await;
         Ok(())
     }
@@ -132,8 +114,8 @@ where
         self.spawn_collecting_task(notifier);
     }
 
-    async fn stop(self: Arc<Self>) -> Result<()> {
-        self.stop_collecting_task().await
+    async fn join(self: Arc<Self>) -> Result<()> {
+        self.join_collecting_task().await
     }
 }
 
@@ -206,6 +188,6 @@ mod tests {
         assert_eq!(outgoing.recv().await.unwrap(), OutgoingNotification::A);
 
         incoming.close();
-        assert!(collector.stop().await.is_ok());
+        assert!(collector.join().await.is_ok());
     }
 }

--- a/notify/src/collector.rs
+++ b/notify/src/collector.rs
@@ -3,7 +3,7 @@ use crate::{converter::Converter, notifier::DynNotify};
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
 use core::fmt::Debug;
-use kaspa_core::{trace, warn};
+use kaspa_core::{debug, trace};
 use kaspa_utils::{channel::Channel, triggers::SingleTrigger};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -90,7 +90,7 @@ where
                 }
             }
 
-            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
+            debug!("[{}] notification stream ended", std::any::type_name::<Self>());
             // Propagate channel closing
             notifier.close();
             collect_shutdown.trigger.trigger();

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -41,6 +41,14 @@ where
     pub fn send(&self, notification: N) -> Result<()> {
         self.inner.send(notification)
     }
+
+    pub fn close(&self) -> bool {
+        self.inner.sender.close()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.inner.sender.is_closed()
+    }
 }
 
 impl<N> Notify<N> for Root<N>
@@ -49,6 +57,10 @@ where
 {
     fn notify(&self, notification: N) -> Result<()> {
         self.inner.notify(notification)
+    }
+
+    fn close(&self) {
+        self.close();
     }
 }
 

--- a/notify/src/subscriber.rs
+++ b/notify/src/subscriber.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use core::fmt::Debug;
-use kaspa_core::{trace, warn};
+use kaspa_core::{debug, trace};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -88,7 +88,7 @@ impl Subscriber {
                 }
             }
 
-            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
+            debug!("[{}] notification stream ended", std::any::type_name::<Self>());
             let _ = self.shutdown.drain();
             let _ = self.shutdown.try_send(());
         });

--- a/notify/src/subscriber.rs
+++ b/notify/src/subscriber.rs
@@ -86,7 +86,7 @@ impl Subscriber {
                                 }
                             }
                         } else {
-                            warn!("[Subscriber] notification stream ended");
+                            warn!("[{}] notification stream ended", std::any::type_name::<Self>());
                             let _ = self.shutdown.drain();
                             let _ = self.shutdown.try_send(());
                             break;

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -259,16 +259,16 @@ impl FlowContext {
     pub async fn on_new_block_template(&self) -> Result<(), ProtocolError> {
         // Clear current template cache
         self.mining_manager().clear_block_template();
-        // TODO: better handle notification errors
-        self.notification_root
-            .notify(Notification::NewBlockTemplate(NewBlockTemplateNotification {}))
-            .map_err(|_| ProtocolError::Other("Notification error"))?;
+        // Notifications from the flow context might be ignored if the inner channel is already closing
+        // due to global shutdown, hence we ignore the possible error
+        let _ = self.notification_root.notify(Notification::NewBlockTemplate(NewBlockTemplateNotification {}));
         Ok(())
     }
 
     /// Notifies that the UTXO set was reset due to pruning point change via IBD.
     pub fn on_pruning_point_utxoset_override(&self) {
-        // TODO: handle notify return error
+        // Notifications from the flow context might be ignored if the inner channel is already closing
+        // due to global shutdown, hence we ignore the possible error
         let _ = self.notification_root.notify(Notification::PruningPointUtxoSetOverride(PruningPointUtxoSetOverrideNotification {}));
     }
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -142,6 +142,10 @@ impl FlowContext {
         self.connection_manager.write().replace(connection_manager);
     }
 
+    pub fn drop_connection_manager(&self) {
+        self.connection_manager.write().take();
+    }
+
     pub fn connection_manager(&self) -> Option<Arc<ConnectionManager>> {
         self.connection_manager.read().clone()
     }

--- a/protocol/flows/src/service.rs
+++ b/protocol/flows/src/service.rs
@@ -81,6 +81,9 @@ impl AsyncService for P2pService {
 
             // Keep the P2P server running until a service shutdown signal is received
             shutdown_signal.await;
+            // Important for cleanup of the P2P adaptor since we have a reference cycle:
+            // flow ctx -> conn manager -> p2p adaptor -> flow ctx (as ConnectionInitializer)
+            self.flow_context.drop_connection_manager();
             p2p_adaptor.terminate_all_peers().await;
             connection_manager.stop().await;
             Ok(())

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -161,6 +161,7 @@ impl HandleRelayInvsFlow {
             }
 
             info!("Accepted block {} via relay", inv.hash);
+            self.ctx.on_new_block_template().await?;
             self.ctx.on_new_block(session.deref(), block).await?;
 
             // Broadcast all *new* virtual parents. As a policy, we avoid directly relaying the new block since
@@ -171,8 +172,6 @@ impl HandleRelayInvsFlow {
                     .broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(new_virtual_parent.into()) }))
                     .await;
             }
-
-            self.ctx.on_new_block_template().await?;
         }
     }
 

--- a/protocol/p2p/src/core/connection_handler.rs
+++ b/protocol/p2p/src/core/connection_handler.rs
@@ -71,7 +71,7 @@ impl ConnectionHandler {
                 .await;
 
             match serve_result {
-                Ok(_) => debug!("P2P, Server stopped: {}", serve_address),
+                Ok(_) => info!("P2P Server stopped: {}", serve_address),
                 Err(err) => panic!("P2P, Server {serve_address} stopped with error: {err:?}"),
             }
         });

--- a/protocol/p2p/src/handshake.rs
+++ b/protocol/p2p/src/handshake.rs
@@ -27,7 +27,7 @@ impl<'a> KaspadHandshake<'a> {
     async fn receive_version_flow(router: &Router, version_receiver: &mut IncomingRoute) -> Result<VersionMessage, ProtocolError> {
         debug!("starting receive version flow");
 
-        let version_message = dequeue_with_timeout!(version_receiver, Payload::Version, Duration::from_secs(2))?;
+        let version_message = dequeue_with_timeout!(version_receiver, Payload::Version, Duration::from_secs(4))?;
         debug!("accepted version message: {version_message:?}");
 
         let verack_message = make_message!(Payload::Verack, VerackMessage {});
@@ -47,7 +47,7 @@ impl<'a> KaspadHandshake<'a> {
         let version_message = make_message!(Payload::Version, version_message);
         router.enqueue(version_message).await?;
 
-        let verack_message = dequeue_with_timeout!(verack_receiver, Payload::Verack, Duration::from_secs(2))?;
+        let verack_message = dequeue_with_timeout!(verack_receiver, Payload::Verack, Duration::from_secs(4))?;
         debug!("accepted verack_message: {verack_message:?}");
 
         Ok(())

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -5,11 +5,7 @@ use self::{
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
 use connection_event::ConnectionEvent;
-use futures::{
-    future::FutureExt, // for `.fuse()`
-    pin_mut,
-    select,
-};
+use futures::{future::FutureExt, pin_mut, select};
 use kaspa_core::{debug, trace};
 use kaspa_grpc_core::{
     channel::NotificationChannel,
@@ -136,15 +132,15 @@ impl GrpcClient {
         }
     }
 
-    /// Stops RPC services.
-    pub async fn stop(&self) -> Result<()> {
+    /// Joins on RPC services.
+    pub async fn join(&self) -> Result<()> {
         match &self.notification_mode {
             NotificationMode::MultiListeners => {
-                self.notifier.as_ref().unwrap().stop().await?;
+                self.notifier.as_ref().unwrap().join().await?;
             }
             NotificationMode::Direct => {
                 if self.collector.as_ref().unwrap().is_started() {
-                    self.collector.as_ref().unwrap().clone().stop().await?;
+                    self.collector.as_ref().unwrap().clone().join().await?;
                 }
             }
         }

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -663,6 +663,9 @@ impl Inner {
             self.receiver_is_running.store(false, Ordering::SeqCst);
             self.send_connection_event(ConnectionEvent::Disconnected);
 
+            // Close the notification channel so that notifiers/collectors/subscribers can be joined on
+            self.notification_channel.close();
+
             if self.receiver_shutdown.request.listener.is_triggered() {
                 self.receiver_shutdown.response.trigger.trigger();
             }

--- a/rpc/grpc/server/src/connection_handler.rs
+++ b/rpc/grpc/server/src/connection_handler.rs
@@ -110,7 +110,7 @@ impl ConnectionHandler {
         self.core_notifier.unregister_listener(self.core_listener_id)?;
 
         // Stop the internal notifier
-        self.notifier().stop().await?;
+        self.notifier().join().await?;
 
         // Close all existing connections
         self.manager.terminate_all_connections();

--- a/rpc/grpc/server/src/connection_handler.rs
+++ b/rpc/grpc/server/src/connection_handler.rs
@@ -64,7 +64,7 @@ impl ConnectionHandler {
     pub(crate) fn serve(self: &Arc<Self>, serve_address: NetAddress) -> OneshotSender<()> {
         let (termination_sender, termination_receiver) = oneshot_channel::<()>();
         let connection_handler = self.clone();
-        info!("gRPC Server starting on: {}", serve_address);
+        info!("GRPC Server starting on: {}", serve_address);
         tokio::spawn(async move {
             let protowire_server = RpcServer::from_arc(connection_handler.clone())
                 .send_compressed(CompressionEncoding::Gzip)
@@ -78,7 +78,7 @@ impl ConnectionHandler {
                 .await;
 
             match serve_result {
-                Ok(_) => info!("gRPC Server stopped: {}", serve_address),
+                Ok(_) => info!("GRPC Server stopped: {}", serve_address),
                 Err(err) => panic!("gRPC Server {serve_address} stopped with error: {err:?}"),
             }
         });

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -142,7 +142,7 @@ impl RpcCoreService {
     }
 
     pub async fn stop(&self) -> RpcResult<()> {
-        self.notifier().stop().await?;
+        self.notifier().join().await?;
         Ok(())
     }
 

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -180,7 +180,7 @@ impl KaspaRpcClient {
         match &self.notification_mode {
             NotificationMode::MultiListeners => {
                 // log_info!("stop notifier...");
-                self.notifier.as_ref().unwrap().stop().await?;
+                self.notifier.as_ref().unwrap().join().await?;
             }
             NotificationMode::Direct => {
                 // log_info!("stop direct...");

--- a/rpc/wrpc/server/src/connection.rs
+++ b/rpc/wrpc/server/src/connection.rs
@@ -63,6 +63,8 @@ impl Notify<Notification> for ConnectionInner {
         self.send(Connection::into_message(&notification, &self.messenger.encoding().into()))
             .map_err(|err| NotifyError::General(err.to_string()))
     }
+
+    fn close(&self) {}
 }
 
 /// [`Connection`] represents a currently connected WebSocket RPC channel.

--- a/rpc/wrpc/server/src/server.rs
+++ b/rpc/wrpc/server/src/server.rs
@@ -126,8 +126,8 @@ impl Server {
                 });
             }
         } else {
-            let _ = connection.grpc_client().stop().await;
             let _ = connection.grpc_client().disconnect().await;
+            let _ = connection.grpc_client().join().await;
         }
 
         self.inner.sockets.lock().unwrap().remove(&connection.id());
@@ -160,7 +160,7 @@ impl Server {
             rpc_core.notification_channel.close();
 
             // Stop the internal notifier
-            rpc_core.wrpc_notifier.stop().await?;
+            rpc_core.wrpc_notifier.join().await?;
         } else {
             // FIXME: check if all existing connections are actually getting a call to self.disconnect(connection)
             //        else do it here

--- a/testing/integration/src/integration_tests.rs
+++ b/testing/integration/src/integration_tests.rs
@@ -6,7 +6,7 @@ use async_channel::unbounded;
 use kaspa_consensus::config::genesis::GENESIS;
 use kaspa_consensus::config::{Config, ConfigBuilder};
 use kaspa_consensus::consensus::factory::Factory as ConsensusFactory;
-use kaspa_consensus::consensus::test_consensus::TestConsensus;
+use kaspa_consensus::consensus::test_consensus::{TestConsensus, TestConsensusFactory};
 use kaspa_consensus::model::stores::block_transactions::{
     BlockTransactionsStore, BlockTransactionsStoreReader, DbBlockTransactionsStore,
 };
@@ -910,7 +910,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
     let external_block_store = DbBlockTransactionsStore::new(external_storage, config.perf.block_data_cache_size);
 
     let (_utxoindex_db_lifetime, utxoindex_db) = create_temp_db();
-    let consensus_manager = Arc::new(ConsensusManager::new(Arc::new(MockFactory::new(tc.clone()))));
+    let consensus_manager = Arc::new(ConsensusManager::new(Arc::new(TestConsensusFactory::new(tc.clone()))));
     let utxoindex = UtxoIndex::new(consensus_manager.clone(), utxoindex_db).unwrap();
     let index_service = Arc::new(IndexService::new(&notify_service.notifier(), Some(utxoindex.clone())));
 
@@ -1033,31 +1033,6 @@ async fn json_test(file_path: &str, concurrency: bool) {
     assert_eq!(virtual_utxos.len(), utxoindex_utxos.len());
     assert!(virtual_utxos.is_subset(&utxoindex_utxos));
     assert!(utxoindex_utxos.is_subset(&virtual_utxos));
-}
-
-struct MockFactory {
-    tc: Arc<TestConsensus>,
-}
-
-impl MockFactory {
-    fn new(tc: Arc<TestConsensus>) -> Self {
-        Self { tc }
-    }
-}
-
-impl kaspa_consensusmanager::ConsensusFactory for MockFactory {
-    fn new_active_consensus(&self) -> (kaspa_consensusmanager::ConsensusInstance, kaspa_consensusmanager::DynConsensusCtl) {
-        let ci = kaspa_consensusmanager::ConsensusInstance::new(self.tc.session_lock(), self.tc.consensus_clone());
-        (ci, self.tc.consensus_clone() as kaspa_consensusmanager::DynConsensusCtl)
-    }
-
-    fn new_staging_consensus(&self) -> (kaspa_consensusmanager::ConsensusInstance, kaspa_consensusmanager::DynConsensusCtl) {
-        unimplemented!()
-    }
-
-    fn close(&self) {
-        self.tc.notification_root().close();
-    }
 }
 
 fn submit_header_chunk(


### PR DESCRIPTION
Implements a controlled shutdown sequence of the notification system, starting from the notification root (consensus) and up through the various index and rpc services. 

Fixes P2P cyclic reference clean up, 

Inspired and applies lessons learned from #197 by @D-Stacks. Adapts Connection Manager shutdown from @someone235's daemon branch.    

Closes #131 #132.