### PR TITLE
Request DB reset when dev/test/sim network restart is detected

### DIFF
--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -81,6 +81,15 @@ impl MultiConsensusManagementStore {
         }
     }
 
+    /// The directory name of the active consensus, if one exists. None otherwise
+    pub fn active_consensus_dir_name(&self) -> StoreResult<Option<String>> {
+        let metadata = self.metadata.read()?;
+        match metadata.current_consensus_key {
+            Some(key) => Ok(Some(self.entries.read(key.into()).unwrap().directory_name)),
+            None => Ok(None),
+        }
+    }
+
     /// The entry type signifies whether the returned entry is an existing/new consensus
     pub fn active_consensus_entry(&mut self) -> StoreResult<ConsensusEntryType> {
         let mut metadata = self.metadata.read()?;

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -249,8 +249,8 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         .build()
         .unwrap();
 
-    if args.testnet && args.testnet_suffix == 11 {
-        // Testnet 11 can be restarted, and when it does we need to reset the DB.
+    if args.testnet || args.devnet || args.simnet {
+        // Non-mainnet can be restarted, and when it does we need to reset the DB.
         // This will check if the current Genesis can be found the active consensus
         // DB (if one exists), and if not then ask to reset the DB.
         let active_consensus_dir_name = MultiConsensusManagementStore::new(meta_db.clone()).active_consensus_dir_name().unwrap();
@@ -291,7 +291,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
                 }
             }
             None => {
-                trace!("Consensus not initialized yet. Skipping genesis check.");
+                info!("Consensus not initialized yet. Skipping genesis check.");
             }
         }
     }

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -266,7 +266,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
                 let headers_store = DbHeadersStore::new(consensus_db, 0);
 
                 if headers_store.has(config.genesis.hash).unwrap() {
-                    trace!("Genesis is found in active consensus DB. No action needed.");
+                    info!("Genesis is found in active consensus DB. No action needed.");
                 } else {
                     let msg = "Genesis not found in active consensus DB. This happens when Testnet 11 is restarted and your database needs to be fully deleted. Do you confirm the delete? (y/n)";
                     get_user_approval_or_exit(msg, args.yes);

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -8,19 +8,15 @@ use kaspa_consensus_core::{
 use kaspa_consensus_notify::{root::ConsensusNotificationRoot, service::NotifyService};
 use kaspa_core::{core::Core, info, trace};
 use kaspa_core::{kaspad_env::version, task::tick::TickService};
-use kaspa_database::{prelude::DbKey, registry::DatabaseStorePrefixes};
 use kaspa_grpc_server::service::GrpcService;
 use kaspa_rpc_service::service::RpcCoreService;
 use kaspa_txscript::caches::TxScriptCacheCounters;
 use kaspa_utils::networking::ContextualNetAddress;
 
 use kaspa_addressmanager::AddressManager;
+use kaspa_consensus::{consensus::factory::Factory as ConsensusFactory, pipeline::ProcessingCounters};
 use kaspa_consensus::{
     consensus::factory::MultiConsensusManagementStore, model::stores::headers::DbHeadersStore, pipeline::monitor::ConsensusMonitor,
-};
-use kaspa_consensus::{
-    consensus::{factory::Factory as ConsensusFactory, storage::ConsensusStorage},
-    pipeline::ProcessingCounters,
 };
 use kaspa_consensusmanager::ConsensusManager;
 use kaspa_core::task::runtime::AsyncRuntime;


### PR DESCRIPTION
This detects if the current Genesis (as defined in code) is in the local active consensus DB - which it always should be. If it isn't, then the network has restarted and the local DB must be deleted. Only applied to non-mainnet networks as mainnet is never retarted.