### PR TITLE
Move to mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,16 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
-dependencies = [
- "quote",
- "syn 2.0.41",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,7 +2860,6 @@ dependencies = [
  "bincode",
  "criterion",
  "crossbeam-channel",
- "ctor",
  "faster-hex 0.6.1",
  "flate2",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,6 +3236,7 @@ dependencies = [
  "kaspa-utxoindex",
  "kaspa-wrpc-server",
  "log",
+ "mimalloc",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -3296,6 +3297,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libredox"
@@ -3525,6 +3536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
+dependencies = [
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2093,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaspa-alloc"
+version = "0.13.1"
+dependencies = [
+ "mimalloc",
+]
+
+[[package]]
 name = "kaspa-bip32"
 version = "0.13.1"
 dependencies = [
@@ -2853,12 +2870,14 @@ dependencies = [
  "bincode",
  "criterion",
  "crossbeam-channel",
+ "ctor",
  "faster-hex 0.6.1",
  "flate2",
  "futures-util",
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "kaspa-addresses",
+ "kaspa-alloc",
  "kaspa-bip32",
  "kaspa-consensus",
  "kaspa-consensus-core",
@@ -3216,6 +3235,7 @@ dependencies = [
  "futures-util",
  "kaspa-addresses",
  "kaspa-addressmanager",
+ "kaspa-alloc",
  "kaspa-consensus",
  "kaspa-consensus-core",
  "kaspa-consensus-notify",
@@ -3236,7 +3256,6 @@ dependencies = [
  "kaspa-utxoindex",
  "kaspa-wrpc-server",
  "log",
- "mimalloc",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -4838,6 +4857,7 @@ dependencies = [
  "futures-util",
  "indexmap 2.1.0",
  "itertools 0.11.0",
+ "kaspa-alloc",
  "kaspa-consensus",
  "kaspa-consensus-core",
  "kaspa-consensus-notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "rothschild",
     "metrics/perf_monitor",
     "metrics/core",
+    "utils/alloc",
 ]
 
 [workspace.package]
@@ -73,7 +74,9 @@ include = [
 ]
 
 [workspace.dependencies]
-mimalloc = { version = "*", default-features = false, features = ['override'] }
+mimalloc = { version = "0.1.39", default-features = false, features = [
+    'override',
+] }
 # kaspa-testing-integration = { version = "0.13.1", path = "testing/integration" }
 kaspa-addresses = { version = "0.13.1", path = "crypto/addresses" }
 kaspa-addressmanager = { version = "0.13.1", path = "components/addressmanager" }
@@ -125,6 +128,8 @@ kaspa-wrpc-proxy = { version = "0.13.1", path = "rpc/wrpc/proxy" }
 kaspa-wrpc-server = { version = "0.13.1", path = "rpc/wrpc/server" }
 kaspa-wrpc-wasm = { version = "0.13.1", path = "rpc/wrpc/wasm" }
 kaspad = { version = "0.13.1", path = "kaspad" }
+kaspa-alloc = { version = "0.13.1", path = "utils/alloc" }
+
 
 # external
 aes = "0.8.3"
@@ -163,7 +168,9 @@ faster-hex = "0.6.1" # TODO "0.8.1" - fails unit tests
 fixedstr = { version = "0.5.4", features = ["serde"] }
 flate2 = "1.0.28"
 futures = { version = "0.3.29" }
-futures-util = { version = "0.3.29", default-features = false, features = [ "alloc", ] }
+futures-util = { version = "0.3.29", default-features = false, features = [
+    "alloc",
+] }
 getrandom = { version = "0.2.10", features = ["js"] }
 h2 = "0.3.21"
 heapless = "0.7.16"
@@ -238,7 +245,10 @@ web-sys = "=0.3.64"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 pin-project-lite = "0.2.13"
-tower-http = { version = "0.4.4", features = ["map-response-body", "map-request-body"] }
+tower-http = { version = "0.4.4", features = [
+    "map-response-body",
+    "map-request-body",
+] }
 tower = "0.4.7"
 hyper = "0.14.27"
 # workflow dependencies that are not a part of core libraries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ include = [
 ]
 
 [workspace.dependencies]
+mimalloc = { version = "*", default-features = false, features = ['override'] }
 # kaspa-testing-integration = { version = "0.13.1", path = "testing/integration" }
 kaspa-addresses = { version = "0.13.1", path = "crypto/addresses" }
 kaspa-addressmanager = { version = "0.13.1", path = "components/addressmanager" }

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -13,7 +13,7 @@ name = "kaspad_lib"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-mimalloc.workspace = true
+kaspa-alloc.workspace = true
 
 kaspa-addresses.workspace = true
 kaspa-addressmanager.workspace = true

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -52,5 +52,5 @@ tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
 workflow-log.workspace = true
 
 [features]
-heap = ["dhat"]
+heap = ["dhat", "kaspa-alloc/heap"]
 devnet-prealloc = ["kaspa-consensus/devnet-prealloc"]

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -13,7 +13,7 @@ name = "kaspad_lib"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-kaspa-alloc.workspace = true
+kaspa-alloc.workspace = true # This changes the global allocator for all of the next dependencies so should be kept first
 
 kaspa-addresses.workspace = true
 kaspa-addressmanager.workspace = true

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -13,6 +13,8 @@ name = "kaspad_lib"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+mimalloc.workspace = true
+
 kaspa-addresses.workspace = true
 kaspa-addressmanager.workspace = true
 kaspa-consensus-core.workspace = true

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -4,6 +4,7 @@ extern crate kaspa_hashes;
 
 use std::sync::Arc;
 
+use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_core::{info, signals::Signals};
 use kaspa_utils::fd_budget;
 use kaspad_lib::{
@@ -11,68 +12,15 @@ use kaspad_lib::{
     daemon::{create_core, DESIRED_DAEMON_SOFT_FD_LIMIT, MINIMUM_DAEMON_SOFT_FD_LIMIT},
 };
 
-#[cfg(not(feature = "heap"))]
-#[cfg(unix)]
-extern "C" {
-    fn mi_option_set_enabled(_: mi_option_e, val: bool);
-}
-
-#[cfg(not(feature = "heap"))]
-#[cfg(unix)]
-#[allow(non_camel_case_types)]
-#[allow(dead_code)]
-#[repr(C)]
-enum mi_option_e {
-    // stable options
-    mi_option_show_errors, // print error messages
-    mi_option_show_stats,  // print statistics on termination
-    mi_option_verbose,     // print verbose messages
-    // the following options are experimental (see src/options.h)
-    mi_option_eager_commit,             // eager commit segments? (after `eager_commit_delay` segments) (=1)
-    mi_option_arena_eager_commit,       // eager commit arenas? Use 2 to enable just on overcommit systems (=2)
-    mi_option_purge_decommits,          // should a memory purge decommit (or only reset) (=1)
-    mi_option_allow_large_os_pages,     // allow large (2MiB) OS pages, implies eager commit
-    mi_option_reserve_huge_os_pages,    // reserve N huge OS pages (1GiB/page) at startup
-    mi_option_reserve_huge_os_pages_at, // reserve huge OS pages at a specific NUMA node
-    mi_option_reserve_os_memory,        // reserve specified amount of OS memory in an arena at startup
-    mi_option_deprecated_segment_cache,
-    mi_option_deprecated_page_reset,
-    mi_option_abandoned_page_purge, // immediately purge delayed purges on thread termination
-    mi_option_deprecated_segment_reset,
-    mi_option_eager_commit_delay,
-    mi_option_purge_delay, // memory purging is delayed by N milli seconds; use 0 for immediate purging or -1 for no purging at all.
-    mi_option_use_numa_nodes, // 0 = use all available numa nodes, otherwise use at most N nodes.
-    mi_option_limit_os_alloc, // 1 = do not use OS memory for allocation (but only programmatically reserved arenas)
-    mi_option_os_tag,      // tag used for OS logging (macOS only for now)
-    mi_option_max_errors,  // issue at most N error messages
-    mi_option_max_warnings, // issue at most N warning messages
-    mi_option_max_segment_reclaim,
-    mi_option_destroy_on_exit, // if set, release all memory on exit; sometimes used for dynamic unloading but can be unsafe.
-    mi_option_arena_reserve,   // initial memory size in KiB for arena reservation (1GiB on 64-bit)
-    mi_option_arena_purge_mult,
-    mi_option_purge_extend_delay,
-    _mi_option_last,
-}
-
 #[cfg(feature = "heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
-
-#[cfg(not(feature = "heap"))]
-use mimalloc::MiMalloc;
-#[cfg(not(feature = "heap"))]
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn main() {
     #[cfg(feature = "heap")]
     let _profiler = dhat::Profiler::builder().file_name("kaspad-heap.json").build();
 
-    #[cfg(unix)]
-    #[cfg(not(feature = "heap"))]
-    unsafe {
-        mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)
-    };
+    init_allocator_with_default_settings();
 
     let args = parse_args();
 

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -15,6 +15,12 @@ use kaspad_lib::{
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
+#[cfg(not(feature = "heap"))]
+use mimalloc::MiMalloc;
+#[cfg(not(feature = "heap"))]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 pub fn main() {
     #[cfg(feature = "heap")]
     let _profiler = dhat::Profiler::builder().file_name("kaspad-heap.json").build();

--- a/kaspad/src/main.rs
+++ b/kaspad/src/main.rs
@@ -11,6 +11,49 @@ use kaspad_lib::{
     daemon::{create_core, DESIRED_DAEMON_SOFT_FD_LIMIT, MINIMUM_DAEMON_SOFT_FD_LIMIT},
 };
 
+#[cfg(not(feature = "heap"))]
+#[cfg(unix)]
+extern "C" {
+    fn mi_option_set_enabled(_: mi_option_e, val: bool);
+}
+
+#[cfg(not(feature = "heap"))]
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+#[repr(C)]
+enum mi_option_e {
+    // stable options
+    mi_option_show_errors, // print error messages
+    mi_option_show_stats,  // print statistics on termination
+    mi_option_verbose,     // print verbose messages
+    // the following options are experimental (see src/options.h)
+    mi_option_eager_commit,             // eager commit segments? (after `eager_commit_delay` segments) (=1)
+    mi_option_arena_eager_commit,       // eager commit arenas? Use 2 to enable just on overcommit systems (=2)
+    mi_option_purge_decommits,          // should a memory purge decommit (or only reset) (=1)
+    mi_option_allow_large_os_pages,     // allow large (2MiB) OS pages, implies eager commit
+    mi_option_reserve_huge_os_pages,    // reserve N huge OS pages (1GiB/page) at startup
+    mi_option_reserve_huge_os_pages_at, // reserve huge OS pages at a specific NUMA node
+    mi_option_reserve_os_memory,        // reserve specified amount of OS memory in an arena at startup
+    mi_option_deprecated_segment_cache,
+    mi_option_deprecated_page_reset,
+    mi_option_abandoned_page_purge, // immediately purge delayed purges on thread termination
+    mi_option_deprecated_segment_reset,
+    mi_option_eager_commit_delay,
+    mi_option_purge_delay, // memory purging is delayed by N milli seconds; use 0 for immediate purging or -1 for no purging at all.
+    mi_option_use_numa_nodes, // 0 = use all available numa nodes, otherwise use at most N nodes.
+    mi_option_limit_os_alloc, // 1 = do not use OS memory for allocation (but only programmatically reserved arenas)
+    mi_option_os_tag,      // tag used for OS logging (macOS only for now)
+    mi_option_max_errors,  // issue at most N error messages
+    mi_option_max_warnings, // issue at most N warning messages
+    mi_option_max_segment_reclaim,
+    mi_option_destroy_on_exit, // if set, release all memory on exit; sometimes used for dynamic unloading but can be unsafe.
+    mi_option_arena_reserve,   // initial memory size in KiB for arena reservation (1GiB on 64-bit)
+    mi_option_arena_purge_mult,
+    mi_option_purge_extend_delay,
+    _mi_option_last,
+}
+
 #[cfg(feature = "heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
@@ -24,6 +67,12 @@ static GLOBAL: MiMalloc = MiMalloc;
 pub fn main() {
     #[cfg(feature = "heap")]
     let _profiler = dhat::Profiler::builder().file_name("kaspad-heap.json").build();
+
+    #[cfg(unix)]
+    #[cfg(not(feature = "heap"))]
+    unsafe {
+        mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)
+    };
 
     let args = parse_args();
 

--- a/simpa/Cargo.toml
+++ b/simpa/Cargo.toml
@@ -9,7 +9,7 @@ include.workspace = true
 license.workspace = true
 
 [dependencies]
-kaspa-alloc.workspace = true
+kaspa-alloc.workspace = true            # This changes the global allocator for all of the next dependencies so should be kept first 
 kaspa-consensus-core.workspace = true
 kaspa-consensus-notify.workspace = true
 kaspa-consensus.workspace = true

--- a/simpa/Cargo.toml
+++ b/simpa/Cargo.toml
@@ -9,6 +9,7 @@ include.workspace = true
 license.workspace = true
 
 [dependencies]
+kaspa-alloc.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-consensus-notify.workspace = true
 kaspa-consensus.workspace = true
@@ -20,7 +21,7 @@ kaspa-utils.workspace = true
 
 async-channel.workspace = true
 clap.workspace = true
-dhat = {workspace = true, optional = true}
+dhat = { workspace = true, optional = true }
 futures-util.workspace = true
 futures.workspace = true
 indexmap.workspace = true

--- a/simpa/Cargo.toml
+++ b/simpa/Cargo.toml
@@ -35,4 +35,4 @@ secp256k1.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
 
 [features]
-heap = ["dhat"]
+heap = ["dhat", "kaspa-alloc/heap"]

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -2,6 +2,7 @@ use async_channel::unbounded;
 use clap::Parser;
 use futures::{future::try_join_all, Future};
 use itertools::Itertools;
+use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_consensus::{
     config::ConfigBuilder,
     consensus::Consensus,
@@ -117,6 +118,8 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 fn main() {
     #[cfg(feature = "heap")]
     let _profiler = dhat::Profiler::builder().file_name("simpa-heap.json").build();
+
+    init_allocator_with_default_settings();
 
     // Get CLI arguments
     let args = Args::parse();

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,7 +8,7 @@ include.workspace = true
 license.workspace = true
 
 [dependencies]
-kaspa-alloc.workspace = true
+kaspa-alloc.workspace = true            # This changes the global allocator for all of the next dependencies so should be kept first
 kaspa-addresses.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-consensus-notify.workspace = true

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -54,7 +54,6 @@ smallvec.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-ctor = "0.2.6"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -8,6 +8,7 @@ include.workspace = true
 license.workspace = true
 
 [dependencies]
+kaspa-alloc.workspace = true
 kaspa-addresses.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-consensus-notify.workspace = true
@@ -53,6 +54,7 @@ smallvec.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+ctor = "0.2.6"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -3,6 +3,7 @@
 //!
 
 use async_channel::unbounded;
+use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_consensus::config::genesis::GENESIS;
 use kaspa_consensus::config::{Config, ConfigBuilder};
 use kaspa_consensus::consensus::factory::Factory as ConsensusFactory;
@@ -173,16 +174,19 @@ fn reachability_stretch_test(use_attack_json: bool) {
 
 #[test]
 fn test_attack_json() {
+    init_allocator_with_default_settings();
     reachability_stretch_test(true);
 }
 
 #[test]
 fn test_noattack_json() {
+    init_allocator_with_default_settings();
     reachability_stretch_test(false);
 }
 
 #[tokio::test]
 async fn consensus_sanity_test() {
+    init_allocator_with_default_settings();
     let genesis_child: Hash = 2.into();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
     let consensus = TestConsensus::new(&config);
@@ -232,6 +236,7 @@ struct GhostdagTestBlock {
 
 #[tokio::test]
 async fn ghostdag_test() {
+    init_allocator_with_default_settings();
     let mut path_strings: Vec<String> =
         common::read_dir("testdata/dags").map(|f| f.unwrap().path().to_str().unwrap().to_owned()).collect();
     path_strings.sort();
@@ -316,6 +321,7 @@ fn strings_to_hashes(strings: &Vec<String>) -> Vec<Hash> {
 
 #[tokio::test]
 async fn block_window_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS)
         .skip_proof_of_work()
         .edit_consensus_params(|p| {
@@ -385,6 +391,7 @@ async fn block_window_test() {
 
 #[tokio::test]
 async fn header_in_isolation_validation_test() {
+    init_allocator_with_default_settings();
     let config = Config::new(MAINNET_PARAMS);
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -453,6 +460,7 @@ async fn header_in_isolation_validation_test() {
 
 #[tokio::test]
 async fn incest_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -481,6 +489,7 @@ async fn incest_test() {
 
 #[tokio::test]
 async fn missing_parents_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -505,6 +514,7 @@ async fn missing_parents_test() {
 // as a known invalid.
 #[tokio::test]
 async fn known_invalid_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -530,6 +540,7 @@ async fn known_invalid_test() {
 
 #[tokio::test]
 async fn median_time_test() {
+    init_allocator_with_default_settings();
     struct Test {
         name: &'static str,
         config: Config,
@@ -603,6 +614,7 @@ async fn median_time_test() {
 
 #[tokio::test]
 async fn mergeset_size_limit_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -828,32 +840,38 @@ impl KaspadGoParams {
 
 #[tokio::test]
 async fn goref_custom_pruning_depth_test() {
+    init_allocator_with_default_settings();
     json_test("testdata/dags_for_json_tests/goref_custom_pruning_depth", false).await
 }
 
 #[tokio::test]
 async fn goref_notx_test() {
+    init_allocator_with_default_settings();
     json_test("testdata/dags_for_json_tests/goref-notx-5000-blocks", false).await
 }
 
 #[tokio::test]
 async fn goref_notx_concurrent_test() {
+    init_allocator_with_default_settings();
     json_test("testdata/dags_for_json_tests/goref-notx-5000-blocks", true).await
 }
 
 #[tokio::test]
 async fn goref_tx_small_test() {
+    init_allocator_with_default_settings();
     json_test("testdata/dags_for_json_tests/goref-905-tx-265-blocks", false).await
 }
 
 #[tokio::test]
 async fn goref_tx_small_concurrent_test() {
+    init_allocator_with_default_settings();
     json_test("testdata/dags_for_json_tests/goref-905-tx-265-blocks", true).await
 }
 
 #[ignore]
 #[tokio::test]
 async fn goref_tx_big_test() {
+    init_allocator_with_default_settings();
     // TODO: add this directory to a data repo and fetch dynamically
     json_test("testdata/dags_for_json_tests/goref-1.6M-tx-10K-blocks", false).await
 }
@@ -861,6 +879,7 @@ async fn goref_tx_big_test() {
 #[ignore]
 #[tokio::test]
 async fn goref_tx_big_concurrent_test() {
+    init_allocator_with_default_settings();
     // TODO: add this file to a data repo and fetch dynamically
     json_test("testdata/dags_for_json_tests/goref-1.6M-tx-10K-blocks", true).await
 }
@@ -1223,6 +1242,7 @@ fn hex_decode(src: &str) -> Vec<u8> {
 
 #[tokio::test]
 async fn bounded_merge_depth_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(DEVNET_PARAMS)
         .skip_proof_of_work()
         .edit_consensus_params(|p| {
@@ -1302,6 +1322,7 @@ async fn bounded_merge_depth_test() {
 
 #[tokio::test]
 async fn difficulty_test() {
+    init_allocator_with_default_settings();
     async fn add_block(consensus: &TestConsensus, block_time: Option<u64>, parents: Vec<Hash>) -> Header {
         let selected_parent = consensus.ghostdag_manager().find_selected_parent(parents.iter().copied());
         let block_time = block_time.unwrap_or_else(|| {
@@ -1620,6 +1641,7 @@ async fn difficulty_test() {
 
 #[tokio::test]
 async fn selected_chain_test() {
+    init_allocator_with_default_settings();
     kaspa_core::log::try_init_logger("info");
 
     let config = ConfigBuilder::new(MAINNET_PARAMS)
@@ -1688,6 +1710,7 @@ fn selected_chain_store_iterator(consensus: &TestConsensus, pruning_point: Hash)
 
 #[tokio::test]
 async fn staging_consensus_test() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).build();
 
     let db_tempdir = get_kaspa_tempdir();

--- a/testing/integration/src/consensus_pipeline_tests.rs
+++ b/testing/integration/src/consensus_pipeline_tests.rs
@@ -1,4 +1,5 @@
 use futures_util::future::try_join_all;
+use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_consensus::{
     config::ConfigBuilder, consensus::test_consensus::TestConsensus, params::MAINNET_PARAMS,
     processes::reachability::tests::StoreValidationExtensions,
@@ -11,6 +12,7 @@ use tokio::join;
 
 #[tokio::test]
 async fn test_concurrent_pipeline() {
+    init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().edit_consensus_params(|p| p.genesis.hash = 1.into()).build();
     let consensus = TestConsensus::new(&config);
     let wait_handles = consensus.init();
@@ -31,7 +33,7 @@ async fn test_concurrent_pipeline() {
 
     for (hash, parents) in blocks {
         // Submit to consensus twice to make sure duplicates are handled
-        let b = consensus.build_block_with_parents(hash, parents).to_immutable();
+        let b: kaspa_consensus_core::block::Block = consensus.build_block_with_parents(hash, parents).to_immutable();
         let results = join!(
             consensus.validate_and_insert_block(b.clone()).virtual_state_task,
             consensus.validate_and_insert_block(b).virtual_state_task
@@ -76,6 +78,7 @@ async fn test_concurrent_pipeline() {
 
 #[tokio::test]
 async fn test_concurrent_pipeline_random() {
+    init_allocator_with_default_settings();
     let genesis: Hash = blockhash::new_unique();
     let bps = 8;
     let delay = 2;

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -1,4 +1,5 @@
 use kaspa_addresses::Address;
+use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_consensusmanager::ConsensusManager;
 use kaspa_core::task::runtime::AsyncRuntime;
 use kaspa_notify::scope::{Scope, VirtualDaaScoreChangedScope};
@@ -10,6 +11,7 @@ use std::{sync::Arc, time::Duration};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_sanity_test() {
+    init_allocator_with_default_settings();
     kaspa_core::log::try_init_logger("INFO");
 
     // let total_fd_limit =  kaspa_utils::fd_budget::get_limit() / 2 - 128;
@@ -32,6 +34,7 @@ async fn daemon_sanity_test() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_mining_test() {
+    init_allocator_with_default_settings();
     kaspa_core::log::try_init_logger("INFO");
 
     let args = Args {
@@ -103,6 +106,7 @@ async fn daemon_mining_test() {
 // The following test runtime parameters are required for a graceful shutdown of the gRPC server
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_cleaning_test() {
+    init_allocator_with_default_settings();
     kaspa_core::log::try_init_logger("info,kaspa_grpc_core=trace,kaspa_grpc_server=trace,kaspa_grpc_client=trace,kaspa_core=trace");
     let args = Args { devnet: true, ..Default::default() };
     let consensus_manager;

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -1,3 +1,8 @@
+#[ctor::ctor]
+fn init_allocator() {
+    kaspa_alloc::init_allocator_with_default_settings();
+}
+
 pub mod common;
 
 #[cfg(test)]

--- a/testing/integration/src/lib.rs
+++ b/testing/integration/src/lib.rs
@@ -1,8 +1,3 @@
-#[ctor::ctor]
-fn init_allocator() {
-    kaspa_alloc::init_allocator_with_default_settings();
-}
-
 pub mod common;
 
 #[cfg(test)]

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kaspa-alloc"
+description = "Kaspa allocator wrapper"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+include.workspace = true
+
+[dependencies]
+mimalloc.workspace = true

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -9,3 +9,6 @@ include.workspace = true
 
 [dependencies]
 mimalloc.workspace = true
+
+[features]
+heap = []

--- a/utils/alloc/src/lib.rs
+++ b/utils/alloc/src/lib.rs
@@ -1,0 +1,57 @@
+#[cfg(not(feature = "heap"))]
+#[cfg(unix)]
+extern "C" {
+    fn mi_option_set_enabled(_: mi_option_e, val: bool);
+}
+
+#[cfg(not(feature = "heap"))]
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+#[repr(C)]
+enum mi_option_e {
+    // stable options
+    mi_option_show_errors, // print error messages
+    mi_option_show_stats,  // print statistics on termination
+    mi_option_verbose,     // print verbose messages
+    // the following options are experimental (see src/options.h)
+    mi_option_eager_commit,             // eager commit segments? (after `eager_commit_delay` segments) (=1)
+    mi_option_arena_eager_commit,       // eager commit arenas? Use 2 to enable just on overcommit systems (=2)
+    mi_option_purge_decommits,          // should a memory purge decommit (or only reset) (=1)
+    mi_option_allow_large_os_pages,     // allow large (2MiB) OS pages, implies eager commit
+    mi_option_reserve_huge_os_pages,    // reserve N huge OS pages (1GiB/page) at startup
+    mi_option_reserve_huge_os_pages_at, // reserve huge OS pages at a specific NUMA node
+    mi_option_reserve_os_memory,        // reserve specified amount of OS memory in an arena at startup
+    mi_option_deprecated_segment_cache,
+    mi_option_deprecated_page_reset,
+    mi_option_abandoned_page_purge, // immediately purge delayed purges on thread termination
+    mi_option_deprecated_segment_reset,
+    mi_option_eager_commit_delay,
+    mi_option_purge_delay, // memory purging is delayed by N milli seconds; use 0 for immediate purging or -1 for no purging at all.
+    mi_option_use_numa_nodes, // 0 = use all available numa nodes, otherwise use at most N nodes.
+    mi_option_limit_os_alloc, // 1 = do not use OS memory for allocation (but only programmatically reserved arenas)
+    mi_option_os_tag,      // tag used for OS logging (macOS only for now)
+    mi_option_max_errors,  // issue at most N error messages
+    mi_option_max_warnings, // issue at most N warning messages
+    mi_option_max_segment_reclaim,
+    mi_option_destroy_on_exit, // if set, release all memory on exit; sometimes used for dynamic unloading but can be unsafe.
+    mi_option_arena_reserve,   // initial memory size in KiB for arena reservation (1GiB on 64-bit)
+    mi_option_arena_purge_mult,
+    mi_option_purge_extend_delay,
+    _mi_option_last,
+}
+
+#[cfg(not(feature = "heap"))]
+use mimalloc::MiMalloc;
+#[cfg(not(feature = "heap"))]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+pub fn init_allocator_with_default_settings() {
+    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(not(feature = "heap"))]
+    unsafe {
+        mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)
+    };
+}

--- a/utils/alloc/src/lib.rs
+++ b/utils/alloc/src/lib.rs
@@ -1,11 +1,11 @@
 #[cfg(not(feature = "heap"))]
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 extern "C" {
     fn mi_option_set_enabled(_: mi_option_e, val: bool);
 }
 
 #[cfg(not(feature = "heap"))]
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
 #[repr(C)]
@@ -48,7 +48,6 @@ use mimalloc::MiMalloc;
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn init_allocator_with_default_settings() {
-    #[cfg(unix)]
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[cfg(not(feature = "heap"))]
     unsafe {

--- a/utils/alloc/src/lib.rs
+++ b/utils/alloc/src/lib.rs
@@ -51,6 +51,7 @@ pub fn init_allocator_with_default_settings() {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[cfg(not(feature = "heap"))]
     unsafe {
+        // Empirical tests show that this option results in the smallest RSS.
         mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)
     };
 }


### PR DESCRIPTION
Since rusty-kaspa uses a lot of allocations, the RSS remains high even after the memory is free. This should be mitigated by using mimalloc which utilizes the use of MADV_FREE and MADV_DONTNEED (and equivalent techniques on non unix-like systems) which tend to release memory earlier and help in keeping the RSS small.