### PR TITLE
Fix a gRPC server deadlock bug caused by duplicate connections

### DIFF
--- a/rpc/grpc/client/src/error.rs
+++ b/rpc/grpc/client/src/error.rs
@@ -9,10 +9,10 @@ pub enum Error {
     #[error("Error: {0}")]
     String(String),
 
-    #[error("gRPC invalid address schema {0}")]
+    #[error("GRPC invalid address schema {0}")]
     GrpcAddressSchema(String),
 
-    #[error("gRPC client error {0}")]
+    #[error("GRPC client error {0}")]
     TonicStatus(#[from] tonic::Status),
 
     /// RPC call timeout

--- a/rpc/grpc/server/src/connection.rs
+++ b/rpc/grpc/server/src/connection.rs
@@ -142,6 +142,10 @@ impl Connection {
         connection_clone
     }
 
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        Arc::ptr_eq(&this.inner, &other.inner)
+    }
+
     pub fn net_address(&self) -> SocketAddr {
         self.inner.net_address
     }
@@ -565,7 +569,7 @@ impl ConnectionT for Connection {
             // The typical case is the manager terminating all connections.
             return false;
         }
-        self.inner.manager.unregister(self.net_address());
+        self.inner.manager.unregister(self.clone());
         true
     }
 

--- a/rpc/grpc/server/src/connection.rs
+++ b/rpc/grpc/server/src/connection.rs
@@ -72,7 +72,7 @@ impl Connection {
         let connection_clone = connection.clone();
         let outgoing_route = connection.inner.outgoing_route.clone();
         // Start the connection receive loop
-        debug!("gRPC: Connection receive loop - starting for client {}", connection);
+        debug!("GRPC: Connection receive loop - starting for client {}", connection);
         tokio::spawn(async move {
             let listener_id: Lazy<ListenerId, _> = Lazy::new(|| notifier.clone().register_new_listener(connection.clone()));
             loop {
@@ -80,13 +80,13 @@ impl Connection {
                     biased; // We use biased polling so that the shutdown signal is always checked first
 
                     _ = &mut shutdown_receiver => {
-                        debug!("gRPC: Connection receive loop - shutdown signal received, exiting connection receive loop, client-id: {}", connection.identity());
+                        debug!("GRPC: Connection receive loop - shutdown signal received, exiting connection receive loop, client-id: {}", connection.identity());
                         break;
                     }
 
                     res = incoming_stream.message() => match res {
                         Ok(Some(request)) => {
-                            //trace!("gRPC: request: {:?}, client-id: {}", request, connection.identity());
+                            //trace!("GRPC: request: {:?}, client-id: {}", request, connection.identity());
 
                             let response = match request.is_subscription() {
                                 true => {
@@ -101,38 +101,38 @@ impl Connection {
                                     match outgoing_route.send(Ok(response)).await {
                                         Ok(()) => {},
                                         Err(e) => {
-                                            debug!("gRPC: Connection receive loop - send error {} for client: {}", e, connection);
+                                            debug!("GRPC: Connection receive loop - send error {} for client: {}", e, connection);
                                             break;
                                         },
                                     }
                                 }
                                 Err(e) => {
-                                    debug!("gRPC: Connection receive loop - request handling error {} for client: {}", e, connection);
+                                    debug!("GRPC: Connection receive loop - request handling error {} for client: {}", e, connection);
                                     break;
                                 }
                             }
 
                         }
                         Ok(None) => {
-                            debug!("gRPC: Connection receive loop - incoming stream ended from client {}", connection);
+                            debug!("GRPC: Connection receive loop - incoming stream ended from client {}", connection);
                             break;
                         }
                         Err(err) => {
                             {
                                 if let Some(io_err) = match_for_io_error(&err) {
                                     if io_err.kind() == ErrorKind::BrokenPipe {
-                                        debug!("gRPC: Connection receive loop - client {} disconnected, broken pipe", connection);
+                                        debug!("GRPC: Connection receive loop - client {} disconnected, broken pipe", connection);
                                         break;
                                     }
                                 }
-                                debug!("gRPC: Connection receive loop - network error: {} from client {}", err, connection);
+                                debug!("GRPC: Connection receive loop - network error: {} from client {}", err, connection);
                             }
                             break;
                         }
                     }
                 }
             }
-            debug!("gRPC: Connection receive loop - terminated for client {}", connection);
+            debug!("GRPC: Connection receive loop - terminated for client {}", connection);
             if let Ok(listener_id) = Lazy::into_value(listener_id) {
                 let _ = notifier.unregister_listener(listener_id);
             }

--- a/rpc/grpc/server/src/connection_handler.rs
+++ b/rpc/grpc/server/src/connection_handler.rs
@@ -78,7 +78,7 @@ impl ConnectionHandler {
 
             match serve_result {
                 Ok(_) => info!("GRPC Server stopped on: {}", serve_address),
-                Err(err) => panic!("gRPC Server {serve_address} stopped with error: {err:?}"),
+                Err(err) => panic!("GRPC Server {serve_address} stopped with error: {err:?}"),
             }
         });
         termination_sender
@@ -90,7 +90,7 @@ impl ConnectionHandler {
     }
 
     pub fn start(&self) {
-        debug!("gRPC: Starting the connection handler");
+        debug!("GRPC: Starting the connection handler");
 
         // Start the internal notifier
         self.notifier().start();
@@ -100,7 +100,7 @@ impl ConnectionHandler {
     }
 
     pub async fn stop(&self) -> RpcResult<()> {
-        debug!("gRPC: Stopping the connection handler");
+        debug!("GRPC: Stopping the connection handler");
 
         // Refuse new incoming connections
         self.running.store(false, Ordering::SeqCst);
@@ -143,7 +143,7 @@ impl Rpc for ConnectionHandler {
             ));
         }
 
-        debug!("gRPC: incoming message stream from {:?}", remote_address);
+        debug!("GRPC: incoming message stream from {:?}", remote_address);
 
         // Build the in/out pipes
         let (outgoing_route, outgoing_receiver) = mpsc_channel(Self::outgoing_route_channel_size());

--- a/rpc/grpc/server/src/manager.rs
+++ b/rpc/grpc/server/src/manager.rs
@@ -20,17 +20,17 @@ impl Manager {
     }
 
     pub fn register(&self, connection: Connection) {
-        debug!("gRPC: registering a new connection from {connection}");
+        debug!("GRPC: registering a new connection from {connection}");
         let mut connections_write = self.connections.write();
         let previous_connection = connections_write.insert(connection.identity(), connection.clone());
-        info!("gRPC: new incoming connection {} #{}", connection, connections_write.len());
+        info!("GRPC: new incoming connection {} #{}", connection, connections_write.len());
 
         // Release the write lock to prevent a deadlock if a previous connection exists and must be closed
         drop(connections_write);
 
         if let Some(previous_connection) = previous_connection {
             previous_connection.close();
-            warn!("gRPC: removing connection with duplicate identity: {}", previous_connection.identity());
+            warn!("GRPC: removing connection with duplicate identity: {}", previous_connection.identity());
         }
     }
 
@@ -44,7 +44,7 @@ impl Manager {
             // This is extremely important in cases of duplicate connection rejection etc.
             if Connection::ptr_eq(entry.get(), &connection) {
                 entry.remove_entry();
-                debug!("gRPC: unregistering connection from {connection}");
+                debug!("GRPC: unregistering connection from {connection}");
             }
         }
     }


### PR DESCRIPTION
Fix a deadlock bug in the gRPC server occurring in case of duplicate connections with the same identity, hence same client network address.