### PR TITLE
Tighten up P2P relay and orphan management in order to perfect high-BPS block exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-bip32"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bs58",
  "faster-hex 0.6.1",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "bincode",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "cfg-if 1.0.0",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "faster-hex 0.6.1",
  "js-sys",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "duration-string",
  "futures",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cfg-if 1.0.0",
  "ctrlc",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-stream",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -2466,14 +2466,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-mining"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "futures-util",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "js-sys",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "bincode",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "secp256k1",
  "thiserror",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "async-trait",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cfg-if 1.0.0",
  "futures",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes",
  "argon2",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "js-sys",
  "kaspa-addresses",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3034,11 +3034,11 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-core"
-version = "0.13.0"
+version = "0.13.1"
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "clap 4.4.7",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3086,14 +3086,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "kaspa-wrpc-client",
 ]
 
 [[package]]
 name = "kaspad"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "clap 4.4.7",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "clap 4.4.7",
  "faster-hex 0.6.1",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel 2.0.0",
  "clap 4.4.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Kaspa developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -72,55 +72,55 @@ include = [
 ]
 
 [workspace.dependencies]
-# kaspa-testing-integration = { version = "0.13.0", path = "testing/integration" }
-kaspa-os = { version = "0.13.0", path = "kaspa-os" }
-kaspa-daemon = { version = "0.13.0", path = "daemon" }
-kaspa-addresses = { version = "0.13.0", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "0.13.0", path = "components/addressmanager" }
-kaspa-bip32 = { version = "0.13.0", path = "wallet/bip32" }
-kaspa-connectionmanager = { version = "0.13.0", path = "components/connectionmanager" }
-kaspa-consensus = { version = "0.13.0", path = "consensus" }
-kaspa-consensus-core = { version = "0.13.0", path = "consensus/core" }
-kaspa-consensus-notify = { version = "0.13.0", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "0.13.0", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "0.13.0", path = "components/consensusmanager" }
-kaspa-core = { version = "0.13.0", path = "core" }
-kaspa-database = { version = "0.13.0", path = "database" }
-kaspa-grpc-client = { version = "0.13.0", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "0.13.0", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "0.13.0", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "0.13.0", path = "crypto/hashes" }
-kaspa-index-core = { version = "0.13.0", path = "indexes/core" }
-kaspa-index-processor = { version = "0.13.0", path = "indexes/processor" }
-kaspa-math = { version = "0.13.0", path = "math" }
-kaspa-merkle = { version = "0.13.0", path = "crypto/merkle" }
-kaspa-mining = { version = "0.13.0", path = "mining" }
-kaspa-mining-errors = { version = "0.13.0", path = "mining/errors" }
-kaspa-muhash = { version = "0.13.0", path = "crypto/muhash" }
-kaspa-notify = { version = "0.13.0", path = "notify" }
-kaspa-p2p-flows = { version = "0.13.0", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "0.13.0", path = "protocol/p2p" }
-kaspa-pow = { version = "0.13.0", path = "consensus/pow" }
-kaspa-rpc-core = { version = "0.13.0", path = "rpc/core" }
-kaspa-rpc-macros = { version = "0.13.0", path = "rpc/macros" }
-kaspa-rpc-service = { version = "0.13.0", path = "rpc/service" }
-kaspa-txscript = { version = "0.13.0", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "0.13.0", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "0.13.0", path = "utils" }
-kaspa-utils-tower = { version = "0.13.0", path = "utils/tower" }
-kaspa-utxoindex = { version = "0.13.0", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "0.13.0", path = "wallet/native" }
-kaspa-cli = { version = "0.13.0", path = "cli" }
-kaspa-wallet-cli-wasm = { version = "0.13.0", path = "wallet/wasm" }
-kaspa-wallet-core = { version = "0.13.0", path = "wallet/core" }
-kaspa-wasm = { version = "0.13.0", path = "wasm" }
-kaspa-wrpc-core = { version = "0.13.0", path = "rpc/wrpc/core" }
-kaspa-wrpc-client = { version = "0.13.0", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "0.13.0", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "0.13.0", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "0.13.0", path = "rpc/wrpc/wasm" }
-kaspad = { version = "0.13.0", path = "kaspad" }
-kaspa-perf-monitor = { version = "0.13.0", path = "metrics/perf_monitor" }
+# kaspa-testing-integration = { version = "0.13.1", path = "testing/integration" }
+kaspa-os = { version = "0.13.1", path = "kaspa-os" }
+kaspa-daemon = { version = "0.13.1", path = "daemon" }
+kaspa-addresses = { version = "0.13.1", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "0.13.1", path = "components/addressmanager" }
+kaspa-bip32 = { version = "0.13.1", path = "wallet/bip32" }
+kaspa-connectionmanager = { version = "0.13.1", path = "components/connectionmanager" }
+kaspa-consensus = { version = "0.13.1", path = "consensus" }
+kaspa-consensus-core = { version = "0.13.1", path = "consensus/core" }
+kaspa-consensus-notify = { version = "0.13.1", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "0.13.1", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "0.13.1", path = "components/consensusmanager" }
+kaspa-core = { version = "0.13.1", path = "core" }
+kaspa-database = { version = "0.13.1", path = "database" }
+kaspa-grpc-client = { version = "0.13.1", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "0.13.1", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "0.13.1", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "0.13.1", path = "crypto/hashes" }
+kaspa-index-core = { version = "0.13.1", path = "indexes/core" }
+kaspa-index-processor = { version = "0.13.1", path = "indexes/processor" }
+kaspa-math = { version = "0.13.1", path = "math" }
+kaspa-merkle = { version = "0.13.1", path = "crypto/merkle" }
+kaspa-mining = { version = "0.13.1", path = "mining" }
+kaspa-mining-errors = { version = "0.13.1", path = "mining/errors" }
+kaspa-muhash = { version = "0.13.1", path = "crypto/muhash" }
+kaspa-notify = { version = "0.13.1", path = "notify" }
+kaspa-p2p-flows = { version = "0.13.1", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "0.13.1", path = "protocol/p2p" }
+kaspa-pow = { version = "0.13.1", path = "consensus/pow" }
+kaspa-rpc-core = { version = "0.13.1", path = "rpc/core" }
+kaspa-rpc-macros = { version = "0.13.1", path = "rpc/macros" }
+kaspa-rpc-service = { version = "0.13.1", path = "rpc/service" }
+kaspa-txscript = { version = "0.13.1", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "0.13.1", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "0.13.1", path = "utils" }
+kaspa-utils-tower = { version = "0.13.1", path = "utils/tower" }
+kaspa-utxoindex = { version = "0.13.1", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "0.13.1", path = "wallet/native" }
+kaspa-cli = { version = "0.13.1", path = "cli" }
+kaspa-wallet-cli-wasm = { version = "0.13.1", path = "wallet/wasm" }
+kaspa-wallet-core = { version = "0.13.1", path = "wallet/core" }
+kaspa-wasm = { version = "0.13.1", path = "wasm" }
+kaspa-wrpc-core = { version = "0.13.1", path = "rpc/wrpc/core" }
+kaspa-wrpc-client = { version = "0.13.1", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "0.13.1", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "0.13.1", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "0.13.1", path = "rpc/wrpc/wasm" }
+kaspad = { version = "0.13.1", path = "kaspad" }
+kaspa-perf-monitor = { version = "0.13.1", path = "metrics/perf_monitor" }
 
 # external
 aes = "0.8.3"

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -65,6 +65,7 @@ pub struct Args {
     pub prealloc_amount: u64,
 
     pub disable_upnp: bool,
+    pub disable_dns_seeding: bool,
 }
 
 impl Default for Args {
@@ -111,6 +112,7 @@ impl Default for Args {
             prealloc_amount: 1_000_000,
 
             disable_upnp: false,
+            disable_dns_seeding: false,
         }
     }
 }
