### PR TITLE
Update WRS to 0.8.0 and async_channel to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,8 +222,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336d835910fab747186c56586562cb46f42809c2843ef3a84f47509009522838"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 3.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -246,7 +259,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-executor",
  "async-io",
  "async-lock",
@@ -281,7 +294,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -291,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
- "async-channel",
+ "async-channel 1.9.0",
  "async-global-executor",
  "async-io",
  "async-lock",
@@ -593,7 +606,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-lock",
  "async-task",
  "atomic-waker",
@@ -761,6 +774,18 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrome-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011ddd3011a285f208817fc8fc6db655cda2e17f89de31d34b90559b5f2a8870"
+dependencies = [
+ "js-sys",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1351,6 +1376,27 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96b852f1345da36d551b9473fa1e2b1eb5c5195585c6c018118bc92a8d91160"
+dependencies = [
+ "event-listener 3.0.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "evpkdf"
@@ -2110,7 +2156,7 @@ dependencies = [
 name = "kaspa-consensus"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "bincode",
  "criterion",
  "crossbeam-channel",
@@ -2189,7 +2235,7 @@ dependencies = [
 name = "kaspa-consensus-notify"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "cfg-if 1.0.0",
  "derive_more",
  "futures",
@@ -2311,7 +2357,7 @@ dependencies = [
 name = "kaspa-grpc-client"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-stream",
  "async-trait",
  "faster-hex 0.6.1",
@@ -2338,7 +2384,7 @@ dependencies = [
 name = "kaspa-grpc-core"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-stream",
  "async-trait",
  "faster-hex 0.6.1",
@@ -2366,7 +2412,7 @@ dependencies = [
 name = "kaspa-grpc-server"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-stream",
  "async-trait",
  "faster-hex 0.6.1",
@@ -2418,7 +2464,7 @@ dependencies = [
 name = "kaspa-index-core"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-trait",
  "derive_more",
  "futures",
@@ -2437,7 +2483,7 @@ dependencies = [
 name = "kaspa-index-processor"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-trait",
  "derive_more",
  "futures",
@@ -2540,7 +2586,7 @@ dependencies = [
 name = "kaspa-notify"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-trait",
  "borsh",
  "derive_more",
@@ -2685,7 +2731,7 @@ dependencies = [
 name = "kaspa-rpc-core"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-trait",
  "borsh",
  "derive_more",
@@ -2758,7 +2804,7 @@ dependencies = [
 name = "kaspa-testing-integration"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "bincode",
  "criterion",
  "crossbeam-channel",
@@ -2843,12 +2889,12 @@ dependencies = [
 name = "kaspa-utils"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-trait",
  "bincode",
  "borsh",
  "criterion",
- "event-listener",
+ "event-listener 2.5.3",
  "faster-hex 0.6.1",
  "futures-util",
  "ipnet",
@@ -3088,7 +3134,7 @@ dependencies = [
 name = "kaspad"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "clap 4.3.19",
  "dhat",
  "dirs 4.0.0",
@@ -3670,9 +3716,9 @@ checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "nw-sys"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde0375029a7d6e44538818aaf2e1791fc4e7b50ca0cfe5067e34a820a2a927c"
+checksum = "8ebcbbf8ce75f465eea419ed8396efaf9ad9da87ad83fe9fce9c8789de00ca79"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4556,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
 dependencies = [
  "js-sys",
  "serde",
@@ -4696,7 +4742,7 @@ dependencies = [
 name = "simpa"
 version = "0.1.7"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "clap 4.3.19",
  "dhat",
  "futures",
@@ -5723,12 +5769,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "workflow-core"
-version = "0.7.0"
+name = "workflow-chrome"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aa299c4c22288222fb1c32711fc801c9b7d8f3a217b0285655d845e130b858"
+checksum = "1f1de928105ae6f56d4cf5e0d2c62907ea1a9dc5462f2df4a5ae2b0e11c82f98"
 dependencies = [
- "async-channel",
+ "cfg-if 1.0.0",
+ "chrome-sys",
+ "js-sys",
+ "thiserror",
+ "wasm-bindgen",
+ "workflow-core",
+ "workflow-log",
+]
+
+[[package]]
+name = "workflow-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7984d281cbda7e3fdad1560dd3b7eadfd8faee31ee94e33c29272661b41f2ae"
+dependencies = [
+ "async-channel 2.0.0",
  "async-std",
  "borsh",
  "bs58 0.5.0",
@@ -5741,7 +5802,7 @@ dependencies = [
  "js-sys",
  "rand 0.8.5",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.1",
  "thiserror",
  "tokio",
  "triggered",
@@ -5754,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-core-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae2d1e38af496237a8bad8273e35d04c1d4e7bbfdb5052cef3c7bd81763ab65"
+checksum = "8d2c60618d38a0755a2049c5b140e40872b3468b695476d5fb0fce3dac1bc12d"
 dependencies = [
  "convert_case 0.6.0",
  "parse-variants",
@@ -5771,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-d3"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6df6000a3af84fc7464557049f5f5a819340c4545d194fe449853f4a9cc4dbd"
+checksum = "8199c10f53bb98bc9fc10e618770c4b404800c95ac63789ed5c05dc5603387bf"
 dependencies = [
  "atomic_float",
  "js-sys",
@@ -5788,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-dom"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4132a4bbf4a175d7d9e98d9a9d003d82743a6cbc22afd57fa14c556b65b16a2c"
+checksum = "84b137bff0c20b7485a0ddfcddb8d8cda7128ef38c59c6b10aad0a07787dd52c"
 dependencies = [
  "futures",
  "js-sys",
@@ -5806,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-log"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a25d247412edc11c88adeca0cfdc5b1570d8f8798f8e2773bb3b2ef70b94229"
+checksum = "740268977c1c5a56a65bc2f822ef29a4bbd344e36e1a91710364f4f688f27c25"
 dependencies = [
  "cfg-if 1.0.0",
  "console",
@@ -5822,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-macro-tools"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56ab2947f966610eeda6b2a443c8417ef7088f324a733ef1a0a3b41523e6403"
+checksum = "5e9ace8db0083631de39c1136b57614affffdb0d0ea66aef5c19f8d3a1bc83b5"
 dependencies = [
  "convert_case 0.6.0",
  "parse-variants",
@@ -5835,9 +5896,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-node"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219b3313c39598738b03bb368815cd92ba8da2a207b07c050cd6a6a8f80ae713"
+checksum = "b0e89fcf4e70cd27e9c888dcc164f30651116cac8d7f53a52aa8c5ccf63ce4d3"
 dependencies = [
  "borsh",
  "futures",
@@ -5856,9 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-nw"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff2e26bc57c8d53b22fad92d8a50c63522b9f56da2fdcfd2e371024cf72a5a0"
+checksum = "6dcca64f129fb66086e8ce873bbb76dbb07388c53ec268672fd7963f9d648b5a"
 dependencies = [
  "ahash 0.8.3",
  "async-trait",
@@ -5868,7 +5929,7 @@ dependencies = [
  "nw-sys",
  "rand 0.8.5",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.1",
  "thiserror",
  "wasm-bindgen",
  "web-sys",
@@ -5880,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-panic-hook"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aac94f680355b4bf8683c514a2804178ea0d30862efd531975b97643a57313"
+checksum = "71d9e2613c2a5c6ee86159dcc7b23bf48f88d7beb58ecf47035e28b2fe124b3d"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
@@ -5905,9 +5966,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-rpc"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a127cad6f030846da58be6ebb7721114818e1c1c5802d0b620df27d7d31ead79"
+checksum = "6ee97618b7391d2f78af1f353dd45b430621b71e31fa5b0766c9ccfee4e97648"
 dependencies = [
  "ahash 0.8.3",
  "async-std",
@@ -5934,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-rpc-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf166c827433bb70bd477aa26fa32d5a17cbca64ababc0fb785bae736805b016"
+checksum = "9b9426a01369807570510214a3f669cee06b067d25740eb2515b88ed4c053904"
 dependencies = [
  "parse-variants",
  "proc-macro-error",
@@ -5947,13 +6008,14 @@ dependencies = [
 
 [[package]]
 name = "workflow-store"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190ead362268f264b197740f233a6c1cac1c970f3d52f0758ae6717b09367660"
+checksum = "216f996db400aa1d46a5fcc55a88110d5768fd0501775c1b347aa56dca15114c"
 dependencies = [
  "async-std",
  "base64 0.21.2",
  "cfg-if 1.0.0",
+ "chrome-sys",
  "faster-hex 0.8.0",
  "home",
  "js-sys",
@@ -5964,6 +6026,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "workflow-chrome",
  "workflow-core",
  "workflow-log",
  "workflow-node",
@@ -5972,9 +6035,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-task"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a390248381acdc70bba88da59940d0937078893b4ad57990c90bea92086cef2"
+checksum = "49c6bf3db3ac369576c8c1a197387c5168aecc9648682605c45b103e6fadecd6"
 dependencies = [
  "futures",
  "thiserror",
@@ -5984,9 +6047,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-task-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2483b389668a39a3e4f9bb4690c587243e9dc07ac7f7032cf3ff375187457b"
+checksum = "8d2ed423384c6911ba0282264875098147a29b913bef34c1e7d58d6852bfee2d"
 dependencies = [
  "convert_case 0.6.0",
  "parse-variants",
@@ -6000,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-terminal"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c742e15960ae991ed73fac227e10b066d3bfb5dc01d1694d670df70c2936c366"
+checksum = "b68669777711b25ab1d3c3cdd689ec1292ccbf87bc2db3cf30ad3b23656084d4"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6029,9 +6092,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-terminal-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a956d554911cc7be0999819c7285ccd466ace36419dd0a894286dc1abe5c69a2"
+checksum = "3356f7cb4599ebdded67d46ac224d242dca2ebf39ce3aab6c13933194f265905"
 dependencies = [
  "convert_case 0.6.0",
  "parse-variants",
@@ -6045,16 +6108,16 @@ dependencies = [
 
 [[package]]
 name = "workflow-wasm"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8af87f5c0ff033d8817ce487fd26fd356e76f5112bac9755532057e262628c"
+checksum = "ffc20af89e41b831fb0c2cd4b65fc1dfe41716e8c812ebb15f43a153be7f7701"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.8.0",
  "futures",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.1",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6066,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "workflow-wasm-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ace2bea71962ba46614d47218c79d439ad658d54ee716ad45dd6f750bf33628"
+checksum = "9a6b17b58556af407eaf9760882bc2e00e6eda4fceec9cf22554c4ff9884f8ee"
 dependencies = [
  "js-sys",
  "proc-macro-error",
@@ -6080,11 +6143,12 @@ dependencies = [
 
 [[package]]
 name = "workflow-websocket"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308c0c658cf678b1c358643a23b5ff8c2f8dcb9a5226c00ffbf74f407670ab6e"
+checksum = "d74a74a9373e2e282f5057c91147dcfd7dfbea90442b72c5e0e86736f0e1af2c"
 dependencies = [
  "ahash 0.8.3",
+ "async-channel 2.0.0",
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ parking_lot = "0.12"
 smallvec = { version = "1.10.0", features = ["serde"] }
 borsh = { version = "0.9.1", features = ["rc"] } # please keep this fixed
 async-std = { version = "1.12.0", features = ['attributes'] }
-async-channel = "1.8.0"
+async-channel = "2.0.0"
 clap = { version = "4.0.23", features = ["derive", "string", "cargo"] }
 derive_more = { version = "0.99" }
 log = "0.4"
@@ -203,16 +203,16 @@ pbkdf2 = { version = "0.12.1" }
 # pbkdf2 = { version = "0.11", default-features = false}
 
 # workflow dependencies
-workflow-d3 = { version = "0.7.0" }
-workflow-nw = { version = "0.7.0" }
-workflow-log = { version = "0.7.0" }
-workflow-core = { version = "0.7.0" }
-workflow-wasm = { version = "0.7.0" }
-workflow-dom = { version = "0.7.0" }
-workflow-rpc = { version = "0.7.0" }
-workflow-node = { version = "0.7.0" }
-workflow-store = { version = "0.7.0" }
-workflow-terminal = { version = "0.7.0" }
+workflow-d3 = { version = "0.8.0" }
+workflow-nw = { version = "0.8.0" }
+workflow-log = { version = "0.8.0" }
+workflow-core = { version = "0.8.0" }
+workflow-wasm = { version = "0.8.0" }
+workflow-dom = { version = "0.8.0" }
+workflow-rpc = { version = "0.8.0" }
+workflow-node = { version = "0.8.0" }
+workflow-store = { version = "0.8.0" }
+workflow-terminal = { version = "0.8.0" }
 nw-sys = "0.1.5"
 
 # if below is enabled, this means that there is an ongoing work

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -38,7 +38,7 @@ kaspa-consensusmanager.workspace = true
 once_cell.workspace = true
 
 crossbeam-channel = "0.5"
-async-channel = "1.8.0"
+async-channel.workspace = true
 secp256k1 = { version = "0.24", features = ["global-context", "rand-std"] }
 
 rand = { workspace = true, features = ["small_rng"] }

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -48,7 +48,7 @@ kaspa-bip32.workspace = true
 kaspa-wrpc-server.workspace = true
 
 crossbeam-channel = "0.5"
-async-channel = "1.8.0"
+async-channel.workspace = true
 secp256k1 = { version = "0.24", features = ["global-context", "rand-std"] }
 flate2 = "1"
 rand_distr = "0.4"


### PR DESCRIPTION
This PR updates `workflow-rs` to `0.8.0` to enable `accept()` functionality in wRPC needed for the file descriptor budget pool being implemented in https://github.com/kaspanet/rusty-kaspa/pull/284

As `workflow-rs` updates the `async_channel` dependency to `2.0.0`, it is also updated.