### PR TITLE
Implement Message Signing WASM

### DIFF
--- a/consensus/wasm/src/keypair.rs
+++ b/consensus/wasm/src/keypair.rs
@@ -246,3 +246,9 @@ impl TryFrom<JsValue> for PublicKey {
         }
     }
 }
+
+impl From<PublicKey> for XOnlyPublicKey {
+    fn from(value: PublicKey) -> Self {
+        value.xonly_public_key
+    }
+}

--- a/wallet/core/src/message.rs
+++ b/wallet/core/src/message.rs
@@ -20,17 +20,6 @@ pub fn sign_message(msg: &PersonalMessage, privkey: &[u8; 32]) -> Result<Vec<u8>
     Ok(sig.to_vec())
 }
 
-pub fn sign_message_with_aux_rand(msg: &PersonalMessage, privkey: &[u8; 32], aux_rand: &[u8; 32]) -> Result<Vec<u8>, Error> {
-    let hash = calc_personal_message_hash(msg);
-
-    let msg = secp256k1::Message::from_slice(hash.as_bytes().as_slice())?;
-    let schnorr_key = secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, privkey)?;
-    let curve = secp256k1::Secp256k1::new();
-    let sig: [u8; 64] = *curve.sign_schnorr_with_aux_rand(&msg, &schnorr_key, aux_rand).as_ref();
-
-    Ok(sig.to_vec())
-}
-
 /// Ok(()) if the signature matches the given message and pubkey
 /// Error if any of the inputs are incorrect, or the signature is invalid
 pub fn verify_message(msg: &PersonalMessage, signature: &Vec<u8>, pubkey: &XOnlyPublicKey) -> Result<(), Error> {
@@ -49,6 +38,19 @@ fn calc_personal_message_hash(msg: &PersonalMessage) -> Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Sign message equivalent that's only used for tests
+    /// Necessary only because of KIP test vectors
+    fn sign_message_with_aux_rand(msg: &PersonalMessage, privkey: &[u8; 32], aux_rand: &[u8; 32]) -> Result<Vec<u8>, Error> {
+        let hash = calc_personal_message_hash(msg);
+
+        let msg = secp256k1::Message::from_slice(hash.as_bytes().as_slice())?;
+        let schnorr_key = secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, privkey)?;
+        let curve = secp256k1::Secp256k1::new();
+        let sig: [u8; 64] = *curve.sign_schnorr_with_aux_rand(&msg, &schnorr_key, aux_rand).as_ref();
+
+        Ok(sig.to_vec())
+    }
 
     #[test]
     fn test_basic_sign_and_verify_sign() {

--- a/wallet/core/src/wasm/message.rs
+++ b/wallet/core/src/wasm/message.rs
@@ -1,29 +1,46 @@
+use crate::imports::*;
 use crate::message::*;
 use kaspa_consensus_wasm::{PrivateKey, PublicKey};
-use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen(js_name = signMessage)]
-pub fn js_sign_message(raw_msg: String, privkey: JsValue) -> String {
-    let mut privkey_bytes = [0u8; 32];
+/// Signs a message with the given private key
+/// @param {object} value - an object containing { message: String, privateKey: String|PrivateKey }
+/// @returns {String} the signature, in hex string format
+#[wasm_bindgen(js_name = signMessage, skip_jsdoc)]
+pub fn js_sign_message(value: JsValue) -> Result<String, Error> {
+    if let Some(object) = Object::try_from(&value) {
+        let private_key = object.get::<PrivateKey>("privateKey")?;
+        let raw_msg = object.get_string("message")?;
+        let mut privkey_bytes = [0u8; 32];
 
-    let private_key = PrivateKey::try_from(privkey).unwrap_throw();
-    privkey_bytes.copy_from_slice(&private_key.secret_bytes());
+        privkey_bytes.copy_from_slice(&private_key.secret_bytes());
 
-    let pm = PersonalMessage(&raw_msg);
+        let pm = PersonalMessage(&raw_msg);
 
-    let sig_result = sign_message(&pm, &privkey_bytes);
-    let sig_vec = sig_result.unwrap_throw();
+        let sig_result = sign_message(&pm, &privkey_bytes);
+        let sig_vec = sig_result.unwrap_throw();
 
-    faster_hex::hex_string(sig_vec.as_slice())
+        Ok(faster_hex::hex_string(sig_vec.as_slice()))
+    } else {
+        Err(Error::custom("Failed to parse input"))
+    }
 }
 
-#[wasm_bindgen(js_name = verifyMessage)]
-pub fn js_verify_message(raw_msg: String, signature: String, pubkey: JsValue) -> bool {
-    let public_key = PublicKey::try_from(pubkey).unwrap_throw();
+/// Verifies with a public key the signature of the given message
+/// @param {object} value - an object containing { message: String, signature: String, publicKey: String|PublicKey }
+/// @returns {bool} true if the signature can be verified with the given public key and message, false otherwise
+#[wasm_bindgen(js_name = verifyMessage, skip_jsdoc)]
+pub fn js_verify_message(value: JsValue) -> Result<bool, Error> {
+    if let Some(object) = Object::try_from(&value) {
+        let public_key = object.get::<PublicKey>("publicKey")?;
+        let raw_msg = object.get_string("message")?;
+        let signature = object.get_string("signature")?;
 
-    let pm = PersonalMessage(&raw_msg);
-    let mut signature_bytes = [0u8; 64];
-    faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap_throw();
+        let pm = PersonalMessage(&raw_msg);
+        let mut signature_bytes = [0u8; 64];
+        faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap_throw();
 
-    verify_message(&pm, &signature_bytes.to_vec(), &public_key.into()).is_ok()
+        Ok(verify_message(&pm, &signature_bytes.to_vec(), &public_key.into()).is_ok())
+    } else {
+        Err(Error::custom("Failed to parse input"))
+    }
 }

--- a/wallet/core/src/wasm/message.rs
+++ b/wallet/core/src/wasm/message.rs
@@ -1,19 +1,13 @@
 use crate::message::*;
 use kaspa_consensus_wasm::{PrivateKey, PublicKey};
-use secp256k1::XOnlyPublicKey;
-use std::str::FromStr;
 use wasm_bindgen::prelude::*;
-use workflow_wasm::prelude::ref_from_abi;
 
 #[wasm_bindgen(js_name = signMessage)]
 pub fn js_sign_message(raw_msg: String, privkey: JsValue) -> String {
     let mut privkey_bytes = [0u8; 32];
 
-    if let Ok(privkey) = ref_from_abi!(PrivateKey, &privkey) {
-        privkey_bytes.copy_from_slice(&privkey.secret_bytes());
-    } else {
-        faster_hex::hex_decode(privkey.as_string().unwrap_throw().as_bytes(), &mut privkey_bytes).unwrap_throw();
-    };
+    let private_key = PrivateKey::try_from(privkey).unwrap_throw();
+    privkey_bytes.copy_from_slice(&private_key.secret_bytes());
 
     let pm = PersonalMessage(&raw_msg);
 
@@ -25,16 +19,11 @@ pub fn js_sign_message(raw_msg: String, privkey: JsValue) -> String {
 
 #[wasm_bindgen(js_name = verifyMessage)]
 pub fn js_verify_message(raw_msg: String, signature: String, pubkey: JsValue) -> bool {
-    let x_only_public_key = if let Ok(pubkey) = ref_from_abi!(PublicKey, &pubkey) {
-        pubkey.into()
-    } else {
-        let pubkey_str = pubkey.as_string().unwrap_throw();
-        XOnlyPublicKey::from_str(pubkey_str.as_str()).unwrap_throw()
-    };
+    let public_key = PublicKey::try_from(pubkey).unwrap_throw();
 
     let pm = PersonalMessage(&raw_msg);
     let mut signature_bytes = [0u8; 64];
     faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap_throw();
 
-    verify_message(&pm, &signature_bytes.to_vec(), &x_only_public_key).is_ok()
+    verify_message(&pm, &signature_bytes.to_vec(), &public_key.into()).is_ok()
 }

--- a/wallet/core/src/wasm/message.rs
+++ b/wallet/core/src/wasm/message.rs
@@ -1,0 +1,40 @@
+use crate::message::*;
+use kaspa_consensus_wasm::{PrivateKey, PublicKey};
+use secp256k1::XOnlyPublicKey;
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+use workflow_wasm::prelude::ref_from_abi;
+
+#[wasm_bindgen(js_name = signMessage)]
+pub fn js_sign_message(raw_msg: String, privkey: JsValue) -> String {
+    let mut privkey_bytes = [0u8; 32];
+
+    if let Ok(privkey) = ref_from_abi!(PrivateKey, &privkey) {
+        privkey_bytes.copy_from_slice(&privkey.secret_bytes());
+    } else {
+        faster_hex::hex_decode(privkey.as_string().unwrap_throw().as_bytes(), &mut privkey_bytes).unwrap_throw();
+    };
+
+    let pm = PersonalMessage(&raw_msg);
+
+    let sig_result = sign_message(&pm, &privkey_bytes);
+    let sig_vec = sig_result.unwrap_throw();
+
+    faster_hex::hex_string(sig_vec.as_slice())
+}
+
+#[wasm_bindgen(js_name = verifyMessage)]
+pub fn js_verify_message(raw_msg: String, signature: String, pubkey: JsValue) -> bool {
+    let x_only_public_key = if let Ok(pubkey) = ref_from_abi!(PublicKey, &pubkey) {
+        pubkey.into()
+    } else {
+        let pubkey_str = pubkey.as_string().unwrap_throw();
+        XOnlyPublicKey::from_str(pubkey_str.as_str()).unwrap_throw()
+    };
+
+    let pm = PersonalMessage(&raw_msg);
+    let mut signature_bytes = [0u8; 64];
+    faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap_throw();
+
+    verify_message(&pm, &signature_bytes.to_vec(), &x_only_public_key).is_ok()
+}

--- a/wallet/core/src/wasm/message.rs
+++ b/wallet/core/src/wasm/message.rs
@@ -16,8 +16,7 @@ pub fn js_sign_message(value: JsValue) -> Result<String, Error> {
 
         let pm = PersonalMessage(&raw_msg);
 
-        let sig_result = sign_message(&pm, &privkey_bytes);
-        let sig_vec = sig_result.unwrap_throw();
+        let sig_vec = sign_message(&pm, &privkey_bytes)?;
 
         Ok(faster_hex::hex_string(sig_vec.as_slice()))
     } else {
@@ -37,7 +36,7 @@ pub fn js_verify_message(value: JsValue) -> Result<bool, Error> {
 
         let pm = PersonalMessage(&raw_msg);
         let mut signature_bytes = [0u8; 64];
-        faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap_throw();
+        faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes)?;
 
         Ok(verify_message(&pm, &signature_bytes.to_vec(), &public_key.into()).is_ok())
     } else {

--- a/wallet/core/src/wasm/mod.rs
+++ b/wallet/core/src/wasm/mod.rs
@@ -1,4 +1,5 @@
 pub mod balance;
+pub mod message;
 pub mod tx;
 pub mod utils;
 pub mod utxo;
@@ -7,6 +8,7 @@ pub mod xprivatekey;
 pub mod xpublickey;
 
 pub use balance::*;
+pub use message::*;
 pub use tx::*;
 pub use utils::*;
 pub use utxo::*;

--- a/wasm/nodejs/message_signing.js
+++ b/wasm/nodejs/message_signing.js
@@ -12,12 +12,12 @@ let message = 'Hello Kaspa!';
 let privkey = 'B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF';
 let pubkey = 'DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659';
 
-function runDemo(message, privkey, pubkey) {
-    let signature = signMessage(message, privkey);
+function runDemo(message, privateKey, publicKey) {
+    let signature = signMessage({message, privateKey});
 
     console.info(`Message: ${message} => Signature: ${signature}`);
 
-    if (verifyMessage(message, signature, pubkey)) {
+    if (verifyMessage({message, signature, publicKey})) {
         console.info('Signature verified!');
     } else {
         console.info('Signature is invalid!');

--- a/wasm/nodejs/message_signing.js
+++ b/wasm/nodejs/message_signing.js
@@ -1,0 +1,30 @@
+let kaspa = require('./kaspa/kaspa_wasm');
+let {
+    PrivateKey,
+    PublicKey,
+    signMessage,
+    verifyMessage,
+} = kaspa;
+
+kaspa.initConsolePanicHook();
+
+let message = 'Hello Kaspa!';
+let privkey = 'B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF';
+let pubkey = 'DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659';
+
+function runDemo(message, privkey, pubkey) {
+    let signature = signMessage(message, privkey);
+
+    console.info(`Message: ${message} => Signature: ${signature}`);
+
+    if (verifyMessage(message, signature, pubkey)) {
+        console.info('Signature verified!');
+    } else {
+        console.info('Signature is invalid!');
+    }
+}
+
+// Using strings:
+runDemo(message, privkey, pubkey);
+// Using Objects:
+runDemo(message, new PrivateKey(privkey), new PublicKey(pubkey));


### PR DESCRIPTION
New JS functions:
- `signMessage(message, privkey)` - privkey can be a hex string or `PrivateKey` object
- `verifyMessage(message, signature, pubkey)` - pubkey can be a hex string or `PublicKey` object