### PR TITLE
Build pruning proof -- Bug fix

### DIFF
--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -618,6 +618,8 @@ impl PruningProofManager {
                         self.block_at_depth(&*self.ghostdag_stores[level + 1], selected_tip_by_level[level + 1], self.pruning_proof_m);
                     if self.reachability_service.is_dag_ancestor_of(block_at_depth_m_at_next_level, block_at_depth_2m) {
                         block_at_depth_m_at_next_level
+                    } else if self.reachability_service.is_dag_ancestor_of(block_at_depth_2m, block_at_depth_m_at_next_level) {
+                        block_at_depth_2m
                     } else {
                         self.find_common_ancestor_in_chain_of_a(
                             &*self.ghostdag_stores[level],

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -419,7 +419,7 @@ impl PruningProofManager {
 
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
-            info!("Validating level {level} from the pruning point proof");
+            info!("Validating level {level} from the pruning point proof ({} headers)", proof[level as usize].len());
             let level_idx = level as usize;
             let mut selected_tip = None;
             for (i, header) in proof[level as usize].iter().enumerate() {


### PR DESCRIPTION
The following line of logic in [kaspad-go](https://github.com/kaspanet/kaspad/blob/master/domain/consensus/processes/pruningproofmanager/pruningproofmanager.go#L199) was missing from rust impl. This means that we were searching for common ancestor when not needed hence loosing contiguous topology guarantees known from proof validation or from ongoing relation maintenance. This in turn lead to not including `block_at_depth_2m` in the proof in some cases, thus deleting it prematurely  