### PR TITLE
Create RPC Integration Tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,9 @@ jobs:
         
       - name: Run cargo test regular features
         run: cargo test --workspace
+      
+      - name: Run RPC tests
+        run: cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo test -p kaspa-hashes --features=no-asm --benches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,8 +123,8 @@ jobs:
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches
 
-      - name: Run cargo doc tests with features=no-asm
-        run: cargo test --doc --release --features=no-asm
+      - name: Run cargo doc tests with features=no-asm on kaspa-hashes
+        run: cargo test --doc --release -p kaspa-hashes --features=no-asm
 
   # test-release:
   #   name: Test Suite Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,12 +117,11 @@ jobs:
       - name: Run cargo test regular features
         run: cargo nextest run --release --workspace
 
-      - name: Run cargo doc tests
-        run: cargo test --release --doc --workspace
-
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches
 
+      - name: Run cargo doc tests
+        run: cargo test --release --doc --workspace --features=no-asm
 
   # test-release:
   #   name: Test Suite Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,9 +113,12 @@ jobs:
 
       - name: Run cargo build with devnet-prealloc feature
         run: cargo build --release --features devnet-prealloc --workspace --all --tests --benches
-        
+
       - name: Run cargo test regular features
         run: cargo nextest run --release --workspace
+
+      - name: Run cargo doc tests
+        run: cargo test --release --doc --workspace
 
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         run: cargo test --workspace
       
       - name: Run RPC tests
-        run: cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
+        run: cargo test --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo test -p kaspa-hashes --features=no-asm --benches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,9 +116,6 @@ jobs:
         
       - name: Run cargo test regular features
         run: cargo nextest run --release --workspace
-      
-      - name: Run RPC tests
-        run: cargo nextest run --release -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,16 +112,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo build with devnet-prealloc feature
-        run: cargo build --features devnet-prealloc --workspace --all --tests --benches
+        run: cargo build --release --features devnet-prealloc --workspace --all --tests --benches
         
       - name: Run cargo test regular features
-        run: cargo nextest run --workspace
+        run: cargo nextest run --release --workspace
       
       - name: Run RPC tests
-        run: cargo nextest run -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
+        run: cargo nextest run --release -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
       - name: Run cargo test on kaspa-hashes without asm
-        run: cargo nextest run -p kaspa-hashes --features=no-asm --benches
+        run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches
 
 
   # test-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest
 
       - name: Cache
         uses: actions/cache@v3
@@ -109,13 +112,13 @@ jobs:
         run: cargo build --features devnet-prealloc --workspace --all --tests --benches
         
       - name: Run cargo test regular features
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
       
       - name: Run RPC tests
-        run: cargo test --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
+        run: cargo nextest run -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
       - name: Run cargo test on kaspa-hashes without asm
-        run: cargo test -p kaspa-hashes --features=no-asm --benches
+        run: cargo nextest run -p kaspa-hashes --features=no-asm --benches
 
 
   # test-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Run cargo test regular features
         run: cargo nextest run --release --workspace
 
-      - name: Run cargo doc tests with features=no-asm
+      - name: Run cargo doc tests
         run: cargo test --doc --release --workspace
 
       - name: Run cargo test on kaspa-hashes without asm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,11 +117,14 @@ jobs:
       - name: Run cargo test regular features
         run: cargo nextest run --release --workspace
 
+      - name: Run cargo doc tests with features=no-asm
+        run: cargo test --doc --release --workspace
+
       - name: Run cargo test on kaspa-hashes without asm
         run: cargo nextest run --release -p kaspa-hashes --features=no-asm --benches
 
-      - name: Run cargo doc tests
-        run: cargo test --release --doc --workspace --features=no-asm
+      - name: Run cargo doc tests with features=no-asm
+        run: cargo test --doc --release --features=no-asm
 
   # test-release:
   #   name: Test Suite Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,9 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
+      
       - name: Install cargo-nextest
         run: cargo install cargo-nextest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
  "kaspa-core",
  "kaspa-database",
  "kaspa-grpc-client",
+ "kaspa-grpc-core",
  "kaspa-hashes",
  "kaspa-index-processor",
  "kaspa-math",

--- a/rpc/core/src/api/Extending RpcApi.md
+++ b/rpc/core/src/api/Extending RpcApi.md
@@ -41,3 +41,6 @@ As an illustration, let's pretend that we add a new `submit_block` method.
 8. Implement the function having a `_call` suffix into `kaspa_grpc_client::GrpcClient`.
 9. In `kaspa_grpc_server::service::RpcService::message_stream`, requests handler, add an arm and implement
    a handler for the new method.
+
+## rpc-test
+1. In file `testing\integration\src\rpc_tests.rs` add a new `match` arm for your payload inside the `sanity_test` test

--- a/test
+++ b/test
@@ -7,6 +7,7 @@ fi
 
 # integration tests
 cargo nextest run --release --workspace -p kaspa-testing-integration --lib
+cargo test --doc --release --workspace --lib
 
 # wasm build (tests for potential multiple exports of the same symbol)
 pushd .

--- a/test
+++ b/test
@@ -6,7 +6,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # integration tests
-cargo test --release --workspace -p kaspa-testing-integration --lib
+cargo nextest run --release --workspace -p kaspa-testing-integration --lib
+cargo nextest run --release -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
 # wasm build (tests for potential multiple exports of the same symbol)
 pushd .

--- a/test
+++ b/test
@@ -7,7 +7,6 @@ fi
 
 # integration tests
 cargo nextest run --release --workspace -p kaspa-testing-integration --lib
-cargo nextest run --release -p kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test
 
 # wasm build (tests for potential multiple exports of the same symbol)
 pushd .

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -15,6 +15,7 @@ kaspa-consensus.workspace = true
 kaspa-consensusmanager.workspace = true
 kaspa-core.workspace = true
 kaspa-grpc-client.workspace = true
+kaspa-grpc-core.workspace = true
 kaspa-hashes.workspace = true
 kaspa-math.workspace = true
 kaspa-merkle.workspace = true

--- a/testing/integration/src/common/mod.rs
+++ b/testing/integration/src/common/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 pub mod client_pool;
 pub mod daemon;
