### PR TITLE
Add P2P reject message support 

### DIFF
--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -450,7 +450,6 @@ impl ConnectionInitializer for FlowContext {
         // Subnets are not currently supported
         let mut self_version_message = Version::new(None, self.node_id, network_name.clone(), None, PROTOCOL_VERSION);
         self_version_message.add_user_agent(name(), version(), &self.config.user_agent_comments);
-        // TODO: full and accurate version info
         // TODO: get number of live services
         // TODO: disable_relay_tx from config/cmd
 
@@ -465,6 +464,7 @@ impl ConnectionInitializer for FlowContext {
         if self.hub.has_peer(router.key()) {
             return Err(ProtocolError::PeerAlreadyExists(router.key()));
         }
+        // And loopback connections...
         if self.node_id == router.identity() {
             return Err(ProtocolError::LoopbackConnection(router.key()));
         }

--- a/protocol/flows/src/flow_trait.rs
+++ b/protocol/flows/src/flow_trait.rs
@@ -15,10 +15,9 @@ where
         tokio::spawn(async move {
             let res = self.start().await;
             if let Err(err) = res {
-                // TODO: imp complete error handler (what happens in go?)
                 if let Some(router) = self.router() {
+                    router.try_sending_reject_message(&err).await;
                     if router.close().await || !err.is_connection_closed_error() {
-                        // TODO: send and receive an explicit reject message for easier tracing of bugs causing disconnections
                         warn!("{} flow error: {}, disconnecting from peer {}.", self.name(), err, router);
                     }
                 }

--- a/protocol/flows/src/flow_trait.rs
+++ b/protocol/flows/src/flow_trait.rs
@@ -1,5 +1,6 @@
 use kaspa_core::warn;
 use kaspa_p2p_lib::{common::ProtocolError, Router};
+use kaspa_utils::any::type_name_short;
 use std::sync::Arc;
 
 #[async_trait::async_trait]
@@ -7,10 +8,14 @@ pub trait Flow
 where
     Self: 'static + Send + Sync,
 {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &'static str {
+        type_name_short::<Self>()
+    }
+
     fn router(&self) -> Option<Arc<Router>>;
 
     async fn start(&mut self) -> Result<(), ProtocolError>;
+
     fn launch(mut self: Box<Self>) {
         tokio::spawn(async move {
             let res = self.start().await;

--- a/protocol/flows/src/v5/address.rs
+++ b/protocol/flows/src/v5/address.rs
@@ -26,10 +26,6 @@ pub struct ReceiveAddressesFlow {
 
 #[async_trait::async_trait]
 impl Flow for ReceiveAddressesFlow {
-    fn name(&self) -> &'static str {
-        "Receive addresses"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }
@@ -74,10 +70,6 @@ pub struct SendAddressesFlow {
 
 #[async_trait::async_trait]
 impl Flow for SendAddressesFlow {
-    fn name(&self) -> &'static str {
-        "Send addresses"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -59,10 +59,6 @@ pub struct HandleRelayInvsFlow {
 
 #[async_trait::async_trait]
 impl Flow for HandleRelayInvsFlow {
-    fn name(&self) -> &'static str {
-        "HANDLE_RELAY_INVS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/blockrelay/handle_requests.rs
+++ b/protocol/flows/src/v5/blockrelay/handle_requests.rs
@@ -16,10 +16,6 @@ pub struct HandleRelayBlockRequests {
 
 #[async_trait::async_trait]
 impl Flow for HandleRelayBlockRequests {
-    fn name(&self) -> &'static str {
-        "HANDLE_RELAY_BLOCK_REQUESTS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -48,10 +48,6 @@ pub struct IbdFlow {
 
 #[async_trait::async_trait]
 impl Flow for IbdFlow {
-    fn name(&self) -> &'static str {
-        "IBD"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/mod.rs
+++ b/protocol/flows/src/v5/mod.rs
@@ -15,8 +15,7 @@ use self::{
 };
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 
-use kaspa_p2p_lib::{pb::kaspad_message::Payload as KaspadMessagePayload, KaspadMessagePayloadType, Router};
-use log::{debug, warn};
+use kaspa_p2p_lib::{KaspadMessagePayloadType, Router};
 use std::sync::Arc;
 
 mod address;
@@ -141,67 +140,12 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
         )),
     ];
 
-    // TEMP: subscribe to remaining messages and ignore them
-    // NOTE: as flows are implemented, the below types should be all commented out
-    let mut unimplemented_messages_route = router.subscribe(vec![
-        // KaspadMessagePayloadType::Addresses,
-        // KaspadMessagePayloadType::Block,
-        // KaspadMessagePayloadType::Transaction,
-        // KaspadMessagePayloadType::BlockLocator,
-        // KaspadMessagePayloadType::RequestAddresses,
-        // KaspadMessagePayloadType::RequestRelayBlocks,
-        // KaspadMessagePayloadType::RequestTransactions,
-        // KaspadMessagePayloadType::IbdBlock,
-        // KaspadMessagePayloadType::InvRelayBlock,
-        // KaspadMessagePayloadType::InvTransactions,
-        // KaspadMessagePayloadType::Ping,
-        // KaspadMessagePayloadType::Pong,
-        // KaspadMessagePayloadType::Verack,
-        // KaspadMessagePayloadType::Version,
-        // KaspadMessagePayloadType::Ready,
-        // KaspadMessagePayloadType::TransactionNotFound,
-        KaspadMessagePayloadType::Reject,
-        // KaspadMessagePayloadType::PruningPointUtxoSetChunk,
-        // KaspadMessagePayloadType::RequestIbdBlocks,
-        // KaspadMessagePayloadType::UnexpectedPruningPoint,
-        // KaspadMessagePayloadType::IbdBlockLocatorHighestHash,
-        // KaspadMessagePayloadType::RequestNextPruningPointUtxoSetChunk,
-        // KaspadMessagePayloadType::DonePruningPointUtxoSetChunks,
-        // KaspadMessagePayloadType::IbdBlockLocatorHighestHashNotFound,
+    // The reject message is handled as a special case by the router
+    // KaspadMessagePayloadType::Reject,
 
-        // We do not register the below two messages since they are deprecated also in go-kaspa
-        // KaspadMessagePayloadType::BlockWithTrustedData,
-        // KaspadMessagePayloadType::IbdBlockLocator,
-
-        // KaspadMessagePayloadType::DoneBlocksWithTrustedData,
-        // KaspadMessagePayloadType::RequestPruningPointAndItsAnticone,
-        // KaspadMessagePayloadType::BlockHeaders,
-        // KaspadMessagePayloadType::RequestNextHeaders,
-        // KaspadMessagePayloadType::DoneHeaders,
-        // KaspadMessagePayloadType::RequestPruningPointUtxoSet,
-        // KaspadMessagePayloadType::RequestHeaders,
-        // KaspadMessagePayloadType::RequestBlockLocator,
-        // KaspadMessagePayloadType::PruningPoints,
-        // KaspadMessagePayloadType::RequestPruningPointProof,
-        // KaspadMessagePayloadType::PruningPointProof,
-        // KaspadMessagePayloadType::BlockWithTrustedDataV4,
-        // KaspadMessagePayloadType::TrustedData,
-        // KaspadMessagePayloadType::RequestIbdChainBlockLocator,
-        // KaspadMessagePayloadType::IbdChainBlockLocator,
-        // KaspadMessagePayloadType::RequestAnticone,
-        // KaspadMessagePayloadType::RequestNextPruningPointAndItsAnticoneBlocks,
-    ]);
-
-    tokio::spawn(async move {
-        while let Some(msg) = unimplemented_messages_route.recv().await {
-            match msg.payload {
-                Some(KaspadMessagePayload::Reject(reject_msg)) => {
-                    warn!("Got a reject message {} from peer {}", reject_msg.reason, router);
-                }
-                _ => debug!("P2P unimplemented routes message: {:?}", msg),
-            }
-        }
-    });
+    // We do not register the below two messages since they are deprecated also in go-kaspa
+    // KaspadMessagePayloadType::BlockWithTrustedData,
+    // KaspadMessagePayloadType::IbdBlockLocator,
 
     flows
 }

--- a/protocol/flows/src/v5/ping.rs
+++ b/protocol/flows/src/v5/ping.rs
@@ -21,10 +21,6 @@ pub struct ReceivePingsFlow {
 
 #[async_trait::async_trait]
 impl Flow for ReceivePingsFlow {
-    fn name(&self) -> &'static str {
-        "Receive pings"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }
@@ -64,10 +60,6 @@ pub struct SendPingsFlow {
 
 #[async_trait::async_trait]
 impl Flow for SendPingsFlow {
-    fn name(&self) -> &'static str {
-        "Send pings"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         self.router.upgrade()
     }

--- a/protocol/flows/src/v5/request_anticone.rs
+++ b/protocol/flows/src/v5/request_anticone.rs
@@ -18,10 +18,6 @@ pub struct HandleAnticoneRequests {
 
 #[async_trait::async_trait]
 impl Flow for HandleAnticoneRequests {
-    fn name(&self) -> &'static str {
-        "HANDLE_ANTICONE_REQUESTS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_block_locator.rs
+++ b/protocol/flows/src/v5/request_block_locator.rs
@@ -17,10 +17,6 @@ pub struct RequestBlockLocatorFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestBlockLocatorFlow {
-    fn name(&self) -> &'static str {
-        "BLOCK_LOCATOR"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_headers.rs
+++ b/protocol/flows/src/v5/request_headers.rs
@@ -20,10 +20,6 @@ pub struct RequestHeadersFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestHeadersFlow {
-    fn name(&self) -> &'static str {
-        "REQUEST_HEADERS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_ibd_blocks.rs
+++ b/protocol/flows/src/v5/request_ibd_blocks.rs
@@ -11,10 +11,6 @@ pub struct HandleIbdBlockRequests {
 
 #[async_trait::async_trait]
 impl Flow for HandleIbdBlockRequests {
-    fn name(&self) -> &'static str {
-        "HANDLE_IBD_BLOCK_REQUESTS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_ibd_chain_block_locator.rs
+++ b/protocol/flows/src/v5/request_ibd_chain_block_locator.rs
@@ -18,10 +18,6 @@ pub struct RequestIbdChainBlockLocatorFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestIbdChainBlockLocatorFlow {
-    fn name(&self) -> &'static str {
-        "IBD_CHAIN_BLOCK_LOCATOR"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_pp_proof.rs
+++ b/protocol/flows/src/v5/request_pp_proof.rs
@@ -18,10 +18,6 @@ pub struct RequestPruningPointProofFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestPruningPointProofFlow {
-    fn name(&self) -> &'static str {
-        "REQUEST_PROOF"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_pruning_point_and_anticone.rs
+++ b/protocol/flows/src/v5/request_pruning_point_and_anticone.rs
@@ -23,10 +23,6 @@ pub struct PruningPointAndItsAnticoneRequestsFlow {
 
 #[async_trait::async_trait]
 impl Flow for PruningPointAndItsAnticoneRequestsFlow {
-    fn name(&self) -> &'static str {
-        "PP_ANTICONE"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/request_pruning_point_utxo_set.rs
+++ b/protocol/flows/src/v5/request_pruning_point_utxo_set.rs
@@ -21,10 +21,6 @@ pub struct RequestPruningPointUtxoSetFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestPruningPointUtxoSetFlow {
-    fn name(&self) -> &'static str {
-        "PP_UTXOS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/flows/src/v5/txrelay/flow.rs
+++ b/protocol/flows/src/v5/txrelay/flow.rs
@@ -48,10 +48,6 @@ pub struct RelayTransactionsFlow {
 
 #[async_trait::async_trait]
 impl Flow for RelayTransactionsFlow {
-    fn name(&self) -> &'static str {
-        "RELAY_TXS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }
@@ -217,10 +213,6 @@ pub struct RequestTransactionsFlow {
 
 #[async_trait::async_trait]
 impl Flow for RequestTransactionsFlow {
-    fn name(&self) -> &'static str {
-        "REQUEST_TXS"
-    }
-
     fn router(&self) -> Option<Arc<Router>> {
         Some(self.router.clone())
     }

--- a/protocol/p2p/src/core/connection_handler.rs
+++ b/protocol/p2p/src/core/connection_handler.rs
@@ -108,7 +108,8 @@ impl ConnectionHandler {
             }
 
             Err(err) => {
-                // Ignoring the router
+                router.try_sending_reject_message(&err).await;
+                // Ignoring the new router
                 router.close().await;
                 debug!("P2P, handshake failed for outbound peer {}: {}", router, err);
                 return Err(ConnectionError::ProtocolError(err));

--- a/utils/src/any.rs
+++ b/utils/src/any.rs
@@ -1,0 +1,30 @@
+/// Provides a best-effort short type name
+pub fn type_name_short<T: ?Sized>() -> &'static str {
+    let s = std::any::type_name::<T>();
+    const SEP: &str = "::";
+    if s.find('<').is_some() {
+        // T is generic so would require more sophisticated processing
+        return s;
+    }
+    match s.rfind(SEP) {
+        Some(i) => s.split_at(i + SEP.len()).1,
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    #[test]
+    fn test_type_name_short() {
+        assert_eq!("u64", type_name_short::<u64>());
+        assert_eq!("IpAddr", type_name_short::<IpAddr>());
+        assert_eq!(
+            std::any::type_name::<Option<String>>(),
+            type_name_short::<Option<String>>(),
+            "generic types are expected to remain long"
+        );
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod any;
 pub mod arc;
 pub mod binary_heap;
 pub mod channel;


### PR DESCRIPTION
Sends an explicit reject message on P2P protocol errors for notifying the peer about the disconnect reason and for easier tracing of logical bugs causing protocol errors.