### PR TITLE
Optimize P2P block processing latency -- Broadcast blocks after Body Processor

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -142,11 +142,11 @@ impl ConsensusSessionOwned {
 }
 
 impl ConsensusSessionOwned {
-    pub fn validate_and_insert_block(&self, block: Block) -> BlockValidationFuture {
+    pub fn validate_and_insert_block(&self, block: Block) -> (BlockValidationFuture, BlockValidationFuture) {
         self.consensus.validate_and_insert_block(block)
     }
 
-    pub fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> BlockValidationFuture {
+    pub fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> (BlockValidationFuture, BlockValidationFuture) {
         self.consensus.validate_and_insert_trusted_block(tb)
     }
 

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -13,7 +13,7 @@ use kaspa_consensus_core::{
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{Transaction, TransactionOutpoint, UtxoEntry},
-    BlockHashSet, ChainPath, Hash,
+    BlockHashSet, BlueWorkType, ChainPath, Hash,
 };
 use kaspa_utils::sync::rwlock::*;
 use std::{ops::Deref, sync::Arc};
@@ -169,6 +169,13 @@ impl ConsensusSessionOwned {
 
     pub async fn async_get_virtual_merge_depth_root(&self) -> Option<Hash> {
         self.clone().spawn_blocking(|c| c.get_virtual_merge_depth_root()).await
+    }
+
+    /// Returns the `BlueWork` threshold at which blocks with lower or equal blue work are considered
+    /// to be un-mergeable by current virtual state.
+    /// (Note: in some rare cases when the node is unsynced the function might return zero as the threshold)
+    pub async fn async_get_virtual_merge_depth_blue_work_threshold(&self) -> BlueWorkType {
+        self.clone().spawn_blocking(|c| c.get_virtual_merge_depth_blue_work_threshold()).await
     }
 
     pub async fn async_get_sink(&self) -> Hash {

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -4,7 +4,7 @@
 
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
-    api::{BlockValidationFuture, ConsensusApi, DynConsensus},
+    api::{BlockValidationFutures, ConsensusApi, DynConsensus},
     block::Block,
     block_count::BlockCount,
     blockstatus::BlockStatus,
@@ -142,11 +142,11 @@ impl ConsensusSessionOwned {
 }
 
 impl ConsensusSessionOwned {
-    pub fn validate_and_insert_block(&self, block: Block) -> (BlockValidationFuture, BlockValidationFuture) {
+    pub fn validate_and_insert_block(&self, block: Block) -> BlockValidationFutures {
         self.consensus.validate_and_insert_block(block)
     }
 
-    pub fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> (BlockValidationFuture, BlockValidationFuture) {
+    pub fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> BlockValidationFutures {
         self.consensus.validate_and_insert_trusted_block(tb)
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -24,6 +24,17 @@ use crate::{
 use kaspa_hashes::Hash;
 pub type BlockValidationFuture = BoxFuture<'static, BlockProcessResult<BlockStatus>>;
 
+/// A struct returned by consensus for block validation processing calls
+pub struct BlockValidationFutures {
+    /// A future triggered when block processing is completed (header and body processing)
+    pub block_task: BlockValidationFuture,
+
+    /// A future triggered when DAG state which included this block has been processed by the virtual processor
+    /// (exceptions are header-only blocks and trusted blocks which have the future completed before virtual
+    /// processing along with the [`block_task`])
+    pub virtual_state_task: BlockValidationFuture,
+}
+
 /// Abstracts the consensus external API
 #[allow(unused_variables)]
 pub trait ConsensusApi: Send + Sync {
@@ -36,11 +47,11 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn validate_and_insert_block(&self, block: Block) -> (BlockValidationFuture, BlockValidationFuture) {
+    fn validate_and_insert_block(&self, block: Block) -> BlockValidationFutures {
         unimplemented!()
     }
 
-    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> (BlockValidationFuture, BlockValidationFuture) {
+    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> BlockValidationFutures {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -36,11 +36,11 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn validate_and_insert_block(&self, block: Block) -> BlockValidationFuture {
+    fn validate_and_insert_block(&self, block: Block) -> (BlockValidationFuture, BlockValidationFuture) {
         unimplemented!()
     }
 
-    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> BlockValidationFuture {
+    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> (BlockValidationFuture, BlockValidationFuture) {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
-    BlockHashSet, ChainPath,
+    BlockHashSet, BlueWorkType, ChainPath,
 };
 use kaspa_hashes::Hash;
 pub type BlockValidationFuture = BoxFuture<'static, BlockProcessResult<BlockStatus>>;
@@ -94,6 +94,13 @@ pub trait ConsensusApi: Send + Sync {
     }
 
     fn get_virtual_merge_depth_root(&self) -> Option<Hash> {
+        unimplemented!()
+    }
+
+    /// Returns the `BlueWork` threshold at which blocks with lower or equal blue work are considered
+    /// to be un-mergeable by current virtual state.
+    /// (Note: in some rare cases when the node is unsynced the function might return zero as the threshold)
+    fn get_virtual_merge_depth_blue_work_threshold(&self) -> BlueWorkType {
         unimplemented!()
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     pipeline::{
         body_processor::BlockBodyProcessor,
-        deps_manager::{BlockProcessingMessage, BlockResultSender, BlockTask},
+        deps_manager::{BlockProcessingMessage, BlockResultSender, BlockTask, VirtualStateProcessingMessage},
         header_processor::HeaderProcessor,
         pruning_processor::processor::{PruningProcessingMessage, PruningProcessor},
         virtual_processor::{errors::PruningImportResult, VirtualStateProcessor},
@@ -159,8 +159,10 @@ impl Consensus {
             unbounded_crossbeam();
         let (body_sender, body_receiver): (CrossbeamSender<BlockProcessingMessage>, CrossbeamReceiver<BlockProcessingMessage>) =
             unbounded_crossbeam();
-        let (virtual_sender, virtual_receiver): (CrossbeamSender<BlockProcessingMessage>, CrossbeamReceiver<BlockProcessingMessage>) =
-            unbounded_crossbeam();
+        let (virtual_sender, virtual_receiver): (
+            CrossbeamSender<VirtualStateProcessingMessage>,
+            CrossbeamReceiver<VirtualStateProcessingMessage>,
+        ) = unbounded_crossbeam();
         let (pruning_sender, pruning_receiver): (
             CrossbeamSender<PruningProcessingMessage>,
             CrossbeamReceiver<PruningProcessingMessage>,

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
-    api::{BlockValidationFuture, ConsensusApi},
+    api::{BlockValidationFutures, ConsensusApi},
     block::{Block, BlockTemplate, TemplateBuildMode, TemplateTransactionSelector},
     block_count::BlockCount,
     blockhash::BlockHashExtensions,
@@ -370,14 +370,14 @@ impl ConsensusApi for Consensus {
         self.virtual_processor.build_block_template(miner_data, tx_selector, build_mode)
     }
 
-    fn validate_and_insert_block(&self, block: Block) -> (BlockValidationFuture, BlockValidationFuture) {
-        let result = self.validate_and_insert_block_impl(BlockTask::Ordinary { block });
-        (Box::pin(result.0), Box::pin(result.1))
+    fn validate_and_insert_block(&self, block: Block) -> BlockValidationFutures {
+        let (block_task, virtual_state_task) = self.validate_and_insert_block_impl(BlockTask::Ordinary { block });
+        BlockValidationFutures { block_task: Box::pin(block_task), virtual_state_task: Box::pin(virtual_state_task) }
     }
 
-    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> (BlockValidationFuture, BlockValidationFuture) {
-        let result = self.validate_and_insert_block_impl(BlockTask::Trusted { block: tb.block });
-        (Box::pin(result.0), Box::pin(result.1))
+    fn validate_and_insert_trusted_block(&self, tb: TrustedBlock) -> BlockValidationFutures {
+        let (block_task, virtual_state_task) = self.validate_and_insert_block_impl(BlockTask::Trusted { block: tb.block });
+        BlockValidationFutures { block_task: Box::pin(block_task), virtual_state_task: Box::pin(virtual_state_task) }
     }
 
     fn validate_mempool_transaction(&self, transaction: &mut MutableTransaction) -> TxResult<()> {

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -134,7 +134,7 @@ impl TestConsensus {
     }
 
     pub fn add_block_with_parents(&self, hash: Hash, parents: Vec<Hash>) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
-        self.validate_and_insert_block(self.build_block_with_parents(hash, parents).to_immutable())
+        self.validate_and_insert_block(self.build_block_with_parents(hash, parents).to_immutable()).1
     }
 
     pub fn add_utxo_valid_block_with_parents(
@@ -144,7 +144,7 @@ impl TestConsensus {
         txs: Vec<Transaction>,
     ) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
         let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
-        self.validate_and_insert_block(self.build_utxo_valid_block_with_parents(hash, parents, miner_data, txs).to_immutable())
+        self.validate_and_insert_block(self.build_utxo_valid_block_with_parents(hash, parents, miner_data, txs).to_immutable()).1
     }
 
     pub fn build_utxo_valid_block_with_parents(

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -134,7 +134,7 @@ impl TestConsensus {
     }
 
     pub fn add_block_with_parents(&self, hash: Hash, parents: Vec<Hash>) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
-        self.validate_and_insert_block(self.build_block_with_parents(hash, parents).to_immutable()).1
+        self.validate_and_insert_block(self.build_block_with_parents(hash, parents).to_immutable()).virtual_state_task
     }
 
     pub fn add_utxo_valid_block_with_parents(
@@ -144,7 +144,8 @@ impl TestConsensus {
         txs: Vec<Transaction>,
     ) -> impl Future<Output = BlockProcessResult<BlockStatus>> {
         let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
-        self.validate_and_insert_block(self.build_utxo_valid_block_with_parents(hash, parents, miner_data, txs).to_immutable()).1
+        self.validate_and_insert_block(self.build_utxo_valid_block_with_parents(hash, parents, miner_data, txs).to_immutable())
+            .virtual_state_task
     }
 
     pub fn build_utxo_valid_block_with_parents(

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -120,17 +120,20 @@ mod tests {
         }
 
         let valid_block = consensus.build_block_with_parents_and_transactions(3.into(), vec![config.genesis.hash], vec![]);
-        consensus.validate_and_insert_block(valid_block.to_immutable()).1.await.unwrap();
+        consensus.validate_and_insert_block(valid_block.to_immutable()).virtual_state_task.await.unwrap();
         {
             let mut block = consensus.build_block_with_parents_and_transactions(2.into(), vec![3.into()], vec![]);
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
             assert_match!(
-                consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 50000000000);
+                consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 50000000000);
 
             // The second time we send an invalid block we expect it to be a known invalid.
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::KnownInvalid));
+            assert_match!(
+                consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
+                Err(RuleError::KnownInvalid)
+            );
         }
 
         {
@@ -139,7 +142,7 @@ mod tests {
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
             assert_match!(
-                consensus.validate_and_insert_block(block.to_immutable()).1.await,
+                consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
                 Err(RuleError::BadCoinbasePayloadBlueScore(_, _))
             );
         }
@@ -149,17 +152,20 @@ mod tests {
             block.transactions[0].payload = vec![];
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::BadCoinbasePayload(_)));
+            assert_match!(
+                consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
+                Err(RuleError::BadCoinbasePayload(_))
+            );
         }
 
         let valid_block_child = consensus.build_block_with_parents_and_transactions(6.into(), vec![3.into()], vec![]);
-        consensus.validate_and_insert_block(valid_block_child.clone().to_immutable()).1.await.unwrap();
+        consensus.validate_and_insert_block(valid_block_child.clone().to_immutable()).virtual_state_task.await.unwrap();
         {
             // The block DAA score is 2, so the subsidy should be calculated according to the deflationary stage.
             let mut block = consensus.build_block_with_parents_and_transactions(7.into(), vec![6.into()], vec![]);
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 44000000000);
+            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 44000000000);
         }
 
         {
@@ -223,10 +229,10 @@ mod tests {
         );
 
         if should_pass {
-            consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
+            consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await.unwrap();
         } else {
             assert_match!(
-                consensus.validate_and_insert_block(block.to_immutable()).1.await,
+                consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
                 Err(RuleError::TxInContextFailed(_, e)) if matches!(e, TxRuleError::NotFinalized(_)));
         }
     }

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -120,17 +120,17 @@ mod tests {
         }
 
         let valid_block = consensus.build_block_with_parents_and_transactions(3.into(), vec![config.genesis.hash], vec![]);
-        consensus.validate_and_insert_block(valid_block.to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(valid_block.to_immutable()).1.await.unwrap();
         {
             let mut block = consensus.build_block_with_parents_and_transactions(2.into(), vec![3.into()], vec![]);
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
             assert_match!(
-                consensus.validate_and_insert_block(block.clone().to_immutable()).await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 50000000000);
+                consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 50000000000);
 
             // The second time we send an invalid block we expect it to be a known invalid.
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).await, Err(RuleError::KnownInvalid));
+            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::KnownInvalid));
         }
 
         {
@@ -139,7 +139,7 @@ mod tests {
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
             assert_match!(
-                consensus.validate_and_insert_block(block.to_immutable()).await,
+                consensus.validate_and_insert_block(block.to_immutable()).1.await,
                 Err(RuleError::BadCoinbasePayloadBlueScore(_, _))
             );
         }
@@ -149,17 +149,17 @@ mod tests {
             block.transactions[0].payload = vec![];
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).await, Err(RuleError::BadCoinbasePayload(_)));
+            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::BadCoinbasePayload(_)));
         }
 
         let valid_block_child = consensus.build_block_with_parents_and_transactions(6.into(), vec![3.into()], vec![]);
-        consensus.validate_and_insert_block(valid_block_child.clone().to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(valid_block_child.clone().to_immutable()).1.await.unwrap();
         {
             // The block DAA score is 2, so the subsidy should be calculated according to the deflationary stage.
             let mut block = consensus.build_block_with_parents_and_transactions(7.into(), vec![6.into()], vec![]);
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 44000000000);
+            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 44000000000);
         }
 
         {
@@ -223,10 +223,10 @@ mod tests {
         );
 
         if should_pass {
-            consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+            consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
         } else {
             assert_match!(
-                consensus.validate_and_insert_block(block.to_immutable()).await,
+                consensus.validate_and_insert_block(block.to_immutable()).1.await,
                 Err(RuleError::TxInContextFailed(_, e)) if matches!(e, TxRuleError::NotFinalized(_)));
         }
     }

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -113,7 +113,7 @@ mod tests {
         params::MAINNET_PARAMS,
     };
     use kaspa_consensus_core::{
-        api::ConsensusApi,
+        api::{BlockValidationFutures, ConsensusApi},
         block::MutableBlock,
         header::Header,
         merkle::calc_hash_merkle_root,
@@ -443,10 +443,12 @@ mod tests {
         let mut block = consensus.build_block_with_parents_and_transactions(1.into(), vec![config.genesis.hash], vec![]);
         block.transactions[0].version += 1;
 
-        assert_match!(
-            consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await,
-            Err(RuleError::BadMerkleRoot(_, _))
-        );
+        let BlockValidationFutures { block_task, virtual_state_task } =
+            consensus.validate_and_insert_block(block.clone().to_immutable());
+
+        assert_match!(block_task.await, Err(RuleError::BadMerkleRoot(_, _)));
+        // Assert that both tasks return the same error
+        assert_match!(virtual_state_task.await, Err(RuleError::BadMerkleRoot(_, _)));
 
         // BadMerkleRoot shouldn't mark the block as known invalid
         assert_match!(

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -443,18 +443,30 @@ mod tests {
         let mut block = consensus.build_block_with_parents_and_transactions(1.into(), vec![config.genesis.hash], vec![]);
         block.transactions[0].version += 1;
 
-        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::BadMerkleRoot(_, _)));
+        assert_match!(
+            consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await,
+            Err(RuleError::BadMerkleRoot(_, _))
+        );
 
         // BadMerkleRoot shouldn't mark the block as known invalid
-        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::BadMerkleRoot(_, _)));
+        assert_match!(
+            consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
+            Err(RuleError::BadMerkleRoot(_, _))
+        );
 
         let mut block = consensus.build_block_with_parents_and_transactions(1.into(), vec![config.genesis.hash], vec![]);
         block.header.parents_by_level[0][0] = 0.into();
 
-        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::MissingParents(_)));
+        assert_match!(
+            consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await,
+            Err(RuleError::MissingParents(_))
+        );
 
         // MissingParents shouldn't mark the block as known invalid
-        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::MissingParents(_)));
+        assert_match!(
+            consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await,
+            Err(RuleError::MissingParents(_))
+        );
 
         consensus.shutdown(wait_handles);
     }

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -443,18 +443,18 @@ mod tests {
         let mut block = consensus.build_block_with_parents_and_transactions(1.into(), vec![config.genesis.hash], vec![]);
         block.transactions[0].version += 1;
 
-        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).await, Err(RuleError::BadMerkleRoot(_, _)));
+        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::BadMerkleRoot(_, _)));
 
         // BadMerkleRoot shouldn't mark the block as known invalid
-        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).await, Err(RuleError::BadMerkleRoot(_, _)));
+        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::BadMerkleRoot(_, _)));
 
         let mut block = consensus.build_block_with_parents_and_transactions(1.into(), vec![config.genesis.hash], vec![]);
         block.header.parents_by_level[0][0] = 0.into();
 
