### PR TITLE
Add request/response size middlewares and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,9 +2834,13 @@ dependencies = [
  "criterion",
  "event-listener 2.5.3",
  "faster-hex 0.6.1",
+ "futures",
  "futures-util",
+ "hyper",
  "ipnet",
  "itertools 0.11.0",
+ "log",
+ "pin-project-lite",
  "rand 0.8.5",
  "rlimit",
  "serde",
@@ -2838,6 +2848,8 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
+ "tower",
+ "tower-http",
  "triggered",
  "uuid 1.5.0",
 ]
@@ -5089,6 +5101,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,6 +5136,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ textwrap = "0.16.0"
 thiserror = "1.0.50"
 tokio = { version = "1.33.0", features = ["sync", "rt-multi-thread"] }
 tokio-stream = "0.1.14"
-tonic = { version = "0.10.2", features = ["tls", "gzip"] }
+tonic = { version = "0.10.2", features = ["tls", "gzip", "transport"] }
 tonic-build = { version = "0.10.2", features = ["prost"] }
 triggered = "0.1.2"
 uuid = { version = "1.5.0", features = ["v4", "fast-rng", "serde"] }
@@ -231,7 +231,10 @@ wasm-bindgen-test = "=0.3.37"
 web-sys = "=0.3.64"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
-
+pin-project-lite = "0.2.13"
+tower-http = { version = "0.4.4", features = ["map-response-body", "map-request-body"] }
+tower = "0.4.7"
+hyper = "0.14.27"
 # workflow dependencies that are not a part of core libraries
 
 # workflow-perf-monitor = { path = "../../../workflow-perf-monitor-rs" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,9 +20,16 @@ smallvec.workspace = true
 thiserror.workspace = true
 triggered.workspace = true
 uuid.workspace = true
+log.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rlimit.workspace = true
+futures.workspace = true
+tower-http.workspace = true
+tower.workspace = true
+hyper.workspace = true
+pin-project-lite.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -190,3 +190,6 @@ pub mod triggers;
 pub mod vec;
 
 pub mod fd_budget;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod request_response_size_middlewares;

--- a/utils/src/request_response_size_middlewares.rs
+++ b/utils/src/request_response_size_middlewares.rs
@@ -1,0 +1,99 @@
+use futures::ready;
+use hyper::{
+    body::{Bytes, HttpBody, SizeHint},
+    HeaderMap,
+};
+use log::{debug, warn};
+use pin_project_lite::pin_project;
+use std::{
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+use tower_http::map_request_body::MapRequestBodyLayer;
+
+pin_project! {
+    pub struct CountBytesBody<B> {
+        #[pin]
+        pub inner: B,
+        pub counter: Arc<AtomicUsize>,
+    }
+}
+
+impl<B> CountBytesBody<B> {
+    pub fn new(inner: B, counter: Arc<AtomicUsize>) -> CountBytesBody<B> {
+        CountBytesBody { inner, counter }
+    }
+}
+
+impl<B> HttpBody for CountBytesBody<B>
+where
+    B: HttpBody<Data = Bytes>,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_data(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+        let counter: Arc<AtomicUsize> = this.counter.clone();
+        match ready!(this.inner.poll_data(cx)) {
+            Some(Ok(chunk)) => {
+                debug!("[SIZE MW] response body chunk size = {}", chunk.len());
+                let previous = counter.fetch_add(chunk.len(), Ordering::Relaxed);
+                debug!("[SIZE MW] total count: {}", previous);
+
+                Poll::Ready(Some(Ok(chunk)))
+            }
+            x => Poll::Ready(x),
+        }
+    }
+
+    fn poll_trailers(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        self.project().inner.poll_trailers(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+pub fn measure_request_body_size_layer<B1, B2, F>(
+    bytes_sent_counter: Arc<AtomicUsize>,
+    f: F,
+) -> MapRequestBodyLayer<impl Fn(B1) -> B2 + Clone>
+where
+    B1: HttpBody<Data = Bytes> + Unpin + Send + 'static,
+    <B1 as HttpBody>::Error: Send,
+    F: Fn(hyper::body::Body) -> B2 + Clone,
+{
+    MapRequestBodyLayer::new(move |mut body: B1| {
+        let (mut tx, new_body) = hyper::Body::channel();
+        let bytes_sent_counter = bytes_sent_counter.clone();
+        tokio::spawn(async move {
+            while let Some(Ok(chunk)) = body.data().await {
+                debug!("[SIZE MW] request body chunk size = {}", chunk.len());
+                let previous = bytes_sent_counter.fetch_add(chunk.len(), Ordering::Relaxed);
+                debug!("[SIZE MW] total count: {}", previous);
+                if let Err(err) = tx.send_data(chunk).await {
+                    warn!("[SIZE MW] error sending data: {}", err)
+                    // error can occurs if only channel is already closed
+                }
+            }
+
+            if let Ok(Some(trailers)) = body.trailers().await {
+                if let Err(err) = tx.send_trailers(trailers).await {
+                    warn!("[SIZE MW] error sending trailers: {}", err)
+                    // error can occurs if only channel is already closed
+                }
+            }
+        });
+        f(new_body)
+    })
+}


### PR DESCRIPTION
Introduced a new module `request_response_size_middlewares` to utils library to count the sizes of request and response bodies. Furthermore, added several dependencies to Cargo.toml and updated Cargo.lock necessary for new functionality. This includes libraries like 'hyper', 'tower', and 'pin-project-lite'. The new implementation will provide us with exact sizes of data transferred.