@@ -317,7 +319,8 @@ pub fn cli() -> Command {
                 .value_parser(clap::value_parser!(u64))
                 .help("Interval in seconds for performance metrics collection."),
         )
-        .arg(arg!(--"disable-upnp" "Disable upnp"));
+        .arg(arg!(--"disable-upnp" "Disable upnp"))
+        .arg(arg!(--"nodnsseed" "Disable DNS seeding for peers"));
 
     #[cfg(feature = "devnet-prealloc")]
     let cmd = cmd
@@ -377,6 +380,7 @@ pub fn parse_args() -> Args {
         #[cfg(feature = "devnet-prealloc")]
         prealloc_amount: m.get_one::<u64>("prealloc-amount").cloned().unwrap_or(defaults.prealloc_amount),
         disable_upnp: m.get_one::<bool>("disable-upnp").cloned().unwrap_or(defaults.disable_upnp),
+        disable_dns_seeding: m.get_one::<bool>("nodnsseed").cloned().unwrap_or(defaults.disable_dns_seeding),
     }
 }
 

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -339,7 +339,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     let p2p_server_addr = args.listen.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_p2p_port());
     // connect_peers means no DNS seeding and no outbound peers
     let outbound_target = if connect_peers.is_empty() { args.outbound_target } else { 0 };