+pub mod utils;
 
 pub fn open_file(file_path: &Path) -> File {
     let file_res = File::open(file_path);

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -1,0 +1,107 @@
+use itertools::Itertools;
+use kaspa_consensus_core::{
+    constants::TX_VERSION,
+    sign::sign,
+    subnets::SUBNETWORK_ID_NATIVE,
+    tx::{ScriptPublicKey, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput},
+    utxo::{
+        utxo_collection::{UtxoCollection, UtxoCollectionExtensions},
+        utxo_diff::UtxoDiff,
+    },
+};
+use kaspa_core::info;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use secp256k1::KeyPair;
+use std::{
+    collections::{hash_map::Entry::Occupied, HashMap, HashSet},
+    sync::Arc,
+};
+
+const EXPAND_FACTOR: u64 = 1;
+const CONTRACT_FACTOR: u64 = 1;
+
+fn estimated_mass(num_inputs: usize, num_outputs: u64) -> u64 {
+    200 + 34 * num_outputs + 1000 * (num_inputs as u64)
+}
+
+fn required_fee(num_inputs: usize, num_outputs: u64) -> u64 {
+    const FEE_PER_MASS: u64 = 10;
+    FEE_PER_MASS * estimated_mass(num_inputs, num_outputs)
+}
+
+/// Builds a TX DAG based on the initial UTXO set and on constant params
+pub fn generate_tx_dag(
+    mut utxoset: UtxoCollection,
+    schnorr_key: KeyPair,
+    spk: ScriptPublicKey,
+    target_levels: usize,
+    target_width: usize,
+) -> Vec<Arc<Transaction>> {
+    /*
+    Algo:
+       perform level by level:
+           for target txs per level:
+               select random utxos (distinctly)
+               create and sign a tx
+               append tx to level txs
+               append tx to utxo diff
+           apply level utxo diff to the utxo collection
+    */
+
+    let num_inputs = CONTRACT_FACTOR as usize;
+    let num_outputs = EXPAND_FACTOR;
+
+    let mut txs = Vec::with_capacity(target_levels * target_width);
+
+    for i in 0..target_levels {
+        let mut utxo_diff = UtxoDiff::default();
+        utxoset
+            .iter()
+            .take(num_inputs * target_width)
+            .chunks(num_inputs)
+            .into_iter()
+            .map(|c| c.into_iter().map(|(o, e)| (TransactionInput::new(*o, vec![], 0, 1), e.clone())).unzip())
+            .collect::<Vec<(Vec<_>, Vec<_>)>>()
+            .into_par_iter()
+            .map(|(inputs, entries)| {
+                let total_in = entries.iter().map(|e| e.amount).sum::<u64>();
+                let total_out = total_in - required_fee(num_inputs, num_outputs);
+                let outputs = (0..num_outputs)
+                    .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone() })
+                    .collect_vec();
+                let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+                sign(SignableTransaction::with_entries(unsigned_tx, entries), schnorr_key)
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .for_each(|signed_tx| {
+                utxo_diff.add_transaction(&signed_tx.as_verifiable(), 0).unwrap();
+                txs.push(Arc::new(signed_tx.tx));
+            });
+        utxoset.remove_collection(&utxo_diff.remove);
+        utxoset.add_collection(&utxo_diff.add);
+
+        if i % (target_levels / 10).max(1) == 0 {
+            info!("Generated {} txs", txs.len());
+        }
+    }
+
+    txs
+}
+
+/// Sanity test verifying that the generated TX DAG is valid, topologically ordered and has no double spends
+pub fn verify_tx_dag(initial_utxoset: &UtxoCollection, txs: &Vec<Arc<Transaction>>) {
+    let mut prev_txs: HashMap<TransactionId, Arc<Transaction>> = HashMap::new();
+    let mut used_outpoints = HashSet::with_capacity(txs.len() * 2);
+    for tx in txs.iter() {
+        for input in tx.inputs.iter() {
+            assert!(used_outpoints.insert(input.previous_outpoint));
+            if let Occupied(e) = prev_txs.entry(input.previous_outpoint.transaction_id) {
+                assert!(e.get().outputs.len() > input.previous_outpoint.index as usize);
+            } else {
+                assert!(initial_utxoset.contains_key(&input.previous_outpoint));
+            }
+        }
+        assert!(prev_txs.insert(tx.id(), tx.clone()).is_none());
+    }
+}

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -12,3 +12,7 @@ pub mod daemon_integration_tests;
 #[cfg(test)]
 #[cfg(feature = "devnet-prealloc")]
 pub mod mempool_benchmarks;
+
+#[cfg(test)]
+#[cfg(feature = "devnet-prealloc")]
+pub mod rpc_tests;

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -14,5 +14,4 @@ pub mod daemon_integration_tests;
 pub mod mempool_benchmarks;
 
 #[cfg(test)]
-#[cfg(feature = "devnet-prealloc")]
 pub mod rpc_tests;

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -1,20 +1,9 @@
-use crate::common::daemon::Daemon;
+use crate::common::{self, daemon::Daemon};
 use async_channel::Sender;
 use futures_util::future::join_all;
-use itertools::Itertools;
 use kaspa_addresses::Address;
 use kaspa_consensus::params::Params;
-use kaspa_consensus_core::{
-    constants::{SOMPI_PER_KASPA, TX_VERSION},
-    network::NetworkType,
-    sign::sign,
-    subnets::SUBNETWORK_ID_NATIVE,
-    tx::{ScriptPublicKey, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput},
-    utxo::{
-        utxo_collection::{UtxoCollection, UtxoCollectionExtensions},
-        utxo_diff::UtxoDiff,
-    },
-};
+use kaspa_consensus_core::{constants::SOMPI_PER_KASPA, network::NetworkType, tx::Transaction};
 use kaspa_core::{debug, info};
 use kaspa_notify::{
     listener::ListenerId,
@@ -28,11 +17,8 @@ use kaspad_lib::args::Args;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rand_distr::{Distribution, Exp};
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use secp256k1::KeyPair;
 use std::{
     cmp::max,
-    collections::{hash_map::Entry::Occupied, HashMap, HashSet},
     fmt::Debug,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -54,94 +40,7 @@ impl Notify<Notification> for ChannelNotify {
     }
 }
 
-fn required_fee(num_inputs: usize, num_outputs: u64) -> u64 {
-    const FEE_PER_MASS: u64 = 10;
-    FEE_PER_MASS * estimated_mass(num_inputs, num_outputs)
-}
-
-fn estimated_mass(num_inputs: usize, num_outputs: u64) -> u64 {
-    200 + 34 * num_outputs + 1000 * (num_inputs as u64)
-}
-
-const EXPAND_FACTOR: u64 = 1;
 const CONTRACT_FACTOR: u64 = 1;
-
-/// Builds a TX DAG based on the initial UTXO set and on constant params
-fn generate_tx_dag(
-    mut utxoset: UtxoCollection,
-    schnorr_key: KeyPair,
-    spk: ScriptPublicKey,
-    target_levels: usize,
-    target_width: usize,
-) -> Vec<Arc<Transaction>> {
-    /*
-    Algo:
-       perform level by level:
-           for target txs per level:
-               select random utxos (distinctly)
-               create and sign a tx
-               append tx to level txs
-               append tx to utxo diff
-           apply level utxo diff to the utxo collection
-    */
-
-    let num_inputs = CONTRACT_FACTOR as usize;
-    let num_outputs = EXPAND_FACTOR;
-
-    let mut txs = Vec::with_capacity(target_levels * target_width);
-
-    for i in 0..target_levels {
-        let mut utxo_diff = UtxoDiff::default();
-        utxoset
-            .iter()
-            .take(num_inputs * target_width)
-            .chunks(num_inputs)
-            .into_iter()
-            .map(|c| c.into_iter().map(|(o, e)| (TransactionInput::new(*o, vec![], 0, 1), e.clone())).unzip())
-            .collect::<Vec<(Vec<_>, Vec<_>)>>()
-            .into_par_iter()
-            .map(|(inputs, entries)| {
-                let total_in = entries.iter().map(|e| e.amount).sum::<u64>();
-                let total_out = total_in - required_fee(num_inputs, num_outputs);
-                let outputs = (0..num_outputs)
-                    .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone() })
-                    .collect_vec();
-                let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
-                sign(SignableTransaction::with_entries(unsigned_tx, entries), schnorr_key)
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .for_each(|signed_tx| {
-                utxo_diff.add_transaction(&signed_tx.as_verifiable(), 0).unwrap();
-                txs.push(Arc::new(signed_tx.tx));
-            });
-        utxoset.remove_collection(&utxo_diff.remove);
-        utxoset.add_collection(&utxo_diff.add);
-
-        if i % (target_levels / 10).max(1) == 0 {
-            info!("Generated {} txs", txs.len());
-        }
-    }
-
-    txs
-}
-
-/// Sanity test verifying that the generated TX DAG is valid, topologically ordered and has no double spends
-fn verify_tx_dag(initial_utxoset: &UtxoCollection, txs: &Vec<Arc<Transaction>>) {
-    let mut prev_txs: HashMap<TransactionId, Arc<Transaction>> = HashMap::new();
-    let mut used_outpoints = HashSet::with_capacity(txs.len() * 2);
-    for tx in txs.iter() {
-        for input in tx.inputs.iter() {
-            assert!(used_outpoints.insert(input.previous_outpoint));
-            if let Occupied(e) = prev_txs.entry(input.previous_outpoint.transaction_id) {
-                assert!(e.get().outputs.len() > input.previous_outpoint.index as usize);
-            } else {
-                assert!(initial_utxoset.contains_key(&input.previous_outpoint));
-            }
-        }
-        assert!(prev_txs.insert(tx.id(), tx.clone()).is_none());
-    }
-}
 
 /// Run this benchmark with the following command line:
 /// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- mempool_benchmarks::bench_bbt_latency --exact --nocapture --ignored`
@@ -203,8 +102,8 @@ async fn bench_bbt_latency() {
     let params: Params = network.into();
 
     let utxoset = args.generate_prealloc_utxos(args.num_prealloc_utxos.unwrap());
-    let txs = generate_tx_dag(utxoset.clone(), schnorr_key, spk, TX_COUNT / TX_LEVEL_WIDTH, TX_LEVEL_WIDTH);
-    verify_tx_dag(&utxoset, &txs);
+    let txs = common::utils::generate_tx_dag(utxoset.clone(), schnorr_key, spk, TX_COUNT / TX_LEVEL_WIDTH, TX_LEVEL_WIDTH);
+    common::utils::verify_tx_dag(&utxoset, &txs);
     info!("Generated overall {} txs", txs.len());
 
     let fd_total_budget = fd_budget::limit();

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -3,10 +3,18 @@ use std::str::FromStr;
 use crate::common::daemon::Daemon;
 use futures_util::future::try_join_all;
 use kaspa_addresses::{Address, Prefix, Version};
-use kaspa_consensus_core::subnets::SubnetworkId;
+use kaspa_consensus::params::SIMNET_GENESIS;
+use kaspa_consensus_core::{constants::MAX_SOMPI, subnets::SubnetworkId, tx::Transaction};
 use kaspa_core::info;
 use kaspa_grpc_core::ops::KaspadPayloadOps;
 use kaspa_hashes::Hash;
+use kaspa_notify::{
+    connection::{ChannelConnection, ChannelType},
+    scope::{
+        BlockAddedScope, FinalityConflictScope, NewBlockTemplateScope, PruningPointUtxoSetOverrideScope, SinkBlueScoreChangedScope,
+        UtxosChangedScope, VirtualChainChangedScope, VirtualDaaScoreChangedScope,
+    },
+};
 use kaspa_rpc_core::{api::rpc::RpcApi, model::*};
 use kaspa_utils::{fd_budget, networking::ContextualNetAddress};
 use kaspad_lib::args::Args;
@@ -16,14 +24,14 @@ use tokio::task::JoinHandle;
 macro_rules! tst {
     ($op:ident, $test_body:block) => {
         tokio::spawn(async move {
-            info!("Testing {:?}", $op);
+            info!("Testing  {:?}", $op);
             $test_body
         })
     };
 
     ($op:ident, $reason:literal) => {
         tokio::spawn(async move {
-            info!("Ignoring {:?} --- {}", $op, $reason);
+            info!("Skipping {:?} --- {}", $op, $reason);
         })
     };
 }
@@ -32,10 +40,7 @@ macro_rules! tst {
 #[tokio::test]
 async fn sanity_test() {
     kaspa_core::panic::configure_panic();
-    kaspa_core::log::try_init_logger(
-        "info",
-        // "info,kaspa_rpc_core=debug,kaspa_rpc_service=debug,kaspa_grpc_client=debug,kaspa_grpc_server=debug",
-    );
+    kaspa_core::log::try_init_logger("info");
 
     let args = Args {
         simnet: true,
@@ -50,185 +55,254 @@ async fn sanity_test() {
     let fd_total_budget = fd_budget::limit();
     let mut daemon = Daemon::new_random_with_args(args, fd_total_budget);
     let client = daemon.start().await;
+    let (sender, _) = async_channel::unbounded();
+    let connection = ChannelConnection::new(sender, ChannelType::Closable);
+    let listener_id = client.register_new_listener(connection);
     let mut tasks: Vec<JoinHandle<()>> = Vec::new();
 
     // The intent of this for/match design (emphasizing the absence of an arm with fallback pattern in the match)
-    // is to force any implementor of a new RpcApi method to add a matching arm here and strongly incentivize
+    // is to force any implementor of a new RpcApi method to add a matching arm here and to strongly incentivize
     // the adding of an actual sanity test of said new method.
     for op in KaspadPayloadOps::list() {
         let task: JoinHandle<()> = match op {
             KaspadPayloadOps::SubmitBlock => {
-                tst!(op, {})
-            }
-            KaspadPayloadOps::GetBlockTemplate => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let _ = rpc_client
+                    // Before submitting a first block, the sink is the genesis,
+                    let response = rpc_client.get_sink_call(GetSinkRequest {}).await.unwrap();
+                    assert_eq!(response.sink, SIMNET_GENESIS.hash);
+                    let response = rpc_client.get_sink_blue_score_call(GetSinkBlueScoreRequest {}).await.unwrap();
+                    assert_eq!(response.blue_score, 0);
+
+                    // the block count is 0
+                    let response = rpc_client.get_block_count_call(GetBlockCountRequest {}).await.unwrap();
+                    assert_eq!(response.block_count, 0);
+
+                    // and the virtual chain is the genesis only
+                    let response = rpc_client
+                        .get_virtual_chain_from_block_call(GetVirtualChainFromBlockRequest {
+                            start_hash: SIMNET_GENESIS.hash,
+                            include_accepted_transaction_ids: false,
+                        })
+                        .await
+                        .unwrap();
+                    assert!(response.added_chain_block_hashes.is_empty());
+                    assert!(response.removed_chain_block_hashes.is_empty());
+
+                    // Get a block template
+                    let GetBlockTemplateResponse { block, is_synced } = rpc_client
                         .get_block_template_call(GetBlockTemplateRequest {
                             pay_address: Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]),
                             extra_data: Vec::new(),
                         })
                         .await
                         .unwrap();
+                    assert!(!is_synced);
+
+                    // Submit the template (no mining, in simnet PoW is skipped)
+                    let response = rpc_client.submit_block(block.clone(), false).await.unwrap();
+                    assert_eq!(response.report, SubmitBlockReport::Success);
+
+                    // After submitting a first block, the sink is the submitted block,
+                    let response = rpc_client.get_sink_call(GetSinkRequest {}).await.unwrap();
+                    assert_eq!(response.sink, block.header.hash);
+
+                    // the block count is 1
+                    let response = rpc_client.get_block_count_call(GetBlockCountRequest {}).await.unwrap();
+                    assert_eq!(response.block_count, 1);
+
+                    // and the virtual chain from genesis contains the added block
+                    let response = rpc_client
+                        .get_virtual_chain_from_block_call(GetVirtualChainFromBlockRequest {
+                            start_hash: SIMNET_GENESIS.hash,
+                            include_accepted_transaction_ids: false,
+                        })
+                        .await
+                        .unwrap();
+                    assert!(response.added_chain_block_hashes.contains(&block.header.hash));
+                    assert!(response.removed_chain_block_hashes.is_empty());
                 })
             }
+
+            KaspadPayloadOps::GetBlockTemplate => {
+                tst!(op, "see SubmitBlock")
+            }
+
             KaspadPayloadOps::GetCurrentNetwork => {
                 let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client.get_current_network_call(GetCurrentNetworkRequest {}).await.unwrap();
-
                     assert_eq!(response.network, daemon.network.network_type);
                 })
             }
+
             KaspadPayloadOps::GetBlock => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
-                    // TODO: Fix by adding actual mempool entries this can pool because otherwise it errors out
-                    let response_result = rpc_client
-                        .get_block_call(GetBlockRequest { hash: Hash::from_bytes([255; 32]), include_transactions: false })
-                        .await;
+                    let result = rpc_client.get_block_call(GetBlockRequest { hash: 0.into(), include_transactions: false }).await;
+                    assert!(result.is_err());
 
-                    assert!(response_result.is_err());
+                    let response = rpc_client
+                        .get_block_call(GetBlockRequest { hash: SIMNET_GENESIS.hash, include_transactions: false })
+                        .await
+                        .unwrap();
+                    assert_eq!(response.block.header.hash, SIMNET_GENESIS.hash);
                 })
             }
