### PR TITLE
Weight ip prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1494,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipgen"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2feff90e2d7307100ba887119bfa8bb9b7703670899b001805ccdd9f2ef187d3"
+dependencies = [
+ "blake2",
+ "ipnetwork",
+]
+
+[[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1579,7 @@ name = "kaspa-addressmanager"
 version = "0.1.2"
 dependencies = [
  "borsh",
+ "ipgen",
  "itertools 0.10.5",
  "kaspa-core",
  "kaspa-database",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "statest",
+ "statrs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alga"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +71,15 @@ name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arc-swap"
@@ -366,7 +386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding",
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -375,7 +395,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -813,7 +833,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "typenum",
 ]
 
@@ -917,7 +937,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1179,6 +1199,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1589,6 +1618,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "serde",
+ "statest",
 ]
 
 [[package]]
@@ -1658,7 +1688,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
- "rand_distr",
+ "rand_distr 0.4.3",
  "rayon",
  "rocksdb",
  "secp256k1",
@@ -2174,7 +2204,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rand 0.8.5",
- "rand_distr",
+ "rand_distr 0.4.3",
  "rayon",
  "rocksdb",
  "secp256k1",
@@ -2662,6 +2692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,6 +2755,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nalgebra"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abb021006c01b126a936a8dd1351e0720d83995f4fc942d0d426c654f990745"
+dependencies = [
+ "alga",
+ "approx",
+ "generic-array 0.13.3",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.7.3",
+ "rand_distr 0.2.2",
+ "typenum",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,12 +2808,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3138,6 +3229,15 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
@@ -3154,6 +3254,12 @@ checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3581,7 +3687,7 @@ dependencies = [
  "log",
  "num_cpus",
  "rand 0.8.5",
- "rand_distr",
+ "rand_distr 0.4.3",
  "rayon",
  "secp256k1",
  "tokio",
@@ -3622,10 +3728,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "statest"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ed65138bd1680f47e4d980ac7d3cf5e827fa99c2fa6683e640094a494602b4"
+dependencies = [
+ "ndarray",
+ "num-traits",
+ "statrs",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e34b58a8f9b7462b6922e0b4e3c83d1b3c2075f7f996a56d6c66afa81590064"
+dependencies = [
+ "nalgebra",
+ "rand 0.7.3",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,15 +360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.6",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,22 +1514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipgen"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2feff90e2d7307100ba887119bfa8bb9b7703670899b001805ccdd9f2ef187d3"
-dependencies = [
- "blake2",
- "ipnetwork",
-]
-
-[[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-
-[[package]]
 name = "is-terminal"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,7 +1583,6 @@ name = "kaspa-addressmanager"
 version = "0.1.2"
 dependencies = [
  "borsh",
- "ipgen",
  "itertools 0.10.5",
  "kaspa-core",
  "kaspa-database",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3104,7 +3104,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3674,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.169"
+version = "1.0.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd51c3db8f9500d531e6c12dd0fd4ad13d133e9117f5aebac3cdbb8b6d9824b0"
+checksum = "a56657f512baabca8f840542f9ca8152aecf182c473c26e46e58d6aab4f6e439"
 dependencies = [
  "serde_derive",
 ]
@@ -3704,13 +3704,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.169"
+version = "1.0.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27738cfea0d944ab72c3ed01f3d5f23ec4322af8a1431e40ce630e4c01ea74fd"
+checksum = "77d477848e6b23adba0db397777d5aad864555bc17fd9c89abb3b8009788b7b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3941,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.24"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ccaf716a23c35ff908f91c971a86a9a71af5998c1d8f10e828d9f55f68ac00"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4002,7 +4002,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4089,7 +4089,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4257,7 +4257,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4491,7 +4491,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -4525,7 +4525,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.24",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -20,3 +20,4 @@ log.workspace = true
 
 [dev-dependencies]
 ipgen = "1.0.2"
+statest = "0.2.2"

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -19,4 +19,5 @@ borsh.workspace = true
 log.workspace = true
 
 [dev-dependencies]
+statrs = "0.13.0"
 statest = "0.2.2"

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -17,3 +17,6 @@ rand.workspace = true
 parking_lot.workspace = true
 borsh.workspace = true
 log.workspace = true
+
+[dev-dependencies]
+ipgen = "1.0.2"

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -19,5 +19,4 @@ borsh.workspace = true
 log.workspace = true
 
 [dev-dependencies]
-ipgen = "1.0.2"
 statest = "0.2.2"

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -202,7 +202,7 @@ mod address_store_with_cache {
                 })
                 .unzip();
 
-            // divide weights by number routing prefix, and subnetwork bytes to normalize distribution over network
+            // Divide weights by size of bucket of the prefix bytes, to normalize distribution over global network.
             for (i, address) in filtered_addresses.iter().enumerate() {
                 weights[i] = weights[i] / (*prefix_counter.get_mut(&address.prefix_bytes()).unwrap() as f64);
             }

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -321,7 +321,7 @@ mod address_store_with_cache {
                 .into_iter()
                 .map(|address| {
                     let prefix_bytes = address.prefix_bytes();
-                    let ord = match prefix_bytes[0] {
+                    match prefix_bytes[0] {
                         0 => match prefix_bytes[1] {
                             0 => 1.0,
                             1 => 2.0,
@@ -340,8 +340,7 @@ mod address_store_with_cache {
                             _ => panic!("unexpected byte"),
                         },
                         _ => panic!("unexpected byte"),
-                    };
-                    ord
+                    }
                 })
                 .collect_vec();
 

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -259,14 +259,14 @@ mod address_store_with_cache {
         /// weight reductions due to ip connection failures.
         ///
         /// The exact weight formula for any given ip, is as follows:
-        ///
+        ///```ignore
         ///         ip_weight = (64 ^ (x - y)) / n
         ///
         ///             whereby:
         ///                 x: max allowed connection failures.
         ///                 y: connection failures of the ip.
         ///                 n: number of ips with the same prefix bytes.
-        ///
+        ///```
         pub fn iterate_prioritized_random_addresses(
             &self,
             exceptions: HashSet<NetAddress>,

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -357,6 +357,7 @@ mod address_store_with_cache {
 
         use super::*;
         use address_manager::AddressManager;
+        use kaspa_consensus_core::config::{params::SIMNET_PARAMS, Config};
         use kaspa_database::utils::create_temp_db;
         use kaspa_utils::networking::IpAddress;
         use statest::ks::KSTest;
@@ -387,7 +388,8 @@ mod address_store_with_cache {
             assert!(bucket_reduction_ratio >= 1.25);
 
             let db = create_temp_db();
-            let am = AddressManager::new(db.1);
+            let config = Config::new(SIMNET_PARAMS);
+            let am = AddressManager::new(Arc::new(config), db.1);
 
             let mut am_guard = am.lock();
 

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -117,6 +117,7 @@ mod address_store_with_cache {
 
     use itertools::Itertools;
     use kaspa_database::prelude::DB;
+    use kaspa_utils::networking::PrefixBucket;
     use rand::{
         distributions::{WeightedError, WeightedIndex},
         prelude::Distribution,
@@ -185,26 +186,43 @@ mod address_store_with_cache {
             self.addresses.values().map(|entry| entry.address)
         }
 
+        /// This iterator functions as the node's ip routing selection algo.
+        /// It first adjusts in respect to the number of connection failures of each ip address,
+        /// whereby each connection failure (up to [`MAX_CONNECTION_FAILED_COUNT`]) reduces an ip's selection weight by a factor of 64,
+        /// Afterwards the weights are normalized uniformly over the ip's [`PrefixBucket`] size.
+        ///
+        /// This ensures a distributed selection across the global network, while respecting
+        /// weight reductions due to ip connection failures.
+        ///
+        /// The exact weight formula for any given ip, is as follows:
+        ///
+        ///         ip_weight = (64 ^ (x - y)) / n
+        ///
+        ///             whereby:
+        ///                 x: max allowed connection failures.
+        ///                 y: connection failures of the ip.
+        ///                 n: number of ips with the same prefix bytes.
+        ///
         pub fn iterate_prioritized_random_addresses(
             &self,
             exceptions: HashSet<NetAddress>,
         ) -> impl ExactSizeIterator<Item = NetAddress> {
             let exceptions: HashSet<AddressKey> = exceptions.into_iter().map(|addr| addr.into()).collect();
-            let mut prefix_counter: HashMap<Vec<u8>, usize> = HashMap::new();
+            let mut prefix_counter: HashMap<PrefixBucket, usize> = HashMap::new();
             let (mut weights, filtered_addresses): (Vec<f64>, Vec<NetAddress>) = self
                 .addresses
                 .iter()
                 .filter(|(addr_key, _)| !exceptions.contains(addr_key))
                 .map(|(_, e)| {
-                    let count = prefix_counter.entry(e.address.clone().prefix_bytes()).or_insert(0);
+                    let count = prefix_counter.entry(e.address.prefix_bucket()).or_insert(0);
                     *count += 1;
                     (64f64.powf((MAX_CONNECTION_FAILED_COUNT + 1 - e.connection_failed_count) as f64), e.address)
                 })
                 .unzip();
 
-            // Divide weights by size of bucket of the prefix bytes, to normalize distribution over global network.
+            // Divide weights by size of bucket of the prefix bytes, to partially uniform the distribution over prefix buckets.
             for (i, address) in filtered_addresses.iter().enumerate() {
-                *weights.get_mut(i).unwrap() /= *prefix_counter.get_mut(&address.prefix_bytes()).unwrap() as f64;
+                *weights.get_mut(i).unwrap() /= *prefix_counter.get(&address.prefix_bucket()).unwrap() as f64;
             }
 
             RandomWeightedIterator::new(weights, filtered_addresses)
@@ -271,15 +289,15 @@ mod address_store_with_cache {
 
     #[cfg(test)]
     mod tests {
+        use std::str::FromStr;
+
         use super::*;
         use address_manager::AddressManager;
         use kaspa_database::utils::create_temp_db;
         use kaspa_utils::networking::IpAddress;
-        use statest::ttest::{ttest1, Side, UPLO};
-        use std::{
-            net::{IpAddr, Ipv6Addr},
-            str::FromStr,
-        };
+        use statest::ks::KSTest;
+        use statrs::distribution::Uniform;
+        use std::net::{IpAddr, Ipv6Addr};
 
         #[test]
         fn test_weighted_iterator() {
@@ -295,59 +313,87 @@ mod address_store_with_cache {
 
         #[test]
         fn test_network_distribution_weighting() {
-            // We need a large sample size for reliability of this test.
-            // Tuple corresponds to: `(num_of_addresses, ip_prefix)` to be generated for the test.
-            let address_distribution =
-                vec![(256, "0.0"), (128, "0.1"), (64, "1.0"), (32, "1.1"), (16, "1.2"), (8, "2.0"), (4, "2.1"), (2, "2.2")];
+            kaspa_core::log::try_init_logger("info");
+
+            // Variables to initialize ip generation with.
+            let largest_bucket: u16 = 2048;
+            let bucket_reduction_ratio: f64 = 2.;
+
+            // Assert that initial distribution is skewed, and hence not uniform from the outset.
+            assert!(bucket_reduction_ratio >= 1.25);
 
             let db = create_temp_db();
             let am = AddressManager::new(db.1);
 
             let mut am_guard = am.lock();
-            for (i, (num_in_bucket, prefix_bytes)) in address_distribution.iter().enumerate() {
-                for j in 0..(*num_in_bucket as usize) {
+
+            let mut num_of_buckets = 0;
+            let mut num_of_addresses = 0;
+            let mut current_bucket_size = largest_bucket;
+
+            for current_prefix_bytes in 0..u16::MAX {
+                num_of_buckets += 1;
+                for current_suffix_bytes in 0..current_bucket_size {
+                    let current_ip_bytes =
+                        [current_prefix_bytes.to_be_bytes(), current_suffix_bytes.to_be_bytes()].concat().to_owned();
                     am_guard.add_address(NetAddress::new(
-                        IpAddress::from_str(format!("{}.{}.{}", *prefix_bytes, i, j).as_str()).unwrap(),
+                        IpAddress::from_str(&format!(
+                            "{0}.{1}.{2}.{3}",
+                            current_ip_bytes[0], current_ip_bytes[1], current_ip_bytes[2], current_ip_bytes[3]
+                        ))
+                        .unwrap(),
                         16111,
                     ));
+                    num_of_addresses += 1;
+                }
+
+                let last_bucket_size = current_bucket_size;
+                current_bucket_size = ((current_bucket_size as f64) * (1.0 / bucket_reduction_ratio)).round() as u16;
+
+                if current_bucket_size == last_bucket_size || current_bucket_size == 0 || current_prefix_bytes == u16::MAX {
+                    // Address generation exhausted - exit loop
+                    break;
                 }
             }
             drop(am_guard);
 
-            let exceptions = HashSet::new();
-            let selected_addresses = am.lock().iterate_prioritized_random_addresses(exceptions).collect_vec();
+            // Assert sample size is large enough.
+            assert!(1024 <= num_of_addresses);
+            // Assert we don't over-generate the address manager's limit.
+            assert!(num_of_addresses <= MAX_ADDRESSES);
+            // Assert that the test has enough buckets to sample from
+            assert!(num_of_buckets >= 12);
 
-            let dist_selected = selected_addresses
-                .into_iter()
-                .map(|address| {
-                    let prefix_bytes = address.prefix_bytes();
-                    match prefix_bytes[0] {
-                        0 => match prefix_bytes[1] {
-                            0 => 1.0,
-                            1 => 2.0,
-                            _ => panic!("unexpected byte"),
-                        },
-                        1 => match prefix_bytes[1] {
-                            0 => 3.0,
-                            1 => 4.0,
-                            2 => 5.0,
-                            _ => panic!("unexpected byte"),
-                        },
-                        2 => match prefix_bytes[1] {
-                            0 => 6.0,
-                            1 => 7.0,
-                            2 => 8.0,
-                            _ => panic!("unexpected byte"),
-                        },
-                        _ => panic!("unexpected byte"),
-                    }
-                })
-                .collect_vec();
+            // Run multiple Kolmogorov–Smirnov tests to offset random noise of the random weighted iterator
+            let num_of_trials = 512;
+            let mut cul_p = 0.;
+            // The target uniform distribution
+            let target_u_dist = Uniform::new(0.0, (num_of_buckets) as f64).unwrap();
+            for _ in 0..num_of_trials {
+                // The weight sampled expected uniform distibution
+                let prioritized_address_distribution = am
+                    .lock()
+                    .iterate_prioritized_random_addresses(HashSet::new())
+                    .take(num_of_buckets)
+                    .map(|addr| addr.prefix_bucket().as_u64() as f64)
+                    .collect_vec();
 
-            let expected_higher_half = &dist_selected.as_slice()[0..(dist_selected.len() / 2)];
-            let dist_mean = (dist_selected.iter().sum::<f64>()) / (dist_selected.len() as f64);
-            let p = 0.00001; // ...1 in 100,000 chance of mean deviation randomly occurring.
-            assert!(ttest1(expected_higher_half, dist_mean, p, Side::One(UPLO::Lower)));
+                let ks_test = KSTest::new(prioritized_address_distribution.as_slice());
+                cul_p += ks_test.ks1(&target_u_dist).0;
+            }
+
+            // Normalize and adjust p to test for uniformity, over average of all trials.
+            let adjusted_p = (0.5 - cul_p / num_of_trials as f64).abs();
+            // Define the significance threshold.
+            let significance = 0.05;
+
+            // Display and assert the result
+            kaspa_core::info!(
+                "Kolmogorov–Smirnov test result for weighted network distribution uniformity: p = {0:.4} (p < {1})",
+                adjusted_p,
+                significance
+            );
+            assert!(adjusted_p < significance)
         }
     }
 }

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -296,7 +296,7 @@ mod address_store_with_cache {
         #[test]
         fn test_network_distribution_weighting() {
             // We need a large sample size for reliability of this test.
-            // Tuple corresponds to: `(num_of_addresses, ip_prefix)` to be generated for the test. 
+            // Tuple corresponds to: `(num_of_addresses, ip_prefix)` to be generated for the test.
             let address_distribution =
                 vec![(256, "0.0"), (128, "0.1"), (64, "1.0"), (32, "1.1"), (16, "1.2"), (8, "2.0"), (4, "2.1"), (2, "2.2")];
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ triggered = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 log4rs = { version = "1", features = ["all_components", "gzip", "background_rotation"] }
-tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread", "time"] }
 ctrlc = "3.2"
 intertrait = "0.2"
 num_cpus.workspace = true

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -17,6 +17,21 @@ impl IpAddress {
     pub fn new(ip: IpAddr) -> Self {
         Self(ip)
     }
+
+    pub fn prefix_bytes(&self) -> Vec<u8> {
+        match self.0 {
+            IpAddr::V4(ipv4) => ipv4.octets().as_slice()[0..2].to_owned(),
+            IpAddr::V6(ipv6) => {
+                if let Some(ipv4) = ipv6.to_ipv4() {
+                    // Try and normalize prefix bytes to ipv4
+                    ipv4.octets().as_slice()[0..2].to_owned()
+                } else {
+                    // Else use first 8 bytes (routing prefix + subnetwork id) of ipv6
+                    ipv6.octets().as_slice()[0..8].to_owned()
+                }
+            }
+        }
+    }
 }
 impl From<IpAddr> for IpAddress {
     fn from(ip: IpAddr) -> Self {
@@ -133,6 +148,10 @@ pub struct NetAddress {
 impl NetAddress {
     pub fn new(ip: IpAddress, port: u16) -> Self {
         Self { ip, port }
+    }
+
+    pub fn prefix_bytes(&self) -> Vec<u8> {
+        self.ip.prefix_bytes()
     }
 }
 

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -8,6 +8,45 @@ use std::{
 };
 use uuid::Uuid;
 
+/// A bucket based on an ip's prefix bytes.
+/// for ipv4 it consists of 6 leading zero bytes, and the first two octets,
+/// for ipv6 it consists of the first 8 octets,
+/// encoded into a big endian u64.  
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+pub struct PrefixBucket(u64);
+
+impl PrefixBucket {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<&IpAddress> for PrefixBucket {
+    fn from(ip_address: &IpAddress) -> Self {
+        match ip_address.0 {
+            IpAddr::V4(ipv4) => {
+                let prefix_bytes = ipv4.octets();
+                Self(u64::from_be_bytes([0u8, 0u8, 0u8, 0u8, 0u8, 0u8, prefix_bytes[0], prefix_bytes[1]]))
+            }
+            IpAddr::V6(ipv6) => {
+                if let Some(ipv4) = ipv6.to_ipv4() {
+                    let prefix_bytes = ipv4.octets();
+                    Self(u64::from_be_bytes([0u8, 0u8, 0u8, 0u8, 0u8, 0u8, prefix_bytes[0], prefix_bytes[1]]))
+                } else {
+                    // Else use first 8 bytes (routing prefix + subnetwork id) of ipv6
+                    Self(u64::from_be_bytes(ipv6.octets().as_slice()[..8].try_into().expect("Slice with incorrect length")))
+                }
+            }
+        }
+    }
+}
+
+impl From<&NetAddress> for PrefixBucket {
+    fn from(net_address: &NetAddress) -> Self {
+        Self::from(&net_address.ip)
+    }
+}
+
 /// An IP address, newtype of [IpAddr].
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug)]
 #[repr(transparent)]
@@ -18,21 +57,11 @@ impl IpAddress {
         Self(ip)
     }
 
-    pub fn prefix_bytes(&self) -> Vec<u8> {
-        match self.0 {
-            IpAddr::V4(ipv4) => ipv4.octets().as_slice()[0..2].to_owned(),
-            IpAddr::V6(ipv6) => {
-                if let Some(ipv4) = ipv6.to_ipv4() {
-                    // Try and normalize prefix bytes to ipv4
-                    ipv4.octets().as_slice()[0..2].to_owned()
-                } else {
-                    // Else use first 8 bytes (routing prefix + subnetwork id) of ipv6
-                    ipv6.octets().as_slice()[0..8].to_owned()
-                }
-            }
-        }
+    pub fn prefix_bucket(&self) -> PrefixBucket {
+        PrefixBucket::from(self)
     }
 }
+
 impl From<IpAddr> for IpAddress {
     fn from(ip: IpAddr) -> Self {
         Self(ip)
@@ -150,8 +179,8 @@ impl NetAddress {
         Self { ip, port }
     }
 
-    pub fn prefix_bytes(&self) -> Vec<u8> {
-        self.ip.prefix_bytes()
+    pub fn prefix_bucket(&self) -> PrefixBucket {
+        PrefixBucket::from(self)
     }
 }
 
@@ -351,5 +380,12 @@ mod tests {
         assert!(addr_v4.is_ok());
         let addr_v6 = NetAddress::from_str("[2a01:4f8:191:1143::2]:5678");
         assert!(addr_v6.is_ok());
+    }
+
+    #[test]
+    fn test_prefix_bucket() {
+        let prefix_bytes: [u8; 2] = [42u8, 43u8];
+        let addr = NetAddress::from_str(format!("{0}.{1}.3.4:5678", prefix_bytes[0], prefix_bytes[1]).as_str()).unwrap();
+        assert!(addr.prefix_bucket() == PrefixBucket(u16::from_be_bytes(prefix_bytes) as u64));
     }
 }


### PR DESCRIPTION
This pr weights the prefix bytes in the address manager for the `iterate_prioritized_random_addresses` method. which should more evenly spread-out the network topology as well as increasing Sybil resistance. 

The improved selection will adjust weights by dividing the weights by the size of the prefix bucket the ip belongs to. this ensures other weighting metrics are still respected, but keep a priority of selecting evenly over all prefix bytes. 