### PR TITLE
Replace .then_some with .then in simpa and kaspad

### DIFF
--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -229,7 +229,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     let consensus_manager = Arc::new(ConsensusManager::new(consensus_factory));
     let consensus_monitor = Arc::new(ConsensusMonitor::new(counters, tick_service.clone()));
 
-    let perf_monitor = args.perf_metrics.then_some({
+    let perf_monitor = args.perf_metrics.then(|| {
         let cb = move |counters| {
             trace!("[{}] metrics: {:?}", kaspa_perf_monitor::SERVICE_NAME, counters);
         };

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
 
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let stop_perf_monitor = args.perf_metrics.then_some({
+    let stop_perf_monitor = args.perf_metrics.then(|| {
         let ts = Arc::new(TickService::new());
         let cb = move |counters| {
             trace!("metrics: {:?}", counters);


### PR DESCRIPTION
currently perf_monitor doesn't consider cli flag and runs always. this pr fixes the behaviour
Updated the use of .then_some with .then in simpa/src/main.rs and kaspad/src/main.rs.