+
             KaspadPayloadOps::GetBlocks => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
-                    let response_result = rpc_client
-                        .get_blocks_call(GetBlocksRequest { include_blocks: false, include_transactions: false, low_hash: None })
-                        .await;
-
-                    // TODO: requires some setup to be meaningful
-                    assert!(response_result.is_ok());
+                    let response = rpc_client
+                        .get_blocks_call(GetBlocksRequest { include_blocks: true, include_transactions: false, low_hash: None })
+                        .await
+                        .unwrap();
+                    assert_eq!(response.blocks.len(), 1, "genesis block should be returned");
+                    assert_eq!(response.blocks[0].header.hash, SIMNET_GENESIS.hash);
+                    assert_eq!(response.block_hashes[0], SIMNET_GENESIS.hash);
                 })
             }
+
             KaspadPayloadOps::GetInfo => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let get_info_call_response = rpc_client.get_info_call(GetInfoRequest {}).await.unwrap();
-                    assert_eq!("0.1.7", get_info_call_response.server_version);
+                    let response = rpc_client.get_info_call(GetInfoRequest {}).await.unwrap();
+                    assert_eq!(response.server_version, kaspa_core::kaspad_env::version().to_string());
+                    assert_eq!(response.mempool_size, 0);
+                    assert!(response.is_utxo_indexed);
+                    assert!(response.has_message_id);
+                    assert!(response.has_notify_command);
                 })
             }
