### PR TITLE
Remove File Descriptor init on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,6 +3081,7 @@ name = "kaspad"
 version = "0.13.0"
 dependencies = [
  "async-channel 2.0.0",
+ "cfg-if 1.0.0",
  "clap 4.4.7",
  "dhat",
  "dirs",

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -35,6 +35,7 @@ kaspa-utxoindex.workspace = true
 kaspa-wrpc-server.workspace = true
 
 async-channel.workspace = true
+cfg-if.workspace = true
 clap.workspace = true
 dhat = { workspace = true, optional = true }
 dirs.workspace = true

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -21,6 +21,7 @@ pub fn main() {
 
     let args = parse_args();
 
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     match fd_budget::try_set_fd_limit(DESIRED_DAEMON_SOFT_FD_LIMIT) {
         Ok(limit) => {
             if limit < MINIMUM_DAEMON_SOFT_FD_LIMIT {


### PR DESCRIPTION
It appears that instead of gracefully handling errors, on Windows `fdlimit` is causing a crash resulting in the daemon halting with `buffer overflow` error without any kind of a panic, even setting `RUST_BACKTRACE=1` is not helping.  With the help of `@Callidon` on Discord #development we narrowed it down to the changes in #333.  In this PR I've isolated the code to run on MacOS and Linux only (as me and @biryukovmaxim have tested it on these platforms manually).