### PR TITLE
Resurrect the heap profiler

### DIFF
--- a/consensus/src/processes/pruning.rs
+++ b/consensus/src/processes/pruning.rs
@@ -208,7 +208,7 @@ impl<
         // we expect to see it later on the list.
         // The first stage is important because the most recent pruning point is pointing to a few
         // pruning points before, so the first few pruning points on the list won't be pointed by
-        // any other pruning point in the list, so we are compelled to check if it's refereced by
+        // any other pruning point in the list, so we are compelled to check if it's referenced by
         // the selected chain.
         let mut expected_pps_queue = VecDeque::new();
         for current in self.reachability_service.backward_chain_iterator(hst, pruning_info.pruning_point, false) {

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -256,7 +256,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         let cb = move |counters| {
             trace!("[{}] metrics: {:?}", kaspa_perf_monitor::SERVICE_NAME, counters);
             #[cfg(feature = "heap")]
-            trace!("heap stats: {:?}", dhat::HeapStats::get());
+            trace!("[{}] heap stats: {:?}", kaspa_perf_monitor::SERVICE_NAME, dhat::HeapStats::get());
         };
         Arc::new(perf_monitor_builder.with_fetch_cb(cb).build())
     } else {

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -7,6 +7,10 @@ use std::sync::Arc;
 use kaspa_core::{info, signals::Signals};
 use kaspad::{args::parse_args, daemon::create_core};
 
+#[cfg(feature = "heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 pub fn main() {
     #[cfg(feature = "heap")]
     let _profiler = dhat::Profiler::builder().file_name("kaspad-heap.json").build();


### PR DESCRIPTION
Return the dhat heap ALLOC profiler which was accidentally dropped when refactoring kaspad main to a daemon