+
             KaspadPayloadOps::Shutdown => {
-                // This block is purposely left blank since shutdown has to be test only after all other
-                // tests joined
+                // This test is purposely left blank since shutdown can only be tested after all other
+                // tests completed
                 tst!(op, "must be run in the end")
             }
+
             KaspadPayloadOps::GetPeerAddresses => {
-                tst!(op, {})
+                tst!(op, "see AddPeer, Ban")
             }
+
             KaspadPayloadOps::GetSink => {
-                tst!(op, {})
+                tst!(op, "see SubmitBlock")
             }
+
             KaspadPayloadOps::GetMempoolEntry => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response_result = rpc_client
                         .get_mempool_entry_call(GetMempoolEntryRequest {
-                            transaction_id: Hash::from_bytes([255; 32]),
-                            include_orphan_pool: false,
+                            transaction_id: 0.into(),
+                            include_orphan_pool: true,
                             filter_transaction_pool: false,
                         })
                         .await;
-
                     // Test Get Mempool Entry:
                     // TODO: Fix by adding actual mempool entries this can get because otherwise it errors out
                     assert!(response_result.is_err());
                 })
             }
+
             KaspadPayloadOps::GetMempoolEntries => {
                 let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client
                         .get_mempool_entries_call(GetMempoolEntriesRequest {
+                            include_orphan_pool: true,
                             filter_transaction_pool: false,
-                            include_orphan_pool: false,
                         })
                         .await
                         .unwrap();
-
                     assert!(response.mempool_entries.is_empty());
                 })
             }
+
             KaspadPayloadOps::GetConnectedPeerInfo => {
                 let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client.get_connected_peer_info_call(GetConnectedPeerInfoRequest {}).await.unwrap();
-
                     assert!(response.peer_info.is_empty());
                 })
             }
+
             KaspadPayloadOps::AddPeer => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let peer_to_add = ContextualNetAddress::from_str("1.2.3.4:16110").unwrap();
+                    let peer_address = ContextualNetAddress::from_str("1.2.3.4").unwrap();
+                    let _ = rpc_client.add_peer_call(AddPeerRequest { peer_address, is_permanent: true }).await.unwrap();
 
                     // Add peer only adds the IP to a connection request. It will only be added to known_addresses if it
-                    // actually can be connected to. So in CI we can't expect it to be added unless we set up an actual peer
-                    let response_result =
-                        rpc_client.add_peer_call(AddPeerRequest { peer_address: peer_to_add, is_permanent: true }).await;
-                    assert!(response_result.is_ok());
+                    // actually can be connected to. So in this test we can't expect it to be added unless we set up an
+                    // actual peer.
+                    let response = rpc_client.get_peer_addresses_call(GetPeerAddressesRequest {}).await.unwrap();
+                    assert!(response.known_addresses.is_empty());
                 })
             }
+
             KaspadPayloadOps::Ban => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let peer_to_ban = ContextualNetAddress::from_str("5.6.7.8:16110").unwrap();
+                    let peer_address = ContextualNetAddress::from_str("5.6.7.8").unwrap();
+                    let ip = peer_address.normalize(1).ip;
 
-                    let _ = rpc_client.add_peer_call(AddPeerRequest { peer_address: peer_to_ban, is_permanent: false }).await.unwrap();
-                    let _ = rpc_client.ban_call(BanRequest { ip: peer_to_ban.normalize(12345).ip }).await.unwrap();
+                    let _ = rpc_client.add_peer_call(AddPeerRequest { peer_address, is_permanent: false }).await.unwrap();
+                    let _ = rpc_client.ban_call(BanRequest { ip }).await.unwrap();
+
                     let response = rpc_client.get_peer_addresses_call(GetPeerAddressesRequest {}).await.unwrap();
+                    assert!(response.banned_addresses.contains(&ip));
 
