### PR TITLE
TN11 -- various fixes concluded from ongoing internal experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
 name = "kaspa-p2p-flows"
 version = "0.13.0"
 dependencies = [
+ "async-channel 2.0.0",
  "async-trait",
  "futures",
  "indexmap 2.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,7 +2575,6 @@ dependencies = [
 name = "kaspa-p2p-flows"
 version = "0.13.0"
 dependencies = [
- "async-channel 2.0.0",
  "async-trait",
  "futures",
  "indexmap 2.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "borsh",
  "igd-next",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-bip32"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "bs58",
  "faster-hex 0.6.1",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "bincode",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "cfg-if 1.0.0",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "faster-hex 0.6.1",
  "js-sys",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "duration-string",
  "futures",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "cfg-if 1.0.0",
  "ctrlc",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -2457,14 +2457,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-mining"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "futures-util",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "js-sys",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "bincode",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "secp256k1",
  "thiserror",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "aes",
  "argon2",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "js-sys",
  "kaspa-addresses",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3007,11 +3007,11 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-core"
-version = "0.1.7"
+version = "0.13.0"
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "clap 4.4.7",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3059,14 +3059,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "kaspa-wrpc-client",
 ]
 
 [[package]]
 name = "kaspad"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "clap 4.4.7",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "clap 4.4.7",
  "faster-hex 0.6.1",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "0.1.7"
+version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
  "clap 4.4.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.13.0"
 authors = ["Kaspa developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -71,54 +71,54 @@ include = [
 ]
 
 [workspace.dependencies]
-# kaspa-testing-integration = { version = "0.1.7", path = "testing/integration" }
-kaspa-os = { version = "0.1.7", path = "kaspa-os" }
-kaspa-daemon = { version = "0.1.7", path = "daemon" }
-kaspa-addresses = { version = "0.1.7", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "0.1.7", path = "components/addressmanager" }
-kaspa-bip32 = { version = "0.1.7", path = "wallet/bip32" }
-kaspa-connectionmanager = { version = "0.1.7", path = "components/connectionmanager" }
-kaspa-consensus = { version = "0.1.7", path = "consensus" }
-kaspa-consensus-core = { version = "0.1.7", path = "consensus/core" }
-kaspa-consensus-notify = { version = "0.1.7", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "0.1.7", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "0.1.7", path = "components/consensusmanager" }
-kaspa-core = { version = "0.1.7", path = "core" }
-kaspa-database = { version = "0.1.7", path = "database" }
-kaspa-grpc-client = { version = "0.1.7", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "0.1.7", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "0.1.7", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "0.1.7", path = "crypto/hashes" }
-kaspa-index-core = { version = "0.1.7", path = "indexes/core" }
-kaspa-index-processor = { version = "0.1.7", path = "indexes/processor" }
-kaspa-math = { version = "0.1.7", path = "math" }
-kaspa-merkle = { version = "0.1.7", path = "crypto/merkle" }
-kaspa-mining = { version = "0.1.7", path = "mining" }
-kaspa-mining-errors = { path = "mining/errors" }
-kaspa-muhash = { version = "0.1.7", path = "crypto/muhash" }
-kaspa-notify = { version = "0.1.7", path = "notify" }
-kaspa-p2p-flows = { version = "0.1.7", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "0.1.7", path = "protocol/p2p" }
-kaspa-pow = { version = "0.1.7", path = "consensus/pow" }
-kaspa-rpc-core = { version = "0.1.7", path = "rpc/core" }
-kaspa-rpc-macros = { version = "0.1.7", path = "rpc/macros" }
-kaspa-rpc-service = { version = "0.1.7", path = "rpc/service" }
-kaspa-txscript = { version = "0.1.7", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "0.1.7", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "0.1.7", path = "utils" }
-kaspa-utxoindex = { version = "0.1.7", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "0.1.7", path = "wallet/native" }
-kaspa-cli = { version = "0.1.7", path = "cli" }
-kaspa-wallet-cli-wasm = { version = "0.1.7", path = "wallet/wasm" }
-kaspa-wallet-core = { version = "0.1.7", path = "wallet/core" }
-kaspa-wasm = { version = "0.1.7", path = "wasm" }
-kaspa-wrpc-core = { version = "0.1.7", path = "rpc/wrpc/core" }
-kaspa-wrpc-client = { version = "0.1.7", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "0.1.7", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "0.1.7", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "0.1.7", path = "rpc/wrpc/wasm" }
-kaspad = { version = "0.1.7", path = "kaspad" }
-kaspa-perf-monitor = { path = "metrics/perf_monitor" }
+# kaspa-testing-integration = { version = "0.13.0", path = "testing/integration" }
+kaspa-os = { version = "0.13.0", path = "kaspa-os" }
+kaspa-daemon = { version = "0.13.0", path = "daemon" }
+kaspa-addresses = { version = "0.13.0", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "0.13.0", path = "components/addressmanager" }
+kaspa-bip32 = { version = "0.13.0", path = "wallet/bip32" }
+kaspa-connectionmanager = { version = "0.13.0", path = "components/connectionmanager" }
+kaspa-consensus = { version = "0.13.0", path = "consensus" }
+kaspa-consensus-core = { version = "0.13.0", path = "consensus/core" }
+kaspa-consensus-notify = { version = "0.13.0", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "0.13.0", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "0.13.0", path = "components/consensusmanager" }
+kaspa-core = { version = "0.13.0", path = "core" }
+kaspa-database = { version = "0.13.0", path = "database" }
+kaspa-grpc-client = { version = "0.13.0", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "0.13.0", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "0.13.0", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "0.13.0", path = "crypto/hashes" }
+kaspa-index-core = { version = "0.13.0", path = "indexes/core" }
+kaspa-index-processor = { version = "0.13.0", path = "indexes/processor" }
+kaspa-math = { version = "0.13.0", path = "math" }
+kaspa-merkle = { version = "0.13.0", path = "crypto/merkle" }
+kaspa-mining = { version = "0.13.0", path = "mining" }
+kaspa-mining-errors = { version = "0.13.0", path = "mining/errors" }
+kaspa-muhash = { version = "0.13.0", path = "crypto/muhash" }
+kaspa-notify = { version = "0.13.0", path = "notify" }
+kaspa-p2p-flows = { version = "0.13.0", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "0.13.0", path = "protocol/p2p" }
+kaspa-pow = { version = "0.13.0", path = "consensus/pow" }
+kaspa-rpc-core = { version = "0.13.0", path = "rpc/core" }
+kaspa-rpc-macros = { version = "0.13.0", path = "rpc/macros" }
+kaspa-rpc-service = { version = "0.13.0", path = "rpc/service" }
+kaspa-txscript = { version = "0.13.0", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "0.13.0", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "0.13.0", path = "utils" }
+kaspa-utxoindex = { version = "0.13.0", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "0.13.0", path = "wallet/native" }
+kaspa-cli = { version = "0.13.0", path = "cli" }
+kaspa-wallet-cli-wasm = { version = "0.13.0", path = "wallet/wasm" }
+kaspa-wallet-core = { version = "0.13.0", path = "wallet/core" }
+kaspa-wasm = { version = "0.13.0", path = "wasm" }
+kaspa-wrpc-core = { version = "0.13.0", path = "rpc/wrpc/core" }
+kaspa-wrpc-client = { version = "0.13.0", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "0.13.0", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "0.13.0", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "0.13.0", path = "rpc/wrpc/wasm" }
+kaspad = { version = "0.13.0", path = "kaspad" }
+kaspa-perf-monitor = { version = "0.13.0", path = "metrics/perf_monitor" }
 
 # external
 aes = "0.8.3"
@@ -155,7 +155,9 @@ evpkdf = "0.2.0"
 faster-hex = "0.6.1" # TODO "0.8.1" - fails unit tests
 flate2 = "1.0.28"
 futures = { version = "0.3.29" }
-futures-util = { version = "0.3.29", default-features = false, features = [ "alloc" ] }
+futures-util = { version = "0.3.29", default-features = false, features = [
+    "alloc",
+] }
 getrandom = { version = "0.2.10", features = ["js"] }
 h2 = "0.3.21"
 heapless = "0.7.16"
@@ -183,7 +185,7 @@ pad = "0.1.6"
 parking_lot = "0.12.1"
 paste = "1.0.14"
 pbkdf2 = "0.12.2"
-portable-atomic = {version = "1.5.1", features = ["float"]}
+portable-atomic = { version = "1.5.1", features = ["float"] }
 prost = "0.12.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -194,7 +196,11 @@ regex = "1.10.2"
 ripemd = { version = "0.1.3", default-features = false }
 rlimit = "0.10.1"
 rocksdb = "0.21.0"
-secp256k1 = { version = "0.24.3", features = [ "global-context", "rand-std", "serde" ] } # TODO "0.28.0"
+secp256k1 = { version = "0.24.3", features = [
+    "global-context",
+    "rand-std",
+    "serde",
+] } # TODO "0.28.0"
 separator = "0.4.1"
 seqlock = "0.2.0"
 serde = { version = "1.0.190", features = ["derive", "rc"] }

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -250,18 +250,19 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(|c| c.get_headers_selected_tip()).await
     }
 