-    let dns_seeders = if connect_peers.is_empty() { config.dns_seeders } else { &[] };
+    let dns_seeders = if connect_peers.is_empty() && !args.disable_dns_seeding { config.dns_seeders } else { &[] };
 
     let grpc_server_addr = args.rpclisten.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_rpc_port());
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -363,7 +363,7 @@ impl FlowContext {
         unorphaned_blocks
     }
 
-    pub async fn revalidate_orphans(&self, consensus: &ConsensusProxy) {
+    pub async fn revalidate_orphans(&self, consensus: &ConsensusProxy) -> (Vec<Hash>, Vec<BlockValidationFuture>) {
         self.orphans_pool.write().await.revalidate_orphans(consensus).await
     }
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -202,10 +202,14 @@ impl BlockEventLogger {
                     (0, 0, 0) => {}
                     (1, 0, 0) => info!("Unorphaned block {}", summary.unorphan()),
                     (n, 0, 0) => info!("Unorphaned {} block(s) ...{}", n, summary.unorphan()),
+                    (0, m, 0) => info!("Orphaned {} block(s) ...{}", m, summary.orphan()),
                     (0, m, l) => info!("Orphaned {} block(s) ...{} and queued {} missing roots", m, summary.orphan(), l),
+                    (n, m, 0) => {
+                        info!("Unorphaned {} block(s) ...{}, orphaned {} block(s) ...{}", n, summary.unorphan(), m, summary.orphan(),)
+                    }
                     (n, m, l) => {
                         info!(
-                            "Unorphaned {} block(s) ...{},  orphaned {} block(s) ...{} and queued {} missing roots",
+                            "Unorphaned {} block(s) ...{}, orphaned {} block(s) ...{} and queued {} missing roots",
                             n,
                             summary.unorphan(),
                             m,

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -38,9 +38,9 @@ use kaspa_p2p_lib::{
 use kaspa_utils::iter::IterExtensions;
 use kaspa_utils::networking::PeerId;
 use parking_lot::{Mutex, RwLock};
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::time::Instant;
+use std::{collections::hash_map::Entry, fmt::Display};
 use std::{
     iter::once,
     ops::Deref,
@@ -69,26 +69,35 @@ const MAX_ORPHANS_UPPER_BOUND: usize = 1024;
 /// The min time to wait before allowing another parallel request
 const REQUEST_SCOPE_WAIT_TIME: Duration = Duration::from_secs(1);
 
+/// Represents a block event to be logged
 #[derive(Debug, PartialEq)]
-pub enum BlockSource {
-    Relay,
-    Submit,
+pub enum BlockLogEvent {
+    /// Accepted block via *relay*
+    Relay(Hash),
+    /// Accepted block via *submit block*
+    Submit(Hash),
+    /// Orphaned block with x missing roots
+    Orphaned(Hash, usize),
+    /// Detected a known orphan with x missing roots
+    OrphanRoots(Hash, usize),
+    /// Unorphaned x blocks with hash being a representative
+    Unorphaned(Hash, usize),
 }
 
-pub struct AcceptedBlockLogger {
+pub struct BlockEventLogger {
     bps: usize,
-    sender: UnboundedSender<(Hash, BlockSource)>,
-    receiver: Mutex<Option<UnboundedReceiver<(Hash, BlockSource)>>>,
+    sender: UnboundedSender<BlockLogEvent>,
+    receiver: Mutex<Option<UnboundedReceiver<BlockLogEvent>>>,
 }
 
-impl AcceptedBlockLogger {
+impl BlockEventLogger {
     pub fn new(bps: usize) -> Self {
         let (sender, receiver) = unbounded_channel();
         Self { bps, sender, receiver: Mutex::new(Some(receiver)) }
     }
 
-    pub fn log(&self, hash: Hash, source: BlockSource) {
-        self.sender.send((hash, source)).unwrap();
+    pub fn log(&self, event: BlockLogEvent) {
+        self.sender.send(event).unwrap();
     }
 
     /// Start the logger listener. Must be called from an async tokio context
@@ -99,21 +108,110 @@ impl AcceptedBlockLogger {
             let chunk_stream = UnboundedReceiverStream::new(receiver).chunks_timeout(chunk_limit, Duration::from_secs(1));
             tokio::pin!(chunk_stream);
             while let Some(chunk) = chunk_stream.next().await {
-                if let Some((i, h)) =
-                    chunk.iter().filter_map(|(h, s)| if *s == BlockSource::Submit { Some(*h) } else { None }).enumerate().last()
-                {
-                    let submit = i + 1; // i is the last index so i + 1 is the number of submit blocks
-                    let relay = chunk.len() - submit;
-                    match (submit, relay) {
-                        (1, 0) => info!("Accepted block {} via submit block", h),
-                        (n, 0) => info!("Accepted {} blocks ...{} via submit block", n, h),
-                        (n, m) => info!("Accepted {} blocks ...{}, {} via relay and {} via submit block", n + m, h, m, n),
+                #[derive(Default)]
+                struct LogSummary {
+                    // Representative
+                    relay_rep: Option<Hash>,
+                    submit_rep: Option<Hash>,
+                    orphan_rep: Option<Hash>,
+                    unorphan_rep: Option<Hash>,
+                    // Counts
+                    relay_count: usize,
+                    submit_count: usize,
+                    orphan_count: usize,
+                    unorphan_count: usize,
+                    orphan_roots_count: usize,
+                }
+
+                struct LogHash {
+                    op: Option<Hash>,
+                }
+
+                impl From<Option<Hash>> for LogHash {
+                    fn from(op: Option<Hash>) -> Self {
+                        Self { op }
                     }
-                } else {
-                    let h = chunk.last().expect("chunk is never empty").0;
-                    match chunk.len() {
-                        1 => info!("Accepted block {} via relay", h),
-                        n => info!("Accepted {} blocks ...{} via relay", n, h),
+                }
+
+                impl Display for LogHash {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        if let Some(hash) = self.op {
+                            hash.fmt(f)
+                        } else {
+                            Ok(())
+                        }
+                    }
+                }
+
+                impl LogSummary {
+                    fn relay(&self) -> LogHash {
+                        self.relay_rep.into()
+                    }
+
+                    fn submit(&self) -> LogHash {
+                        self.submit_rep.into()
+                    }
+
+                    fn orphan(&self) -> LogHash {
+                        self.orphan_rep.into()
+                    }
+
+                    fn unorphan(&self) -> LogHash {
+                        self.unorphan_rep.into()
+                    }
+                }
+
+                let summary = chunk.into_iter().fold(LogSummary::default(), |mut summary, ev| {
+                    match ev {
+                        BlockLogEvent::Relay(hash) => {
+                            summary.relay_count += 1;
+                            summary.relay_rep = Some(hash)
+                        }
+                        BlockLogEvent::Submit(hash) => {
+                            summary.submit_count += 1;
+                            summary.submit_rep = Some(hash)
+                        }
+                        BlockLogEvent::Orphaned(hash, roots_count) => {
+                            summary.orphan_roots_count += roots_count;
+                            summary.orphan_count += 1;
+                            summary.orphan_rep = Some(hash)
+                        }
+                        BlockLogEvent::OrphanRoots(_, roots_count) => {
+                            summary.orphan_roots_count += roots_count;
+                        }
+                        BlockLogEvent::Unorphaned(hash, count) => {
+                            summary.unorphan_count += count;
+                            summary.unorphan_rep = Some(hash)
+                        }
+                    }
+                    summary
+                });
+
+                match (summary.submit_count, summary.relay_count) {
+                    (0, 0) => {}
+                    (1, 0) => info!("Accepted block {} via submit block", summary.submit()),
+                    (n, 0) => info!("Accepted {} blocks ...{} via submit block", n, summary.submit()),
+                    (0, 1) => info!("Accepted block {} via relay", summary.relay()),
+                    (0, m) => info!("Accepted {} blocks ...{} via relay", m, summary.relay()),
+                    (n, m) => {
+                        info!("Accepted {} blocks ...{}, {} via relay and {} via submit block", n + m, summary.submit(), m, n)
+                    }
+                }
+
+                match (summary.unorphan_count, summary.orphan_count, summary.orphan_roots_count) {
+                    (0, 0, 0) => {}
+                    (1, 0, 0) => info!("Unorphaned block {}", summary.unorphan()),
+                    (n, 0, 0) => info!("Unorphaned {} block(s) ...{}", n, summary.unorphan()),
+                    (0, m, l) => info!("Orphaned {} block(s) ...{} and queued {} missing roots", m, summary.orphan(), l),
+                    (n, m, l) => {
+                        info!(
+                            "Unorphaned {} block(s) ...{},  orphaned {} block(s) ...{} and queued {} missing roots",
+                            n,
+                            summary.unorphan(),
+                            m,
+                            summary.orphan(),
+                            l
+                        )
                     }
                 }
             }
@@ -139,7 +237,7 @@ pub struct FlowContextInner {
     notification_root: Arc<ConsensusNotificationRoot>,
 
     // Special sampling logger used only for high-bps networks where logs must be throttled
-    accepted_block_logger: Option<AcceptedBlockLogger>,
+    block_event_logger: Option<BlockEventLogger>,
 
     // Orphan parameters
     orphan_resolution_range: u32,
@@ -240,7 +338,7 @@ impl FlowContext {
                 mining_manager,
                 tick_service,
                 notification_root,
-                accepted_block_logger: if config.bps() > 1 { Some(AcceptedBlockLogger::new(config.bps() as usize)) } else { None },
+                block_event_logger: if config.bps() > 1 { Some(BlockEventLogger::new(config.bps() as usize)) } else { None },
                 orphan_resolution_range,
                 max_orphans,
                 config,
@@ -261,7 +359,7 @@ impl FlowContext {
     }
 
     pub fn start_async_services(&self) {
-        if let Some(logger) = self.accepted_block_logger.as_ref() {
+        if let Some(logger) = self.block_event_logger.as_ref() {
             logger.start();
         }
     }
@@ -352,11 +450,7 @@ impl FlowContext {
     }
 
     pub async fn add_orphan(&self, consensus: &ConsensusProxy, orphan_block: Block) -> Option<OrphanOutput> {
-        if self.is_log_throttled() {
-            debug!("Received a block with missing parents, adding to orphan pool: {}", orphan_block.hash());
-        } else {
-            info!("Received a block with missing parents, adding to orphan pool: {}", orphan_block.hash());
-        }
+        self.log_block_event(BlockLogEvent::Orphaned(orphan_block.hash(), 0));
         self.orphans_pool.write().await.add_orphan(consensus, orphan_block).await
     }
 
@@ -380,13 +474,17 @@ impl FlowContext {
                 Err(e) => warn!("Validation failed for orphan block {}: {}", block.hash(), e),
             }
         }
-        match unorphaned_blocks.len() {
-            0 => {}
-            1 => info!("Unorphaned block {}", unorphaned_blocks[0].0.hash()),
-            n => match self.is_log_throttled() {
-                true => info!("Unorphaned {} blocks ...{}", n, unorphaned_blocks.last().unwrap().0.hash()),
-                false => info!("Unorphaned {} blocks: {}", n, unorphaned_blocks.iter().map(|b| b.0.hash()).reusable_format(", ")),
-            },
+
+        // Log or send to event logger
+        if !unorphaned_blocks.is_empty() {
+            if let Some(logger) = self.block_event_logger.as_ref() {
+                logger.log(BlockLogEvent::Unorphaned(unorphaned_blocks[0].0.hash(), unorphaned_blocks.len()));
+            } else {
+                match unorphaned_blocks.len() {
+                    1 => info!("Unorphaned block {}", unorphaned_blocks[0].0.hash()),
+                    n => info!("Unorphaned {} blocks: {}", n, unorphaned_blocks.iter().map(|b| b.0.hash()).reusable_format(", ")),
+                }
+            }
         }
         unorphaned_blocks
     }
@@ -410,24 +508,27 @@ impl FlowContext {
         self.hub.broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(hash.into()) })).await;
 
         self.on_new_block(consensus, block, virtual_state_task).await;
-        self.log_block_acceptance(hash, BlockSource::Submit);
+        self.log_block_event(BlockLogEvent::Submit(hash));
 
         Ok(())
     }
 
-    pub fn log_block_acceptance(&self, hash: Hash, source: BlockSource) {
-        if let Some(logger) = self.accepted_block_logger.as_ref() {
-            logger.log(hash, source)
+    pub fn log_block_event(&self, event: BlockLogEvent) {
+        if let Some(logger) = self.block_event_logger.as_ref() {
+            logger.log(event)
         } else {
-            match source {
-                BlockSource::Relay => info!("Accepted block {} via relay", hash),
-                BlockSource::Submit => info!("Accepted block {} via submit block", hash),
+            match event {
+                BlockLogEvent::Relay(hash) => info!("Accepted block {} via relay", hash),
+                BlockLogEvent::Submit(hash) => info!("Accepted block {} via submit block", hash),
+                BlockLogEvent::Orphaned(orphan, _) => {
+                    info!("Received a block with missing parents, adding to orphan pool: {}", orphan)
+                }
+                BlockLogEvent::OrphanRoots(orphan, roots_count) => {
+                    info!("Block {} has {} missing ancestors. Adding them to the invs queue...", orphan, roots_count)
+                }
+                _ => {}
             }
         }
-    }
-
-    pub fn is_log_throttled(&self) -> bool {
-        self.accepted_block_logger.is_some()
     }
 
     /// Updates the mempool after a new block arrival, relays newly unorphaned transactions

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -1,5 +1,5 @@
 use crate::flowcontext::{
-    orphans::{OrphanBlocksPool, OrphanRootsOutput},
+    orphans::{OrphanBlocksPool, OrphanOutput},
     process_queue::ProcessQueue,
     transactions::TransactionsSpread,
 };
@@ -327,7 +327,7 @@ impl FlowContext {
         Self::try_adding_request_impl(req, &self.shared_transaction_requests)
     }
 
-    pub async fn add_orphan(&self, consensus: &ConsensusProxy, orphan_block: Block) -> Option<OrphanRootsOutput> {
+    pub async fn add_orphan(&self, consensus: &ConsensusProxy, orphan_block: Block) -> Option<OrphanOutput> {
         if self.is_log_throttled() {
             debug!("Received a block with missing parents, adding to orphan pool: {}", orphan_block.hash());
         } else {
@@ -340,7 +340,7 @@ impl FlowContext {
         self.orphans_pool.read().await.is_known_orphan(hash)
     }
 
-    pub async fn get_orphan_roots_if_known(&self, consensus: &ConsensusProxy, orphan: Hash) -> OrphanRootsOutput {
+    pub async fn get_orphan_roots_if_known(&self, consensus: &ConsensusProxy, orphan: Hash) -> OrphanOutput {
         self.orphans_pool.read().await.get_orphan_roots_if_known(consensus, orphan).await
     }
 

--- a/protocol/flows/src/flowcontext/orphans.rs
+++ b/protocol/flows/src/flowcontext/orphans.rs
@@ -237,6 +237,8 @@ mod tests {
         let d = Block::from_precomputed_hash(11.into(), vec![10.into()]);
         let e = Block::from_precomputed_hash(12.into(), vec![10.into()]);
         let f = Block::from_precomputed_hash(13.into(), vec![12.into()]);
+        let g = Block::from_precomputed_hash(14.into(), vec![13.into()]);
+        let h = Block::from_precomputed_hash(15.into(), vec![14.into()]);
 
         pool.add_orphan(c.clone());
         pool.add_orphan(d.clone());
@@ -256,10 +258,15 @@ mod tests {
         pool.add_orphan(d.clone());
         pool.add_orphan(e.clone());
         pool.add_orphan(f.clone());
-        assert_eq!(pool.orphans.len(), 3);
+        pool.add_orphan(h.clone());
+        assert_eq!(pool.orphans.len(), 4);
+        pool.revalidate_orphans(&consensus).await;
+        assert_eq!(pool.orphans.len(), 1);
+        assert!(pool.orphans.contains_key(&h.hash())); // h's parent, g, was never inserted to the pool
+        pool.add_orphan(g.clone());
         pool.revalidate_orphans(&consensus).await;
         assert!(pool.orphans.is_empty());
 
-        drop((a, b, c, d, e, f));
+        drop((a, b, c, d, e, f, g, h));
     }
 }

--- a/protocol/flows/src/flowcontext/orphans.rs
+++ b/protocol/flows/src/flowcontext/orphans.rs
@@ -174,19 +174,19 @@ impl OrphanBlocksPool {
         }
 
         // Now process the roots and unorphan their descendents
-        let mut tasks = Vec::with_capacity(roots.len());
-        let mut hashes = Vec::with_capacity(roots.len());
+        let mut virtual_processing_tasks = Vec::with_capacity(roots.len());
+        let mut queued_hashes = Vec::with_capacity(roots.len());
         for root in roots {
             let root_hash = root.hash();
             let BlockValidationFutures { block_task: _, virtual_state_task: root_task } = consensus.validate_and_insert_block(root);
-            tasks.push(root_task);
-            hashes.push(root_hash);
+            virtual_processing_tasks.push(root_task);
+            queued_hashes.push(root_hash);
             let (unorphan_blocks, _, unorphan_tasks) = self.unorphan_blocks(consensus, root_hash).await;
-            tasks.extend(unorphan_tasks);
-            hashes.extend(unorphan_blocks.into_iter().map(|b| b.hash()));
+            virtual_processing_tasks.extend(unorphan_tasks);
+            queued_hashes.extend(unorphan_blocks.into_iter().map(|b| b.hash()));
         }
 
-        (hashes, tasks)
+        (queued_hashes, virtual_processing_tasks)
     }
 }
 

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -1,7 +1,7 @@
 use crate::{
     flow_context::{BlockSource, FlowContext, RequestScope},
     flow_trait::Flow,
-    flowcontext::orphans::OrphanRootsOutput,
+    flowcontext::orphans::OrphanOutput,
 };
 use kaspa_consensus_core::{api::BlockValidationFutures, block::Block, blockstatus::BlockStatus, errors::block::RuleError};
 use kaspa_consensusmanager::ConsensusProxy;
@@ -100,9 +100,9 @@ impl HandleRelayInvsFlow {
             }
 
             match self.ctx.get_orphan_roots_if_known(&session, inv.hash).await {
-                OrphanRootsOutput::Unknown => {}                                       // Keep processing this inv
-                OrphanRootsOutput::NoRoots | OrphanRootsOutput::NotOrphan => continue, // Existing orphan w/o roots
-                OrphanRootsOutput::Roots(roots) => {
+                OrphanOutput::Unknown => {}                                  // Keep processing this inv
+                OrphanOutput::NoRoots | OrphanOutput::NotOrphan => continue, // Existing orphan w/o roots
+                OrphanOutput::Roots(roots) => {
                     // Known orphan with roots to enqueue
                     self.enqueue_orphan_roots(inv.hash, roots);
                     continue;
@@ -241,9 +241,9 @@ impl HandleRelayInvsFlow {
                 // There is a sync gap between consensus and the orphan pool, meaning that consensus might have indicated
                 // that this block is orphan, but by the time it got to the orphan pool we discovered it is no longer so.
                 // We signal this to the caller by returning false, triggering a consensus processing retry
-                Some(OrphanRootsOutput::NotOrphan) => return Ok(false),
-                Some(OrphanRootsOutput::Roots(roots)) => self.enqueue_orphan_roots(hash, roots),
-                None | Some(OrphanRootsOutput::Unknown | OrphanRootsOutput::NoRoots) => {}
+                Some(OrphanOutput::NotOrphan) => return Ok(false),
+                Some(OrphanOutput::Roots(roots)) => self.enqueue_orphan_roots(hash, roots),
+                None | Some(OrphanOutput::Unknown | OrphanOutput::NoRoots) => {}
             }
         } else {
             // Send the block to IBD flow via the dedicated job channel. If the channel has a pending job, we prefer

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -283,7 +283,7 @@ impl HandleRelayInvsFlow {
     /// By checking whether the current orphan DAA score is within the range (R - M/10, R + M/2)** we make sure that in this
     /// case we keep ~M/2 blocks in the orphan pool which are all unorphaned when IBD completes (see revalidate_orphans),
     /// and the node reaches full sync state asap. We use M/10 for the lower bound since we only want to cover anticone(R)
-    /// in that region (which is expectedly small), whereas the M/2 upper bound is for covering the most recent segment in
+    /// in that region (which is expectedly small), whereas the M/2 upper bound is for covering the most early segment in
     /// future(R). Overall we avoid keeping more than ~M/2 in order to not enter the area where blocks start getting evicted
     /// from the orphan pool.
     ///

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -320,7 +320,9 @@ impl HandleRelayInvsFlow {
         // with current syncer-side implementations (in both go-kaspa and this codebase) we could query only the last one,
         // but we prefer not relying on such details for correctness
         //
-        // TODO: change syncer-side to only send the most early block since it's sufficient for our needs
+        // The current syncer-side implementation sends a full locator even though it suffices to only send the
+        // most early block. We keep it this way in order to allow future syncee-side implementations to do more
+        // with the full incremental info and because it is only a small set of hashes.
         for h in locator_hashes.into_iter().rev() {
             if consensus.async_get_block_status(h).await.is_some_and(|s| s.has_block_body()) {
                 return Ok(true);

--- a/protocol/flows/src/v5/blockrelay/flow.rs
+++ b/protocol/flows/src/v5/blockrelay/flow.rs
@@ -223,8 +223,8 @@ impl HandleRelayInvsFlow {
         }
     }
 
-    /// Process the orphan block. Returns a boolean indicating whether the block is
-    /// actually an orphan. If the block has no missing roots the function returns `false`.
+    /// Process the orphan block. Returns `false` if the block has no missing roots, indicating
+    /// a retry is recommended
     async fn process_orphan(
         &mut self,
         consensus: &ConsensusProxy,

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -5,7 +5,7 @@ use crate::{
         Flow,
     },
 };
-use futures::future::try_join_all;
+use futures::future::{join_all, try_join_all};
 use kaspa_consensus_core::{
     api::BlockValidationFuture,
     block::Block,
@@ -132,7 +132,20 @@ impl IbdFlow {
         self.sync_missing_block_bodies(&session, relay_block.hash()).await?;
 
         // Following IBD we revalidate orphans since many of them might have been processed during the IBD
-        self.ctx.revalidate_orphans(&session).await;
+        // or are now processable
+        let (hashes, tasks) = self.ctx.revalidate_orphans(&session).await;
+        let mut unorphaned_hashes = Vec::with_capacity(hashes.len());
+        let results = join_all(tasks).await;
+        for (hash, result) in hashes.into_iter().zip(results) {
+            match result {
+                Ok(_) => unorphaned_hashes.push(hash),
+                Err(e) => warn!("Validation failed for orphan block {}: {}", hash, e),
+            }
+        }
+        match unorphaned_hashes.len() {
+            0 => {}
+            n => info!("IBD post processing: unorphaned {} blocks ...{}", n, unorphaned_hashes.last().unwrap()),
+        }
 
         Ok(())
     }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -71,7 +71,7 @@ impl IbdFlow {
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
         while let Ok(relay_block) = self.relay_receiver.recv().await {
-            if let Some(_guard) = self.ctx.try_set_ibd_running(self.router.key()) {
+            if let Some(_guard) = self.ctx.try_set_ibd_running(self.router.key(), relay_block.header.daa_score) {
                 info!("IBD started with peer {}", self.router);
 
                 match self.ibd(relay_block).await {


### PR DESCRIPTION
Includes 3 major components which can be reviewed separately:

1. Complete a full "revalidate orphans" algorithm including unorphaning (to be run post IBD)
2. Close the sync gap between consensus and the block orphan pool leading to stuck orphans
3. Add an IBD-related heuristic for deciding if to keep orphans  

The end result tested via an internal TN11 testnet shows that with all the above, on-going P2P block exchange is smooth also on a 10BPS network and between peers with RTT > block time (=100ms) 