-                    assert!(response.banned_addresses.contains(&peer_to_ban.normalize(12345).ip));
-
-                    let _ = rpc_client.unban_call(UnbanRequest { ip: peer_to_ban.normalize(12345).ip }).await.unwrap();
+                    let _ = rpc_client.unban_call(UnbanRequest { ip }).await.unwrap();
+                    let response = rpc_client.get_peer_addresses_call(GetPeerAddressesRequest {}).await.unwrap();
+                    assert!(!response.banned_addresses.contains(&ip));
                 })
             }
+
             KaspadPayloadOps::Unban => {
-                // Covered already by the Ban test above
-                tst!(op, {})
+                tst!(op, "see Ban")
             }
+
             KaspadPayloadOps::SubmitTransaction => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                tst!(op, {
+                    // Build an erroneous transaction...
+                    let transaction = Transaction::new(0, vec![], vec![], 0, SubnetworkId::default(), 0, vec![]);
+                    let result = rpc_client.submit_transaction((&transaction).into(), false).await;
+                    // ...that gets rejected by the consensus
+                    assert!(result.is_err());
+                })
             }
+
             KaspadPayloadOps::GetSubnetwork => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let response_result =
+                    let result =
                         rpc_client.get_subnetwork_call(GetSubnetworkRequest { subnetwork_id: SubnetworkId::from_byte(0) }).await;
 
                     // Err because it's currently unimplemented
-                    assert!(response_result.is_err());
+                    assert!(result.is_err());
                 })
             }
-            KaspadPayloadOps::GetVirtualChainFromBlock => {
-                let rpc_client = daemon.new_client().await;
-                tst!(op, {
-                    let response_result = rpc_client
-                        .get_virtual_chain_from_block_call(GetVirtualChainFromBlockRequest {
-                            start_hash: Hash::from_bytes([255; 32]),
-                            include_accepted_transaction_ids: false,
-                        })
-                        .await;
 
-                    // TODO: requires some setup
-                    assert!(response_result.is_err());
-                })
+            KaspadPayloadOps::GetVirtualChainFromBlock => {
+                tst!(op, "see SubmitBlock")
             }
+
             KaspadPayloadOps::GetBlockCount => {
+                tst!(op, "see SubmitBlock")
+            }
+
+            KaspadPayloadOps::GetBlockDagInfo => {
                 let rpc_client = client.clone();
                 tst!(op, {
-                    let _ = rpc_client.get_block_count_call(GetBlockCountRequest {}).await.unwrap();
+                    let response = rpc_client.get_block_dag_info_call(GetBlockDagInfoRequest {}).await.unwrap();
+                    assert_eq!(response.network, daemon.network);
                 })
             }
-            KaspadPayloadOps::GetBlockDagInfo => {
-                let rpc_client = daemon.new_client().await;
-                tst!(op, {
-                    let _ = rpc_client.get_block_dag_info_call(GetBlockDagInfoRequest {}).await.unwrap();
-                })
-            }
+
             KaspadPayloadOps::ResolveFinalityConflict => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response_result = rpc_client
                         .resolve_finality_conflict_call(ResolveFinalityConflictRequest {
@@ -240,26 +314,30 @@ async fn sanity_test() {
                     assert!(response_result.is_err());
                 })
             }
+
             KaspadPayloadOps::GetHeaders => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response_result = rpc_client
-                        .get_headers_call(GetHeadersRequest { start_hash: Hash::from_bytes([255; 32]), limit: 1, is_ascending: true })
+                        .get_headers_call(GetHeadersRequest { start_hash: SIMNET_GENESIS.hash, limit: 1, is_ascending: true })
                         .await;
 
                     // Err because it's currently unimplemented
                     assert!(response_result.is_err());
                 })
             }
+
             KaspadPayloadOps::GetUtxosByAddresses => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let addresses = vec![Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32])];
-                    let _ = rpc_client.get_utxos_by_addresses_call(GetUtxosByAddressesRequest { addresses }).await.unwrap();
+                    let response = rpc_client.get_utxos_by_addresses_call(GetUtxosByAddressesRequest { addresses }).await.unwrap();
+                    assert!(response.entries.is_empty());
                 })
             }
+
             KaspadPayloadOps::GetBalanceByAddress => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client
                         .get_balance_by_address_call(GetBalanceByAddressRequest {
@@ -267,25 +345,39 @@ async fn sanity_test() {
                         })
                         .await
                         .unwrap();
+                    assert_eq!(response.balance, 0);
+                })
+            }
 
-                    assert_eq!(0, response.balance);
-                })
-            }
             KaspadPayloadOps::GetBalancesByAddresses => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
-                    let addresses = vec![Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32])];
-                    let _ = rpc_client.get_balances_by_addresses_call(GetBalancesByAddressesRequest { addresses }).await.unwrap();
+                    let addresses = vec![Address::new(Prefix::Simnet, Version::PubKey, &[1u8; 32])];
+                    let response = rpc_client
+                        .get_balances_by_addresses_call(GetBalancesByAddressesRequest::new(addresses.clone()))
+                        .await
+                        .unwrap();
+                    assert_eq!(response.entries.len(), 1);
+                    assert_eq!(response.entries[0].address, addresses[0]);
+                    assert_eq!(response.entries[0].balance, Some(0));
+
+                    let response =
+                        rpc_client.get_balances_by_addresses_call(GetBalancesByAddressesRequest::new(vec![])).await.unwrap();
+                    assert!(response.entries.is_empty());
                 })
             }
+
             KaspadPayloadOps::GetSinkBlueScore => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
-                    let _ = rpc_client.get_sink_blue_score_call(GetSinkBlueScoreRequest {}).await.unwrap();
+                    let response = rpc_client.get_sink_blue_score_call(GetSinkBlueScoreRequest {}).await.unwrap();
+                    // A concurrent test may have added a single block so the blue score can be either 0 or 1
+                    assert!(response.blue_score < 2);
                 })
             }
+
             KaspadPayloadOps::EstimateNetworkHashesPerSecond => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response_result = rpc_client
                         .estimate_network_hashes_per_second_call(EstimateNetworkHashesPerSecondRequest {
@@ -293,43 +385,46 @@ async fn sanity_test() {
                             start_hash: None,
                         })
                         .await;
-
-                    // TODO: Fix by increasing the actual window_size until this works
-                    // Current error: difficulty error: under min allowed window size (0 < 1000)
+                    // The current DAA window is almost empty so an error is expected
                     assert!(response_result.is_err());
                 })
             }
+
             KaspadPayloadOps::GetMempoolEntriesByAddresses => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let addresses = vec![Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32])];
-                    let _ = rpc_client
-                        .get_mempool_entries_by_addresses_call(GetMempoolEntriesByAddressesRequest {
-                            addresses,
-                            include_orphan_pool: false,
-                            filter_transaction_pool: false,
-                        })
+                    let response = rpc_client
+                        .get_mempool_entries_by_addresses_call(GetMempoolEntriesByAddressesRequest::new(
+                            addresses.clone(),
+                            true,
+                            false,
+                        ))
                         .await
                         .unwrap();
+                    assert_eq!(response.entries.len(), 1);
+                    assert_eq!(response.entries[0].address, addresses[0]);
+                    assert!(response.entries[0].receiving.is_empty());
+                    assert!(response.entries[0].sending.is_empty());
                 })
             }
