### PR TITLE
Fix gcc-multilib installation in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,7 +229,9 @@ jobs:
 
       - name: Install gcc-multilib
         # gcc-multilib allows clang to find gnu libraries properly
-        run: sudo apt install -y gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt install -y gcc-multilib
 
       - name: Install stable toolchain
         if: steps.install_llvm.outcome == 'success' && steps.install_llvm.conclusion == 'success'
@@ -290,7 +292,9 @@ jobs:
 
       - name: Install gcc-multilib
         # gcc-multilib allows clang to find gnu libraries properly
-        run: sudo apt install -y gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt install -y gcc-multilib
 
       - name: Install stable toolchain
         if: steps.install_llvm.outcome == 'success' && steps.install_llvm.conclusion == 'success'


### PR DESCRIPTION
Updated commands for installing gcc-multilib in ci.yaml to ensure fresh package lists are obtained before installation by invoking apt-get update first. This will prevent issues if older versions of gcc-multilib are cached, enhancing reliability of CI builds.