### PR TITLE
Fixes a bug with deleting level relations during pruning 

### DIFF
--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -1,11 +1,11 @@
 use itertools::Itertools;
 use kaspa_consensus_core::BlockHashSet;
 use kaspa_consensus_core::{blockhash::BlockHashes, BlockHashMap, BlockHasher, BlockLevel, HashMapCustomHasher};
-use kaspa_database::prelude::MemoryWriter;
 use kaspa_database::prelude::StoreError;
 use kaspa_database::prelude::DB;
 use kaspa_database::prelude::{BatchDbWriter, DbWriter};
 use kaspa_database::prelude::{CachedDbAccess, DbKey, DirectDbWriter};
+use kaspa_database::prelude::{DirectWriter, MemoryWriter};
 use kaspa_database::registry::{DatabaseStorePrefixes, SEPARATOR};
 use kaspa_hashes::Hash;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
@@ -24,7 +24,7 @@ pub trait RelationsStoreReader {
 
 /// Low-level write API for `RelationsStore`
 pub trait RelationsStore: RelationsStoreReader {
-    type DefaultWriter: DbWriter;
+    type DefaultWriter: DbWriter + DirectWriter;
     fn default_writer(&self) -> Self::DefaultWriter;
 
     fn set_parents(&mut self, writer: impl DbWriter, hash: Hash, parents: BlockHashes) -> Result<(), StoreError>;

--- a/consensus/src/model/stores/relations.rs
+++ b/consensus/src/model/stores/relations.rs
@@ -23,7 +23,7 @@ pub trait RelationsStoreReader {
 
 /// Low-level write API for `RelationsStore`
 pub trait RelationsStore: RelationsStoreReader {
-    type DefaultWriter: DbWriter + DirectWriter;
+    type DefaultWriter: DirectWriter;
     fn default_writer(&self) -> Self::DefaultWriter;
 
     fn set_parents(&mut self, writer: impl DbWriter, hash: Hash, parents: BlockHashes) -> Result<(), StoreError>;

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -344,7 +344,8 @@ impl PruningProcessor {
             if !keep_blocks.contains(&current) {
                 let mut batch = WriteBatch::default();
                 let mut level_relations_write = self.relations_stores.write();
-                let mut staging_relations = StagingRelationsStore::new(self.reachability_relations_store.upgradable_read());
+                let mut reachability_relations_write = self.reachability_relations_store.write();
+                let mut staging_relations = StagingRelationsStore::new(&mut reachability_relations_write);
                 let mut staging_reachability = StagingReachabilityStore::new(reachability_read);
                 let mut statuses_write = self.statuses_store.write();
 
@@ -370,8 +371,10 @@ impl PruningProcessor {
                     // TODO: consider adding block level to compact header data
                     let block_level = self.headers_store.get_header_with_block_level(current).unwrap().block_level;
                     (0..=block_level as usize).for_each(|level| {
-                        relations::delete_level_relations(BatchDbWriter::new(&mut batch), &mut level_relations_write[level], current)
+                        let mut staging_level_relations = StagingRelationsStore::new(&mut level_relations_write[level]);
+                        relations::delete_level_relations(MemoryWriter::default(), &mut staging_level_relations, current)
                             .unwrap_option();
+                        staging_level_relations.commit(&mut batch).unwrap();
                         self.ghostdag_stores[level].delete_batch(&mut batch, current).unwrap_option();
                     });
 
@@ -388,7 +391,7 @@ impl PruningProcessor {
                 }
 
                 let reachability_write = staging_reachability.commit(&mut batch).unwrap();
-                let reachability_relations_write = staging_relations.commit(&mut batch).unwrap();
+                staging_relations.commit(&mut batch).unwrap();
 
                 // Flush the batch to the DB
                 self.db.write(batch).unwrap();

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -508,7 +508,7 @@ impl VirtualStateProcessor {
                     // All blocks with lower blue work than filtering_root are:
                     // 1. not in its future (bcs blue work is monotonic),
                     // 2. will be removed eventually by the bounded merge check.
-                    // So we prefer doing it in advance to allow better tips to be considered.
+                    // Hence as an optimization we prefer removing such blocks in advance to allow valid tips to be considered.
                     let filtering_root = self.depth_store.merge_depth_root(candidate).unwrap();
                     let filtering_blue_work = self.ghostdag_primary_store.get_blue_work(filtering_root).unwrap_or_default();
                     return (

--- a/consensus/src/processes/block_depth.rs
+++ b/consensus/src/processes/block_depth.rs
@@ -64,7 +64,8 @@ impl<S: DepthStoreReader, U: ReachabilityStoreReader, V: GhostdagStoreReader> Bl
         };
 
         // In this case we expect the pruning point or a block above it to be the block at depth.
-        // Note that above we already verified the chain and distance conditions for this
+        // Note that above we already verified the chain and distance conditions for this.
+        // Additionally observe that if `current` is a valid hash it must not be pruned for the same reason.
         if current == ORIGIN {
             current = pruning_point;
         }

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -325,8 +325,9 @@ impl PruningProofManager {
 
             // Prepare batch
             let mut batch = WriteBatch::default();
+            let mut reachability_relations_write = self.reachability_relations_store.write();
             let mut staging_reachability = StagingReachabilityStore::new(reachability_read);
-            let mut staging_reachability_relations = StagingRelationsStore::new(self.reachability_relations_store.upgradable_read());
+            let mut staging_reachability_relations = StagingRelationsStore::new(&mut reachability_relations_write);
 
             // Stage
             staging_reachability_relations.insert(hash, reachability_parents_hashes.clone()).unwrap();
@@ -340,7 +341,7 @@ impl PruningProofManager {
 
             // Commit
             let reachability_write = staging_reachability.commit(&mut batch).unwrap();
-            let reachability_relations_write = staging_reachability_relations.commit(&mut batch).unwrap();
+            staging_reachability_relations.commit(&mut batch).unwrap();
 
             // Write
             self.db.write(batch).unwrap();

--- a/consensus/src/processes/reachability/inquirer.rs
+++ b/consensus/src/processes/reachability/inquirer.rs
@@ -391,8 +391,9 @@ mod tests {
 
         // Add blocks via a staging store
         {
+            let mut relations_write = relations.write();
             let mut staging_reachability = StagingReachabilityStore::new(reachability.upgradable_read());
-            let mut staging_relations = StagingRelationsStore::new(relations.upgradable_read());
+            let mut staging_relations = StagingRelationsStore::new(&mut relations_write);
             let mut builder = DagBuilder::new(&mut staging_reachability, &mut staging_relations);
             builder.init();
             builder.add_block(DagBlock::new(test.genesis.into(), vec![ORIGIN]));
@@ -404,7 +405,7 @@ mod tests {
             {
                 let mut batch = WriteBatch::default();
                 let reachability_write = staging_reachability.commit(&mut batch).unwrap();
-                let relations_write = staging_relations.commit(&mut batch).unwrap();
+                staging_relations.commit(&mut batch).unwrap();
                 db.write(batch).unwrap();
                 drop(reachability_write);
                 drop(relations_write);
@@ -443,8 +444,9 @@ mod tests {
         drop(relations_read);
 
         let mut batch = WriteBatch::default();
+        let mut relations_write = relations.write();
         let mut staging_reachability = StagingReachabilityStore::new(reachability.upgradable_read());
-        let mut staging_relations = StagingRelationsStore::new(relations.upgradable_read());
+        let mut staging_relations = StagingRelationsStore::new(&mut relations_write);
 
         for (i, block) in
             test.ids().choose_multiple(&mut rand::thread_rng(), test.blocks.len()).into_iter().chain(once(test.genesis)).enumerate()
@@ -460,7 +462,7 @@ mod tests {
                 // Commit the staging changes
                 {
                     let reachability_write = staging_reachability.commit(&mut batch).unwrap();
-                    let relations_write = staging_relations.commit(&mut batch).unwrap();
+                    staging_relations.commit(&mut batch).unwrap();
                     db.write(batch).unwrap();
                     drop(reachability_write);
                     drop(relations_write);
@@ -483,8 +485,9 @@ mod tests {
 
                 // Recapture staging stores
                 batch = WriteBatch::default();
+                relations_write = relations.write();
                 staging_reachability = StagingReachabilityStore::new(reachability.upgradable_read());
-                staging_relations = StagingRelationsStore::new(relations.upgradable_read());
+                staging_relations = StagingRelationsStore::new(&mut relations_write);
             }
         }
     }

--- a/consensus/src/processes/reachability/tests/mod.rs
+++ b/consensus/src/processes/reachability/tests/mod.rs
@@ -18,7 +18,7 @@ use kaspa_consensus_core::{
     blockhash::{BlockHashExtensions, BlockHashes, ORIGIN},
     BlockHashMap, BlockHashSet,
 };
-use kaspa_database::prelude::{DbWriter, StoreError};
+use kaspa_database::prelude::{DbWriter, DirectWriter, StoreError};
 use kaspa_hashes::Hash;
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
@@ -120,7 +120,7 @@ impl<'a, T: ReachabilityStore + ?Sized, S: RelationsStore + ?Sized> DagBuilder<'
         self.delete_block_with_writer(self.relations.default_writer(), hash)
     }
 
-    pub fn delete_block_with_writer(&mut self, writer: impl DbWriter, hash: Hash) -> &mut Self {
+    pub fn delete_block_with_writer(&mut self, writer: impl DbWriter + DirectWriter, hash: Hash) -> &mut Self {
         let mergeset = delete_reachability_relations(writer, self.relations, self.reachability, hash);
         delete_block(self.reachability, hash, &mut mergeset.iter().cloned()).unwrap();
         self

--- a/consensus/src/processes/reachability/tests/mod.rs
+++ b/consensus/src/processes/reachability/tests/mod.rs
@@ -18,7 +18,7 @@ use kaspa_consensus_core::{
     blockhash::{BlockHashExtensions, BlockHashes, ORIGIN},
     BlockHashMap, BlockHashSet,
 };
-use kaspa_database::prelude::{DbWriter, DirectWriter, StoreError};
+use kaspa_database::prelude::{DirectWriter, StoreError};
 use kaspa_hashes::Hash;
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
@@ -120,7 +120,7 @@ impl<'a, T: ReachabilityStore + ?Sized, S: RelationsStore + ?Sized> DagBuilder<'
         self.delete_block_with_writer(self.relations.default_writer(), hash)
     }
 
-    pub fn delete_block_with_writer(&mut self, writer: impl DbWriter + DirectWriter, hash: Hash) -> &mut Self {
+    pub fn delete_block_with_writer(&mut self, writer: impl DirectWriter, hash: Hash) -> &mut Self {
         let mergeset = delete_reachability_relations(writer, self.relations, self.reachability, hash);
         delete_block(self.reachability, hash, &mut mergeset.iter().cloned()).unwrap();
         self

--- a/consensus/src/processes/relations.rs
+++ b/consensus/src/processes/relations.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
     blockhash::{BlockHashIteratorExtensions, BlockHashes, ORIGIN},
     BlockHashSet,
 };
-use kaspa_database::prelude::{BatchDbWriter, DbWriter, StoreError};
+use kaspa_database::prelude::{BatchDbWriter, DbWriter, DirectWriter, StoreError};
 use kaspa_hashes::Hash;
 use rocksdb::WriteBatch;
 
@@ -46,12 +46,10 @@ where
 /// (and writes will not accumulate if the entry gets out of the cache in between the calls)
 pub fn delete_reachability_relations<W, S, U>(mut writer: W, relations: &mut S, reachability: &U, hash: Hash) -> BlockHashSet
 where
-    W: DbWriter,
+    W: DbWriter + DirectWriter,
     S: RelationsStore + ?Sized,
     U: ReachabilityService + ?Sized,
 {
-    assert!(!W::IS_BATCH, "batch writes are not supported for this algo, see doc.");
-
     let selected_parent = reachability.get_chain_parent(hash);
     let parents = relations.get_parents(hash).unwrap();
     let children = relations.get_children(hash).unwrap();

--- a/consensus/src/processes/relations.rs
+++ b/consensus/src/processes/relations.rs
@@ -26,7 +26,7 @@ pub fn init<S: RelationsStore + ?Sized>(relations: &mut S) {
 /// (and writes will not accumulate if the entry gets out of the cache in between the calls)
 pub fn delete_level_relations<W, S>(mut writer: W, relations: &mut S, hash: Hash) -> Result<(), StoreError>
 where
-    W: DbWriter + DirectWriter,
+    W: DirectWriter,
     S: RelationsStore + ?Sized,
 {
     let children = relations.get_children(hash)?; // if the first entry was found, we expect all others as well, hence we unwrap below
@@ -49,7 +49,7 @@ where
 /// (and writes will not accumulate if the entry gets out of the cache in between the calls)
 pub fn delete_reachability_relations<W, S, U>(mut writer: W, relations: &mut S, reachability: &U, hash: Hash) -> BlockHashSet
 where
-    W: DbWriter + DirectWriter,
+    W: DirectWriter,
     S: RelationsStore + ?Sized,
     U: ReachabilityService + ?Sized,
 {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     pub use super::cache::Cache;
     pub use super::item::CachedDbItem;
     pub use super::key::DbKey;
-    pub use super::writer::{BatchDbWriter, DbWriter, DirectDbWriter, MemoryWriter};
+    pub use super::writer::{BatchDbWriter, DbWriter, DirectDbWriter, DirectWriter, MemoryWriter};
     pub use db::{delete_db, open_db, DB};
     pub use errors::{StoreError, StoreResult, StoreResultEmptyTuple, StoreResultExtensions};
 }


### PR DESCRIPTION
Fixes a pruning-processor bug which can be easily reproduced with zero-cache sizes but is extremally rare if cache sizes are normal (though nonetheless can happen with some probability).

The bug is fixed by using a staging relations store for the delete operation. Required slightly refactoring the current `StagingRelationsStore` in order to fit all use cases