+
             KaspadPayloadOps::GetCoinSupply => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client.get_coin_supply_call(GetCoinSupplyRequest {}).await.unwrap();
-
-                    // Nothing mined, so there should be nothing circulating
-                    assert_eq!(0, response.circulating_sompi);
-                    // Max sompi should always be higher than 0
-                    assert!(response.max_sompi > 0);
+                    assert_eq!(response.circulating_sompi, 0);
+                    assert_eq!(response.max_sompi, MAX_SOMPI);
                 })
             }
+
             KaspadPayloadOps::Ping => {
                 let rpc_client = client.clone();
                 tst!(op, {
                     let _ = rpc_client.ping_call(PingRequest {}).await.unwrap();
                 })
             }
+
             KaspadPayloadOps::GetMetrics => {
                 let rpc_client = client.clone();
                 tst!(op, {
@@ -337,7 +432,6 @@ async fn sanity_test() {
                         .get_metrics_call(GetMetricsRequest { consensus_metrics: true, process_metrics: true })
                         .await
                         .unwrap();
-
                     assert!(get_metrics_call_response.process_metrics.is_some());
                     assert!(get_metrics_call_response.consensus_metrics.is_some());
 
@@ -345,7 +439,6 @@ async fn sanity_test() {
                         .get_metrics_call(GetMetricsRequest { consensus_metrics: false, process_metrics: true })
                         .await
                         .unwrap();
-
                     assert!(get_metrics_call_response.process_metrics.is_some());
                     assert!(get_metrics_call_response.consensus_metrics.is_none());
 
@@ -353,7 +446,6 @@ async fn sanity_test() {
                         .get_metrics_call(GetMetricsRequest { consensus_metrics: true, process_metrics: false })
                         .await
                         .unwrap();
-
                     assert!(get_metrics_call_response.process_metrics.is_none());
                     assert!(get_metrics_call_response.consensus_metrics.is_some());
 
@@ -361,72 +453,113 @@ async fn sanity_test() {
                         .get_metrics_call(GetMetricsRequest { consensus_metrics: false, process_metrics: false })
                         .await
                         .unwrap();
-
                     assert!(get_metrics_call_response.process_metrics.is_none());
                     assert!(get_metrics_call_response.consensus_metrics.is_none());
                 })
             }
+
             KaspadPayloadOps::GetServerInfo => {
-                let rpc_client = daemon.new_client().await;
+                let rpc_client = client.clone();
                 tst!(op, {
                     let response = rpc_client.get_server_info_call(GetServerInfoRequest {}).await.unwrap();
-
                     assert!(response.has_utxo_index); // we set utxoindex above
                     assert_eq!(response.network_id, daemon.network);
                 })
             }
-            KaspadPayloadOps::GetSyncStatus => {
-                let rpc_client = daemon.new_client().await;
-                tst!(op, {
-                    let response_result = rpc_client.get_sync_status_call(GetSyncStatusRequest {}).await;
 
-                    assert!(response_result.is_ok());
+            KaspadPayloadOps::GetSyncStatus => {
+                let rpc_client = client.clone();
+                tst!(op, {
+                    let _ = rpc_client.get_sync_status_call(GetSyncStatusRequest {}).await.unwrap();
                 })
             }
+
             KaspadPayloadOps::NotifyBlockAdded => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, BlockAddedScope {}.into()).await.unwrap();
+                })
             }
+
             KaspadPayloadOps::NotifyNewBlockTemplate => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, NewBlockTemplateScope {}.into()).await.unwrap();
+                })
             }
+
             KaspadPayloadOps::NotifyFinalityConflict => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, FinalityConflictScope {}.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::NotifyUtxosChanged => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, UtxosChangedScope { addresses: vec![] }.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::NotifySinkBlueScoreChanged => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, SinkBlueScoreChangedScope {}.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::NotifyPruningPointUtxoSetOverride => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, PruningPointUtxoSetOverrideScope {}.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::NotifyVirtualDaaScoreChanged => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, VirtualDaaScoreChangedScope {}.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::NotifyVirtualChainChanged => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client
+                        .start_notify(id, VirtualChainChangedScope { include_accepted_transaction_ids: false }.into())
+                        .await
+                        .unwrap();
+                })
             }
             KaspadPayloadOps::StopNotifyingUtxosChanged => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.stop_notify(id, UtxosChangedScope { addresses: vec![] }.into()).await.unwrap();
+                })
             }
             KaspadPayloadOps::StopNotifyingPruningPointUtxoSetOverride => {
-                tst!(op, {})
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.stop_notify(id, PruningPointUtxoSetOverrideScope {}.into()).await.unwrap();
+                })
             }
         };
         tasks.push(task);
     }
 
-    // These are covered by other tests:
-    // submit_transaction_call
-    // submit_block_call
-
-    // shutdown_call
-
     let _results = try_join_all(tasks).await;
 
+    // Unregister the notification listener
+    assert!(client.unregister_listener(listener_id).await.is_ok());
+
     // Shutdown should only be tested after everything