-    /// Returns the anticone of block `hash` from the POV of `context`, i.e. `anticone(hash) ∩ past(context)`.
+    /// Returns the antipast of block `hash` from the POV of `context`, i.e. `antipast(hash) ∩ past(context)`.
     /// Since this might be an expensive operation for deep blocks, we allow the caller to specify a limit
     /// `max_traversal_allowed` on the maximum amount of blocks to traverse for obtaining the answer
-    pub async fn async_get_anticone_from_pov(
+    pub async fn async_get_antipast_from_pov(
         &self,
         hash: Hash,
         context: Hash,
         max_traversal_allowed: Option<u64>,
     ) -> ConsensusResult<Vec<Hash>> {
-        self.clone().spawn_blocking(move |c| c.get_anticone_from_pov(hash, context, max_traversal_allowed)).await
+        self.clone().spawn_blocking(move |c| c.get_antipast_from_pov(hash, context, max_traversal_allowed)).await
     }
 
+    /// Returns the anticone of block `hash` from the POV of `virtual`
     pub async fn async_get_anticone(&self, hash: Hash) -> ConsensusResult<Vec<Hash>> {
         self.clone().spawn_blocking(move |c| c.get_anticone(hash)).await
     }

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -193,13 +193,14 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    /// Returns the anticone of block `hash` from the POV of `context`, i.e. `anticone(hash) ∩ past(context)`.
+    /// Returns the antipast of block `hash` from the POV of `context`, i.e. `antipast(hash) ∩ past(context)`.
     /// Since this might be an expensive operation for deep blocks, we allow the caller to specify a limit
     /// `max_traversal_allowed` on the maximum amount of blocks to traverse for obtaining the answer
-    fn get_anticone_from_pov(&self, hash: Hash, context: Hash, max_traversal_allowed: Option<u64>) -> ConsensusResult<Vec<Hash>> {
+    fn get_antipast_from_pov(&self, hash: Hash, context: Hash, max_traversal_allowed: Option<u64>) -> ConsensusResult<Vec<Hash>> {
         unimplemented!()
     }
 
+    /// Returns the anticone of block `hash` from the POV of `virtual`
     fn get_anticone(&self, hash: Hash) -> ConsensusResult<Vec<Hash>> {
         unimplemented!()
     }

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -161,7 +161,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn apply_pruning_proof(&self, proof: PruningPointProof, trusted_set: &[TrustedBlock]) {
+    fn apply_pruning_proof(&self, proof: PruningPointProof, trusted_set: &[TrustedBlock]) -> PruningImportResult<()> {
         unimplemented!()
     }
 

--- a/consensus/core/src/errors/pruning.rs
+++ b/consensus/core/src/errors/pruning.rs
@@ -39,6 +39,9 @@ pub enum PruningImportError {
     #[error("block {0} already appeared in the proof headers for level {1}")]
     PruningProofDuplicateHeaderAtLevel(Hash, BlockLevel),
 
+    #[error("got header-only trusted block {0} which is not in pruning point past according to available reachability")]
+    PruningPointPastMissingReachability(Hash),
+
     #[error("new pruning point has an invalid transaction {0}: {1}")]
     NewPruningPointTxError(Hash, TxRuleError),
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -589,10 +589,11 @@ impl ConsensusApi for Consensus {
         self.headers_selected_tip_store.read().get().unwrap().hash
     }
 
-    fn get_anticone_from_pov(&self, hash: Hash, context: Hash, max_traversal_allowed: Option<u64>) -> ConsensusResult<Vec<Hash>> {
+    fn get_antipast_from_pov(&self, hash: Hash, context: Hash, max_traversal_allowed: Option<u64>) -> ConsensusResult<Vec<Hash>> {
         let _guard = self.pruning_lock.blocking_read();
         self.validate_block_exists(hash)?;
-        Ok(self.services.dag_traversal_manager.anticone(hash, std::iter::once(context), max_traversal_allowed)?)
+        self.validate_block_exists(context)?;
+        Ok(self.services.dag_traversal_manager.antipast(hash, std::iter::once(context), max_traversal_allowed)?)
     }
 
     fn get_anticone(&self, hash: Hash) -> ConsensusResult<Vec<Hash>> {

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::{max, Reverse},
-    collections::hash_map::Entry::Vacant,
-    collections::BinaryHeap,
+    collections::{hash_map::Entry, BinaryHeap},
+    collections::{hash_map::Entry::Vacant, VecDeque},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -12,7 +12,7 @@ use parking_lot::{Mutex, RwLock};
 use rocksdb::WriteBatch;
 
 use kaspa_consensus_core::{
-    blockhash::{BlockHashExtensions, BlockHashes, ORIGIN},
+    blockhash::{self, BlockHashExtensions, BlockHashes, ORIGIN},
     errors::{
         consensus::{ConsensusError, ConsensusResult},
         pruning::{PruningImportError, PruningImportResult},
@@ -179,7 +179,7 @@ impl PruningProofManager {
         drop(pruning_point_write);
     }
 
-    pub fn apply_proof(&self, mut proof: PruningPointProof, trusted_set: &[TrustedBlock]) {
+    pub fn apply_proof(&self, mut proof: PruningPointProof, trusted_set: &[TrustedBlock]) -> PruningImportResult<()> {
         let pruning_point_header = proof[0].last().unwrap().clone();
         let pruning_point = pruning_point_header.hash;
 
@@ -196,6 +196,17 @@ impl PruningProofManager {
 
         proof[0].sort_by(|a, b| a.blue_work.cmp(&b.blue_work));
         self.populate_reachability_and_headers(&proof);
+
+        {
+            let reachability_read = self.reachability_store.read();
+            for tb in trusted_set.iter() {
+                // Header-only trusted blocks are expected to be in pruning point past
+                if tb.block.is_header_only() && !reachability_read.is_dag_ancestor_of(tb.block.hash(), pruning_point) {
+                    return Err(PruningImportError::PruningPointPastMissingReachability(tb.block.hash()));
+                }
+            }
+        }
+
         for (level, headers) in proof.iter().enumerate() {
             trace!("Applying level {} from the pruning point proof", level);
             self.ghostdag_stores[level].insert(ORIGIN, self.ghostdag_managers[level].origin_ghostdag_data()).unwrap();
@@ -251,6 +262,8 @@ impl PruningProofManager {
             .unwrap();
         self.selected_chain_store.write().init_with_pruning_point(&mut batch, pruning_point).unwrap();
         self.db.write(batch).unwrap();
+
+        Ok(())
     }
 
     fn estimate_proof_unique_size(&self, proof: &PruningPointProof) -> usize {
@@ -670,6 +683,26 @@ impl PruningProofManager {
         }
     }
 
+    /// Returns the k + 1 chain blocks below this hash (inclusive). If data is missing
+    /// the search is halted and a partial chain is returned.
+    ///
+    /// The returned hashes are guaranteed to have GHOSTDAG data
+    pub(crate) fn get_ghostdag_chain_k_depth(&self, hash: Hash) -> Vec<Hash> {
+        let mut hashes = Vec::with_capacity(self.ghostdag_k as usize + 1);
+        let mut current = hash;
+        for _ in 0..=self.ghostdag_k {
+            hashes.push(current);
+            let Some(parent) = self.ghostdag_stores[0].get_selected_parent(current).unwrap_option() else {
+                break;
+            };
+            if parent == self.genesis_hash || parent == blockhash::ORIGIN {
+                break;
+            }
+            current = parent;
+        }
+        hashes
+    }
+
     pub(crate) fn calculate_pruning_point_anticone_and_trusted_data(
         &self,
         pruning_point: Hash,
@@ -685,6 +718,8 @@ impl PruningProofManager {
         let mut daa_window_blocks = BlockHashMap::new();
         let mut ghostdag_blocks = BlockHashMap::new();
 
+        // PRUNE SAFETY: called either via consensus under the prune guard or by the pruning processor (hence no pruning in parallel)
+
         for anticone_block in anticone.iter().copied() {
             let window = self
                 .window_manager
@@ -692,26 +727,56 @@ impl PruningProofManager {
                 .unwrap();
 
             for hash in window.deref().iter().map(|block| block.0.hash) {
-                if daa_window_blocks.contains_key(&hash) {
-                    continue;
-                }
-
-                daa_window_blocks.insert(
-                    hash,
-                    TrustedHeader {
+                if let Entry::Vacant(e) = daa_window_blocks.entry(hash) {
+                    e.insert(TrustedHeader {
                         header: self.headers_store.get_header(hash).unwrap(),
                         ghostdag: (&*self.ghostdag_stores[0].get_data(hash).unwrap()).into(),
-                    },
-                );
+                    });
+                }
             }
 
-            let mut current = anticone_block;
-            for _ in 0..=self.ghostdag_k {
-                let current_gd = self.ghostdag_stores[0].get_data(current).unwrap();
-                ghostdag_blocks.insert(current, (&*current_gd).into());
-                current = current_gd.selected_parent;
-                if current == self.genesis_hash {
-                    break;
+            let ghostdag_chain = self.get_ghostdag_chain_k_depth(anticone_block);
+            for hash in ghostdag_chain {
+                if let Entry::Vacant(e) = ghostdag_blocks.entry(hash) {
+                    let ghostdag = self.ghostdag_stores[0].get_data(hash).unwrap();
+                    e.insert((&*ghostdag).into());
+
+                    // We fill `ghostdag_blocks` only for kaspad-go legacy reasons, but the real set we
+                    // send is `daa_window_blocks` which represents the full trusted sub-DAG in the antifuture
+                    // of the pruning point which kaspad-rust nodes expect to get when synced with headers proof
+                    if let Entry::Vacant(e) = daa_window_blocks.entry(hash) {
+                        e.insert(TrustedHeader {
+                            header: self.headers_store.get_header(hash).unwrap(),
+                            ghostdag: (&*ghostdag).into(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // We traverse the DAG in the past of the pruning point and its anticone in order to make sure
+        // that the sub-DAG we share (which contains the union of DAA windows), is contiguous and includes
+        // all blocks between the pruning point and the DAA window blocks. This is crucial for the syncee
+        // to be able to build full reachability data of the sub-DAG and to actually validate that only the
+        // claimed anticone is indeed the pp anticone and all the rest of the blocks are in the pp past.
+
+        // We use the min blue-work in order to identify where the traversal can halt
+        let min_blue_work = daa_window_blocks.values().map(|th| th.header.blue_work).min().expect("non empty");
+        let mut queue = VecDeque::from_iter(anticone.iter().copied());
+        let mut visited = BlockHashSet::from_iter(queue.iter().copied());
+        while let Some(current) = queue.pop_front() {
+            if let Entry::Vacant(e) = daa_window_blocks.entry(current) {
+                let header = self.headers_store.get_header(current).unwrap();
+                if header.blue_work < min_blue_work {
+                    continue;
+                }
+                let ghostdag = (&*self.ghostdag_stores[0].get_data(current).unwrap()).into();
+                e.insert(TrustedHeader { header, ghostdag });
+            }
+            let parents = self.relations_stores.read()[0].get_parents(current).unwrap();
+            for parent in parents.iter().copied() {
+                if visited.insert(parent) {
+                    queue.push_back(parent);
                 }
             }
         }

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -763,7 +763,7 @@ impl PruningProofManager {
         // We use the min blue-work in order to identify where the traversal can halt
         let min_blue_work = daa_window_blocks.values().map(|th| th.header.blue_work).min().expect("non empty");
         let mut queue = VecDeque::from_iter(anticone.iter().copied());
-        let mut visited = BlockHashSet::from_iter(queue.iter().copied());
+        let mut visited = BlockHashSet::from_iter(queue.iter().copied().chain(std::iter::once(blockhash::ORIGIN))); // Mark origin as visited to avoid processing it
         while let Some(current) = queue.pop_front() {
             if let Entry::Vacant(e) = daa_window_blocks.entry(current) {
                 let header = self.headers_store.get_header(current).unwrap();

--- a/consensus/src/processes/traversal_manager.rs
+++ b/consensus/src/processes/traversal_manager.rs
@@ -54,19 +54,39 @@ impl<T: GhostdagStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader
         tips: impl Iterator<Item = Hash>,
         max_traversal_allowed: Option<u64>,
     ) -> TraversalResult<Vec<Hash>> {
+        self.antipast_traversal(tips, block, max_traversal_allowed, true)
+    }
+
+    pub fn antipast(
+        &self,
+        block: Hash,
+        tips: impl Iterator<Item = Hash>,
+        max_traversal_allowed: Option<u64>,
+    ) -> TraversalResult<Vec<Hash>> {
+        self.antipast_traversal(tips, block, max_traversal_allowed, false)
+    }
+
+    fn antipast_traversal(
+        &self,
+        tips: impl Iterator<Item = Hash>,
+        block: Hash,
+        max_traversal_allowed: Option<u64>,
+        return_anticone_only: bool,
+    ) -> Result<Vec<Hash>, TraversalError> {
         /*
            In some cases we search for the anticone of the pruning point starting from virtual parents.
            This means we might traverse ~pruning_depth blocks which are all stored in the visited set.
            Experiments (and theory) show that w/o completely tracking visited, the queue might grow in
            size quadratically due to many duplicate blocks, easily resulting in OOM errors if the DAG is
-           wide. On the other hand, even at 10 BPS depth is around 2M blocks which is approx 64MB, a modest
+           wide. On the other hand, even at 10 BPS, pruning depth is around 2M blocks which is approx 64MB, a modest
            memory peak which happens at most once a in a pruning period (since pruning anticone is cached).
         */
-        let mut anticone = Vec::new();
+        let mut output = Vec::new(); // Anticone or antipast, depending on args
         let mut queue = VecDeque::from_iter(tips);
         let mut visited = BlockHashSet::from_iter(queue.iter().copied());
         let mut traversal_count = 0;
         while let Some(current) = queue.pop_front() {
+            // We reached a block in `past(block)` so we can terminate the BFS from this point on
             if self.reachability_service.is_dag_ancestor_of(current, block) {
                 continue;
             }
@@ -85,13 +105,13 @@ impl<T: GhostdagStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader
                     "[TRAVERSAL MANAGER] Traversal count: {}, queue size: {}, anticone size: {}, visited size: {}",
                     traversal_count,
                     queue.len(),
-                    anticone.len(),
+                    output.len(),
                     visited.len()
                 );
             }
 
-            if !self.reachability_service.is_dag_ancestor_of(block, current) {
-                anticone.push(current);
+            if !return_anticone_only || !self.reachability_service.is_dag_ancestor_of(block, current) {
+                output.push(current);
             }
 
             for parent in self.relations_store.get_parents(current).unwrap().iter().copied() {
@@ -101,7 +121,7 @@ impl<T: GhostdagStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader
             }
         }
 
-        Ok(anticone)
+        Ok(output)
     }
 
     pub fn lowest_chain_block_above_or_equal_to_blue_score(&self, high: Hash, blue_score: u64) -> Hash {

--- a/consensus/src/processes/traversal_manager.rs
+++ b/consensus/src/processes/traversal_manager.rs
@@ -109,7 +109,7 @@ impl<T: GhostdagStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader
                     visited.len()
                 );
             }
-
+            // At this point, we know `current` is in antipast of `block`. The second condition is there to check if it's in the anticone
             if !return_anticone_only || !self.reachability_service.is_dag_ancestor_of(block, current) {
                 output.push(current);
             }

--- a/protocol/flows/Cargo.toml
+++ b/protocol/flows/Cargo.toml
@@ -23,6 +23,7 @@ kaspa-consensusmanager.workspace = true
 kaspa-mining.workspace = true
 kaspa-notify.workspace = true
 
+async-channel.workspace = true
 async-trait.workspace = true
 futures = { workspace = true, features = ["alloc"] }
 indexmap.workspace = true

--- a/protocol/flows/Cargo.toml
+++ b/protocol/flows/Cargo.toml
@@ -23,7 +23,6 @@ kaspa-consensusmanager.workspace = true
 kaspa-mining.workspace = true
 kaspa-notify.workspace = true
 
-async-channel.workspace = true
 async-trait.workspace = true
 futures = { workspace = true, features = ["alloc"] }
 indexmap.workspace = true

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -374,8 +374,12 @@ impl FlowContext {
         // Broadcast as soon as the block has been validated and inserted into the DAG
         self.hub.broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(hash.into()) })).await;
 
-        self.on_new_block(consensus, block, virtual_state_task).await;
-        self.log_block_acceptance(hash, BlockSource::Submit);
+        let ctx = self.clone();
+        let consensus = consensus.clone();
+        tokio::spawn(async move {
+            ctx.on_new_block(&consensus, block, virtual_state_task).await;
+            ctx.log_block_acceptance(hash, BlockSource::Submit);
+        });
 
         Ok(())
     }

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -2,7 +2,6 @@ use crate::{
     flow_context::{BlockSource, FlowContext, RequestScope},
     flow_trait::Flow,
 };
-use async_channel::TrySendError;
 use kaspa_consensus_core::{api::BlockValidationFutures, block::Block, blockstatus::BlockStatus, errors::block::RuleError};
 use kaspa_consensusmanager::ConsensusProxy;
 use kaspa_core::{debug, info};
@@ -13,7 +12,7 @@ use kaspa_p2p_lib::{
     pb::{kaspad_message::Payload, InvRelayBlockMessage, RequestBlockLocatorMessage, RequestRelayBlocksMessage},
     IncomingRoute, Router, SharedIncomingRoute,
 };
-use kaspa_utils::channel::JobSender;
+use kaspa_utils::channel::{JobSender, JobTrySendError as TrySendError};
 use std::{collections::VecDeque, sync::Arc};
 
 pub struct RelayInvMessage {

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -2,6 +2,7 @@ use crate::{
     flow_context::{BlockSource, FlowContext, RequestScope},
     flow_trait::Flow,
 };
+use async_channel::TrySendError;
 use kaspa_consensus_core::{api::BlockValidationFutures, block::Block, blockstatus::BlockStatus, errors::block::RuleError};
 use kaspa_consensusmanager::ConsensusProxy;
 use kaspa_core::{debug, info};
@@ -12,8 +13,8 @@ use kaspa_p2p_lib::{
     pb::{kaspad_message::Payload, InvRelayBlockMessage, RequestBlockLocatorMessage, RequestRelayBlocksMessage},
     IncomingRoute, Router, SharedIncomingRoute,
 };
+use kaspa_utils::channel::JobSender;
 use std::{collections::VecDeque, sync::Arc};
-use tokio::sync::mpsc::{error::TrySendError, Sender};
 
 pub struct RelayInvMessage {
     hash: Hash,
@@ -54,7 +55,7 @@ pub struct HandleRelayInvsFlow {
     /// A route for other messages such as Block and BlockLocator
     msg_route: IncomingRoute,
     /// A channel sender for sending blocks to be handled by the IBD flow (of this peer)
-    ibd_sender: Sender<Block>,
+    ibd_sender: JobSender<Block>,
 }
 
 #[async_trait::async_trait]
@@ -74,7 +75,7 @@ impl HandleRelayInvsFlow {
         router: Arc<Router>,
         invs_route: SharedIncomingRoute,
         msg_route: IncomingRoute,
-        ibd_sender: Sender<Block>,
+        ibd_sender: JobSender<Block>,
     ) -> Self {
         Self { ctx, router, invs_route: TwoWayIncomingRoute::new(invs_route), msg_route, ibd_sender }
     }
@@ -222,10 +223,9 @@ impl HandleRelayInvsFlow {
             self.ctx.add_orphan(block).await;
             self.enqueue_orphan_roots(consensus, hash).await;
         } else {
-            // Send the block to IBD flow via the dedicated channel.
-            // Note that this is a non-blocking send and we don't care about being rejected if channel is full,
-            // since if IBD is already running, there is no need to trigger it
-            match self.ibd_sender.try_send(block) {
+            // Send the block to IBD flow via the dedicated job channel. If the channel has a pending job, we prefer
+            // the block with higher blue work, since it is usually more recent
+            match self.ibd_sender.try_send(block, |b, c| if b.header.blue_work > c.header.blue_work { b } else { c }) {
                 Ok(_) | Err(TrySendError::Full(_)) => {}
                 Err(TrySendError::Closed(_)) => return Err(ProtocolError::ConnectionClosed), // This indicates that IBD flow has exited
             }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -5,7 +5,6 @@ use crate::{
         Flow,
     },
 };
-use async_channel::Receiver;
 use futures::future::try_join_all;
 use kaspa_consensus_core::{
     api::BlockValidationFuture,
@@ -28,6 +27,7 @@ use kaspa_p2p_lib::{
     },
     IncomingRoute, Router,
 };
+use kaspa_utils::channel::JobReceiver;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -42,7 +42,7 @@ pub struct IbdFlow {
     pub(super) incoming_route: IncomingRoute,
 
     // Receives relay blocks from relay flow which are out of orphan resolution range and hence trigger IBD
-    relay_receiver: Receiver<Block>,
+    relay_receiver: JobReceiver<Block>,
 }
 
 #[async_trait::async_trait]
@@ -65,7 +65,7 @@ pub enum IbdType {
 // TODO: define a peer banning strategy
 
 impl IbdFlow {
-    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, relay_receiver: Receiver<Block>) -> Self {
+    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, relay_receiver: JobReceiver<Block>) -> Self {
         Self { ctx, router, incoming_route, relay_receiver }
     }
 

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -385,8 +385,9 @@ impl IbdFlow {
             return Ok(());
         }
 
-        // Send a special header request for the selected tip anticone. This is expected to
-        // be a small set, as it is bounded to the size of virtual's mergeset.
+        // Send a special header request for the sink antipast. This is expected to
+        // be a relatively small set since virtual and relay blocks should be close topologically.
+        // See server-side handling of `RequestAnticone` for further details.
         self.router
             .enqueue(make_message!(
                 Payload::RequestAnticone,

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -267,7 +267,7 @@ impl IbdFlow {
                 .clone()
                 .spawn_blocking(move |c| {
                     let ref_proof = proof.clone();
-                    c.apply_pruning_proof(proof, &trusted_set);
+                    c.apply_pruning_proof(proof, &trusted_set)?;
                     c.import_pruning_points(pruning_points);
 
                     info!("Building the proof which was just applied (sanity test)");
@@ -290,19 +290,21 @@ impl IbdFlow {
                     } else {
                         info!("Proof was locally built successfully");
                     }
-                    trusted_set
+                    Result::<_, ProtocolError>::Ok(trusted_set)
                 })
-                .await;
+                .await?;
         } else {
             trusted_set = staging
                 .clone()
                 .spawn_blocking(move |c| {
-                    c.apply_pruning_proof(proof, &trusted_set);
+                    c.apply_pruning_proof(proof, &trusted_set)?;
                     c.import_pruning_points(pruning_points);
-                    trusted_set
+                    Result::<_, ProtocolError>::Ok(trusted_set)
                 })
-                .await;
+                .await?;
         }
+
+        // TODO: add logs to staging commit process
 
         info!("Starting to process {} trusted blocks", trusted_set.len());
         let mut last_time = Instant::now();

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -23,7 +23,7 @@ use kaspa_p2p_lib::{
     convert::model::trusted::TrustedDataPackage,
     dequeue_with_timeout, make_message,
     pb::{
-        kaspad_message::Payload, RequestAnticoneMessage, RequestHeadersMessage, RequestIbdBlocksMessage,
+        kaspad_message::Payload, RequestAntipastMessage, RequestHeadersMessage, RequestIbdBlocksMessage,
         RequestPruningPointAndItsAnticoneMessage, RequestPruningPointProofMessage, RequestPruningPointUtxoSetMessage,
     },
     IncomingRoute, Router,
@@ -390,8 +390,8 @@ impl IbdFlow {
         // See server-side handling of `RequestAnticone` for further details.
         self.router
             .enqueue(make_message!(
-                Payload::RequestAnticone,
-                RequestAnticoneMessage {
+                Payload::RequestAntipast,
+                RequestAntipastMessage {
                     block_hash: Some(syncer_virtual_selected_parent.into()),
                     context_hash: Some(relay_block_hash.into())
                 }

--- a/protocol/flows/src/v5/ibd/streams.rs
+++ b/protocol/flows/src/v5/ibd/streams.rs
@@ -39,7 +39,14 @@ impl<'a, 'b> TrustedEntryStream<'a, 'b> {
             Ok(op) => {
                 if let Some(msg) = op {
                     match msg.payload {
-                        Some(Payload::BlockWithTrustedDataV4(payload)) => Ok(Some(payload.try_into()?)),
+                        Some(Payload::BlockWithTrustedDataV4(payload)) => {
+                            let entry: TrustedDataEntry = payload.try_into()?;
+                            if entry.block.is_header_only() {
+                                Err(ProtocolError::OtherOwned(format!("trusted entry block {} is header only", entry.block.hash())))
+                            } else {
+                                Ok(Some(entry))
+                            }
+                        }
                         Some(Payload::DoneBlocksWithTrustedData(_)) => {
                             debug!("trusted entry stream completed after {} items", self.i);
                             Ok(None)

--- a/protocol/flows/src/v5/mod.rs
+++ b/protocol/flows/src/v5/mod.rs
@@ -16,6 +16,7 @@ use self::{
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 
 use kaspa_p2p_lib::{KaspadMessagePayloadType, Router, SharedIncomingRoute};
+use kaspa_utils::channel;
 use std::sync::Arc;
 
 pub(crate) mod address;
@@ -33,8 +34,9 @@ pub(crate) mod request_pruning_point_utxo_set;
 pub(crate) mod txrelay;
 
 pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
-    // IBD flow <-> invs flow channel requires no buffering hence the minimal size possible
-    let (ibd_sender, relay_receiver) = tokio::sync::mpsc::channel(1);
+    // IBD flow <-> invs flow communication uses a job channel in order to always
+    // maintain at most a single pending job which can be updated
+    let (ibd_sender, relay_receiver) = channel::job();
     let flows: Vec<Box<dyn Flow>> = vec![
         Box::new(IbdFlow::new(
             ctx.clone(),

--- a/protocol/flows/src/v5/mod.rs
+++ b/protocol/flows/src/v5/mod.rs
@@ -3,7 +3,7 @@ use self::{
     blockrelay::{flow::HandleRelayInvsFlow, handle_requests::HandleRelayBlockRequests},
     ibd::IbdFlow,
     ping::{ReceivePingsFlow, SendPingsFlow},
-    request_anticone::HandleAnticoneRequests,
+    request_antipast::HandleAntipastRequests,
     request_block_locator::RequestBlockLocatorFlow,
     request_headers::RequestHeadersFlow,
     request_ibd_blocks::HandleIbdBlockRequests,
@@ -23,7 +23,7 @@ pub(crate) mod address;
 pub(crate) mod blockrelay;
 pub(crate) mod ibd;
 pub(crate) mod ping;
-pub(crate) mod request_anticone;
+pub(crate) mod request_antipast;
 pub(crate) mod request_block_locator;
 pub(crate) mod request_headers;
 pub(crate) mod request_ibd_blocks;
@@ -111,10 +111,10 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestIbdBlocks]),
         )),
-        Box::new(HandleAnticoneRequests::new(
+        Box::new(HandleAntipastRequests::new(
             ctx.clone(),
             router.clone(),
-            router.subscribe(vec![KaspadMessagePayloadType::RequestAnticone]),
+            router.subscribe(vec![KaspadMessagePayloadType::RequestAntipast]),
         )),
         Box::new(RelayTransactionsFlow::new(
             ctx.clone(),

--- a/protocol/flows/src/v6/mod.rs
+++ b/protocol/flows/src/v6/mod.rs
@@ -3,7 +3,7 @@ use crate::v5::{
     blockrelay::{flow::HandleRelayInvsFlow, handle_requests::HandleRelayBlockRequests},
     ibd::IbdFlow,
     ping::{ReceivePingsFlow, SendPingsFlow},
-    request_anticone::HandleAnticoneRequests,
+    request_antipast::HandleAntipastRequests,
     request_block_locator::RequestBlockLocatorFlow,
     request_headers::RequestHeadersFlow,
     request_ibd_blocks::HandleIbdBlockRequests,
@@ -89,10 +89,10 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestIbdBlocks]),
         )),
-        Box::new(HandleAnticoneRequests::new(
+        Box::new(HandleAntipastRequests::new(
             ctx.clone(),
             router.clone(),
-            router.subscribe(vec![KaspadMessagePayloadType::RequestAnticone]),
+            router.subscribe(vec![KaspadMessagePayloadType::RequestAntipast]),
         )),
         Box::new(RelayTransactionsFlow::new(
             ctx.clone(),

--- a/protocol/flows/src/v6/mod.rs
+++ b/protocol/flows/src/v6/mod.rs
@@ -16,11 +16,13 @@ use crate::v5::{
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 
 use kaspa_p2p_lib::{KaspadMessagePayloadType, Router, SharedIncomingRoute};
+use kaspa_utils::channel;
 use std::sync::Arc;
 
 pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
-    // IBD flow <-> invs flow channel requires no buffering hence the minimal size possible
-    let (ibd_sender, relay_receiver) = tokio::sync::mpsc::channel(1);
+    // IBD flow <-> invs flow communication uses a job channel in order to always
+    // maintain at most a single pending job which can be updated
+    let (ibd_sender, relay_receiver) = channel::job();
 
     let mut flows: Vec<Box<dyn Flow>> = vec![
         Box::new(IbdFlow::new(

--- a/protocol/flows/src/v6/mod.rs
+++ b/protocol/flows/src/v6/mod.rs
@@ -9,7 +9,6 @@ use crate::v5::{
     request_ibd_blocks::HandleIbdBlockRequests,
     request_ibd_chain_block_locator::RequestIbdChainBlockLocatorFlow,
     request_pp_proof::RequestPruningPointProofFlow,
-    request_pruning_point_and_anticone::PruningPointAndItsAnticoneRequestsFlow,
     request_pruning_point_utxo_set::RequestPruningPointUtxoSetFlow,
     txrelay::flow::{RelayTransactionsFlow, RequestTransactionsFlow},
 };
@@ -18,6 +17,10 @@ use crate::{flow_context::FlowContext, flow_trait::Flow};
 use kaspa_p2p_lib::{KaspadMessagePayloadType, Router, SharedIncomingRoute};
 use kaspa_utils::channel;
 use std::sync::Arc;
+
+use crate::v6::request_pruning_point_and_anticone::PruningPointAndItsAnticoneRequestsFlow;
+
+pub(crate) mod request_pruning_point_and_anticone;
 
 pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
     // IBD flow <-> invs flow communication uses a job channel in order to always

--- a/protocol/flows/src/v6/request_pruning_point_and_anticone.rs
+++ b/protocol/flows/src/v6/request_pruning_point_and_anticone.rs
@@ -1,0 +1,100 @@
+//!
+//! In v6 of the P2P protocol we dropped the filling of DAA and GHOSTDAG indices for each trusted entry
+//! since the syncee no longer uses them in the rusty-kaspa design where the full sub-DAG is sent
+//!
+
+use itertools::Itertools;
+use kaspa_p2p_lib::{
+    common::ProtocolError,
+    dequeue, dequeue_with_request_id, make_response,
+    pb::{
+        self, kaspad_message::Payload, BlockWithTrustedDataV4Message, DoneBlocksWithTrustedDataMessage, PruningPointsMessage,
+        TrustedDataMessage,
+    },
+    IncomingRoute, Router,
+};
+use log::debug;
+use std::sync::Arc;
+
+use crate::{flow_context::FlowContext, flow_trait::Flow, v5::ibd::IBD_BATCH_SIZE};
+
+pub struct PruningPointAndItsAnticoneRequestsFlow {
+    ctx: FlowContext,
+    router: Arc<Router>,
+    incoming_route: IncomingRoute,
+}
+
+#[async_trait::async_trait]
+impl Flow for PruningPointAndItsAnticoneRequestsFlow {
+    fn router(&self) -> Option<Arc<Router>> {
+        Some(self.router.clone())
+    }
+
+    async fn start(&mut self) -> Result<(), ProtocolError> {
+        self.start_impl().await
+    }
+}
+
+impl PruningPointAndItsAnticoneRequestsFlow {
+    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute) -> Self {
+        Self { ctx, router, incoming_route }
+    }
+
+    async fn start_impl(&mut self) -> Result<(), ProtocolError> {
+        loop {
+            let (_, request_id) = dequeue_with_request_id!(self.incoming_route, Payload::RequestPruningPointAndItsAnticone)?;
+            debug!("Got request for pruning point and its anticone");
+
+            let consensus = self.ctx.consensus();
+            let mut session = consensus.session().await;
+
+            let pp_headers = session.async_pruning_point_headers().await;
+            self.router
+                .enqueue(make_response!(
+                    Payload::PruningPoints,
+                    PruningPointsMessage { headers: pp_headers.into_iter().map(|header| <pb::BlockHeader>::from(&*header)).collect() },
+                    request_id
+                ))
+                .await?;
+
+            let trusted_data = session.async_get_pruning_point_anticone_and_trusted_data().await?;
+            self.router
+                .enqueue(make_response!(
+                    Payload::TrustedData,
+                    TrustedDataMessage {
+                        daa_window: trusted_data.daa_window_blocks.iter().map(|daa_block| daa_block.into()).collect_vec(),
+                        ghostdag_data: trusted_data.ghostdag_blocks.iter().map(|gd| gd.into()).collect_vec()
+                    },
+                    request_id
+                ))
+                .await?;
+
+            for hashes in trusted_data.anticone.chunks(IBD_BATCH_SIZE) {
+                for &hash in hashes {
+                    let block = session.async_get_block(hash).await?;
+                    self.router
+                        .enqueue(make_response!(
+                            Payload::BlockWithTrustedDataV4,
+                            // No need to send window indices in v6
+                            BlockWithTrustedDataV4Message { block: Some((&block).into()), ..Default::default() },
+                            request_id
+                        ))
+                        .await?;
+                }
+
+                if hashes.len() == IBD_BATCH_SIZE {
+                    // No timeout here, as we don't care if the syncee takes its time computing,
+                    // since it only blocks this dedicated flow
+                    drop(session); // Avoid holding the session through dequeue calls
+                    dequeue!(self.incoming_route, Payload::RequestNextPruningPointAndItsAnticoneBlocks)?;
+                    session = consensus.session().await;
+                }
+            }
+
+            self.router
+                .enqueue(make_response!(Payload::DoneBlocksWithTrustedData, DoneBlocksWithTrustedDataMessage {}, request_id))
+                .await?;
+            debug!("Finished sending pruning point anticone")
+        }
+    }
+}

--- a/protocol/p2p/proto/messages.proto
+++ b/protocol/p2p/proto/messages.proto
@@ -50,7 +50,7 @@ message KaspadMessage {
     TrustedDataMessage trustedData = 52;
     RequestIBDChainBlockLocatorMessage requestIBDChainBlockLocator = 53;
     IbdChainBlockLocatorMessage ibdChainBlockLocator = 54;
-    RequestAnticoneMessage requestAnticone = 55;
+    RequestAntipastMessage requestAntipast = 55;
     RequestNextPruningPointAndItsAnticoneBlocksMessage requestNextPruningPointAndItsAnticoneBlocks = 56;
   }
 }

--- a/protocol/p2p/proto/p2p.proto
+++ b/protocol/p2p/proto/p2p.proto
@@ -222,6 +222,7 @@ message RequestPruningPointAndItsAnticoneMessage {
 message RequestNextPruningPointAndItsAnticoneBlocksMessage{
 }
 
+// TODO: remove once v4 is obsolete
 message BlockWithTrustedDataMessage {
   BlockMessage block = 1;
   uint64 daaScore = 2;
@@ -229,16 +230,19 @@ message BlockWithTrustedDataMessage {
   repeated BlockGhostdagDataHashPair ghostdagData = 4;
 }
 
+// TODO: rename to `TrustedBlock` once v5 is obsolete
 message DaaBlock {
   BlockMessage block = 3;
   GhostdagData ghostdagData = 2;
 }
 
+// TODO: rename to `TrustedHeader` once v5 is obsolete
 message DaaBlockV4 {
   BlockHeader header = 1;
   GhostdagData ghostdagData = 2;
 }
 
+// TODO: remove once v5 is obsolete
 message BlockGhostdagDataHashPair {
   Hash hash = 1;
   GhostdagData ghostdagData = 2;
@@ -281,11 +285,11 @@ message ReadyMessage {
 
 message BlockWithTrustedDataV4Message {
   BlockMessage block = 1;
-  repeated uint64 daaWindowIndices = 2;
-  repeated uint64 ghostdagDataIndices = 3;
+  repeated uint64 daaWindowIndices = 2; // TODO: remove once v5 is obsolete
+  repeated uint64 ghostdagDataIndices = 3; // TODO: remove once v5 is obsolete
 }
 
 message TrustedDataMessage {
-  repeated DaaBlockV4 daaWindow = 1;
-  repeated BlockGhostdagDataHashPair ghostdagData = 2;
+  repeated DaaBlockV4 daaWindow = 1; // TODO: rename to `trustedSubDag` once v5 is obsolete
+  repeated BlockGhostdagDataHashPair ghostdagData = 2; // TODO: remove once v5 is obsolete
 }

--- a/protocol/p2p/proto/p2p.proto
+++ b/protocol/p2p/proto/p2p.proto
@@ -199,7 +199,8 @@ message IbdChainBlockLocatorMessage {
   repeated Hash blockLocatorHashes = 1;
 }
 
-message RequestAnticoneMessage{
+// Legacy name of this message is `RequestAnticoneMessage`
+message RequestAntipastMessage{
   Hash blockHash = 1;
   Hash contextHash = 2;
 }

--- a/protocol/p2p/src/convert/messages.rs
+++ b/protocol/p2p/src/convert/messages.rs
@@ -214,9 +214,9 @@ impl TryFrom<protowire::RequestBlockLocatorMessage> for (Hash, u32) {
     }
 }
 
-impl TryFrom<protowire::RequestAnticoneMessage> for (Hash, Hash) {
+impl TryFrom<protowire::RequestAntipastMessage> for (Hash, Hash) {
     type Error = ConversionError;
-    fn try_from(msg: protowire::RequestAnticoneMessage) -> Result<Self, Self::Error> {
+    fn try_from(msg: protowire::RequestAntipastMessage) -> Result<Self, Self::Error> {
         Ok((msg.block_hash.try_into_ex()?, msg.context_hash.try_into_ex()?))
     }
 }

--- a/protocol/p2p/src/core/payload_type.rs
+++ b/protocol/p2p/src/core/payload_type.rs
@@ -44,7 +44,7 @@ pub enum KaspadMessagePayloadType {
     TrustedData,
     RequestIbdChainBlockLocator,
     IbdChainBlockLocator,
-    RequestAnticone,
+    RequestAntipast,
     RequestNextPruningPointAndItsAnticoneBlocks,
 }
 
@@ -96,7 +96,7 @@ impl From<&KaspadMessagePayload> for KaspadMessagePayloadType {
             KaspadMessagePayload::TrustedData(_) => KaspadMessagePayloadType::TrustedData,
             KaspadMessagePayload::RequestIbdChainBlockLocator(_) => KaspadMessagePayloadType::RequestIbdChainBlockLocator,
             KaspadMessagePayload::IbdChainBlockLocator(_) => KaspadMessagePayloadType::IbdChainBlockLocator,
-            KaspadMessagePayload::RequestAnticone(_) => KaspadMessagePayloadType::RequestAnticone,
+            KaspadMessagePayload::RequestAntipast(_) => KaspadMessagePayloadType::RequestAntipast,
             KaspadMessagePayload::RequestNextPruningPointAndItsAnticoneBlocks(_) => {
                 KaspadMessagePayloadType::RequestNextPruningPointAndItsAnticoneBlocks
             }

--- a/protocol/p2p/src/echo.rs
+++ b/protocol/p2p/src/echo.rs
@@ -62,7 +62,7 @@ impl EchoFlow {
             KaspadMessagePayloadType::TrustedData,
             KaspadMessagePayloadType::RequestIbdChainBlockLocator,
             KaspadMessagePayloadType::IbdChainBlockLocator,
-            KaspadMessagePayloadType::RequestAnticone,
+            KaspadMessagePayloadType::RequestAntipast,
             KaspadMessagePayloadType::RequestNextPruningPointAndItsAnticoneBlocks,
         ]);
         let mut echo_flow = EchoFlow { router, receiver };

--- a/testing/integration/src/common/client_notify.rs
+++ b/testing/integration/src/common/client_notify.rs
@@ -4,7 +4,13 @@ use kaspa_rpc_core::Notification;
 
 #[derive(Debug)]
 pub struct ChannelNotify {
-    pub sender: Sender<Notification>,
+    sender: Sender<Notification>,
+}
+
+impl ChannelNotify {
+    pub fn new(sender: Sender<Notification>) -> Self {
+        Self { sender }
+    }
 }
 
 impl Notify<Notification> for ChannelNotify {

--- a/testing/integration/src/common/client_notify.rs
+++ b/testing/integration/src/common/client_notify.rs
@@ -1,0 +1,15 @@
+use async_channel::Sender;
+use kaspa_notify::notifier::Notify;
+use kaspa_rpc_core::Notification;
+
+#[derive(Debug)]
+pub struct ChannelNotify {
+    pub sender: Sender<Notification>,
+}
+
+impl Notify<Notification> for ChannelNotify {
+    fn notify(&self, notification: Notification) -> kaspa_notify::error::Result<()> {
+        self.sender.try_send(notification)?;
+        Ok(())
+    }
+}

--- a/testing/integration/src/common/mod.rs
+++ b/testing/integration/src/common/mod.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+pub mod client_notify;
 pub mod client_pool;
 pub mod daemon;
 pub mod utils;

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -17,8 +17,8 @@ use std::{
     sync::Arc,
 };
 
-const EXPAND_FACTOR: u64 = 1;
-const CONTRACT_FACTOR: u64 = 1;
+pub(crate) const EXPAND_FACTOR: u64 = 1;
+pub(crate) const CONTRACT_FACTOR: u64 = 1;
 
 fn estimated_mass(num_inputs: usize, num_outputs: u64) -> u64 {
     200 + 34 * num_outputs + 1000 * (num_inputs as u64)

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -949,9 +949,8 @@ async fn json_test(file_path: &str, concurrency: bool) {
             })
             .collect_vec();
 
-        // TODO: Add consensus validation that the pruning point is one of the trusted blocks.
         let trusted_blocks = gzip_file_lines(&main_path.join("trusted.json.gz")).map(json_trusted_line_to_block_and_gd).collect_vec();
-        tc.apply_pruning_proof(proof, &trusted_blocks);
+        tc.apply_pruning_proof(proof, &trusted_blocks).unwrap();
 
         let past_pruning_points =
             gzip_file_lines(&main_path.join("past-pps.json.gz")).map(|line| json_line_to_block(line).header).collect_vec();

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -54,7 +54,7 @@ async fn daemon_mining_test() {
     assert_eq!(rpc_client2.get_connected_peer_info().await.unwrap().peer_info.len(), 1);
 
     let (sender, event_receiver) = async_channel::unbounded();
-    rpc_client1.start(Some(Arc::new(ChannelNotify { sender }))).await;
+    rpc_client1.start(Some(Arc::new(ChannelNotify::new(sender)))).await;
     rpc_client1.start_notify(Default::default(), Scope::VirtualDaaScoreChanged(VirtualDaaScoreChangedScope {})).await.unwrap();
 
     // Mine 10 blocks to daemon #1

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -1,10 +1,11 @@
 use kaspa_addresses::Address;
 use kaspa_consensusmanager::ConsensusManager;
 use kaspa_core::task::runtime::AsyncRuntime;
-use kaspa_rpc_core::api::rpc::RpcApi;
+use kaspa_notify::scope::{Scope, VirtualDaaScoreChangedScope};
+use kaspa_rpc_core::{api::rpc::RpcApi, Notification};
 use kaspad_lib::args::Args;
 
-use crate::common::daemon::Daemon;
+use crate::common::{client_notify::ChannelNotify, daemon::Daemon};
 use std::{sync::Arc, time::Duration};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -52,15 +53,35 @@ async fn daemon_mining_test() {
     tokio::time::sleep(Duration::from_secs(1)).await; // Let it connect
     assert_eq!(rpc_client2.get_connected_peer_info().await.unwrap().peer_info.len(), 1);
 
+    let (sender, event_receiver) = async_channel::unbounded();
+    rpc_client1.start(Some(Arc::new(ChannelNotify { sender }))).await;
+    rpc_client1.start_notify(Default::default(), Scope::VirtualDaaScoreChanged(VirtualDaaScoreChangedScope {})).await.unwrap();
+
     // Mine 10 blocks to daemon #1
     let mut last_block_hash = None;
-    for _ in 0..10 {
+    for i in 0..10 {
         let template = rpc_client1
             .get_block_template(Address::new(kaspad1.network.into(), kaspa_addresses::Version::PubKey, &[0; 32]), vec![])
             .await
             .unwrap();
         last_block_hash = Some(template.block.header.hash);
         rpc_client1.submit_block(template.block, false).await.unwrap();
+
+        while let Ok(notification) = match tokio::time::timeout(Duration::from_secs(1), event_receiver.recv()).await {
+            Ok(res) => res,
+            Err(elapsed) => panic!("expected virtual event before {}", elapsed),
+        } {
+            match notification {
+                Notification::VirtualDaaScoreChanged(msg) if msg.virtual_daa_score == i + 1 => {
+                    break;
+                }
+                Notification::VirtualDaaScoreChanged(msg) if msg.virtual_daa_score > i + 1 => {
+                    panic!("DAA score too high for number of submitted blocks")
+                }
+                Notification::VirtualDaaScoreChanged(_) => {}
+                _ => panic!("expected only DAA score notifications"),
+            }
+        }
     }
 
     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -109,7 +109,7 @@ async fn bench_bbt_latency() {
 
     let executing = Arc::new(AtomicBool::new(true));
     let (sender, receiver) = async_channel::unbounded();
-    bbt_client.start(Some(Arc::new(ChannelNotify { sender }))).await;
+    bbt_client.start(Some(Arc::new(ChannelNotify::new(sender)))).await;
     bbt_client.start_notify(ListenerId::default(), Scope::NewBlockTemplate(NewBlockTemplateScope {})).await.unwrap();
 
     let submit_block_pool = daemon

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -1,5 +1,4 @@
-use crate::common::{self, daemon::Daemon};
-use async_channel::Sender;
+use crate::common::{self, client_notify::ChannelNotify, daemon::Daemon, utils::CONTRACT_FACTOR};
 use futures_util::future::join_all;
 use kaspa_addresses::Address;
 use kaspa_consensus::params::Params;
@@ -7,7 +6,6 @@ use kaspa_consensus_core::{constants::SOMPI_PER_KASPA, network::NetworkType, tx:
 use kaspa_core::{debug, info};
 use kaspa_notify::{
     listener::ListenerId,
-    notifier::Notify,
     scope::{NewBlockTemplateScope, Scope},
 };
 use kaspa_rpc_core::{api::rpc::RpcApi, Notification, RpcError};
@@ -19,7 +17,6 @@ use rand::thread_rng;
 use rand_distr::{Distribution, Exp};
 use std::{
     cmp::max,
-    fmt::Debug,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -27,20 +24,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::join;
-
-#[derive(Debug)]
-struct ChannelNotify {
-    sender: Sender<Notification>,
-}
-
-impl Notify<Notification> for ChannelNotify {
-    fn notify(&self, notification: Notification) -> kaspa_notify::error::Result<()> {
-        self.sender.try_send(notification)?;
-        Ok(())
-    }
-}
-
-const CONTRACT_FACTOR: u64 = 1;
 
 /// Run this benchmark with the following command line:
 /// `cargo test --release --package kaspa-testing-integration --lib --features devnet-prealloc -- mempool_benchmarks::bench_bbt_latency --exact --nocapture --ignored`

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -70,7 +70,7 @@ async fn sanity_test() {
                 tst!(op, {
                     // Register to basic virtual events in order to keep track of block submission
                     let (sender, event_receiver) = async_channel::unbounded();
-                    rpc_client.start(Some(Arc::new(ChannelNotify { sender }))).await;
+                    rpc_client.start(Some(Arc::new(ChannelNotify::new(sender)))).await;
                     rpc_client
                         .start_notify(Default::default(), Scope::VirtualDaaScoreChanged(VirtualDaaScoreChangedScope {}))
                         .await


### PR DESCRIPTION
Partial list:

1. Bump version to 0.13.0 which is higher in order than current kaspad-go version (important for miners/tools who rely on node version for selecting the GRPC version)
2. Make RPC submit block not wait for virtual processing and fix corresponding tests which assume it does
3. IBD: fix fetch relay block past to include blocks in future(sink)
4. IBD: update pending relay block to the latest block, this should shorten the usual IBD loop when syncing a node (loop meaning there is a long IBD followed by a shorter one and so on until it decays and the node finally syncs; with this change it should decay faster)
5. IBD: syncer: fill DAG gaps in trusted blocks set; syncee: verify all blocks w/o body are in pruning point past