### PR TITLE
IBD: fix some syncer-syncee miscommunications which are more apparent with 10 bps 

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -331,7 +331,7 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(move |c| c.get_missing_block_body_hashes(high)).await
     }
 
-    pub async fn async_pruning_point(&self) -> Option<Hash> {
+    pub async fn async_pruning_point(&self) -> Hash {
         self.clone().spawn_blocking(|c| c.pruning_point()).await
     }
 

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -256,12 +256,12 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(|c| c.get_pruning_point_proof()).await
     }
 
-    pub async fn async_create_headers_selected_chain_block_locator(
+    pub async fn async_create_virtual_selected_chain_block_locator(
         &self,
         low: Option<Hash>,
         high: Option<Hash>,
     ) -> ConsensusResult<Vec<Hash>> {
-        self.clone().spawn_blocking(move |c| c.create_headers_selected_chain_block_locator(low, high)).await
+        self.clone().spawn_blocking(move |c| c.create_virtual_selected_chain_block_locator(low, high)).await
     }
 
     pub async fn async_create_block_locator_from_pruning_point(&self, high: Hash, limit: usize) -> ConsensusResult<Vec<Hash>> {

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -169,7 +169,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn create_headers_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> ConsensusResult<Vec<Hash>> {
+    fn create_virtual_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> ConsensusResult<Vec<Hash>> {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -238,7 +238,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn pruning_point(&self) -> Option<Hash> {
+    fn pruning_point(&self) -> Hash {
         unimplemented!()
     }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -74,6 +74,7 @@ impl HashMapCustomHasher for BlockHashSet {
     }
 }
 
+#[derive(Default)]
 pub struct ChainPath {
     pub added: Vec<Hash>,
     pub removed: Vec<Hash>,

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -74,7 +74,7 @@ impl HashMapCustomHasher for BlockHashSet {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ChainPath {
     pub added: Vec<Hash>,
     pub removed: Vec<Hash>,

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -690,10 +690,7 @@ impl ConsensusApi for Consensus {
 
     fn create_block_locator_from_pruning_point(&self, high: Hash, limit: usize) -> ConsensusResult<Vec<Hash>> {
         self.validate_block_exists(high)?;
-
-        let pp_read_guard = self.pruning_point_store.read();
-        let pp = pp_read_guard.pruning_point().unwrap();
-        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, pp, Some(limit))?)
+        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, self.pruning_point().unwrap(), Some(limit))?)
     }
 
     fn estimate_network_hashes_per_second(&self, start_hash: Option<Hash>, window_size: usize) -> ConsensusResult<u64> {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -682,7 +682,9 @@ impl ConsensusApi for Consensus {
         for _ in 0..=self.config.params.ghostdag_k {
             hashes.push(current);
             // TODO: ideally the syncee should validate it got all of the associated data up
-            // to k blocks back and then we would be able to safely unwrap here.
+            // to k blocks back and then we would be able to safely unwrap here. For now we
+            // just break the loop, since if the data was truly missing we wouldn't accept
+            // the staging consensus in the first place
             let Some(parent) = self.ghostdag_primary_store.get_selected_parent(current).unwrap_option() else { break; };
             current = parent;
         }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -566,6 +566,9 @@ impl ConsensusApi for Consensus {
             self.validate_block_exists(high)?;
         }
 
+        let low = low.unwrap_or_else(|| self.pruning_point().unwrap());
+        let high = high.unwrap_or_else(|| self.get_sink());
+
         Ok(self.services.sync_manager.create_headers_selected_chain_block_locator(low, high)?)
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -679,11 +679,12 @@ impl ConsensusApi for Consensus {
 
         let mut hashes = Vec::with_capacity(self.config.params.ghostdag_k as usize);
         let mut current = hash;
-        // TODO: This will crash if we don't have the data for k blocks in the past of
-        // current. The syncee should validate it got all of the associated data.
         for _ in 0..=self.config.params.ghostdag_k {
             hashes.push(current);
-            current = self.ghostdag_primary_store.get_selected_parent(current).unwrap();
+            // TODO: ideally the syncee should validate it got all of the associated data up
+            // to k blocks back and then we would be able to safely unwrap here.
+            let Some(parent) = self.ghostdag_primary_store.get_selected_parent(current).unwrap_option() else { break; };
+            current = parent;
         }
         Ok(hashes)
     }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -557,7 +557,7 @@ impl ConsensusApi for Consensus {
         self.services.pruning_proof_manager.get_pruning_point_proof()
     }
 
-    fn create_headers_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> ConsensusResult<Vec<Hash>> {
+    fn create_virtual_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> ConsensusResult<Vec<Hash>> {
         if let Some(low) = low {
             self.validate_block_exists(low)?;
         }
@@ -569,7 +569,7 @@ impl ConsensusApi for Consensus {
         let low = low.unwrap_or_else(|| self.pruning_point());
         let high = high.unwrap_or_else(|| self.get_sink());
 
-        Ok(self.services.sync_manager.create_headers_selected_chain_block_locator(low, high)?)
+        Ok(self.services.sync_manager.create_virtual_selected_chain_block_locator(low, high)?)
     }
 
     fn pruning_point_headers(&self) -> Vec<Arc<Header>> {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -566,9 +566,6 @@ impl ConsensusApi for Consensus {
             self.validate_block_exists(high)?;
         }
 
-        let low = low.unwrap_or_else(|| self.pruning_point());
-        let high = high.unwrap_or_else(|| self.get_sink());
-
         Ok(self.services.sync_manager.create_virtual_selected_chain_block_locator(low, high)?)
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -566,7 +566,7 @@ impl ConsensusApi for Consensus {
             self.validate_block_exists(high)?;
         }
 
-        let low = low.unwrap_or_else(|| self.pruning_point().unwrap());
+        let low = low.unwrap_or_else(|| self.pruning_point());
         let high = high.unwrap_or_else(|| self.get_sink());
 
         Ok(self.services.sync_manager.create_headers_selected_chain_block_locator(low, high)?)
@@ -655,8 +655,8 @@ impl ConsensusApi for Consensus {
         Ok(self.services.sync_manager.get_missing_block_body_hashes(high)?)
     }
 
-    fn pruning_point(&self) -> Option<Hash> {
-        self.pruning_point_store.read().pruning_point().unwrap_option()
+    fn pruning_point(&self) -> Hash {
+        self.pruning_point_store.read().pruning_point().unwrap()
     }
 
     fn get_daa_window(&self, hash: Hash) -> ConsensusResult<Vec<Hash>> {
@@ -676,7 +676,7 @@ impl ConsensusApi for Consensus {
         self.validate_block_exists(hash)?;
 
         // In order to guarantee the chain height is at least k, we check that the pruning point is not genesis.
-        if self.pruning_point().unwrap() == self.config.genesis.hash {
+        if self.pruning_point() == self.config.genesis.hash {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
 
@@ -693,7 +693,7 @@ impl ConsensusApi for Consensus {
 
     fn create_block_locator_from_pruning_point(&self, high: Hash, limit: usize) -> ConsensusResult<Vec<Hash>> {
         self.validate_block_exists(high)?;
-        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, self.pruning_point().unwrap(), Some(limit))?)
+        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, self.pruning_point(), Some(limit))?)
     }
 
     fn estimate_network_hashes_per_second(&self, start_hash: Option<Hash>, window_size: usize) -> ConsensusResult<u64> {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -690,7 +690,10 @@ impl ConsensusApi for Consensus {
 
     fn create_block_locator_from_pruning_point(&self, high: Hash, limit: usize) -> ConsensusResult<Vec<Hash>> {
         self.validate_block_exists(high)?;
-        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, self.pruning_point(), Some(limit))?)
+        // Keep the pruning point read guard throughout building the locator
+        let pruning_point_read = self.pruning_point_store.read();
+        let pruning_point = pruning_point_read.pruning_point().unwrap();
+        Ok(self.services.sync_manager.create_block_locator_from_pruning_point(high, pruning_point, Some(limit))?)
     }
 
     fn estimate_network_hashes_per_second(&self, start_hash: Option<Hash>, window_size: usize) -> ConsensusResult<u64> {

--- a/consensus/src/model/stores/selected_chain.rs
+++ b/consensus/src/model/stores/selected_chain.rs
@@ -17,6 +17,7 @@ use super::U64Key;
 pub trait SelectedChainStoreReader {
     fn get_by_hash(&self, hash: Hash) -> StoreResult<u64>;
     fn get_by_index(&self, index: u64) -> StoreResult<Hash>;
+    fn get_tip(&self) -> StoreResult<(u64, Hash)>;
 }
 
 /// Write API for `SelectedChainStore`. The set function is deliberately `mut`
@@ -67,6 +68,12 @@ impl SelectedChainStoreReader for DbSelectedChainStore {
 
     fn get_by_index(&self, index: u64) -> StoreResult<Hash> {
         self.access_hash_by_index.read(index.into())
+    }
+
+    fn get_tip(&self) -> StoreResult<(u64, Hash)> {
+        let idx = self.access_highest_index.read()?;
+        let hash = self.access_hash_by_index.read(idx.into())?;
+        Ok((idx, hash))
     }
 }
 

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -19,7 +19,6 @@ use crate::{
             pruning::{DbPruningStore, PruningPointInfo, PruningStoreReader},
             reachability::{DbReachabilityStore, StagingReachabilityStore},
             relations::{DbRelationsStore, RelationsStoreReader},
-            selected_chain::{DbSelectedChainStore, SelectedChainStore},
             statuses::{DbStatusesStore, StatusesStore, StatusesStoreBatchExtensions, StatusesStoreReader},
             DB,
         },
@@ -136,7 +135,6 @@ pub struct HeaderProcessor {
     pub(super) daa_excluded_store: Arc<DbDaaStore>,
     pub(super) headers_store: Arc<DbHeadersStore>,
     pub(super) headers_selected_tip_store: Arc<RwLock<DbHeadersSelectedTipStore>>,
-    pub(super) selected_chain_store: Arc<RwLock<DbSelectedChainStore>>,
     pub(super) depth_store: Arc<DbDepthStore>,
 
     // Managers and services
@@ -187,7 +185,6 @@ impl HeaderProcessor {
             headers_store: storage.headers_store.clone(),
             depth_store: storage.depth_store.clone(),
             headers_selected_tip_store: storage.headers_selected_tip_store.clone(),
-            selected_chain_store: storage.selected_chain_store.clone(),
             block_window_cache_for_difficulty: storage.block_window_cache_for_difficulty.clone(),
             block_window_cache_for_past_median_time: storage.block_window_cache_for_past_median_time.clone(),
 
@@ -392,18 +389,13 @@ impl HeaderProcessor {
         // Non-append only stores need to use write locks.
         // Note we need to keep the lock write guards until the batch is written.
         let mut hst_write = self.headers_selected_tip_store.write();
-        let mut sc_write = self.selected_chain_store.write();
         let prev_hst = hst_write.get().unwrap();
-        // We can't calculate chain path for blocks that do not have the pruning point in their chain, so we just skip them.
         if SortableBlock::new(ctx.hash, header.blue_work) > prev_hst
             && reachability::is_chain_ancestor_of(&staging, pp, ctx.hash).unwrap()
         {
             // Hint reachability about the new tip.
             reachability::hint_virtual_selected_parent(&mut staging, ctx.hash).unwrap();
             hst_write.set_batch(&mut batch, SortableBlock::new(ctx.hash, header.blue_work)).unwrap();
-            let mut chain_path = self.dag_traversal_manager.calculate_chain_path(prev_hst.hash, ghostdag_data[0].selected_parent);
-            chain_path.added.push(ctx.hash);
-            sc_write.apply_changes(&mut batch, chain_path).unwrap();
         }
 
         //
@@ -437,7 +429,6 @@ impl HeaderProcessor {
         drop(reachability_relations_write);
         drop(relations_write);
         drop(hst_write);
-        drop(sc_write);
     }
 
     fn commit_trusted_header(&self, ctx: HeaderProcessingContext, _header: &Header) {
@@ -463,13 +454,10 @@ impl HeaderProcessor {
     pub fn process_genesis(&self) {
         // Init headers selected tip and selected chain stores
         let mut batch = WriteBatch::default();
-        let mut sc_write = self.selected_chain_store.write();
-        sc_write.init_with_pruning_point(&mut batch, self.genesis.hash).unwrap();
         let mut hst_write = self.headers_selected_tip_store.write();
         hst_write.set_batch(&mut batch, SortableBlock::new(self.genesis.hash, 0.into())).unwrap();
         self.db.write(batch).unwrap();
         drop(hst_write);
-        drop(sc_write);
 
         // Write the genesis header
         let mut genesis_header: Header = (&self.genesis).into();

--- a/consensus/src/pipeline/virtual_processor/mod.rs
+++ b/consensus/src/pipeline/virtual_processor/mod.rs
@@ -2,5 +2,6 @@ pub mod errors;
 mod processor;
 mod utxo_validation;
 pub use processor::*;
+pub mod test_block_builder;
 #[cfg(test)]
 mod tests;

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -25,7 +25,7 @@ use crate::{
             pruning_utxoset::PruningUtxosetStores,
             reachability::DbReachabilityStore,
             relations::{DbRelationsStore, RelationsStoreReader},
-            selected_chain::{DbSelectedChainStore, SelectedChainStore},
+            selected_chain::{DbSelectedChainStore, SelectedChainStore, SelectedChainStoreReader},
             statuses::{DbStatusesStore, StatusesStore, StatusesStoreBatchExtensions, StatusesStoreReader},
             tips::{DbTipsStore, TipsStoreReader},
             utxo_diffs::{DbUtxoDiffsStore, UtxoDiffsStoreReader},
@@ -211,6 +211,22 @@ impl VirtualStateProcessor {
     }
 
     pub fn worker(self: &Arc<Self>) {
+        // TEMP: upgrade from prev DB version where the chain was the headers selected chain
+        if let Some(virtual_state) = self.virtual_stores.read().state.get().unwrap_option() {
+            let sink = virtual_state.ghostdag_data.selected_parent;
+            let mut selected_chain_write = self.selected_chain_store.write();
+            if let Some((_, tip)) = selected_chain_write.get_tip().unwrap_option() {
+                // This means we are upgrading from the previous version
+                if sink != tip {
+                    let chain_path = self.dag_traversal_manager.calculate_chain_path(tip, sink);
+                    info!("Upgrading the DB from HSC storage to VSC storage: {:?}", chain_path);
+                    let mut batch = WriteBatch::default();
+                    selected_chain_write.apply_changes(&mut batch, &chain_path).unwrap();
+                    self.db.write(batch).unwrap();
+                }
+            }
+        }
+
         'outer: while let Ok(msg) = self.receiver.recv() {
             if msg.is_exit_message() {
                 break;

--- a/consensus/src/pipeline/virtual_processor/test_block_builder.rs
+++ b/consensus/src/pipeline/virtual_processor/test_block_builder.rs
@@ -1,14 +1,34 @@
+use std::{ops::Deref, sync::Arc};
+
 use crate::model::stores::{
     pruning::PruningStoreReader, utxo_multisets::UtxoMultisetsStoreReader, virtual_state::VirtualStateStoreReader,
 };
 use kaspa_consensus_core::{
-    block::BlockTemplate, coinbase::MinerData, errors::block::RuleError, tx::Transaction, utxo::utxo_view::UtxoViewComposition,
+    block::BlockTemplate, blockhash::ORIGIN, coinbase::MinerData, errors::block::RuleError, tx::Transaction,
+    utxo::utxo_view::UtxoViewComposition,
 };
 use kaspa_hashes::Hash;
 
 use super::VirtualStateProcessor;
 
-impl VirtualStateProcessor {
+/// Wrapper for virtual processor with util methods for building a block with any parent context
+pub struct TestBlockBuilder {
+    processor: Arc<VirtualStateProcessor>,
+}
+
+impl Deref for TestBlockBuilder {
+    type Target = VirtualStateProcessor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.processor
+    }
+}
+
+impl TestBlockBuilder {
+    pub fn new(processor: Arc<VirtualStateProcessor>) -> Self {
+        Self { processor }
+    }
+
     /// Test-only helper method for building a block template with specific parents
     pub(crate) fn build_block_template_with_parents(
         &self,
@@ -16,21 +36,31 @@ impl VirtualStateProcessor {
         miner_data: MinerData,
         txs: Vec<Transaction>,
     ) -> Result<BlockTemplate, RuleError> {
+        //
+        // In the context of this method "pov virtual" is the virtual block which has `parents` as tips and not the actual virtual
+        //
         let pruning_point = self.pruning_point_store.read().pruning_point().unwrap();
         let virtual_read = self.virtual_stores.read();
-        let state = virtual_read.state.get().unwrap();
-        let finality_point = self.virtual_finality_point(&state.ghostdag_data, pruning_point);
-        let sink = state.ghostdag_data.selected_parent;
-        let mut accumulated_diff = state.utxo_diff.clone().to_reversed();
-        let (new_sink, virtual_parent_candidates) =
+        let virtual_state = virtual_read.state.get().unwrap();
+        let finality_point = ORIGIN; // No real finality point since we are not actually building virtual here
+        let sink = virtual_state.ghostdag_data.selected_parent;
+        let mut accumulated_diff = virtual_state.utxo_diff.clone().to_reversed();
+        // Search for the sink block from the PoV of this virtual
+        let (pov_sink, virtual_parent_candidates) =
             self.sink_search_algorithm(&virtual_read, &mut accumulated_diff, sink, parents, finality_point, pruning_point);
-        let (virtual_parents, virtual_ghostdag_data) = self.pick_virtual_parents(new_sink, virtual_parent_candidates, pruning_point);
-        let sink_multiset = self.utxo_multisets_store.get(new_sink).unwrap();
-        let new_virtual_state =
-            self.calculate_virtual_state(&virtual_read, virtual_parents, virtual_ghostdag_data, sink_multiset, &mut accumulated_diff)?;
-        let virtual_utxo_view = (&virtual_read.utxo_set).compose(accumulated_diff);
-        self.validate_block_template_transactions(&txs, &new_virtual_state, &virtual_utxo_view)?;
+        let (pov_virtual_parents, pov_virtual_ghostdag_data) =
+            self.pick_virtual_parents(pov_sink, virtual_parent_candidates, pruning_point);
+        let pov_sink_multiset = self.utxo_multisets_store.get(pov_sink).unwrap();
+        let pov_virtual_state = self.calculate_virtual_state(
+            &virtual_read,
+            pov_virtual_parents,
+            pov_virtual_ghostdag_data,
+            pov_sink_multiset,
+            &mut accumulated_diff,
+        )?;
+        let pov_virtual_utxo_view = (&virtual_read.utxo_set).compose(accumulated_diff);
+        self.validate_block_template_transactions(&txs, &pov_virtual_state, &pov_virtual_utxo_view)?;
         drop(virtual_read);
-        self.build_block_template_from_virtual_state(new_virtual_state, miner_data, txs)
+        self.build_block_template_from_virtual_state(pov_virtual_state, miner_data, txs)
     }
 }

--- a/consensus/src/pipeline/virtual_processor/test_block_builder.rs
+++ b/consensus/src/pipeline/virtual_processor/test_block_builder.rs
@@ -1,0 +1,36 @@
+use crate::model::stores::{
+    pruning::PruningStoreReader, utxo_multisets::UtxoMultisetsStoreReader, virtual_state::VirtualStateStoreReader,
+};
+use kaspa_consensus_core::{
+    block::BlockTemplate, coinbase::MinerData, errors::block::RuleError, tx::Transaction, utxo::utxo_view::UtxoViewComposition,
+};
+use kaspa_hashes::Hash;
+
+use super::VirtualStateProcessor;
+
+impl VirtualStateProcessor {
+    /// Test-only helper method for building a block template with specific parents
+    pub(crate) fn build_block_template_with_parents(
+        &self,
+        parents: Vec<Hash>,
+        miner_data: MinerData,
+        txs: Vec<Transaction>,
+    ) -> Result<BlockTemplate, RuleError> {
+        let pruning_point = self.pruning_point_store.read().pruning_point().unwrap();
+        let virtual_read = self.virtual_stores.read();
+        let state = virtual_read.state.get().unwrap();
+        let finality_point = self.virtual_finality_point(&state.ghostdag_data, pruning_point);
+        let sink = state.ghostdag_data.selected_parent;
+        let mut accumulated_diff = state.utxo_diff.clone().to_reversed();
+        let (new_sink, virtual_parent_candidates) =
+            self.sink_search_algorithm(&virtual_read, &mut accumulated_diff, sink, parents, finality_point, pruning_point);
+        let (virtual_parents, virtual_ghostdag_data) = self.pick_virtual_parents(new_sink, virtual_parent_candidates, pruning_point);
+        let sink_multiset = self.utxo_multisets_store.get(new_sink).unwrap();
+        let new_virtual_state =
+            self.calculate_virtual_state(&virtual_read, virtual_parents, virtual_ghostdag_data, sink_multiset, &mut accumulated_diff)?;
+        let virtual_utxo_view = (&virtual_read.utxo_set).compose(accumulated_diff);
+        self.validate_block_template_transactions(&txs, &new_virtual_state, &virtual_utxo_view)?;
+        drop(virtual_read);
+        self.build_block_template_from_virtual_state(new_virtual_state, miner_data, txs)
+    }
+}

--- a/consensus/src/processes/sync/mod.rs
+++ b/consensus/src/processes/sync/mod.rs
@@ -118,7 +118,9 @@ impl<
             .expect("because of the pruning rules such block has to exist")
     }
 
-    pub fn create_headers_selected_chain_block_locator(&self, low: Hash, high: Hash) -> SyncManagerResult<Vec<Hash>> {
+    /// Returns a logarithmic amount of blocks sampled from the virtual selected chain between `low` and `high`.
+    /// Expects both blocks to be on the virtual selected chain, otherwise an error is returned
+    pub fn create_virtual_selected_chain_block_locator(&self, low: Hash, high: Hash) -> SyncManagerResult<Vec<Hash>> {
         let sc_read = self.selected_chain_store.read();
 
         if low == high {

--- a/consensus/src/processes/sync/mod.rs
+++ b/consensus/src/processes/sync/mod.rs
@@ -214,10 +214,8 @@ impl<
         let mut locator = Vec::new();
         loop {
             locator.push(current);
-            if let Some(limit) = limit {
-                if locator.len() == limit {
-                    break;
-                }
+            if limit == Some(locator.len()) {
+                break;
             }
 
             let current_gd = self.ghostdag_store.get_compact_data(current).unwrap();

--- a/consensus/src/processes/sync/mod.rs
+++ b/consensus/src/processes/sync/mod.rs
@@ -120,9 +120,10 @@ impl<
 
     /// Returns a logarithmic amount of blocks sampled from the virtual selected chain between `low` and `high`.
     /// Expects both blocks to be on the virtual selected chain, otherwise an error is returned
-    pub fn create_virtual_selected_chain_block_locator(&self, low: Hash, high: Hash) -> SyncManagerResult<Vec<Hash>> {
+    pub fn create_virtual_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> SyncManagerResult<Vec<Hash>> {
+        let low = low.unwrap_or_else(|| self.pruning_point_store.read().get().unwrap().pruning_point);
         let sc_read = self.selected_chain_store.read();
-
+        let high = high.unwrap_or_else(|| sc_read.get_tip().unwrap().1);
         if low == high {
             return Ok(vec![low]);
         }

--- a/consensus/src/processes/sync/mod.rs
+++ b/consensus/src/processes/sync/mod.rs
@@ -118,10 +118,7 @@ impl<
             .expect("because of the pruning rules such block has to exist")
     }
 
-    pub fn create_headers_selected_chain_block_locator(&self, low: Option<Hash>, high: Option<Hash>) -> SyncManagerResult<Vec<Hash>> {
-        let low = low.unwrap_or_else(|| self.pruning_point_store.read().get().unwrap().pruning_point);
-        let high = high.unwrap_or_else(|| self.header_selected_tip_store.read().get().unwrap().hash);
-
+    pub fn create_headers_selected_chain_block_locator(&self, low: Hash, high: Hash) -> SyncManagerResult<Vec<Hash>> {
         let sc_read = self.selected_chain_store.read();
 
         if low == high {

--- a/consensus/src/processes/sync/mod.rs
+++ b/consensus/src/processes/sync/mod.rs
@@ -235,7 +235,7 @@ impl<
                 current_gd.blue_score - step
             };
 
-            // Walk down currentHash's selected parent chain to the appropriate ancestor
+            // Walk down current's selected parent chain to the appropriate ancestor
             current = self.traversal_manager.lowest_chain_block_above_or_equal_to_blue_score(current, next_bs);
 
             // Double the distance between included hashes

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -27,14 +27,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::sync::Arc;
 
-// ~~~
-// TODO - discuss handling
 use args::{Args, Defaults};
-// use clap::Parser;
-// ~~~
-
-// TODO: testnet 11 tasks:
-// coinbase rewards
 
 use kaspa_consensus::config::ConfigBuilder;
 use kaspa_utxoindex::UtxoIndex;

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -183,7 +183,7 @@ impl FlowContext {
     ) -> Self {
         let hub = Hub::new();
 
-        let orphan_resolution_range = BASELINE_ORPHAN_RESOLUTION_RANGE + (config.bps() as f64).log(3.0).min(2.0) as u32;
+        let orphan_resolution_range = BASELINE_ORPHAN_RESOLUTION_RANGE + (config.bps() as f64).log2().min(3.0) as u32;
 
         // The maximum amount of orphans allowed in the orphans pool. This number is an
         // approximation of how many orphans there can possibly be on average.

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -205,7 +205,7 @@ impl HandleRelayInvsFlow {
 
         // Add the block to the orphan pool if it's within orphan resolution range.
         // If the block is indirect it means one of its descendants was already is resolution range, so
-        // we can save the query.
+        // we can avoid the query.
         if is_indirect_inv || self.check_orphan_resolution_range(consensus, block.hash()).await? {
             let hash = block.hash();
             self.ctx.add_orphan(block).await;
@@ -224,8 +224,8 @@ impl HandleRelayInvsFlow {
 
     /// Finds out whether the given block hash should be retrieved via the unorphaning
     /// mechanism or via IBD. This method sends a BlockLocator request to the peer with
-    /// a limit of ORPHAN_RESOLUTION_RANGE. In the response, if we know none of the hashes,
-    /// we should retrieve the given blockHash via IBD. Otherwise, via unorphaning.
+    /// a limit of `ctx.orphan_resolution_range`. In the response, if we know none of the hashes,
+    /// we should retrieve the given block `hash` via IBD. Otherwise, via unorphaning.
     async fn check_orphan_resolution_range(&mut self, consensus: &ConsensusProxy, hash: Hash) -> Result<bool, ProtocolError> {
         self.router
             .enqueue(make_message!(

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -125,10 +125,10 @@ impl IbdFlow {
             }
         }
 
-        // We sync missing bodies only in the past of the relay block, since only for that we
+        // We sync missing bodies only in the past of the relay block, since only for those we
         // have a guarantee that syncer has full blocks (otherwise it wouldn't relay it). On
-        // the hand for `past(syncer_header_selected_tip)` we don't have this guarantee yet, so
-        // requesting such bodies might trigger a peer disconnect.
+        // the other hand for `past(syncer_header_selected_tip)` we don't have this guarantee
+        // yet, so requesting such bodies might trigger a peer disconnect.
         self.sync_missing_block_bodies(&session, relay_block.hash()).await
     }
 

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -125,11 +125,10 @@ impl IbdFlow {
             }
         }
 
-        // Sync missing bodies in the past of syncer selected tip
-        self.sync_missing_block_bodies(&session, negotiation_output.syncer_header_selected_tip).await?;
-
-        // Relay block might be in the anticone of syncer selected tip, thus
-        // check its chain for missing bodies as well.
+        // We sync missing bodies only in the past of the relay block, since only for that we
+        // have a guarantee that syncer has full blocks (otherwise it wouldn't relay it). On
+        // the hand for `past(syncer_header_selected_tip)` we don't have this guarantee yet, so
+        // requesting such bodies might trigger a peer disconnect.
         self.sync_missing_block_bodies(&session, relay_block.hash()).await
     }
 

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -125,10 +125,11 @@ impl IbdFlow {
             }
         }
 
-        // We sync missing bodies only in the past of the relay block, since only for those we
-        // have a guarantee that syncer has full blocks (otherwise it wouldn't relay it). On
-        // the other hand for `past(syncer_header_selected_tip)` we don't have this guarantee
-        // yet, so requesting such bodies might trigger a peer disconnect.
+        // Sync missing bodies in the past of syncer selected tip
+        self.sync_missing_block_bodies(&session, negotiation_output.syncer_header_selected_tip).await?;
+
+        // Relay block might be in the anticone of syncer selected tip, thus
+        // check its chain for missing bodies as well.
         self.sync_missing_block_bodies(&session, relay_block.hash()).await
     }
 

--- a/protocol/flows/src/v5/ibd/negotiate.rs
+++ b/protocol/flows/src/v5/ibd/negotiate.rs
@@ -12,7 +12,10 @@ use kaspa_p2p_lib::{
 };
 
 pub struct ChainNegotiationOutput {
-    pub syncer_header_selected_tip: Hash,
+    // Note: previous version peers (especially golang nodes) might return the headers selected tip here. Nonetheless
+    // we name here following the currently implemented logic by which the syncer returns the virtual selected parent
+    // chain on block locator queries
+    pub syncer_virtual_selected_parent: Hash,
     pub highest_known_syncer_chain_hash: Option<Hash>,
 }
 
@@ -42,7 +45,7 @@ impl IbdFlow {
             locator_hashes.last().unwrap()
         );
 
-        let mut syncer_header_selected_tip = locator_hashes[0]; // Syncer header selected tip hash
+        let mut syncer_virtual_selected_parent = locator_hashes[0]; // Syncer sink (virtual selected parent)
         let highest_known_syncer_chain_hash: Option<Hash>;
         let mut negotiation_restart_counter = 0;
         let mut negotiation_zoom_counts = 0;
@@ -152,13 +155,13 @@ impl IbdFlow {
                 );
 
                 initial_locator_len = locator_hashes.len();
-                // Reset syncer's header selected tip
-                syncer_header_selected_tip = locator_hashes[0];
+                // Reset syncer's virtual selected parent
+                syncer_virtual_selected_parent = locator_hashes[0];
             }
         }
 
         debug!("Found highest known syncer chain block {:?} from peer {}", highest_known_syncer_chain_hash, self.router);
-        Ok(ChainNegotiationOutput { syncer_header_selected_tip, highest_known_syncer_chain_hash })
+        Ok(ChainNegotiationOutput { syncer_virtual_selected_parent, highest_known_syncer_chain_hash })
     }
 
     async fn get_syncer_chain_block_locator(

--- a/protocol/flows/src/v5/request_ibd_chain_block_locator.rs
+++ b/protocol/flows/src/v5/request_ibd_chain_block_locator.rs
@@ -38,11 +38,12 @@ impl RequestIbdChainBlockLocatorFlow {
             let (low, high) = msg.try_into()?;
 
             let locator =
-                match (self.ctx.consensus().session().await).async_create_headers_selected_chain_block_locator(low, high).await {
+                match (self.ctx.consensus().session().await).async_create_virtual_selected_chain_block_locator(low, high).await {
                     Ok(locator) => Ok(locator),
                     Err(e) => {
                         let orig = e.clone();
                         if let ConsensusError::SyncManagerError(SyncManagerError::BlockNotInSelectedParentChain(_)) = e {
+                            // This signals a reset to the locator zoom-in process. The syncee is expected to restart the search
                             Ok(vec![])
                         } else {
                             Err(orig)

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -500,7 +500,7 @@ impl RpcApi for RpcCoreService {
             self.consensus_converter.get_difficulty_ratio(session.async_get_virtual_bits().await),
             session.async_get_virtual_past_median_time().await,
             session.async_get_virtual_parents().await.iter().copied().collect::<Vec<_>>(),
-            session.async_pruning_point().await.unwrap_or_default(),
+            session.async_pruning_point().await,
             session.async_get_virtual_daa_score().await,
         ))
     }


### PR DESCRIPTION
This PR mainly refactors the consensus database by making the indexed selected chain store represent the *virtual* selected chain rather than the *headers* selected chain. 

Background:

- The indexed chain store indexes the selected chain with an integer index (supporting random access by index) so that it can be sampled efficiently in a logarithmic number of steps. This index is used by IBD syncing peers to sample the syncer chain and find the chain segment they are missing in ~log^2 communication rounds.
- For historic reasons the indexed chain used to represent the *headers* selected chain. Meaning it included blocks which might have not been body/utxo-processed yet. This is wrong in the context of IBD since a syncer should wish to share only fully-processed blocks
- Specifically, with 10 BPS testnet and frequent small IBDs, this created several situations where as a result of chain negotiation the syncee was requesting blocks which the syncer had only headers for, which is considered a protocol error thus yielding constant disconnections and overall an unhealthy network 

Solution:

- The indexed chain now follows the *virtual* selected chain meaning it now includes only fully processed blocks, solving the above problem in the most fundamental and correct way
- In order to support testing this new chain construction, this PR also includes test helpers (`TestBlockBuilder`) for building UTXO-valid block for any parent context, which required slight refactoring of virtual processor methods 