### PR TITLE
Refactor 'addressmanager', reorder fetching sources for-external ip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,7 @@ dependencies = [
  "serde",
  "statest",
  "statrs",
+ "thiserror",
  "tokio",
 ]
 

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot.workspace = true
 borsh.workspace = true
 log.workspace = true
 tokio.workspace = true
-
+thiserror.workspace = true
 local-ip-address = "0.5.3"
 igd-next = { version = "0.14.2", features = ["aio_tokio"] }
 

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -72,7 +72,7 @@ impl AddressManager {
         let extender = if self.local_net_addresses.is_empty() && !self.config.disable_upnp {
             let (net_address, ExtendHelper { gateway, local_addr, external_port }) = match self.upnp() {
                 Err(err) => {
-                    warn!("Error adding port mapping: {err}");
+                    warn!("[UPnP] Error adding port mapping: {err}");
                     return None;
                 }
                 Ok(None) => return None,
@@ -148,14 +148,14 @@ impl AddressManager {
     }
 
     fn upnp(&self) -> Result<Option<(NetAddress, ExtendHelper)>, UpnpError> {
-        info!("Attempting to register upnp... (to disable run the node with --disable-upnp)");
+        info!("[UPnP] Attempting to register upnp... (to disable run the node with --disable-upnp)");
         let gateway = igd::search_gateway(Default::default())?;
         let ip = IpAddress::new(gateway.get_external_ip()?);
         if !ip.is_publicly_routable() {
-            info!("Non-publicly routable external ip from gateway using upnp {} not added to store", ip);
+            info!("[UPnP] Non-publicly routable external ip from gateway using upnp {} not added to store", ip);
             return Ok(None);
         }
-        info!("Got external ip from gateway using upnp: {ip}");
+        info!("[UPnP] Got external ip from gateway using upnp: {ip}");
 
         let default_port = self.config.default_p2p_port();
 
@@ -174,7 +174,7 @@ impl AddressManager {
             UPNP_REGISTRATION_NAME,
         ) {
             Ok(_) => {
-                info!("Added port mapping to default external port: {ip}:{default_port}");
+                info!("[UPnP] Added port mapping to default external port: {ip}:{default_port}");
                 Ok(Some((NetAddress { ip, port: default_port }, ExtendHelper { gateway, local_addr, external_port: default_port })))
             }
             Err(AddPortError::PortInUse {}) => {
@@ -184,7 +184,7 @@ impl AddressManager {
                     UPNP_DEADLINE_SEC as u32,
                     UPNP_REGISTRATION_NAME,
                 )?;
-                info!("Added port mapping to random external port: {ip}:{port}");
+                info!("[UPnP] Added port mapping to random external port: {ip}:{port}");
                 Ok(Some((NetAddress { ip, port }, ExtendHelper { gateway, local_addr, external_port: port })))
             }
             Err(err) => Err(err.into()),

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -2,7 +2,7 @@ mod port_mapping_extender;
 mod stores;
 extern crate self as address_manager;
 
-use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration};
 
 use address_manager::port_mapping_extender::Extender;
 use igd_next::{self as igd, aio::tokio::Tokio, AddPortError, Gateway};
@@ -55,124 +55,123 @@ impl AddressManager {
     }
 
     fn init_local_addresses(&mut self, tick_service: Arc<TickService>) -> Option<Extender> {
-        if let Some((net_addr, extend)) = self.configured_address() {
-            self.local_net_addresses.push(net_addr);
+        self.local_net_addresses = self.local_addresses().collect();
 
-            if let Some(ExtendHelper { gateway, local_addr, external_port }) = extend {
-                let gateway: igd_next::aio::Gateway<Tokio> = igd_next::aio::Gateway {
-                    addr: gateway.addr,
-                    root_url: gateway.root_url,
-                    control_url: gateway.control_url,
-                    control_schema_url: gateway.control_schema_url,
-                    control_schema: gateway.control_schema,
-                    provider: Tokio,
-                };
-                Some(Extender::new(
-                    tick_service,
-                    Duration::from_secs(UPNP_EXTEND_PERIOD),
-                    UPNP_DEADLINE_SEC,
-                    gateway,
-                    external_port,
-                    local_addr,
-                ))
-            } else {
-                None
-            }
+        let extender = if self.local_net_addresses.is_empty() && !self.config.disable_upnp {
+            let Some((net_address, ExtendHelper { gateway, local_addr, external_port })) = self.upnp() else { return None };
+            self.local_net_addresses.push(net_address);
+
+            let gateway: igd_next::aio::Gateway<Tokio> = igd_next::aio::Gateway {
+                addr: gateway.addr,
+                root_url: gateway.root_url,
+                control_url: gateway.control_url,
+                control_schema_url: gateway.control_schema_url,
+                control_schema: gateway.control_schema,
+                provider: Tokio,
+            };
+            Some(Extender::new(
+                tick_service,
+                Duration::from_secs(UPNP_EXTEND_PERIOD),
+                UPNP_DEADLINE_SEC,
+                gateway,
+                external_port,
+                local_addr,
+            ))
         } else {
-            self.add_routable_addresses_from_net_interfaces();
             None
-        }
+        };
+
+        self.local_net_addresses.iter().for_each(|net_addr| {
+            info!("Publicly routable local address {} added to store", net_addr);
+        });
+        extender
     }
 
-    fn configured_address(&self) -> Option<(NetAddress, Option<ExtendHelper>)> {
+    fn local_addresses(&self) -> impl Iterator<Item = NetAddress> + '_ {
         match self.config.externalip {
             // An external IP was passed, we will try to bind that if it's valid
             Some(local_net_address) if local_net_address.ip.is_publicly_routable() => {
-                info!("External address {} added to store", local_net_address);
-                Some((local_net_address, None))
+                info!("External address is publicly routable {}", local_net_address);
+                return itertools::Either::Left(iter::once(local_net_address));
             }
             Some(local_net_address) => {
-                info!("Non-publicly routable external address {} not added to store", local_net_address);
+                info!("External address is not publicly routable {}", local_net_address);
+            }
+            None => {}
+        };
+
+        itertools::Either::Right(self.routable_addresses_from_net_interfaces())
+    }
+
+    fn routable_addresses_from_net_interfaces(&self) -> impl Iterator<Item = NetAddress> + '_ {
+        // check whatever was passed as listen address (if routable)
+        // otherwise(listen_address === 0.0.0.0) check all interfaces
+        let listen_address = self.config.p2p_listen_address.normalize(self.config.default_p2p_port());
+        if listen_address.ip.is_publicly_routable() {
+            info!("Publicly routable local address found: {}", listen_address.ip);
+            itertools::Either::Left(Some(listen_address).into_iter())
+        } else if listen_address.ip.is_unspecified() {
+            let network_interfaces = list_afinet_netifas();
+            let Ok(network_interfaces) = network_interfaces else {
+                warn!("Error getting network interfaces: {:?}", network_interfaces);
+                return itertools::Either::Left(None.into_iter());
+            };
+            // TODO: Add Check IPv4 or IPv6 match from Go code
+            itertools::Either::Right(network_interfaces.into_iter().map(|(_, ip)| IpAddress::from(ip)).filter_map(|ip| {
+                ip.is_publicly_routable().then(|| {
+                    info!("Publicly routable local address found: {}", ip);
+                    NetAddress::new(ip, self.config.default_p2p_port())
+                })
+            }))
+        } else {
+            itertools::Either::Left(None.into_iter())
+        }
+    }
+
+    fn upnp(&self) -> Option<(NetAddress, ExtendHelper)> {
+        info!("Attempting to register upnp... (to disable run the node with --disable-upnp)");
+        let gateway = igd::search_gateway(Default::default()).ok()?;
+        let ip = IpAddress::new(gateway.get_external_ip().ok()?);
+        if !ip.is_publicly_routable() {
+            info!("Non-publicly routable external ip from gateway using upnp {} not added to store", ip);
+            return None;
+        }
+        info!("Got external ip from gateway using upnp: {ip}");
+
+        let default_port = self.config.default_p2p_port();
+
+        let normalized_p2p_listen_address = self.config.p2p_listen_address.normalize(default_port);
+        let local_addr = if normalized_p2p_listen_address.ip.is_unspecified() {
+            SocketAddr::new(local_ip_address::local_ip().unwrap(), normalized_p2p_listen_address.port)
+        } else {
+            normalized_p2p_listen_address.into()
+        };
+
+        match gateway.add_port(
+            igd::PortMappingProtocol::TCP,
+            default_port,
+            local_addr,
+            UPNP_DEADLINE_SEC as u32,
+            UPNP_REGISTRATION_NAME,
+        ) {
+            Ok(_) => {
+                info!("Added port mapping to default external port: {ip}:{default_port}");
+                Some((NetAddress { ip, port: default_port }, ExtendHelper { gateway, local_addr, external_port: default_port }))
+            }
+            Err(AddPortError::PortInUse {}) => {
+                let port = gateway
+                    .add_any_port(igd::PortMappingProtocol::TCP, local_addr, UPNP_DEADLINE_SEC as u32, UPNP_REGISTRATION_NAME)
+                    .ok()?;
+                info!("Added port mapping to random external port: {ip}:{port}");
+                Some((NetAddress { ip, port }, ExtendHelper { gateway, local_addr, external_port: port }))
+            }
+            Err(err) => {
+                warn!("error adding port: {err}");
                 None
             }
-            None if !self.config.disable_upnp => {
-                let gateway = igd::search_gateway(Default::default()).ok()?;
-                let ip = IpAddress::new(gateway.get_external_ip().ok()?);
-                if !ip.is_publicly_routable() {
-                    info!("Non-publicly routable external ip from gateway using upnp {} not added to store", ip);
-                    return None;
-                }
-                info!("Got external ip from gateway using upnp: {ip}");
-
-                let default_port = self.config.default_p2p_port();
-
-                let normalized_p2p_listen_address = self.config.p2p_listen_address.normalize(default_port);
-                let local_addr = if normalized_p2p_listen_address.ip.is_unspecified() {
-                    SocketAddr::new(local_ip_address::local_ip().unwrap(), normalized_p2p_listen_address.port)
-                } else {
-                    normalized_p2p_listen_address.into()
-                };
-
-                match gateway.add_port(
-                    igd::PortMappingProtocol::TCP,
-                    default_port,
-                    local_addr,
-                    UPNP_DEADLINE_SEC as u32,
-                    UPNP_REGISTRATION_NAME,
-                ) {
-                    Ok(_) => {
-                        info!("Added port mapping to default external port: {ip}:{default_port}");
-                        Some((
-                            NetAddress { ip, port: default_port },
-                            Some(ExtendHelper { gateway, local_addr, external_port: default_port }),
-                        ))
-                    }
-                    Err(AddPortError::PortInUse {}) => {
-                        let port = gateway
-                            .add_any_port(igd::PortMappingProtocol::TCP, local_addr, UPNP_DEADLINE_SEC as u32, UPNP_REGISTRATION_NAME)
-                            .ok()?;
-                        info!("Added port mapping to random external port: {ip}:{port}");
-                        Some((NetAddress { ip, port }, Some(ExtendHelper { gateway, local_addr, external_port: port })))
-                    }
-                    Err(err) => {
-                        warn!("error adding port: {err}");
-                        None
-                    }
-                }
-            }
-            None => None,
         }
     }
-    fn add_routable_addresses_from_net_interfaces(&mut self) {
-        // If listen_address === 0.0.0.0, bind all interfaces
-        // else, bind whatever was passed as listen address (if routable)
-        let listen_address = self.config.p2p_listen_address.normalize(self.config.default_p2p_port());
 
-        if listen_address.ip.is_unspecified() {
-            let network_interfaces = list_afinet_netifas();
-
-            if let Ok(network_interfaces) = network_interfaces {
-                for (_, ip) in network_interfaces.iter() {
-                    let curr_ip = IpAddress::new(*ip);
-
-                    // TODO: Add Check IPv4 or IPv6 match from Go code
-                    if curr_ip.is_publicly_routable() {
-                        info!("Publicly routable local address {} added to store", curr_ip);
-                        self.local_net_addresses.push(NetAddress { ip: curr_ip, port: self.config.default_p2p_port() });
-                    } else {
-                        debug!("Non-publicly routable interface address {} not added to store", curr_ip);
-                    }
-                }
-            } else {
-                warn!("Error getting network interfaces: {:?}", network_interfaces);
-            }
-        } else if listen_address.ip.is_publicly_routable() {
-            info!("Publicly routable P2P listen address {} added to store", listen_address.ip);
-            self.local_net_addresses.push(listen_address);
-        } else {
-            debug!("Non-publicly routable listen address {} not added to store.", listen_address.ip);
-        }
-    }
     pub fn best_local_address(&mut self) -> Option<NetAddress> {
         if self.local_net_addresses.is_empty() {
             None

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -174,7 +174,7 @@ impl AddressManager {
             match gateway.get_generic_port_mapping_entry(index) {
                 Ok(entry) => {
                     if entry.enabled && entry.external_port == default_port {
-                        info!("[UPnP] Found existing mapping that uses the same external port. description: {}, external port: {}, internal port: {}, client: {}, lease duration: {}", entry.port_mapping_description, entry.external_port, entry.internal_port, entry.internal_client, entry.lease_duration);
+                        info!("[UPnP] Found existing mapping that uses the same external port. Description: {}, external port: {}, internal port: {}, client: {}, lease duration: {}", entry.port_mapping_description, entry.external_port, entry.internal_port, entry.internal_client, entry.lease_duration);
                         break true;
                     }
                     index += 1;

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -174,7 +174,7 @@ impl AddressManager {
             match gateway.get_generic_port_mapping_entry(index) {
                 Ok(entry) => {
                     if entry.enabled && entry.external_port == default_port {
-                        info!("[UPnP] found existing mapping that uses the same external port. description: {}, external port: {}, internal port: {}, client: {}, lease duration: {}", entry.port_mapping_description, entry.external_port, entry.internal_port, entry.internal_client, entry.lease_duration);
+                        info!("[UPnP] Found existing mapping that uses the same external port. description: {}, external port: {}, internal port: {}, client: {}, lease duration: {}", entry.port_mapping_description, entry.external_port, entry.internal_port, entry.internal_client, entry.lease_duration);
                         break true;
                     }
                     index += 1;

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -7,7 +7,7 @@ use std::{collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration
 use address_manager::port_mapping_extender::Extender;
 use igd_next::{
     self as igd, aio::tokio::Tokio, AddAnyPortError, AddPortError, Gateway, GetExternalIpError, GetGenericPortMappingEntryError,
-    PortMappingEntry, SearchError,
+    SearchError,
 };
 use itertools::Itertools;
 use kaspa_consensus_core::config::Config;

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -7,7 +7,7 @@ use std::{collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration
 use address_manager::port_mapping_extender::Extender;
 use igd_next::{
     self as igd, aio::tokio::Tokio, AddAnyPortError, AddPortError, Gateway, GetExternalIpError, GetGenericPortMappingEntryError,
-    SearchError,
+    PortMappingEntry, SearchError,
 };
 use itertools::Itertools;
 use kaspa_consensus_core::config::Config;
@@ -183,7 +183,11 @@ impl AddressManager {
                     index += 1;
                     continue;
                 }
-                Err(_) => break false,
+                Err(GetGenericPortMappingEntryError::RequestError(err)) => {
+                    warn!("[UPnP] request existing port mapping err: {:?}", err);
+                    break false;
+                }
+                Err(GetGenericPortMappingEntryError::SpecifiedArrayIndexInvalid) => break false,
             }
         };
         if already_in_use {

--- a/components/addressmanager/src/port_mapping_extender.rs
+++ b/components/addressmanager/src/port_mapping_extender.rs
@@ -49,9 +49,9 @@ impl Extender {
                 )
                 .await
             {
-                warn!("extend external ip mapping err: {e:?}");
+                warn!("[UPnP] Extend external ip mapping err: {e:?}");
             } else {
-                debug!("extend external ip mapping");
+                debug!("[UPnP] Extend external ip mapping");
             }
         }
         // Let the system print final logs before exiting

--- a/components/addressmanager/src/port_mapping_extender.rs
+++ b/components/addressmanager/src/port_mapping_extender.rs
@@ -1,6 +1,6 @@
 use igd_next::{aio::tokio::Tokio, AddPortError};
 use kaspa_core::{
-    debug, error,
+    debug, error, info,
     task::{
         service::{AsyncService, AsyncServiceFuture},
         tick::{TickReason, TickService},
@@ -81,6 +81,11 @@ impl AsyncService for Extender {
 
     fn stop(self: Arc<Self>) -> AsyncServiceFuture {
         Box::pin(async move {
+            if let Err(err) = self.gateway.remove_port(igd_next::PortMappingProtocol::TCP, self.external_port).await {
+                warn!("[UPnP] Remove port mapping err: {err:?}");
+            } else {
+                info!("[UPnP] Successfully removed port mapping, external port: {}", self.external_port);
+            }
             trace!("{} stopped", SERVICE_NAME);
             Ok(())
         })


### PR DESCRIPTION
reorder fetching sources for external ip according to: 
   external ip -> provided local address -> net interfaces -> upnp

The 'addressmanager' component of the codebase has been thoroughly refined for improved readability and maintainability. Firstly, the logic for assigning local network addresses has been streamlined and broken down into smaller methods for more clarity. Old methods 'add_routable_addresses_from_net_interfaces' and 'configured_address' have been replaced by 'routable_addresses_from_net_interfaces', 'local_addresses', and 'upnp'. This also led to the removal of redundant code.