-        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).await, Err(RuleError::MissingParents(_)));
+        assert_match!(consensus.validate_and_insert_block(block.clone().to_immutable()).1.await, Err(RuleError::MissingParents(_)));
 
         // MissingParents shouldn't mark the block as known invalid
-        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).await, Err(RuleError::MissingParents(_)));
+        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).1.await, Err(RuleError::MissingParents(_)));
 
         consensus.shutdown(wait_handles);
     }

--- a/consensus/src/pipeline/deps_manager.rs
+++ b/consensus/src/pipeline/deps_manager.rs
@@ -12,12 +12,12 @@ pub type BlockResultSender = oneshot::Sender<BlockProcessResult<BlockStatus>>;
 
 pub enum BlockProcessingMessage {
     Exit,
-    Process(BlockTask, BlockResultSender),
+    Process(BlockTask, BlockResultSender, BlockResultSender),
 }
 
 impl BlockProcessingMessage {
     pub fn is_processing_message(&self) -> bool {
-        matches!(self, BlockProcessingMessage::Process(_, _))
+        matches!(self, BlockProcessingMessage::Process(_, _, _))
     }
 
     pub fn is_exit_message(&self) -> bool {
@@ -62,12 +62,13 @@ struct BlockTaskInternal {
     task: Option<BlockTask>,
 
     // A list of channel senders for transmitting the processing result of this task to the async callers
-    result_transmitter: BlockResultSender,
+    block_result_transmitter: BlockResultSender,
+    virtual_state_result_transmitter: BlockResultSender,
 }
 
 impl BlockTaskInternal {
-    fn new(task: BlockTask, result_transmitter: BlockResultSender) -> Self {
-        Self { task: Some(task), result_transmitter }
+    fn new(task: BlockTask, block_result_transmitter: BlockResultSender, virtual_state_result_transmitter: BlockResultSender) -> Self {
+        Self { task: Some(task), block_result_transmitter, virtual_state_result_transmitter }
     }
 }
 
@@ -169,17 +170,26 @@ impl BlockTaskDependencyManager {
     /// with the additional task and the function returns `None` indicating that the task shall
     /// not be queued for processing yet. The function is expected to be called by a single worker
     /// controlling the reception of block processing tasks.
-    pub fn register(&self, task: BlockTask, result_transmitter: BlockResultSender) -> Option<TaskId> {
+    pub fn register(
+        &self,
+        task: BlockTask,
+        block_result_transmitter: BlockResultSender,
+        virtual_state_result_transmitter: BlockResultSender,
+    ) -> Option<TaskId> {
         let mut pending = self.pending.lock();
         let hash = task.block().hash();
         match pending.entry(hash) {
             Vacant(e) => {
-                e.insert(BlockTaskGroup::new(BlockTaskInternal::new(task, result_transmitter)));
+                e.insert(BlockTaskGroup::new(BlockTaskInternal::new(
+                    task,
+                    block_result_transmitter,
+                    virtual_state_result_transmitter,
+                )));
                 Some(hash)
             }
             e => {
                 e.and_modify(|g| {
-                    g.tasks.push_back(BlockTaskInternal::new(task, result_transmitter));
+                    g.tasks.push_back(BlockTaskInternal::new(task, block_result_transmitter, virtual_state_result_transmitter));
                 });
                 None
             }
@@ -213,7 +223,7 @@ impl BlockTaskDependencyManager {
     /// and returns a list of `dependent_tasks` which should be requeued to workers.
     pub fn end<F>(&self, task: BlockTask, callback: F) -> Vec<TaskId>
     where
-        F: Fn(BlockTask, BlockResultSender),
+        F: Fn(BlockTask, BlockResultSender, BlockResultSender),
     {
         let task_id = task.block().hash();
         // Re-lock for post-processing steps
@@ -230,7 +240,7 @@ impl BlockTaskDependencyManager {
         assert!(internal_task.task.is_none());
 
         // Callback within the lock
-        callback(task, internal_task.result_transmitter);
+        callback(task, internal_task.block_result_transmitter, internal_task.virtual_state_result_transmitter);
 
         if pending.is_empty() {
             self.idle_signal.notify_one();

--- a/consensus/src/pipeline/deps_manager.rs
+++ b/consensus/src/pipeline/deps_manager.rs
@@ -25,6 +25,21 @@ impl BlockProcessingMessage {
     }
 }
 
+pub enum VirtualStateProcessingMessage {
+    Exit,
+    Process(BlockTask, BlockResultSender),
+}
+
+impl VirtualStateProcessingMessage {
+    pub fn is_processing_message(&self) -> bool {
+        matches!(self, VirtualStateProcessingMessage::Process(_, _))
+    }
+
+    pub fn is_exit_message(&self) -> bool {
+        matches!(self, VirtualStateProcessingMessage::Exit)
+    }
+}
+
 pub enum BlockTask {
     /// Ordinary block processing task, requiring full validation. The block might be header-only
     Ordinary { block: Block },

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -215,8 +215,9 @@ impl HeaderProcessor {
                 BlockProcessingMessage::Exit => {
                     break;
                 }
-                BlockProcessingMessage::Process(task, result_transmitter) => {
-                    if let Some(task_id) = self.task_manager.register(task, result_transmitter) {
+                BlockProcessingMessage::Process(task, block_result_transmitter, virtual_state_result_transmitter) => {
+                    if let Some(task_id) = self.task_manager.register(task, block_result_transmitter, virtual_state_result_transmitter)
+                    {
                         let processor = self.clone();
                         self.thread_pool.spawn(move || {
                             processor.queue_block(task_id);
@@ -237,14 +238,22 @@ impl HeaderProcessor {
         if let Some(task) = self.task_manager.try_begin(task_id) {
             let res = self.process_header(&task);
 
-            let dependent_tasks = self.task_manager.end(task, |task, result_transmitter| {
-                if res.is_err() || task.block().is_header_only() {
-                    // We don't care if receivers were dropped
-                    let _ = result_transmitter.send(res.clone());
-                } else {
-                    self.body_sender.send(BlockProcessingMessage::Process(task, result_transmitter)).unwrap();
-                }
-            });
+            let dependent_tasks = self.task_manager.end(
+                task,
+                |task,
+                 block_result_transmitter: tokio::sync::oneshot::Sender<Result<BlockStatus, RuleError>>,
+                 virtual_state_result_transmitter| {
+                    if res.is_err() || task.block().is_header_only() {
+                        // We don't care if receivers were dropped
+                        let _ = block_result_transmitter.send(res.clone());
+                        let _ = virtual_state_result_transmitter.send(res.clone());
+                    } else {
+                        self.body_sender
+                            .send(BlockProcessingMessage::Process(task, block_result_transmitter, virtual_state_result_transmitter))
+                            .unwrap();
+                    }
+                },
+            );
 
             for dep in dependent_tasks {
                 let processor = self.clone();

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -249,9 +249,9 @@ impl VirtualStateProcessor {
             for msg in messages {
                 match msg {
                     BlockProcessingMessage::Exit => break 'outer,
-                    BlockProcessingMessage::Process(task, result_transmitter) => {
+                    BlockProcessingMessage::Process(task, _, virtual_state_result_transmitter) => {
                         // We don't care if receivers were dropped
-                        let _ = result_transmitter.send(Ok(statuses_read.get(task.block().hash()).unwrap()));
+                        let _ = virtual_state_result_transmitter.send(Ok(statuses_read.get(task.block().hash()).unwrap()));
                     }
                 };
             }

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -125,7 +125,7 @@ impl TestContext {
     }
 
     pub async fn validate_and_insert_block(&mut self, block: Block) -> &mut Self {
-        let status = self.consensus.validate_and_insert_block(block).1.await.unwrap();
+        let status = self.consensus.validate_and_insert_block(block).virtual_state_task.await.unwrap();
         assert!(status.has_block_body());
         self
     }

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -125,7 +125,7 @@ impl TestContext {
     }
 
     pub async fn validate_and_insert_block(&mut self, block: Block) -> &mut Self {
-        let status = self.consensus.validate_and_insert_block(block).await.unwrap();
+        let status = self.consensus.validate_and_insert_block(block).1.await.unwrap();
         assert!(status.has_block_body());
         self
     }

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -500,6 +500,8 @@ impl MiningManager {
         block_transactions: &[Transaction],
     ) -> MiningManagerResult<Vec<Arc<Transaction>>> {
         // TODO: should use tx acceptance data to verify that new block txs are actually accepted into virtual state.
+        // TODO: avoid returning a result from this function (and the underlying function). Any possible error is a
+        // problem of the internal implementation and unrelated to the caller
 
         // write lock on mempool
         let unorphaned_transactions = self.mempool.write().handle_new_block_transactions(block_daa_score, block_transactions)?;

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -322,7 +322,7 @@ impl FlowContext {
             return Err(RuleError::NoTransactions)?;
         }
         let hash = block.hash();
-        if let Err(err) = self.consensus().session().await.validate_and_insert_block(block.clone()).await {
+        if let Err(err) = self.consensus().session().await.validate_and_insert_block(block.clone()).1.await {
             warn!("Validation failed for block {}: {}", hash, err);
             return Err(err)?;
         }

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -322,7 +322,7 @@ impl FlowContext {
             return Err(RuleError::NoTransactions)?;
         }
         let hash = block.hash();
-        if let Err(err) = self.consensus().session().await.validate_and_insert_block(block.clone()).1.await {
+        if let Err(err) = self.consensus().session().await.validate_and_insert_block(block.clone()).virtual_state_task.await {
             warn!("Validation failed for block {}: {}", hash, err);
             return Err(err)?;
         }

--- a/protocol/flows/src/flowcontext/transactions.rs
+++ b/protocol/flows/src/flowcontext/transactions.rs
@@ -3,7 +3,6 @@ use itertools::Itertools;
 use kaspa_consensus_core::tx::TransactionId;
 use kaspa_core::debug;
 use kaspa_p2p_lib::{
-    common::ProtocolError,
     make_message,
     pb::{kaspad_message::Payload, InvTransactionsMessage, KaspadMessage},
     Hub,
@@ -78,15 +77,12 @@ impl TransactionsSpread {
     /// capacity.
     ///
     /// _GO-KASPAD: EnqueueTransactionIDsForPropagation_
-    pub async fn broadcast_transactions<I: IntoIterator<Item = TransactionId>>(
-        &mut self,
-        transaction_ids: I,
-    ) -> Result<(), ProtocolError> {
+    pub async fn broadcast_transactions<I: IntoIterator<Item = TransactionId>>(&mut self, transaction_ids: I) {
         self.transaction_ids.enqueue_chunk(transaction_ids);
 
         let now = Instant::now();
         if now < self.last_broadcast_time + BROADCAST_INTERVAL && self.transaction_ids.len() < MAX_INV_PER_TX_INV_MSG {
-            return Ok(());
+            return;
         }
 
         while !self.transaction_ids.is_empty() {
@@ -97,7 +93,6 @@ impl TransactionsSpread {
         }
 
         self.last_broadcast_time = Instant::now();
-        Ok(())
     }
 
     async fn broadcast(&self, msg: KaspadMessage) {

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -143,7 +143,7 @@ impl HandleRelayInvsFlow {
 
             // TODO: consider storing the future in a task queue and polling it (without awaiting) in order to continue
             // queueing the following relay blocks. On the other hand we might have sufficient concurrency from all parallel relay flows
-            match session.validate_and_insert_block(block.clone()).await {
+            match session.validate_and_insert_block(block.clone()).1.await {
                 Ok(_) => {}
                 Err(RuleError::MissingParents(missing_parents)) => {
                     debug!("Block {} is orphan and has missing parents: {:?}", block.hash(), missing_parents);

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -111,10 +111,11 @@ impl HandleRelayInvsFlow {
             }
 
             // We keep the request scope alive until consensus processes the block
-            let Some((block, _request_scope)) = self.request_block(inv.hash).await? else {
+            let Some((block, request_scope)) = self.request_block(inv.hash).await? else {
                 debug!("Relay block {} was already requested from another peer, continuing...", inv.hash);
                 continue;
             };
+            request_scope.report_obtained();
 
             if block.is_header_only() {
                 return Err(ProtocolError::OtherOwned(format!("sent header of {} where expected block with body", block.hash())));

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -2,7 +2,7 @@ use crate::{
     flow_context::{BlockSource, FlowContext, RequestScope},
     flow_trait::Flow,
 };
-use kaspa_consensus_core::{block::Block, blockstatus::BlockStatus, errors::block::RuleError};
+use kaspa_consensus_core::{api::BlockValidationFutures, block::Block, blockstatus::BlockStatus, errors::block::RuleError};
 use kaspa_consensusmanager::ConsensusProxy;
 use kaspa_core::{debug, info};
 use kaspa_hashes::Hash;
@@ -120,30 +120,27 @@ impl HandleRelayInvsFlow {
                 return Err(ProtocolError::OtherOwned(format!("sent header of {} where expected block with body", block.hash())));
             }
 
-            // Note we do not apply the heuristic below if inv was queued indirectly (as an orphan root), since
+            let blue_work_threshold = session.async_get_virtual_merge_depth_blue_work_threshold().await;
+            // Since `blue_work` respects topology, the negation of this condition means that the relay
+            // block is not in the future of virtual's merge depth root, and thus cannot be merged unless
+            // other valid blocks Kosherize it (in which case it will be obtained once the merger is relayed)
+            let broadcast = block.header.blue_work > blue_work_threshold;
+
+            // We do not apply the skip heuristic below if inv was queued indirectly (as an orphan root), since
             // that means the process started by a proper and relevant relay block
-            if !inv.is_indirect {
-                // Check bounded merge depth to avoid requesting irrelevant data which cannot be merged under virtual
-                if let Some(virtual_merge_depth_root) = session.async_get_virtual_merge_depth_root().await {
-                    let root_header = session.async_get_header(virtual_merge_depth_root).await.unwrap();
-                    // Since `blue_work` respects topology, this condition means that the relay
-                    // block is not in the future of virtual's merge depth root, and thus cannot be merged unless
-                    // other valid blocks Kosherize it, in which case it will be obtained once the merger is relayed
-                    if block.header.blue_work <= root_header.blue_work {
-                        debug!(
-                            "Relay block {} has lower blue work than virtual's merge depth root {} ({} <= {}), hence we are skipping it",
-                            inv.hash, virtual_merge_depth_root, block.header.blue_work, root_header.blue_work
-                        );
-                        continue;
-                    }
-                }
+            if !inv.is_indirect && !broadcast {
+                debug!(
+                    "Relay block {} has lower blue work than virtual's merge depth root ({} <= {}), hence we are skipping it",
+                    inv.hash, block.header.blue_work, blue_work_threshold
+                );
+                continue;
             }
 
-            let prev_virtual_parents = session.async_get_virtual_parents().await;
+            let BlockValidationFutures { block_task, virtual_state_task } = session.validate_and_insert_block(block.clone());
 
             // TODO: consider storing the future in a task queue and polling it (without awaiting) in order to continue
             // queueing the following relay blocks. On the other hand we might have sufficient concurrency from all parallel relay flows
-            match session.validate_and_insert_block(block.clone()).virtual_state_task.await {
+            match block_task.await {
                 Ok(_) => {}
                 Err(RuleError::MissingParents(missing_parents)) => {
                     debug!("Block {} is orphan and has missing parents: {:?}", block.hash(), missing_parents);
@@ -153,18 +150,23 @@ impl HandleRelayInvsFlow {
                 Err(rule_error) => return Err(rule_error.into()),
             }
 
+            // As a policy, we only relay blocks who stand a chance to enter past(virtual).
+            // The only mining rule which permanently excludes a block is the merge depth bound
+            // (as opposed to "max parents" and "mergeset size limit" rules)
+            if broadcast {
+                self.ctx
+                    .hub()
+                    .broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(inv.hash.into()) }))
+                    .await;
+            }
+
+            // We only care about waiting for virtual to process the block before proceeding with post-processing
+            // actions such as updating the mempool. We know this will not err since `block_task` already completed w/o error
+            let _ = virtual_state_task.await;
+
             self.ctx.log_block_acceptance(inv.hash, BlockSource::Relay);
             self.ctx.on_new_block(&session, block).await?;
             self.ctx.on_new_block_template().await?;
-
-            // Broadcast all *new* virtual parents. As a policy, we avoid directly relaying the new block since
-            // we wish to relay only blocks who entered past(virtual).
-            for new_virtual_parent in session.async_get_virtual_parents().await.difference(&prev_virtual_parents) {
-                self.ctx
-                    .hub()
-                    .broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(new_virtual_parent.into()) }))
-                    .await;
-            }
         }
     }
 

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -143,7 +143,7 @@ impl HandleRelayInvsFlow {
 
             // TODO: consider storing the future in a task queue and polling it (without awaiting) in order to continue
             // queueing the following relay blocks. On the other hand we might have sufficient concurrency from all parallel relay flows
-            match session.validate_and_insert_block(block.clone()).1.await {
+            match session.validate_and_insert_block(block.clone()).virtual_state_task.await {
                 Ok(_) => {}
                 Err(RuleError::MissingParents(missing_parents)) => {
                     debug!("Block {} is orphan and has missing parents: {:?}", block.hash(), missing_parents);

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -316,7 +316,7 @@ impl IbdFlow {
                 last_index = i;
             }
             // TODO: queue and join in batches
-            staging.validate_and_insert_trusted_block(tb).1.await?;
+            staging.validate_and_insert_trusted_block(tb).virtual_state_task.await?;
         }
         info!("Done processing trusted blocks");
         Ok(proof_pruning_point)
@@ -346,12 +346,14 @@ impl IbdFlow {
         if let Some(chunk) = chunk_stream.next().await? {
             let mut prev_daa_score = chunk.last().expect("chunk is never empty").daa_score;
             let mut prev_jobs: Vec<BlockValidationFuture> =
-                chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
+                chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).virtual_state_task).collect();
 
             while let Some(chunk) = chunk_stream.next().await? {
                 let current_daa_score = chunk.last().expect("chunk is never empty").daa_score;
-                let current_jobs =
-                    chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
+                let current_jobs = chunk
+                    .into_iter()
+                    .map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).virtual_state_task)
+                    .collect();
                 let prev_chunk_len = prev_jobs.len();
                 // Join the previous chunk so that we always concurrently process a chunk and receive another
                 try_join_all(prev_jobs).await?;
@@ -398,7 +400,7 @@ impl IbdFlow {
         let msg = dequeue_with_timeout!(self.incoming_route, Payload::BlockHeaders)?;
         let chunk: HeadersChunk = msg.try_into()?;
         let jobs: Vec<BlockValidationFuture> =
-            chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
+            chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).virtual_state_task).collect();
         try_join_all(jobs).await?;
         dequeue_with_timeout!(self.incoming_route, Payload::DoneHeaders)?;
 
@@ -512,7 +514,7 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
                 return Err(ProtocolError::OtherOwned(format!("sent header of {} where expected block with body", block.hash())));
             }
             current_daa_score = block.header.daa_score;
-            jobs.push(consensus.validate_and_insert_block(block).1);
+            jobs.push(consensus.validate_and_insert_block(block).virtual_state_task);
         }
 
         Ok((jobs, current_daa_score))

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -486,7 +486,7 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
         try_join_all(prev_jobs).await?;
         progress_reporter.report_completion(prev_chunk_len);
 
-        self.ctx.on_new_block_template().await?;
+        self.ctx.on_new_block_template().await;
 
         Ok(())
     }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -316,7 +316,7 @@ impl IbdFlow {
                 last_index = i;
             }
             // TODO: queue and join in batches
-            staging.validate_and_insert_trusted_block(tb).await?;
+            staging.validate_and_insert_trusted_block(tb).1.await?;
         }
         info!("Done processing trusted blocks");
         Ok(proof_pruning_point)
@@ -346,11 +346,12 @@ impl IbdFlow {
         if let Some(chunk) = chunk_stream.next().await? {
             let mut prev_daa_score = chunk.last().expect("chunk is never empty").daa_score;
             let mut prev_jobs: Vec<BlockValidationFuture> =
-                chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h))).collect();
+                chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
 
             while let Some(chunk) = chunk_stream.next().await? {
                 let current_daa_score = chunk.last().expect("chunk is never empty").daa_score;
-                let current_jobs = chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h))).collect();
+                let current_jobs =
+                    chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
                 let prev_chunk_len = prev_jobs.len();
                 // Join the previous chunk so that we always concurrently process a chunk and receive another
                 try_join_all(prev_jobs).await?;
@@ -397,7 +398,7 @@ impl IbdFlow {
         let msg = dequeue_with_timeout!(self.incoming_route, Payload::BlockHeaders)?;
         let chunk: HeadersChunk = msg.try_into()?;
         let jobs: Vec<BlockValidationFuture> =
-            chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h))).collect();
+            chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).1).collect();
         try_join_all(jobs).await?;
         dequeue_with_timeout!(self.incoming_route, Payload::DoneHeaders)?;
 
@@ -511,7 +512,7 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
                 return Err(ProtocolError::OtherOwned(format!("sent header of {} where expected block with body", block.hash())));
             }
             current_daa_score = block.header.daa_score;
-            jobs.push(consensus.validate_and_insert_block(block));
+            jobs.push(consensus.validate_and_insert_block(block).1);
         }
 
         Ok((jobs, current_daa_score))

--- a/protocol/flows/src/v5/txrelay/flow.rs
+++ b/protocol/flows/src/v5/txrelay/flow.rs
@@ -204,7 +204,7 @@ impl RelayTransactionsFlow {
                 Ok(x) => Some(x.id()),
                 Err(_) => None,
             }))
-            .await?;
+            .await;
 
         Ok(())
     }

--- a/protocol/p2p/src/core/hub.rs
+++ b/protocol/p2p/src/core/hub.rs
@@ -95,12 +95,24 @@ impl Hub {
         }
     }
 
-    /// Broadcast a message to all peers. Note that broadcast can also be called on a
-    /// specific router and will eventually lead to the same call (via the hub event loop)
+    /// Broadcast a message to all peers
     pub async fn broadcast(&self, msg: KaspadMessage) {
         let peers = self.peers.read().values().cloned().collect::<Vec<_>>();
         for router in peers {
             let _ = router.enqueue(msg.clone()).await;
+        }
+    }
+
+    /// Broadcast a vector of messages to all peers
+    pub async fn broadcast_many(&self, msgs: Vec<KaspadMessage>) {
+        if msgs.is_empty() {
+            return;
+        }
+        let peers = self.peers.read().values().cloned().collect::<Vec<_>>();
+        for router in peers {
+            for msg in msgs.iter().cloned() {
+                let _ = router.enqueue(msg).await;
+            }
         }
     }
 

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -347,7 +347,7 @@ fn submit_chunk(
             src_consensus.headers_store.get_header(hash).unwrap(),
             src_consensus.block_transactions_store.get(hash).unwrap(),
         );
-        let f = dst_consensus.validate_and_insert_block(block).1;
+        let f = dst_consensus.validate_and_insert_block(block).virtual_state_task;
         futures.push(f);
     }
     futures

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -347,7 +347,7 @@ fn submit_chunk(
             src_consensus.headers_store.get_header(hash).unwrap(),
             src_consensus.block_transactions_store.get(hash).unwrap(),
         );
-        let f = dst_consensus.validate_and_insert_block(block);
+        let f = dst_consensus.validate_and_insert_block(block).1;
         futures.push(f);
     }
     futures

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -211,7 +211,7 @@ impl Miner {
             Suspension::Halt
         } else {
             let session = self.consensus.acquire_session();
-            let status = futures::executor::block_on(self.consensus.validate_and_insert_block(block)).unwrap();
+            let status = futures::executor::block_on(self.consensus.validate_and_insert_block(block).1).unwrap();
             assert!(status.is_utxo_valid_or_pending());
             drop(session);
             Suspension::Idle

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -211,7 +211,7 @@ impl Miner {
             Suspension::Halt
         } else {
             let session = self.consensus.acquire_session();
-            let status = futures::executor::block_on(self.consensus.validate_and_insert_block(block).1).unwrap();
+            let status = futures::executor::block_on(self.consensus.validate_and_insert_block(block).virtual_state_task).unwrap();
             assert!(status.is_utxo_valid_or_pending());
             drop(session);
             Suspension::Idle

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -190,6 +190,7 @@ async fn consensus_sanity_test() {
 
     consensus
         .validate_and_insert_block(consensus.build_block_with_parents(genesis_child, vec![MAINNET_PARAMS.genesis.hash]).to_immutable())
+        .1
         .await
         .unwrap();
 
@@ -258,7 +259,7 @@ async fn ghostdag_test() {
             let block_header = consensus.build_header_with_parents(block_id, strings_to_hashes(&block.parents));
 
             // Submit to consensus
-            consensus.validate_and_insert_block(Block::from_header(block_header)).await.unwrap();
+            consensus.validate_and_insert_block(Block::from_header(block_header)).1.await.unwrap();
         }
 
         // Clone with a new cache in order to verify correct writes to the DB itself
@@ -357,7 +358,7 @@ async fn block_window_test() {
         );
 
         // Submit to consensus
-        consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
 
         let window = consensus
             .window_manager()
@@ -393,7 +394,7 @@ async fn header_in_isolation_validation_test() {
         let mut block = block.clone();
         let block_version = BLOCK_VERSION - 1;
         block.header.version = block_version;
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::WrongBlockVersion(wrong_version)) => {
                 assert_eq!(wrong_version, block_version)
             }
@@ -410,7 +411,7 @@ async fn header_in_isolation_validation_test() {
         let now = unix_now();
         let block_ts = now + config.legacy_timestamp_deviation_tolerance * config.target_time_per_block + 2000;
         block.header.timestamp = block_ts;
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::TimeTooFarIntoTheFuture(ts, _)) => {
                 assert_eq!(ts, block_ts)
             }
@@ -424,7 +425,7 @@ async fn header_in_isolation_validation_test() {
         let mut block = block.clone();
         block.header.hash = 3.into();
         block.header.parents_by_level[0] = vec![];
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::NoParents) => {}
             res => {
                 panic!("Unexpected result: {res:?}")
@@ -436,7 +437,7 @@ async fn header_in_isolation_validation_test() {
         let mut block = block.clone();
         block.header.hash = 4.into();
         block.header.parents_by_level[0] = (5..(config.max_block_parents + 6)).map(|x| (x as u64).into()).collect();
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::TooManyParents(num_parents, limit)) => {
                 assert_eq!((config.max_block_parents + 1) as usize, num_parents);
                 assert_eq!(limit, config.max_block_parents as usize);
@@ -456,11 +457,11 @@ async fn incest_test() {
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
     let block = consensus.build_block_with_parents(1.into(), vec![config.genesis.hash]);
-    consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+    consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
 
     let mut block = consensus.build_block_with_parents(2.into(), vec![config.genesis.hash]);
     block.header.parents_by_level[0] = vec![1.into(), config.genesis.hash];
-    match consensus.validate_and_insert_block(block.to_immutable()).await {
+    match consensus.validate_and_insert_block(block.to_immutable()).1.await {
         Err(RuleError::InvalidParentsRelation(a, b)) => {
             assert_eq!(a, config.genesis.hash);
             assert_eq!(b, 1.into());
@@ -480,7 +481,7 @@ async fn missing_parents_test() {
     let wait_handles = consensus.init();
     let mut block = consensus.build_block_with_parents(1.into(), vec![config.genesis.hash]);
     block.header.parents_by_level[0] = vec![0.into()];
-    match consensus.validate_and_insert_block(block.to_immutable()).await {
+    match consensus.validate_and_insert_block(block.to_immutable()).1.await {
         Err(RuleError::MissingParents(missing)) => {
             assert_eq!(missing, vec![0.into()]);
         }
@@ -502,14 +503,14 @@ async fn known_invalid_test() {
     let mut block = consensus.build_block_with_parents(1.into(), vec![config.genesis.hash]);
     block.header.timestamp -= 1;
 
-    match consensus.validate_and_insert_block(block.clone().to_immutable()).await {
+    match consensus.validate_and_insert_block(block.clone().to_immutable()).1.await {
         Err(RuleError::TimeTooOld(_, _)) => {}
         res => {
             panic!("Unexpected result: {res:?}")
         }
     }
 
-    match consensus.validate_and_insert_block(block.to_immutable()).await {
+    match consensus.validate_and_insert_block(block.to_immutable()).1.await {
         Err(RuleError::KnownInvalid) => {}
         res => {
             panic!("Unexpected result: {res:?}")
@@ -560,13 +561,13 @@ async fn median_time_test() {
             let parent = if i == 1 { test.config.genesis.hash } else { (i - 1).into() };
             let mut block = consensus.build_block_with_parents(i.into(), vec![parent]);
             block.header.timestamp = test.config.genesis.timestamp + i;
-            consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+            consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
         }
 
         let mut block = consensus.build_block_with_parents((num_blocks + 2).into(), vec![num_blocks.into()]);
         // We set the timestamp to be less than the median time and expect the block to be rejected
         block.header.timestamp = test.config.genesis.timestamp + num_blocks - timestamp_deviation_tolerance - 1;
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::TimeTooOld(_, _)) => {}
             res => {
                 panic!("{}: Unexpected result: {:?}", test.name, res)
@@ -576,7 +577,7 @@ async fn median_time_test() {
         let mut block = consensus.build_block_with_parents((num_blocks + 3).into(), vec![num_blocks.into()]);
         // We set the timestamp to be the exact median time and expect the block to be rejected
         block.header.timestamp = test.config.genesis.timestamp + num_blocks - timestamp_deviation_tolerance;
-        match consensus.validate_and_insert_block(block.to_immutable()).await {
+        match consensus.validate_and_insert_block(block.to_immutable()).1.await {
             Err(RuleError::TimeTooOld(_, _)) => {}
             res => {
                 panic!("{}: Unexpected result: {:?}", test.name, res)
@@ -586,7 +587,7 @@ async fn median_time_test() {
         let mut block = consensus.build_block_with_parents((num_blocks + 4).into(), vec![(num_blocks).into()]);
         // We set the timestamp to be bigger than the median time and expect the block to be inserted successfully.
         block.header.timestamp = test.config.genesis.timestamp + timestamp_deviation_tolerance + 1;
-        consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
 
         consensus.shutdown(wait_handles);
     }
@@ -604,18 +605,18 @@ async fn mergeset_size_limit_test() {
     for i in 1..(num_blocks_per_chain + 1) {
         let block = consensus.build_block_with_parents(i.into(), vec![tip1_hash]);
         tip1_hash = block.header.hash;
-        consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
     }
 
     let mut tip2_hash = config.genesis.hash;
     for i in (num_blocks_per_chain + 2)..(2 * num_blocks_per_chain + 1) {
         let block = consensus.build_block_with_parents(i.into(), vec![tip2_hash]);
         tip2_hash = block.header.hash;
-        consensus.validate_and_insert_block(block.to_immutable()).await.unwrap();
+        consensus.validate_and_insert_block(block.to_immutable()).1.await.unwrap();
     }
 
     let block = consensus.build_block_with_parents((3 * num_blocks_per_chain + 1).into(), vec![tip1_hash, tip2_hash]);
-    match consensus.validate_and_insert_block(block.to_immutable()).await {
+    match consensus.validate_and_insert_block(block.to_immutable()).1.await {
         Err(RuleError::MergeSetTooBig(a, b)) => {
             assert_eq!(a, config.mergeset_size_limit + 1);
             assert_eq!(b, config.mergeset_size_limit);
@@ -952,7 +953,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
 
         info!("Processing {} trusted blocks...", trusted_blocks.len());
         for tb in trusted_blocks.into_iter() {
-            tc.validate_and_insert_trusted_block(tb).await.unwrap();
+            tc.validate_and_insert_trusted_block(tb).1.await.unwrap();
         }
         Some(pruning_point)
     } else {
@@ -985,7 +986,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
 
             external_block_store.insert(hash, block.transactions).unwrap();
             let block = Block::from_header_arc(block.header);
-            let status = tc.validate_and_insert_block(block).await.unwrap_or_else(|e| panic!("block {hash} failed: {e}"));
+            let status = tc.validate_and_insert_block(block).1.await.unwrap_or_else(|e| panic!("block {hash} failed: {e}"));
             assert!(status.is_header_only());
         }
     }
@@ -1024,7 +1025,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
     } else {
         for hash in missing_bodies {
             let block = Block::from_arcs(tc.get_header(hash).unwrap(), external_block_store.get(hash).unwrap());
-            let status = tc.validate_and_insert_block(block).await.unwrap_or_else(|e| panic!("block {hash} failed: {e}"));
+            let status = tc.validate_and_insert_block(block).1.await.unwrap_or_else(|e| panic!("block {hash} failed: {e}"));
             assert!(status.is_utxo_valid_or_pending());
         }
     }
@@ -1055,7 +1056,7 @@ fn submit_header_chunk(
         let block = json_line_to_block(line);
         external_block_store.insert(block.hash(), block.transactions).unwrap();
         let block = Block::from_header_arc(block.header);
-        let f = tc.validate_and_insert_block(block);
+        let f = tc.validate_and_insert_block(block).1;
         futures.push(f);
     }
     futures
@@ -1069,7 +1070,7 @@ fn submit_body_chunk(
     let mut futures = Vec::new();
     for hash in chunk {
         let block = Block::from_arcs(tc.get_header(hash).unwrap(), external_block_store.get(hash).unwrap());
-        let f = tc.validate_and_insert_block(block);
+        let f = tc.validate_and_insert_block(block).1;
         futures.push(f);
     }
     futures
@@ -1299,7 +1300,7 @@ async fn difficulty_test() {
         });
         let mut header = consensus.build_header_with_parents(new_unique(), parents);
         header.timestamp = block_time;
-        consensus.validate_and_insert_block(Block::new(header.clone(), vec![])).await.unwrap();
+        consensus.validate_and_insert_block(Block::new(header.clone(), vec![])).1.await.unwrap();
         header
     }
 

--- a/testing/integration/src/consensus_pipeline_tests.rs
+++ b/testing/integration/src/consensus_pipeline_tests.rs
@@ -32,7 +32,7 @@ async fn test_concurrent_pipeline() {
     for (hash, parents) in blocks {
         // Submit to consensus twice to make sure duplicates are handled
         let b = consensus.build_block_with_parents(hash, parents).to_immutable();
-        let results = join!(consensus.validate_and_insert_block(b.clone()), consensus.validate_and_insert_block(b));
+        let results = join!(consensus.validate_and_insert_block(b.clone()).1, consensus.validate_and_insert_block(b).1);
         results.0.unwrap();
         results.1.unwrap();
     }
@@ -102,7 +102,7 @@ async fn test_concurrent_pipeline_random() {
             let b = consensus.build_block_with_parents_and_transactions(hash, tips.clone(), vec![]).to_immutable();
 
             // Submit to consensus
-            let f = consensus.validate_and_insert_block(b);
+            let f = consensus.validate_and_insert_block(b).1;
             futures.push(f);
         }
         try_join_all(futures).await.unwrap();

--- a/testing/integration/src/consensus_pipeline_tests.rs
+++ b/testing/integration/src/consensus_pipeline_tests.rs
@@ -32,7 +32,10 @@ async fn test_concurrent_pipeline() {
     for (hash, parents) in blocks {
         // Submit to consensus twice to make sure duplicates are handled
         let b = consensus.build_block_with_parents(hash, parents).to_immutable();
-        let results = join!(consensus.validate_and_insert_block(b.clone()).1, consensus.validate_and_insert_block(b).1);
+        let results = join!(
+            consensus.validate_and_insert_block(b.clone()).virtual_state_task,
+            consensus.validate_and_insert_block(b).virtual_state_task
+        );
         results.0.unwrap();
         results.1.unwrap();
     }
@@ -102,7 +105,7 @@ async fn test_concurrent_pipeline_random() {
             let b = consensus.build_block_with_parents_and_transactions(hash, tips.clone(), vec![]).to_immutable();
 
             // Submit to consensus
-            let f = consensus.validate_and_insert_block(b).1;
+            let f = consensus.validate_and_insert_block(b).virtual_state_task;
             futures.push(f);
         }
         try_join_all(futures).await.unwrap();


### PR DESCRIPTION
Changes:
1. Refactor validate_and_insert_block to return two futures - Added in [b134d61](https://github.com/kaspanet/rusty-kaspa/pull/295/commits/b134d6128b0fe11803db77dc42218e3393804460)
- one future resolves when body processor is complete
- the other future resolves when virtual state processor is complete

  The second future is used by all original callers, making the current implementation behave the same as before.

2. Change BodyProcessorMessage to VirtualStateProcessorMessage when passing the block from body-processor to virtual-processor - Added in [af066c5](https://github.com/kaspanet/rusty-kaspa/pull/295/commits/af066c50ca4e65688e19cb7be9ec797a156e286e)
3. Add conditions/checks to see if we can broadcast
4. Actually broadcast the block after Body Processor