-    let rpc_client = daemon.new_client().await;
+    let rpc_client = client.clone();
     let _ = rpc_client.shutdown_call(ShutdownRequest {}).await.unwrap();
 
     //

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -22,6 +22,7 @@ macro_rules! rpc_function_test {
 
 /// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test`
 #[tokio::test]
+#[cfg(feature = "devnet-prealloc")]
 async fn base_test() {
     kaspa_core::panic::configure_panic();
     kaspa_core::log::try_init_logger("info,kaspa_core::time=debug,kaspa_mining::monitor=debug");

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -20,9 +20,8 @@ macro_rules! rpc_function_test {
     };
 }
 
-/// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test --exact --nocapture --ignored`
+/// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test`
 #[tokio::test]
-#[ignore = "bmk"]
 async fn base_test() {
     kaspa_core::panic::configure_panic();
     kaspa_core::log::try_init_logger("info,kaspa_core::time=debug,kaspa_mining::monitor=debug");
@@ -113,8 +112,9 @@ async fn base_test() {
     rpc_function_test!(tasks, rpc_client, {
         let response = rpc_client.get_coin_supply_call(GetCoinSupplyRequest {}).await.unwrap();
 
-        assert!(response.circulating_sompi > 0);
-        assert!(response.max_sompi > 0);
+        let devnet_prealloc_amount = 500 * SOMPI_PER_KASPA * (TX_LEVEL_WIDTH as u64);
+        assert_eq!(devnet_prealloc_amount, response.circulating_sompi);
+        assert!(response.max_sompi > devnet_prealloc_amount);
     });
 
     // Test Get Server Info: get_server_info_call
@@ -122,7 +122,7 @@ async fn base_test() {
     rpc_function_test!(tasks, rpc_client, {
         let response = rpc_client.get_server_info_call(GetServerInfoRequest {}).await.unwrap();
 
-        assert!(response.has_utxo_index);
+        assert!(response.has_utxo_index); // we set utxoindex above
         assert_eq!(response.network_id, daemon.network);
     });
 

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -4,6 +4,7 @@ use crate::common::daemon::Daemon;
 use futures_util::future::try_join_all;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::subnets::SubnetworkId;
+use kaspa_grpc_core::ops::KaspadPayloadOps;
 use kaspa_hashes::Hash;
 use kaspa_rpc_core::{api::rpc::RpcApi, model::*};
 use kaspa_utils::{fd_budget, networking::ContextualNetAddress};

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -177,18 +177,6 @@ async fn base_test() {
         let _ = rpc_client.unban_call(UnbanRequest { ip: peer_to_ban.normalize(12345).ip }).await.unwrap();
     });
 
-    // Test Get Selected Tip Hash:
-    let rpc_client = daemon.new_client().await;
-    rpc_function_test!(tasks, rpc_client, {
-        let _ = rpc_client.get_selected_tip_hash_call(GetSelectedTipHashRequest {}).await.unwrap();
-    });
-
-    // Test Get Selected Tip Hash:
-    let rpc_client = daemon.new_client().await;
-    rpc_function_test!(tasks, rpc_client, {
-        let _ = rpc_client.get_selected_tip_hash_call(GetSelectedTipHashRequest {}).await.unwrap();
-    });
-
     // Test Get Mempool Entries:
     let rpc_client = daemon.new_client().await;
     rpc_function_test!(tasks, rpc_client, {

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -1,0 +1,377 @@
+use std::str::FromStr;
+
+use crate::common::{self, daemon::Daemon};
+use futures_util::future::try_join_all;
+use kaspa_addresses::{Address, Prefix, Version};
+use kaspa_consensus_core::{constants::SOMPI_PER_KASPA, network::NetworkType};
+use kaspa_core::{debug, info};
+use kaspa_rpc_core::{api::rpc::RpcApi, model::*};
+use kaspa_txscript::pay_to_address_script;
+use kaspa_utils::{fd_budget, networking::ContextualNetAddress};
+use kaspad_lib::args::Args;
+use rand::thread_rng;
+use tokio::task::JoinHandle;
+
+#[macro_export]
+macro_rules! rpc_function_test {
+    ($tasks:ident, $rpc_client:ident, $test_body:block) => {
+        let task: JoinHandle<()> = tokio::spawn(async move { $test_body });
+        $tasks.push(task);
+    };
+}
+
+/// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test --exact --nocapture --ignored`
+#[tokio::test]
+#[ignore = "bmk"]
+async fn base_test() {
+    kaspa_core::panic::configure_panic();
+    kaspa_core::log::try_init_logger("info,kaspa_core::time=debug,kaspa_mining::monitor=debug");
+
+    // Constants
+    const TX_COUNT: usize = 1_400_000;
+    const TX_LEVEL_WIDTH: usize = 20_000;
+
+    if TX_COUNT < TX_LEVEL_WIDTH {
+        panic!()
+    }
+
+    //
+    // Setup
+    //
+    let (prealloc_sk, prealloc_pk) = secp256k1::generate_keypair(&mut thread_rng());
+    let prealloc_address =
+        Address::new(NetworkType::Simnet.into(), kaspa_addresses::Version::PubKey, &prealloc_pk.x_only_public_key().0.serialize());
+    let schnorr_key = secp256k1::KeyPair::from_secret_key(secp256k1::SECP256K1, &prealloc_sk);
+    let spk = pay_to_address_script(&prealloc_address);
+
+    let args = Args {
+        simnet: true,
+        disable_upnp: true, // UPnP registration might take some time and is not needed for this test
+        enable_unsynced_mining: true,
+        num_prealloc_utxos: Some(TX_LEVEL_WIDTH as u64 * 1),
+        prealloc_address: Some(prealloc_address.to_string()),
+        prealloc_amount: 500 * SOMPI_PER_KASPA,
+        block_template_cache_lifetime: Some(0),
+        utxoindex: true,
+        unsafe_rpc: true,
+        ..Default::default()
+    };
+
+    let utxoset = args.generate_prealloc_utxos(args.num_prealloc_utxos.unwrap());
+    let txs = common::utils::generate_tx_dag(utxoset.clone(), schnorr_key, spk, TX_COUNT / TX_LEVEL_WIDTH, TX_LEVEL_WIDTH);
+    common::utils::verify_tx_dag(&utxoset, &txs);
+    info!("Generated overall {} txs", txs.len());
+
+    let fd_total_budget = fd_budget::limit();
+    let mut daemon = Daemon::new_random_with_args(args, fd_total_budget);
+    let client = daemon.start().await;
+    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
+
+    // Test Ping:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.ping_call(PingRequest {}).await.unwrap();
+    });
+
+    // Test Get Info:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let get_info_call_response = rpc_client.get_info_call(GetInfoRequest {}).await.unwrap();
+        assert_eq!("0.1.7", get_info_call_response.server_version);
+    });
+
+    // Test Get Metrics:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let get_metrics_call_response =
+            rpc_client.get_metrics_call(GetMetricsRequest { consensus_metrics: true, process_metrics: true }).await.unwrap();
+
+        assert!(get_metrics_call_response.process_metrics.is_some());
+        assert!(get_metrics_call_response.consensus_metrics.is_some());
+
+        let get_metrics_call_response =
+            rpc_client.get_metrics_call(GetMetricsRequest { consensus_metrics: false, process_metrics: true }).await.unwrap();
+
+        assert!(get_metrics_call_response.process_metrics.is_some());
+        assert!(get_metrics_call_response.consensus_metrics.is_none());
+
+        let get_metrics_call_response =
+            rpc_client.get_metrics_call(GetMetricsRequest { consensus_metrics: true, process_metrics: false }).await.unwrap();
+
+        assert!(get_metrics_call_response.process_metrics.is_none());
+        assert!(get_metrics_call_response.consensus_metrics.is_some());
+
+        let get_metrics_call_response =
+            rpc_client.get_metrics_call(GetMetricsRequest { consensus_metrics: false, process_metrics: false }).await.unwrap();
+
+        assert!(get_metrics_call_response.process_metrics.is_none());
+        assert!(get_metrics_call_response.consensus_metrics.is_none());
+    });
+
+    // Test Get Coin Supply:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let response = rpc_client.get_coin_supply_call(GetCoinSupplyRequest {}).await.unwrap();
+
+        assert!(response.circulating_sompi > 0);
+        assert!(response.max_sompi > 0);
+    });
+
+    // Test Get Server Info: get_server_info_call
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let response = rpc_client.get_server_info_call(GetServerInfoRequest {}).await.unwrap();
+
+        assert!(response.has_utxo_index);
+        assert_eq!(response.network_id, daemon.network);
+    });
+
+    // Test Get Sync Status:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_sync_status_call(GetSyncStatusRequest {}).await.unwrap();
+
+        // assert!(response.is_synced);
+    });
+
+    // Test Get Current Network:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let response = rpc_client.get_current_network_call(GetCurrentNetworkRequest {}).await.unwrap();
+
+        assert_eq!(response.network, daemon.network.network_type);
+    });
+
+    // Test Get Block Template:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client
+            .get_block_template_call(GetBlockTemplateRequest {
+                pay_address: Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]),
+                extra_data: Vec::new(),
+            })
+            .await
+            .unwrap();
+    });
+
+    // Test Add Peer, Ban Peer, Unban, Get Peer Addresses:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let peer_to_add = ContextualNetAddress::from_str("1.2.3.4:16110").unwrap();
+        let peer_to_ban = ContextualNetAddress::from_str("5.6.7.8:16110").unwrap();
+
+        let _ = rpc_client.add_peer_call(AddPeerRequest { peer_address: peer_to_add, is_permanent: true }).await.unwrap();
+        let response = rpc_client.get_peer_addresses_call(GetPeerAddressesRequest {}).await.unwrap();
+
+        debug_assert!(!response.known_addresses.is_empty());
+        debug!("{:?}", response.known_addresses);
+        debug_assert!(response.known_addresses.contains(&peer_to_add.normalize(12345)));
+        assert!(response.banned_addresses.is_empty());
+
+        let _ = rpc_client.add_peer_call(AddPeerRequest { peer_address: peer_to_ban, is_permanent: false }).await.unwrap();
+        let _ = rpc_client.ban_call(BanRequest { ip: peer_to_ban.normalize(12345).ip }).await.unwrap();
+        let response = rpc_client.get_peer_addresses_call(GetPeerAddressesRequest {}).await.unwrap();
+
+        assert!(response.banned_addresses.contains(&peer_to_ban.normalize(12345).ip));
+
+        let _ = rpc_client.unban_call(UnbanRequest { ip: peer_to_ban.normalize(12345).ip }).await.unwrap();
+    });
+
+    // Test Get Selected Tip Hash:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_selected_tip_hash_call(GetSelectedTipHashRequest {}).await.unwrap();
+    });
+
+    // Test Get Selected Tip Hash:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_selected_tip_hash_call(GetSelectedTipHashRequest {}).await.unwrap();
+    });
+
+    // Test Get Mempool Entries:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let response = rpc_client
+            .get_mempool_entries_call(GetMempoolEntriesRequest { filter_transaction_pool: false, include_orphan_pool: false })
+            .await
+            .unwrap();
+
+        assert!(response.mempool_entries.is_empty());
+    });
+
+    // Test Get Connected Peer Info:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let response = rpc_client.get_connected_peer_info_call(GetConnectedPeerInfoRequest {}).await.unwrap();
+
+        assert!(response.peer_info.is_empty());
+    });
+
+    // Test Get Block Count:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_block_count_call(GetBlockCountRequest {}).await.unwrap();
+    });
+
+    // Test Block Dag Info:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_block_dag_info_call(GetBlockDagInfoRequest {}).await.unwrap();
+    });
+
+    // Test get Balance By Address:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client
+            .get_balance_by_address_call(GetBalanceByAddressRequest {
+                address: Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]),
+            })
+            .await
+            .unwrap();
+    });
+
+    // Test Get Balances By Addresses:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let mut addresses = Vec::new();
+        addresses.push(Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]));
+        let _ = rpc_client.get_balances_by_addresses_call(GetBalancesByAddressesRequest { addresses }).await.unwrap();
+    });
+
+    // Test Utxos By Addresses:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let mut addresses = Vec::new();
+        addresses.push(Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]));
+        let _ = rpc_client.get_utxos_by_addresses_call(GetUtxosByAddressesRequest { addresses }).await.unwrap();
+    });
+
+    // Test Get Sink Blue Score:
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let _ = rpc_client.get_sink_blue_score_call(GetSinkBlueScoreRequest {}).await.unwrap();
+    });
+
+    // Test Get Mempool Entries By Addresses
+    let rpc_client = daemon.new_client().await;
+    rpc_function_test!(tasks, rpc_client, {
+        let mut addresses = Vec::new();
+        addresses.push(Address::new(Prefix::Simnet, Version::PubKey, &[0u8; 32]));
+        let _ = rpc_client
+            .get_mempool_entries_by_addresses_call(GetMempoolEntriesByAddressesRequest {
+                addresses,
+                include_orphan_pool: false,
+                filter_transaction_pool: false,
+            })
+            .await
+            .unwrap();
+    });
+
+    // Test Resolve Finality Conflict:
+    // TODO: CURRENTLY UNIMPLEMENTED
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client.resolve_finality_conflict_call(ResolveFinalityConflictRequest {
+    //         finality_block_hash: Hash::from_bytes([0; 32])
+    //     }).await.unwrap();
+    // });
+
+    // Test Get Headers:
+    // TODO: CURRENTLY UNIMPLEMENTED
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .get_headers_call(GetHeadersRequest { start_hash: Hash::from_bytes([255; 32]), limit: 1, is_ascending: true })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // Test Subnetwork:
+    // TODO: CURRENTLY UNIMPLEMENTED
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client.get_subnetwork_call(GetSubnetworkRequest { subnetwork_id: SubnetworkId::from_byte(0) }).await.unwrap();
+    // });
+
+    // Test Get Virtual Chain From Block
+    // TODO: Find some actual block
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .get_virtual_chain_from_block_call(GetVirtualChainFromBlockRequest {
+    //             start_hash: Hash::from_bytes([255; 32]),
+    //             include_accepted_transaction_ids: false,
+    //         })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // Test Get Blocks:
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .get_blocks_call(GetBlocksRequest { include_blocks: false, include_transactions: false, low_hash: None })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // TODO: Fix by increasing the actual window_size until this works
+    // Current error: difficulty error: under min allowed window size (0 < 1000)
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .estimate_network_hashes_per_second_call(EstimateNetworkHashesPerSecondRequest {
+    //             window_size: 1000,
+    //             start_hash: None,
+    //         })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // Test Get Mempool Entry:
+    // TODO: Fix by adding actual mempool entries this can get because otherwise it errors out
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .get_mempool_entry_call(GetMempoolEntryRequest {
+    //             transaction_id: Hash::from_bytes([255; 32]),
+    //             include_orphan_pool: false,
+    //             filter_transaction_pool: false,
+    //         })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // Test Block:
+    // TODO: Fix by adding actual mempool entries this can pool because otherwise it errors out
+    // let rpc_client = daemon.new_client().await;
+    // rpc_function_test!(tasks, rpc_client, {
+    //     let _ = rpc_client
+    //         .get_block_call(GetBlockRequest {
+    //             hash: Hash::from_bytes([255; 32]),
+    //             include_transactions: false,
+    //         })
+    //         .await
+    //         .unwrap();
+    // });
+
+    // These are covered by other tests:
+    // submit_transaction_call
+    // submit_block_call
+
+    // shutdown_call
+
+    let _results = try_join_all(tasks).await;
+
+    // Shutdown should only be tested after everything
+    let rpc_client = daemon.new_client().await;
+    let _ = rpc_client.shutdown_call(ShutdownRequest {}).await.unwrap();
+
+    //
+    // Fold-up
+    //
+    client.disconnect().await.unwrap();
+    drop(client);
+    daemon.shutdown();
+}

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -98,8 +98,8 @@ async fn sanity_test() {
                         .get_blocks_call(GetBlocksRequest { include_blocks: false, include_transactions: false, low_hash: None })
                         .await;
 
-                    // TODO: requires some setup
-                    assert!(response_result.is_err());
+                    // TODO: requires some setup to be meaningful
+                    assert!(response_result.is_ok());
                 })
             }
             KaspadPayloadOps::GetInfo => {


### PR DESCRIPTION
# Introduction
Test currently covers all RPC calls, but those that are failing or those that are unimplemented are commented out

To execute this test, run:
```
cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- rpc_tests::base_test --exact --nocapture --ignored
```

# TODO
- [x] Add calling the above to a github action
- [x] Fix the commented out sections for failing tests