### PR TITLE
Add base implementation of local address management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,12 +414,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-
-[[package]]
-name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
@@ -1247,16 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getaddrs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efba1d44fc45a1639dd3aae2b59fd966d75cb925dc2bbd2839d9e49afaa0c92d"
-dependencies = [
- "bitflags 0.9.1",
- "libc",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,12 +1614,12 @@ name = "kaspa-addressmanager"
 version = "0.1.2"
 dependencies = [
  "borsh",
- "getaddrs",
  "itertools 0.10.5",
  "kaspa-consensus-core",
  "kaspa-core",
  "kaspa-database",
  "kaspa-utils",
+ "local-ip-address",
  "log",
  "parking_lot",
  "rand 0.8.5",
@@ -2620,6 +2604,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
+name = "local-ip-address"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2815836665de176ba66deaa449ada98fdf208d84730d1a84a22cbeed6151a6fa"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2777,31 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3343,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "ring"
@@ -3450,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -268,7 +268,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -411,6 +411,12 @@ dependencies = [
  "shlex",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
@@ -686,7 +692,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1197,7 +1203,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1238,6 +1244,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getaddrs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efba1d44fc45a1639dd3aae2b59fd966d75cb925dc2bbd2839d9e49afaa0c92d"
+dependencies = [
+ "bitflags 0.9.1",
+ "libc",
 ]
 
 [[package]]
@@ -1540,6 +1556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,7 +1630,9 @@ name = "kaspa-addressmanager"
 version = "0.1.2"
 dependencies = [
  "borsh",
+ "getaddrs",
  "itertools 0.10.5",
+ "kaspa-consensus-core",
  "kaspa-core",
  "kaspa-database",
  "kaspa-utils",
@@ -1713,6 +1737,7 @@ dependencies = [
  "kaspa-merkle",
  "kaspa-muhash",
  "kaspa-txscript-errors",
+ "kaspa-utils",
  "secp256k1",
  "serde",
  "smallvec",
@@ -2256,6 +2281,7 @@ dependencies = [
  "criterion",
  "event-listener",
  "futures-util",
+ "ipnet",
  "itertools 0.10.5",
  "rand 0.8.5",
  "serde",
@@ -2855,7 +2881,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3003,7 +3029,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3090,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -3294,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3306,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3558,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.167"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -3588,13 +3614,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.167"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3804,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3865,7 +3891,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3952,7 +3978,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4120,7 +4146,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4354,7 +4380,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -4388,7 +4414,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ wasm-bindgen-futures = "0.4.33"
 js-sys = "0.3.56"
 getrandom = { version = "0.2.8", features = ["js"] }
 uuid = { version = "1.2.2", features = ["v4", "fast-rng", "serde"] }
+getaddrs = "0.1.0"
 
 # bip32 dependencies
 rand_core = { version = "0.6", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ wasm-bindgen-futures = "0.4.33"
 js-sys = "0.3.56"
 getrandom = { version = "0.2.8", features = ["js"] }
 uuid = { version = "1.2.2", features = ["v4", "fast-rng", "serde"] }
-getaddrs = "0.1.0"
 
 # bip32 dependencies
 rand_core = { version = "0.6", features = ["std"] }

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -18,3 +18,4 @@ rand.workspace = true
 parking_lot.workspace = true
 borsh.workspace = true
 log.workspace = true
+getaddrs.workspace = true

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 rocksdb.workspace = true
 kaspa-utils.workspace = true
+kaspa-consensus-core.workspace = true
 kaspa-core.workspace = true
 kaspa-database.workspace = true
 serde.workspace = true

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -18,4 +18,4 @@ rand.workspace = true
 parking_lot.workspace = true
 borsh.workspace = true
 log.workspace = true
-getaddrs.workspace = true
+local-ip-address = "0.5.3"

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -54,7 +54,7 @@ impl AddressManager {
             None => {
                 // If listen_address === 0.0.0.0, bind all interfaces
                 // else, bind whatever was passed as listen address (if routable)
-                let listen_address = self.config.listen.normalize(self.config.default_p2p_port());
+                let listen_address = self.config.p2p_listen_address.normalize(self.config.default_p2p_port());
 
                 if listen_address.ip.is_unspecified() {
                     let network_interfaces = list_afinet_netifas();

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -12,6 +12,7 @@ kaspa-muhash.workspace = true
 kaspa-merkle.workspace = true
 kaspa-math.workspace = true
 kaspa-addresses.workspace = true
+kaspa-utils.workspace = true
 kaspa-txscript-errors.workspace = true
 
 thiserror.workspace = true

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -5,7 +5,7 @@ pub mod params;
 
 use std::ops::Deref;
 
-use kaspa_utils::networking::{IpAddress, ContextualNetAddress};
+use kaspa_utils::networking::{ContextualNetAddress, IpAddress};
 
 use {
     constants::perf::{PerfParams, PERF_PARAMS},

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -5,6 +5,8 @@ pub mod params;
 
 use std::ops::Deref;
 
+use kaspa_utils::networking::IpAddress;
+
 use {
     constants::perf::{PerfParams, PERF_PARAMS},
     params::Params,
@@ -46,6 +48,8 @@ pub struct Config {
     pub enable_mainnet_mining: bool,
 
     pub user_agent_comments: Vec<String>,
+
+    pub externalip: Option<IpAddress>,
 }
 
 impl Config {
@@ -65,6 +69,7 @@ impl Config {
             enable_unsynced_mining: false,
             enable_mainnet_mining: false,
             user_agent_comments: Default::default(),
+            externalip: None,
         }
     }
 

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -50,7 +50,7 @@ pub struct Config {
     pub user_agent_comments: Vec<String>,
 
     // If undefined, sets it to 0.0.0.0
-    pub listen: ContextualNetAddress,
+    pub p2p_listen_address: ContextualNetAddress,
 
     pub externalip: Option<IpAddress>,
 }
@@ -73,7 +73,7 @@ impl Config {
             enable_mainnet_mining: false,
             user_agent_comments: Default::default(),
             externalip: None,
-            listen: ContextualNetAddress::unspecified(),
+            p2p_listen_address: ContextualNetAddress::unspecified(),
         }
     }
 

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -5,7 +5,7 @@ pub mod params;
 
 use std::ops::Deref;
 
-use kaspa_utils::networking::IpAddress;
+use kaspa_utils::networking::{IpAddress, ContextualNetAddress};
 
 use {
     constants::perf::{PerfParams, PERF_PARAMS},
@@ -49,6 +49,9 @@ pub struct Config {
 
     pub user_agent_comments: Vec<String>,
 
+    // If undefined, sets it to 0.0.0.0
+    pub listen: ContextualNetAddress,
+
     pub externalip: Option<IpAddress>,
 }
 
@@ -70,6 +73,7 @@ impl Config {
             enable_mainnet_mining: false,
             user_agent_comments: Default::default(),
             externalip: None,
+            listen: ContextualNetAddress::unspecified(),
         }
     }
 

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -3,7 +3,7 @@ use clap::ArgAction;
 use clap::{arg, command, Arg, Command};
 use kaspa_consensus::config::Config;
 use kaspa_core::kaspad_env::version;
-use kaspa_utils::networking::ContextualNetAddress;
+use kaspa_utils::networking::{ContextualNetAddress, IpAddress};
 
 pub struct Defaults {
     pub appdir: &'static str,
@@ -86,6 +86,7 @@ pub struct Args {
     pub archival: bool,
     pub sanity: bool,
     pub yes: bool,
+    pub externalip: Option<IpAddress>,
 }
 
 pub fn cli(defaults: &Defaults) -> Command {
@@ -224,6 +225,15 @@ pub fn cli(defaults: &Defaults) -> Command {
                 .require_equals(true)
                 .help("Comment to add to the user agent -- See BIP 14 for more information."),
         )
+        .arg(
+            Arg::new("externalip")
+                .long("externalip")
+                .value_name("externalip")
+                .require_equals(true)
+                .default_missing_value(None)
+                .value_parser(clap::value_parser!(IpAddress))
+                .help("Add an ip to the list of local addresses we claim to listen on to peers"),
+        )
 }
 
 impl Args {
@@ -258,6 +268,7 @@ impl Args {
             sanity: m.get_one::<bool>("sanity").cloned().unwrap_or(defaults.sanity),
             yes: m.get_one::<bool>("yes").cloned().unwrap_or(defaults.yes),
             user_agent_comments: m.get_many::<String>("user_agent_comments").unwrap_or_default().cloned().collect(),
+            externalip: m.get_one::<IpAddress>("externalip").cloned(),
         }
     }
 
@@ -270,6 +281,7 @@ impl Args {
         // TODO: change to `config.enable_sanity_checks = self.sanity` when we reach stable versions
         config.enable_sanity_checks = true;
         config.user_agent_comments = self.user_agent_comments.clone();
+        config.externalip = self.externalip;
     }
 }
 

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -281,7 +281,7 @@ impl Args {
         // TODO: change to `config.enable_sanity_checks = self.sanity` when we reach stable versions
         config.enable_sanity_checks = true;
         config.user_agent_comments = self.user_agent_comments.clone();
-        config.listen = self.listen.unwrap_or(ContextualNetAddress::unspecified());
+        config.p2p_listen_address = self.listen.unwrap_or(ContextualNetAddress::unspecified());
         config.externalip = self.externalip;
     }
 }

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -281,6 +281,7 @@ impl Args {
         // TODO: change to `config.enable_sanity_checks = self.sanity` when we reach stable versions
         config.enable_sanity_checks = true;
         config.user_agent_comments = self.user_agent_comments.clone();
+        config.listen = self.listen.unwrap_or(ContextualNetAddress::unspecified());
         config.externalip = self.externalip;
     }
 }

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -245,7 +245,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         None
     };
 
-    let address_manager = AddressManager::new(meta_db);
+    let address_manager = AddressManager::new(config.clone(), meta_db);
     let mining_manager =
         MiningManagerProxy::new(Arc::new(MiningManager::new(config.target_time_per_block, false, config.max_block_mass, None)));
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -450,15 +450,7 @@ impl ConnectionInitializer for FlowContext {
 
         let network_name = self.config.network_name();
 
-        let mut local_address = None;
-
-        match self.address_manager.lock().best_local_address() {
-            None => {}
-            Some(local_net_address) => {
-                info!("Local node is using {} for P2P", local_net_address);
-                local_address = Some(local_net_address);
-            }
-        }
+        let local_address = self.address_manager.lock().best_local_address();
 
         // Build the local version message
         // Subnets are not currently supported

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -509,8 +509,16 @@ impl ConnectionInitializer for FlowContext {
             flow.launch();
         }
 
-        if router.is_outbound() {
-            self.address_manager.lock().add_address(router.net_address().into());
+        if router.is_outbound() || peer_version.address.is_some() {
+            let mut address_manager = self.address_manager.lock();
+
+            if router.is_outbound() {
+                address_manager.add_address(router.net_address().into());
+            }
+
+            if let Some(peer_ip_address) = peer_version.address {
+                address_manager.add_address(peer_ip_address);
+            }
         }
 
         // Note: we deliberately do not hold the handshake in memory so at this point receivers for handshake subscriptions

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -451,13 +451,13 @@ impl ConnectionInitializer for FlowContext {
         let network_name = self.config.network_name();
 
         let mut local_address = None;
-    
+
         match self.address_manager.lock().best_local_address() {
-            None => {},
+            None => {}
             Some(local_net_address) => {
                 info!("Local node is using {} for P2P", local_net_address);
                 local_address = Some(local_net_address);
-            },
+            }
         }
 
         // Build the local version message

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -30,7 +30,7 @@ use kaspa_p2p_lib::{
     ConnectionInitializer, Hub, KaspadHandshake, PeerKey, PeerProperties, Router,
 };
 use kaspa_utils::iter::IterExtensions;
-use kaspa_utils::networking::{PeerId, NetAddress};
+use kaspa_utils::networking::PeerId;
 use parking_lot::{Mutex, RwLock};
 use std::{
     collections::HashSet,
@@ -452,11 +452,9 @@ impl ConnectionInitializer for FlowContext {
 
         let mut local_address = None;
     
-        match self.config.externalip {
+        match self.address_manager.lock().best_local_address() {
             None => {},
-            Some(externalip) => {
-                // TODO: Check if the port logic I'm using is correct
-                let local_net_address = NetAddress::new(externalip, self.config.default_p2p_port());
+            Some(local_net_address) => {
                 info!("Local node is using {} for P2P", local_net_address);
                 local_address = Some(local_net_address);
             },

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,6 +15,7 @@ itertools.workspace = true
 
 triggered = "0.1"
 event-listener = "2.5.3"
+ipnet = "2.8.0"
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -375,119 +375,119 @@ mod tests {
     #[test]
     fn test_is_publicly_routable() {
         // RFC 2544 tests
-        assert_eq!(false, IpAddress::from_str("198.18.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("198.19.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("198.17.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("198.20.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("198.18.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("198.19.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("198.17.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("198.20.0.0").unwrap().is_publicly_routable());
 
         // Zero net tests
-        assert_eq!(false, IpAddress::from_str("0.0.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("0.0.0.1").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("0.0.1.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("0.1.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("0.0.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("0.0.0.1").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("0.0.1.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("0.1.0.0").unwrap().is_publicly_routable());
 
         // RFC 3849
-        assert_eq!(false, IpAddress::from_str("2001:db8::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:db7:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:db9::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:db8::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:db7:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:db9::").unwrap().is_publicly_routable());
 
         // Localhost
-        assert_eq!(false, IpAddress::from_str("127.0.0.1").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("127.0.0.1").unwrap().is_publicly_routable());
 
         // Some random routable IP
-        assert_eq!(true, IpAddress::from_str("123.45.67.89").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("123.45.67.89").unwrap().is_publicly_routable());
 
         // RFC 1918
-        assert_eq!(false, IpAddress::from_str("10.0.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("10.255.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("9.255.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("11.0.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("10.0.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("10.255.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("9.255.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("11.0.0.0").unwrap().is_publicly_routable());
 
-        assert_eq!(false, IpAddress::from_str("172.16.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("172.31.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("172.15.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("172.32.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("172.16.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("172.31.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("172.15.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("172.32.0.0").unwrap().is_publicly_routable());
 
-        assert_eq!(false, IpAddress::from_str("192.168.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("192.168.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("192.167.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("192.169.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("192.168.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("192.168.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("192.167.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("192.169.0.0").unwrap().is_publicly_routable());
 
         // RFC 3927
-        assert_eq!(false, IpAddress::from_str("169.254.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("169.254.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("169.253.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("169.255.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("169.254.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("169.254.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("169.253.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("169.255.0.0").unwrap().is_publicly_routable());
 
         // RFC 3964
-        assert_eq!(false, IpAddress::from_str("2002::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2003::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2002::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2003::").unwrap().is_publicly_routable());
 
         // RFC 4193
-        assert_eq!(false, IpAddress::from_str("fc00::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("fb00:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("fe00::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("fc00::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("fb00:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("fe00::").unwrap().is_publicly_routable());
 
         // RFC 4380
-        assert_eq!(false, IpAddress::from_str("2001::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("2001:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2000:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:1::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2000:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:1::").unwrap().is_publicly_routable());
 
         // RFC 4843
-        assert_eq!(false, IpAddress::from_str("2001:10::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("2001:1f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:20::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:10::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:1f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:20::").unwrap().is_publicly_routable());
 
         // RFC 4862
-        assert_eq!(false, IpAddress::from_str("fe80::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("fe80::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("fe7f::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("fe81::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("fe80::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("fe80::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("fe7f::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("fe81::").unwrap().is_publicly_routable());
 
         // RFC 5737
-        assert_eq!(false, IpAddress::from_str("192.0.2.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("192.0.2.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("192.0.1.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("192.0.3.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("192.0.2.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("192.0.2.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("192.0.1.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("192.0.3.0").unwrap().is_publicly_routable());
 
-        assert_eq!(false, IpAddress::from_str("198.51.100.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("198.51.100.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("198.51.99.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("198.51.101.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("198.51.100.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("198.51.100.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("198.51.99.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("198.51.101.0").unwrap().is_publicly_routable());
 
-        assert_eq!(false, IpAddress::from_str("203.0.113.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("203.0.113.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("203.0.112.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("203.0.114.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("203.0.113.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("203.0.113.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("203.0.112.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("203.0.114.0").unwrap().is_publicly_routable());
 
         // RFC 6052
-        assert_eq!(false, IpAddress::from_str("64:ff9b::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("64:ff9b::ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("64:ff9a::ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("64:ff9b:1::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("64:ff9b::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("64:ff9b::ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("64:ff9a::ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("64:ff9b:1::").unwrap().is_publicly_routable());
 
         // RFC 6145
-        assert_eq!(false, IpAddress::from_str("::ffff:0:0:0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("::ffff:0:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("::fffe:0:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("::ffff:1:0:0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("::ffff:0:0:0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("::ffff:0:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("::fffe:0:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("::ffff:1:0:0").unwrap().is_publicly_routable());
 
         // RFC 6598
-        assert_eq!(false, IpAddress::from_str("100.64.0.0").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("100.127.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("100.63.255.255").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("100.128.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("100.64.0.0").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("100.127.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("100.63.255.255").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("100.128.0.0").unwrap().is_publicly_routable());
 
         // Hurricane Electric IPv6 address block.
-        assert_eq!(false, IpAddress::from_str("2001:470::").unwrap().is_publicly_routable());
-        assert_eq!(false, IpAddress::from_str("2001:470:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:46f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
-        assert_eq!(true, IpAddress::from_str("2001:471::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:470::").unwrap().is_publicly_routable());
+        assert!(!IpAddress::from_str("2001:470:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:46f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert!(IpAddress::from_str("2001:471::").unwrap().is_publicly_routable());
     }
 }

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -17,6 +17,11 @@ impl IpAddress {
     pub fn new(ip: IpAddr) -> Self {
         Self(ip)
     }
+
+    pub fn is_publicly_routable(&self) -> bool {
+        // TODO: return true if this is routable over the internet
+        false
+    }
 }
 impl From<IpAddr> for IpAddress {
     fn from(ip: IpAddr) -> Self {

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::Display,
@@ -7,7 +8,6 @@ use std::{
     str::FromStr,
 };
 use uuid::Uuid;
-use ipnet::IpNet;
 
 /// An IP address, newtype of [IpAddr].
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug)]
@@ -53,7 +53,7 @@ impl IpAddress {
             }
         }
 
-        return true;
+        true
     }
 }
 impl From<IpAddr> for IpAddress {

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -386,12 +386,108 @@ mod tests {
         assert_eq!(false, IpAddress::from_str("0.0.1.0").unwrap().is_publicly_routable());
         assert_eq!(false, IpAddress::from_str("0.1.0.0").unwrap().is_publicly_routable());
 
+        // RFC 3849
+        assert_eq!(false, IpAddress::from_str("2001:db8::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:db7:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:db9::").unwrap().is_publicly_routable());
+
         // Localhost
         assert_eq!(false, IpAddress::from_str("127.0.0.1").unwrap().is_publicly_routable());
 
         // Some random routable IP
         assert_eq!(true, IpAddress::from_str("123.45.67.89").unwrap().is_publicly_routable());
 
-        // TODO: Write more unit tests for the rest of the ranges
+        // RFC 1918
+        assert_eq!(false, IpAddress::from_str("10.0.0.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("10.255.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("9.255.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("11.0.0.0").unwrap().is_publicly_routable());
+
+        assert_eq!(false, IpAddress::from_str("172.16.0.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("172.31.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("172.15.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("172.32.0.0").unwrap().is_publicly_routable());
+
+        assert_eq!(false, IpAddress::from_str("192.168.0.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("192.168.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("192.167.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("192.169.0.0").unwrap().is_publicly_routable());
+
+        // RFC 3927
+        assert_eq!(false, IpAddress::from_str("169.254.0.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("169.254.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("169.253.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("169.255.0.0").unwrap().is_publicly_routable());
+
+        // RFC 3964
+        assert_eq!(false, IpAddress::from_str("2002::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2003::").unwrap().is_publicly_routable());
+
+        // RFC 4193
+        assert_eq!(false, IpAddress::from_str("fc00::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("fb00:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("fe00::").unwrap().is_publicly_routable());
+
+        // RFC 4380
+        assert_eq!(false, IpAddress::from_str("2001::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("2001:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2000:0:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:1::").unwrap().is_publicly_routable());
+
+        // RFC 4843
+        assert_eq!(false, IpAddress::from_str("2001:10::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("2001:1f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:20::").unwrap().is_publicly_routable());
+
+        // RFC 4862
+        assert_eq!(false, IpAddress::from_str("fe80::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("fe80::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("fe7f::ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("fe81::").unwrap().is_publicly_routable());
+
+        // RFC 5737
+        assert_eq!(false, IpAddress::from_str("192.0.2.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("192.0.2.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("192.0.1.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("192.0.3.0").unwrap().is_publicly_routable());
+
+        assert_eq!(false, IpAddress::from_str("198.51.100.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("198.51.100.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("198.51.99.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("198.51.101.0").unwrap().is_publicly_routable());
+
+        assert_eq!(false, IpAddress::from_str("203.0.113.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("203.0.113.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("203.0.112.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("203.0.114.0").unwrap().is_publicly_routable());
+
+        // RFC 6052
+        assert_eq!(false, IpAddress::from_str("64:ff9b::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("64:ff9b::ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("64:ff9a::ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("64:ff9b:1::").unwrap().is_publicly_routable());
+
+        // RFC 6145
+        assert_eq!(false, IpAddress::from_str("::ffff:0:0:0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("::ffff:0:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("::fffe:0:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("::ffff:1:0:0").unwrap().is_publicly_routable());
+
+        // RFC 6598
+        assert_eq!(false, IpAddress::from_str("100.64.0.0").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("100.127.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("100.63.255.255").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("100.128.0.0").unwrap().is_publicly_routable());
+
+        // Hurricane Electric IPv6 address block.
+        assert_eq!(false, IpAddress::from_str("2001:470::").unwrap().is_publicly_routable());
+        assert_eq!(false, IpAddress::from_str("2001:470:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:46f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap().is_publicly_routable());
+        assert_eq!(true, IpAddress::from_str("2001:471::").unwrap().is_publicly_routable());
     }
 }


### PR DESCRIPTION
- If we can add local addresses, this assumes the first one is always the best
- If `--listen` is passed, it is added as the local address, if it's routable
- Adds the `externalip` flag
  - If an external IP is passed, it is assumed to be the best one to use
  - The value is added as a local address, if it's routable
- Passes the "best local IP address" to the version message
- If neither `--listen` nor `--externalip` is passed (most common default), then all interfaces are checked for local addresses that are routable and adds them to the list