### PR TITLE
RPC mempool transaction query -- Bug fix

### DIFF
--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -15,6 +15,7 @@ use crate::{
         candidate_tx::CandidateTransaction,
         owner_txs::{GroupedOwnerTransactions, ScriptPublicKeySet},
         topological_sort::IntoIterTopologically,
+        tx_query::TransactionQuery,
     },
     MiningCounters,
 };
@@ -435,43 +436,35 @@ impl MiningManager {
     /// Try to return a mempool transaction by its id.
     ///
     /// Note: the transaction is an orphan if tx.is_fully_populated() returns false.
-    pub fn get_transaction(
-        &self,
-        transaction_id: &TransactionId,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
-    ) -> Option<MutableTransaction> {
-        assert!(include_transaction_pool || include_orphan_pool, "at least one of either transactions or orphans must be included");
-        self.mempool.read().get_transaction(transaction_id, include_transaction_pool, include_orphan_pool)
+    pub fn get_transaction(&self, transaction_id: &TransactionId, query: TransactionQuery) -> Option<MutableTransaction> {
+        self.mempool.read().get_transaction(transaction_id, query)
     }
 
     /// Returns whether the mempool holds this transaction in any form.
-    pub fn has_transaction(&self, transaction_id: &TransactionId, include_transaction_pool: bool, include_orphan_pool: bool) -> bool {
-        assert!(include_transaction_pool || include_orphan_pool, "at least one of either transactions or orphans must be included");
-        self.mempool.read().has_transaction(transaction_id, include_transaction_pool, include_orphan_pool)
+    pub fn has_transaction(&self, transaction_id: &TransactionId, query: TransactionQuery) -> bool {
+        self.mempool.read().has_transaction(transaction_id, query)
     }
 
-    pub fn get_all_transactions(
-        &self,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
-    ) -> (Vec<MutableTransaction>, Vec<MutableTransaction>) {
+    pub fn get_all_transactions(&self, query: TransactionQuery) -> (Vec<MutableTransaction>, Vec<MutableTransaction>) {
         const TRANSACTION_CHUNK_SIZE: usize = 1000;
-        assert!(include_transaction_pool || include_orphan_pool, "at least one of either transactions or orphans must be included");
         // read lock on mempool by transaction chunks
-        let transactions = if include_transaction_pool {
-            let transaction_ids = self.mempool.read().get_all_transaction_ids(true, false).0;
-            let mut transactions = Vec::with_capacity(self.mempool.read().transaction_count(true, false));
+        let transactions = if query.include_transaction_pool() {
+            let transaction_ids = self.mempool.read().get_all_transaction_ids(TransactionQuery::TransactionsOnly).0;
+            let mut transactions = Vec::with_capacity(self.mempool.read().transaction_count(TransactionQuery::TransactionsOnly));
             for chunks in transaction_ids.chunks(TRANSACTION_CHUNK_SIZE) {
                 let mempool = self.mempool.read();
-                transactions.extend(chunks.iter().filter_map(|x| mempool.get_transaction(x, true, false)));
+                transactions.extend(chunks.iter().filter_map(|x| mempool.get_transaction(x, TransactionQuery::TransactionsOnly)));
             }
             transactions
         } else {
             vec![]
         };
         // read lock on mempool
-        let orphans = if include_orphan_pool { self.mempool.read().get_all_transactions(false, true).1 } else { vec![] };
+        let orphans = if query.include_orphan_pool() {
+            self.mempool.read().get_all_transactions(TransactionQuery::OrphansOnly).1
+        } else {
+            vec![]
+        };
         (transactions, orphans)
     }
 
@@ -482,17 +475,14 @@ impl MiningManager {
     pub fn get_transactions_by_addresses(
         &self,
         script_public_keys: &ScriptPublicKeySet,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
+        query: TransactionQuery,
     ) -> GroupedOwnerTransactions {
-        assert!(include_transaction_pool || include_orphan_pool, "at least one of either transactions or orphans must be included");
         // TODO: break the monolithic lock
-        self.mempool.read().get_transactions_by_addresses(script_public_keys, include_transaction_pool, include_orphan_pool)
+        self.mempool.read().get_transactions_by_addresses(script_public_keys, query)
     }
 
-    pub fn transaction_count(&self, include_transaction_pool: bool, include_orphan_pool: bool) -> usize {
-        assert!(include_transaction_pool || include_orphan_pool, "at least one of either transactions or orphans must be included");
-        self.mempool.read().transaction_count(include_transaction_pool, include_orphan_pool)
+    pub fn transaction_count(&self, query: TransactionQuery) -> usize {
+        self.mempool.read().transaction_count(query)
     }
 
     pub fn handle_new_block_transactions(
@@ -565,7 +555,7 @@ impl MiningManager {
         let mut transactions = Vec::with_capacity(transaction_ids.len());
         for chunk in &transaction_ids.iter().chunks(TRANSACTION_CHUNK_SIZE) {
             let mempool = self.mempool.read();
-            transactions.extend(chunk.filter_map(|x| mempool.get_transaction(x, true, false)));
+            transactions.extend(chunk.filter_map(|x| mempool.get_transaction(x, TransactionQuery::TransactionsOnly)));
         }
 
         let mut valid: usize = 0;
@@ -592,7 +582,7 @@ impl MiningManager {
                 if mempool.has_accepted_transaction(&transaction_id) {
                     accepted += 1;
                     None
-                } else if mempool.has_transaction(&transaction_id, true, false) {
+                } else if mempool.has_transaction(&transaction_id, TransactionQuery::TransactionsOnly) {
                     x.clear_entries();
                     mempool.populate_mempool_entries(&mut x);
                     match x.is_fully_populated() {
@@ -648,7 +638,7 @@ impl MiningManager {
                             valid += 1;
                         }
                         Err(RuleError::RejectMissingOutpoint) => {
-                            let transaction = mempool.get_transaction(&transaction_id, true, false).unwrap();
+                            let transaction = mempool.get_transaction(&transaction_id, TransactionQuery::TransactionsOnly).unwrap();
                             let missing_txs = transaction
                                 .entries
                                 .iter()
@@ -829,39 +819,21 @@ impl MiningManagerProxy {
     /// Try to return a mempool transaction by its id.
     ///
     /// Note: the transaction is an orphan if tx.is_fully_populated() returns false.
-    pub async fn get_transaction(
-        self,
-        transaction_id: TransactionId,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
-    ) -> Option<MutableTransaction> {
-        spawn_blocking(move || self.inner.get_transaction(&transaction_id, include_transaction_pool, include_orphan_pool))
-            .await
-            .unwrap()
+    pub async fn get_transaction(self, transaction_id: TransactionId, query: TransactionQuery) -> Option<MutableTransaction> {
+        spawn_blocking(move || self.inner.get_transaction(&transaction_id, query)).await.unwrap()
     }
 
     /// Returns whether the mempool holds this transaction in any form.
-    pub async fn has_transaction(
-        self,
-        transaction_id: TransactionId,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
-    ) -> bool {
-        spawn_blocking(move || self.inner.has_transaction(&transaction_id, include_transaction_pool, include_orphan_pool))
-            .await
-            .unwrap()
+    pub async fn has_transaction(self, transaction_id: TransactionId, query: TransactionQuery) -> bool {
+        spawn_blocking(move || self.inner.has_transaction(&transaction_id, query)).await.unwrap()
     }
 
-    pub async fn transaction_count(self, include_transaction_pool: bool, include_orphan_pool: bool) -> usize {
-        spawn_blocking(move || self.inner.transaction_count(include_transaction_pool, include_orphan_pool)).await.unwrap()
+    pub async fn transaction_count(self, query: TransactionQuery) -> usize {
+        spawn_blocking(move || self.inner.transaction_count(query)).await.unwrap()
     }
 
-    pub async fn get_all_transactions(
-        self,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
-    ) -> (Vec<MutableTransaction>, Vec<MutableTransaction>) {
-        spawn_blocking(move || self.inner.get_all_transactions(include_transaction_pool, include_orphan_pool)).await.unwrap()
+    pub async fn get_all_transactions(self, query: TransactionQuery) -> (Vec<MutableTransaction>, Vec<MutableTransaction>) {
+        spawn_blocking(move || self.inner.get_all_transactions(query)).await.unwrap()
     }
 
     /// get_transactions_by_addresses returns the sending and receiving transactions for
@@ -871,14 +843,9 @@ impl MiningManagerProxy {
     pub async fn get_transactions_by_addresses(
         self,
         script_public_keys: ScriptPublicKeySet,
-        include_transaction_pool: bool,
-        include_orphan_pool: bool,
+        query: TransactionQuery,
     ) -> GroupedOwnerTransactions {
-        spawn_blocking(move || {
-            self.inner.get_transactions_by_addresses(&script_public_keys, include_transaction_pool, include_orphan_pool)
-        })
-        .await
-        .unwrap()
+        spawn_blocking(move || self.inner.get_transactions_by_addresses(&script_public_keys, query)).await.unwrap()
     }
 
     /// Returns whether a transaction id was registered as accepted in the mempool, meaning

--- a/mining/src/model/mod.rs
+++ b/mining/src/model/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod candidate_tx;
 pub mod owner_txs;
 pub mod topological_index;
 pub mod topological_sort;
+pub mod tx_query;
 
 /// A set of unique transaction ids
 pub type TransactionIdSet = HashSet<TransactionId>;

--- a/mining/src/model/tx_query.rs
+++ b/mining/src/model/tx_query.rs
@@ -1,0 +1,19 @@
+/// Indicates whether the mempool query result should include transactions/orphans or both
+pub enum TransactionQuery {
+    /// Include only non-orphan transactions from the ordinary mempool tx pool
+    TransactionsOnly,
+    /// Include orphan transactions only
+    OrphansOnly,
+    /// Include both orphan and non-orphan transactions
+    All,
+}
+
+impl TransactionQuery {
+    pub fn include_transaction_pool(&self) -> bool {
+        matches!(self, TransactionQuery::TransactionsOnly | TransactionQuery::All)
+    }
+
+    pub fn include_orphan_pool(&self) -> bool {
+        matches!(self, TransactionQuery::OrphansOnly | TransactionQuery::All)
+    }
+}

--- a/protocol/flows/src/v5/txrelay/flow.rs
+++ b/protocol/flows/src/v5/txrelay/flow.rs
@@ -11,6 +11,7 @@ use kaspa_mining::{
         errors::RuleError,
         tx::{Orphan, Priority},
     },
+    model::tx_query::TransactionQuery,
 };
 use kaspa_p2p_lib::{
     common::{ProtocolError, DEFAULT_TIMEOUT},
@@ -239,7 +240,9 @@ impl RequestTransactionsFlow {
             let msg = dequeue!(self.incoming_route, Payload::RequestTransactions)?;
             let tx_ids: Vec<_> = msg.try_into()?;
             for transaction_id in tx_ids {
-                if let Some(mutable_tx) = self.ctx.mining_manager().clone().get_transaction(transaction_id, true, false).await {
+                if let Some(mutable_tx) =
+                    self.ctx.mining_manager().clone().get_transaction(transaction_id, TransactionQuery::TransactionsOnly).await
+                {
                     // trace!("Send transaction {} to {}", mutable_tx.id(), self.router.identity());
                     self.router.enqueue(make_message!(Payload::Transaction, (&*mutable_tx.tx).into())).await?;
                 } else {

--- a/rpc/core/src/error.rs
+++ b/rpc/core/src/error.rs
@@ -109,6 +109,9 @@ pub enum RpcError {
 
     #[error("RpcCtl dispatch error")]
     RpcCtlDispatchError,
+
+    #[error("transaction query must either not filter transactions or include orphans")]
+    InconsistentMempoolTxQuery,
 }
 
 impl From<String> for RpcError {


### PR DESCRIPTION
Refactor mempool tx query to an enum instead of 2 booleans. This makes it impossible to make an inconsistent query (previously managed by internal mempool assertions). Fixes an rpc crash bug