### PR TITLE
Adds missing logs and other minor convenient additions 

### DIFF
--- a/consensus/core/src/errors/pruning.rs
+++ b/consensus/core/src/errors/pruning.rs
@@ -56,6 +56,9 @@ pub enum PruningImportError {
 
     #[error("pruning import data lead to validation rule error")]
     PruningImportRuleError(#[from] RuleError),
+
+    #[error("process exit was initiated while validating pruning point proof")]
+    PruningValidationInterrupted,
 }
 
 pub type PruningImportResult<T> = std::result::Result<T, PruningImportError>;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -128,7 +128,7 @@ pub struct Consensus {
     creation_timestamp: u64,
 
     // Signals
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl Deref for Consensus {
@@ -151,7 +151,7 @@ impl Consensus {
     ) -> Self {
         let params = &config.params;
         let perf_params = &config.perf;
-        let is_process_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let is_consensus_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         //
         // Storage layer
@@ -163,8 +163,13 @@ impl Consensus {
         // Services and managers
         //
 
-        let services =
-            ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters, is_process_exiting.clone());
+        let services = ConsensusServices::new(
+            db.clone(),
+            storage.clone(),
+            config.clone(),
+            tx_script_cache_counters,
+            is_consensus_exiting.clone(),
+        );
 
         //
         // Processor channels
@@ -265,7 +270,7 @@ impl Consensus {
             &services,
             pruning_lock.clone(),
             config.clone(),
-            is_process_exiting.clone(),
+            is_consensus_exiting.clone(),
         ));
 
         // Ensure the relations stores are initialized
@@ -294,7 +299,7 @@ impl Consensus {
             counters,
             config,
             creation_timestamp,
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -350,7 +355,7 @@ impl Consensus {
     }
 
     pub fn signal_exit(&self) {
-        self.is_process_exiting.store(true, Ordering::SeqCst);
+        self.is_consensus_exiting.store(true, Ordering::SeqCst);
         self.block_sender.send(BlockProcessingMessage::Exit).unwrap();
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -163,7 +163,8 @@ impl Consensus {
         // Services and managers
         //
 
-        let services = ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters);
+        let services =
+            ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters, is_process_exiting.clone());
 
         //
         // Processor channels

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -355,7 +355,7 @@ impl Consensus {
     }
 
     pub fn signal_exit(&self) {
-        self.is_consensus_exiting.store(true, Ordering::SeqCst);
+        self.is_consensus_exiting.store(true, Ordering::Relaxed);
         self.block_sender.send(BlockProcessingMessage::Exit).unwrap();
     }
 

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use itertools::Itertools;
 use kaspa_txscript::caches::TxScriptCacheCounters;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 
 pub type DbGhostdagManager =
     GhostdagManager<DbGhostdagStore, MTRelationsService<DbRelationsStore>, MTReachabilityService<DbReachabilityStore>, DbHeadersStore>;
@@ -71,6 +71,7 @@ impl ConsensusServices {
         storage: Arc<ConsensusStorage>,
         config: Arc<Config>,
         tx_script_cache_counters: Arc<TxScriptCacheCounters>,
+        is_process_exiting: Arc<AtomicBool>,
     ) -> Arc<Self> {
         let params = &config.params;
 
@@ -185,6 +186,7 @@ impl ConsensusServices {
             params.pruning_proof_m,
             params.anticone_finalization_depth(),
             params.ghostdag_k,
+            is_process_exiting,
         ));
 
         let sync_manager = SyncManager::new(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -71,7 +71,7 @@ impl ConsensusServices {
         storage: Arc<ConsensusStorage>,
         config: Arc<Config>,
         tx_script_cache_counters: Arc<TxScriptCacheCounters>,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Arc<Self> {
         let params = &config.params;
 
@@ -186,7 +186,7 @@ impl ConsensusServices {
             params.pruning_proof_m,
             params.anticone_finalization_depth(),
             params.ghostdag_k,
-            is_process_exiting,
+            is_consensus_exiting,
         ));
 
         let sync_manager = SyncManager::new(

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -345,7 +345,7 @@ impl PruningProcessor {
             if lock_acquire_time.elapsed() > Duration::from_millis(5) {
                 drop(reachability_read);
                 // An exit signal was received. Exit from this long running process.
-                if self.is_consensus_exiting.load(Ordering::SeqCst) {
+                if self.is_consensus_exiting.load(Ordering::Relaxed) {
                     drop(prune_guard);
                     info!("Header and Block pruning interrupted: Process is exiting");
                     return;

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -45,7 +45,10 @@ use rocksdb::WriteBatch;
 use std::{
     collections::VecDeque,
     ops::Deref,
-    sync::{Arc, atomic::{AtomicBool, Ordering}},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -81,7 +81,7 @@ pub struct PruningProcessor {
     config: Arc<Config>,
 
     // Signals
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl Deref for PruningProcessor {
@@ -100,7 +100,7 @@ impl PruningProcessor {
         services: &Arc<ConsensusServices>,
         pruning_lock: SessionLock,
         config: Arc<Config>,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             receiver,
@@ -112,7 +112,7 @@ impl PruningProcessor {
             pruning_proof_manager: services.pruning_proof_manager.clone(),
             pruning_lock,
             config,
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -345,7 +345,7 @@ impl PruningProcessor {
             if lock_acquire_time.elapsed() > Duration::from_millis(5) {
                 drop(reachability_read);
                 // An exit signal was received. Exit from this long running process.
-                if self.is_process_exiting.load(Ordering::SeqCst) {
+                if self.is_consensus_exiting.load(Ordering::SeqCst) {
                     drop(prune_guard);
                     info!("Header and Block pruning interrupted: Process is exiting");
                     return;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -119,7 +119,7 @@ pub struct PruningProofManager {
     anticone_finalization_depth: u64,
     ghostdag_k: KType,
 
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl PruningProofManager {
@@ -137,7 +137,7 @@ impl PruningProofManager {
         pruning_proof_m: u64,
         anticone_finalization_depth: u64,
         ghostdag_k: KType,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             db,
@@ -169,7 +169,7 @@ impl PruningProofManager {
             anticone_finalization_depth,
             ghostdag_k,
 
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -446,7 +446,7 @@ impl PruningProofManager {
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
             // Before processing this level, check if the process is exiting so we can end early
-            if self.is_process_exiting.load(Ordering::SeqCst) {
+            if self.is_consensus_exiting.load(Ordering::SeqCst) {
                 return Err(PruningImportError::PruningValidationInterrupted);
             }
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -3,7 +3,10 @@ use std::{
     collections::{hash_map::Entry, BinaryHeap},
     collections::{hash_map::Entry::Vacant, VecDeque},
     ops::{Deref, DerefMut},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use itertools::Itertools;
@@ -115,6 +118,8 @@ pub struct PruningProofManager {
     pruning_proof_m: u64,
     anticone_finalization_depth: u64,
     ghostdag_k: KType,
+
+    is_process_exiting: Arc<AtomicBool>,
 }
 
 impl PruningProofManager {
@@ -132,6 +137,7 @@ impl PruningProofManager {
         pruning_proof_m: u64,
         anticone_finalization_depth: u64,
         ghostdag_k: KType,
+        is_process_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             db,
@@ -162,6 +168,8 @@ impl PruningProofManager {
             pruning_proof_m,
             anticone_finalization_depth,
             ghostdag_k,
+
+            is_process_exiting,
         }
     }
 
@@ -437,6 +445,11 @@ impl PruningProofManager {
 
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
+            // Before processing this level, check if the process is exiting so we can end early
+            if self.is_process_exiting.load(Ordering::SeqCst) {
+                return Err(PruningImportError::PruningValidationInterrupted);
+            }
+
             info!("Validating level {level} from the pruning point proof ({} headers)", proof[level as usize].len());
             let level_idx = level as usize;
             let mut selected_tip = None;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -446,7 +446,7 @@ impl PruningProofManager {
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
             // Before processing this level, check if the process is exiting so we can end early
-            if self.is_consensus_exiting.load(Ordering::SeqCst) {
+            if self.is_consensus_exiting.load(Ordering::Relaxed) {
                 return Err(PruningImportError::PruningValidationInterrupted);
             }
 

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -101,7 +101,7 @@ impl Default for Args {
             user_agent_comments: vec![],
             yes: false,
             perf_metrics: false,
-            perf_metrics_interval_sec: 1,
+            perf_metrics_interval_sec: 10,
             externalip: None,
             block_template_cache_lifetime: None,
 

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -6,9 +6,7 @@ use kaspa_consensus_core::{
     errors::config::{ConfigError, ConfigResult},
 };
 use kaspa_consensus_notify::{root::ConsensusNotificationRoot, service::NotifyService};
-#[cfg(feature = "heap")]
-use kaspa_core::trace;
-use kaspa_core::{core::Core, info};
+use kaspa_core::{core::Core, info, trace};
 use kaspa_core::{kaspad_env::version, task::tick::TickService};
 use kaspa_database::prelude::CachePolicy;
 use kaspa_grpc_server::service::GrpcService;
@@ -381,7 +379,8 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         .with_tick_service(tick_service.clone());
     let perf_monitor = if args.perf_metrics {
         let cb = move |counters: CountersSnapshot| {
-            info!("{}", counters);
+            trace!("[{}] {}", kaspa_perf_monitor::SERVICE_NAME, counters.to_process_metrics_display());
+            trace!("[{}] {}", kaspa_perf_monitor::SERVICE_NAME, counters.to_io_metrics_display());
             #[cfg(feature = "heap")]
             trace!("[{}] heap stats: {:?}", kaspa_perf_monitor::SERVICE_NAME, dhat::HeapStats::get());
         };

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -83,11 +83,20 @@ pub struct CountersSnapshot {
     pub disk_io_write_per_sec: f64,
 }
 
-fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) -> String {
-    let units = ["", "K", "M", "G", "T", "P", "E"];
-    let mut found_unit = "";
+impl CountersSnapshot {
+    pub fn to_process_metrics_display(&self) -> ProcessMetricsDisplay {
+        ProcessMetricsDisplay(self)
+    }
 
-    for unit in units {
+    pub fn to_io_metrics_display(&self) -> IoMetricsDisplay {
+        IoMetricsDisplay(self)
+    }
+}
+
+fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) -> String {
+    const UNITS: [&str; 7] = ["", "K", "M", "G", "T", "P", "E"];
+    let mut found_unit = "";
+    for unit in UNITS {
         if number_to_format < 1000.0 {
             found_unit = unit;
             break;
@@ -99,31 +108,39 @@ fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) 
     format!("{number_to_format:.precision$}{}{}", found_unit, suffix)
 }
 
-impl Display for CountersSnapshot {
+pub struct ProcessMetricsDisplay<'a>(&'a CountersSnapshot);
+
+pub struct IoMetricsDisplay<'a>(&'a CountersSnapshot);
+
+impl Display for ProcessMetricsDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Performance Metrics")?;
-        writeln!(
-            f,
-            "Process Metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage (per core): {}",
-            self.resident_set_size,
-            to_human_readable(self.resident_set_size as f64, 2, "B"),
-            self.virtual_memory_size,
-            to_human_readable(self.virtual_memory_size as f64, 2, "B"),
-            self.core_num,
-            self.cpu_usage
-        )?;
         write!(
             f,
-            "Disk IO Metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
-            self.fd_num,
-            self.disk_io_read_bytes,
-            to_human_readable(self.disk_io_read_bytes as f64, 0, "B"),
-            self.disk_io_write_bytes,
-            to_human_readable(self.disk_io_write_bytes as f64, 0, "B"),
-            self.disk_io_read_per_sec,
-            to_human_readable(self.disk_io_read_per_sec, 0, "B/s"),
-            self.disk_io_write_per_sec,
-            to_human_readable(self.disk_io_write_per_sec, 0, "B/s")
+            "process metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage: {}",
+            self.0.resident_set_size,
+            to_human_readable(self.0.resident_set_size as f64, 2, "B"),
+            self.0.virtual_memory_size,
+            to_human_readable(self.0.virtual_memory_size as f64, 2, "B"),
+            self.0.core_num,
+            self.0.cpu_usage
+        )
+    }
+}
+
+impl Display for IoMetricsDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "disk io metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
+            self.0.fd_num,
+            self.0.disk_io_read_bytes,
+            to_human_readable(self.0.disk_io_read_bytes as f64, 0, "B"),
+            self.0.disk_io_write_bytes,
+            to_human_readable(self.0.disk_io_write_bytes as f64, 0, "B"),
+            self.0.disk_io_read_per_sec,
+            to_human_readable(self.0.disk_io_read_per_sec, 0, "B/s"),
+            self.0.disk_io_write_per_sec,
+            to_human_readable(self.0.disk_io_write_per_sec, 0, "B/s")
         )
     }
 }

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -116,13 +116,14 @@ impl Display for ProcessMetricsDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "process metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage: {}",
+            "process metrics: RSS: {} ({}), VIRT: {} ({}), FD: {}, cores: {}, total cpu usage: {:.4}",
             self.0.resident_set_size,
             to_human_readable(self.0.resident_set_size as f64, 2, "B"),
             self.0.virtual_memory_size,
             to_human_readable(self.0.virtual_memory_size as f64, 2, "B"),
+            self.0.fd_num,
             self.0.core_num,
-            self.0.cpu_usage
+            self.0.cpu_usage,
         )
     }
 }
@@ -131,8 +132,7 @@ impl Display for IoMetricsDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "disk io metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
-            self.0.fd_num,
+            "disk io metrics: read: {} ({}), write: {} ({}), read rate: {:.3} ({}), write rate: {:.3} ({})",
             self.0.disk_io_read_bytes,
             to_human_readable(self.0.disk_io_read_bytes as f64, 0, "B"),
             self.0.disk_io_write_bytes,

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -95,17 +95,11 @@ impl CountersSnapshot {
 
 fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) -> String {
     const UNITS: [&str; 7] = ["", "K", "M", "G", "T", "P", "E"];
-    let mut found_unit = "";
-    for unit in UNITS {
-        if number_to_format < 1000.0 {
-            found_unit = unit;
-            break;
-        } else {
-            number_to_format /= 1000.0
-        }
-    }
-
-    format!("{number_to_format:.precision$}{}{}", found_unit, suffix)
+    const DIV: [f64; 7] =
+        [1.0, 1_000.0, 1_000_000.0, 1_000_000_000.0, 1_000_000_000_000.0, 1_000_000_000_000_000.0, 1_000_000_000_000_000_000.0];
+    let i = (number_to_format.log(1000.0) as usize).min(UNITS.len() - 1);
+    number_to_format /= DIV[i];
+    format!("{number_to_format:.precision$}{}{}", UNITS[i], suffix)
 }
 
 pub struct ProcessMetricsDisplay<'a>(&'a CountersSnapshot);
@@ -116,7 +110,7 @@ impl Display for ProcessMetricsDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "process metrics: RSS: {} ({}), VIRT: {} ({}), FD: {}, cores: {}, total cpu usage: {:.4}",
+            "process metrics: RAM: {} ({}), VIRT: {} ({}), FD: {}, cores: {}, total cpu usage: {:.4}",
             self.0.resident_set_size,
             to_human_readable(self.0.resident_set_size as f64, 2, "B"),
             self.0.virtual_memory_size,

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -1,5 +1,8 @@
 use portable_atomic::{AtomicF64, AtomicUsize};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    fmt::Display,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 #[derive(Debug, Default)]
 pub(crate) struct Counters {
@@ -78,4 +81,49 @@ pub struct CountersSnapshot {
     pub disk_io_write_bytes: u64,
     pub disk_io_read_per_sec: f64,
     pub disk_io_write_per_sec: f64,
+}
+
+fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) -> String {
+    let units = ["", "K", "M", "G", "T", "P", "E"];
+    let mut found_unit = "";
+
+    for unit in units {
+        if number_to_format < 1000.0 {
+            found_unit = unit;
+            break;
+        } else {
+            number_to_format /= 1000.0
+        }
+    }
+
+    format!("{number_to_format:.precision$}{}{}", found_unit, suffix)
+}
+
+impl Display for CountersSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Performance Metrics")?;
+        writeln!(
+            f,
+            "Process Metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage (per core): {}",
+            self.resident_set_size,
+            to_human_readable(self.resident_set_size as f64, 2, "B"),
+            self.virtual_memory_size,
+            to_human_readable(self.virtual_memory_size as f64, 2, "B"),
+            self.core_num,
+            self.cpu_usage
+        )?;
+        write!(
+            f,
+            "Disk IO Metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
+            self.fd_num,
+            self.disk_io_read_bytes,
+            to_human_readable(self.disk_io_read_bytes as f64, 0, "B"),
+            self.disk_io_write_bytes,
+            to_human_readable(self.disk_io_write_bytes as f64, 0, "B"),
+            self.disk_io_read_per_sec,
+            to_human_readable(self.disk_io_read_per_sec, 0, "B/s"),
+            self.disk_io_write_per_sec,
+            to_human_readable(self.disk_io_write_per_sec, 0, "B/s")
+        )
+    }
 }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -5,7 +5,7 @@ use crate::{
         Flow,
     },
 };
-use futures::future::{join_all, try_join_all};
+use futures::future::{join_all, select, try_join_all, Either};
 use kaspa_consensus_core::{
     api::BlockValidationFuture,
     block::Block,
@@ -32,6 +32,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use tokio::time::sleep;
 
 use super::{progress::ProgressReporter, HeadersChunk, PruningPointUtxosetChunkStream, IBD_BATCH_SIZE};
 
@@ -486,7 +487,23 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
 
     async fn sync_missing_block_bodies(&mut self, consensus: &ConsensusProxy, high: Hash) -> Result<(), ProtocolError> {
         // TODO: query consensus in batches
-        let hashes = consensus.async_get_missing_block_body_hashes(high).await?;
+        let sleep_task = sleep(Duration::from_secs(2));
+        let hashes_task = consensus.async_get_missing_block_body_hashes(high);
+        tokio::pin!(sleep_task);
+        tokio::pin!(hashes_task);
+        let hashes = match select(sleep_task, hashes_task).await {
+            Either::Left((_, hashes_task)) => {
+                // We select between the tasks in order to inform the user if this operation is taking too long. On full IBD
+                // this operation requires traversing the full DAG which indeed might take several seconds or even minutes.
+                info!(
+                    "IBD: searching for missing block bodies to request from peer {}. This operation might take several seconds.",
+                    self.router
+                );
+                // Now re-await the original task
+                hashes_task.await
+            }
+            Either::Right((hashes_result, _)) => hashes_result,
+        }?;
         if hashes.is_empty() {
             return Ok(());
         }

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -112,11 +112,16 @@ impl IbdFlow {
                 match self.ibd_with_headers_proof(&staging, negotiation_output.syncer_virtual_selected_parent, &relay_block).await {
                     Ok(()) => {
                         spawn_blocking(|| staging.commit()).await.unwrap();
+                        info!(
+                            "Header download stage of IBD with headers proof completed successfully from {}. Committed staging consensus.",
+                            self.router
+                        );
                         self.ctx.on_pruning_point_utxoset_override();
                         // This will reobtain the freshly committed staging consensus
                         session = self.ctx.consensus().session().await;
                     }
                     Err(e) => {
+                        info!("IBD with headers proof from {} was unsuccessful ({})", self.router, e);
                         staging.cancel();
                         return Err(e);
                     }

--- a/protocol/p2p/src/core/connection_handler.rs
+++ b/protocol/p2p/src/core/connection_handler.rs
@@ -165,8 +165,8 @@ impl ConnectionHandler {
                     return Err(ConnectionError::ProtocolError(err));
                 }
                 Err(err) => {
+                    debug!("P2P, connect retry #{} failed with error {:?}, peer: {:?}", counter, err, address);
                     if counter < retry_attempts {
-                        debug!("P2P, connect retry #{} failed with error {:?}, peer: {:?}", counter, err, address);
                         // Await `retry_interval` time before retrying
                         tokio::time::sleep(retry_interval).await;
                     } else {

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -147,7 +147,8 @@ fn main_impl(mut args: Args) {
         let ts = Arc::new(TickService::new());
 
         let cb = move |counters: CountersSnapshot| {
-            trace!("{}", counters);
+            trace!("[{}] {}", kaspa_perf_monitor::SERVICE_NAME, counters.to_process_metrics_display());
+            trace!("[{}] {}", kaspa_perf_monitor::SERVICE_NAME, counters.to_io_metrics_display());
             #[cfg(feature = "heap")]
             trace!("heap stats: {:?}", dhat::HeapStats::get());
         };

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -24,7 +24,7 @@ use kaspa_core::{info, task::service::AsyncService, task::tick::TickService, tim
 use kaspa_database::prelude::ConnBuilder;
 use kaspa_database::{create_temp_db, load_existing_db};
 use kaspa_hashes::Hash;
-use kaspa_perf_monitor::builder::Builder;
+use kaspa_perf_monitor::{builder::Builder, counters::CountersSnapshot};
 use kaspa_utils::fd_budget;
 use simulator::network::KaspaNetworkSimulator;
 use std::{collections::VecDeque, sync::Arc, time::Duration};
@@ -145,8 +145,9 @@ fn main_impl(mut args: Args) {
 
     let stop_perf_monitor = args.perf_metrics.then(|| {
         let ts = Arc::new(TickService::new());
-        let cb = move |counters| {
-            trace!("metrics: {:?}", counters);
+
+        let cb = move |counters: CountersSnapshot| {
+            trace!("{}", counters);
             #[cfg(feature = "heap")]
             trace!("heap stats: {:?}", dhat::HeapStats::get());
         };


### PR DESCRIPTION
Adds some missing logs and is meant to be an aggregated PR for other minor convenient additions. Please open a PR over this branch if you wish to add anything. All changes should be small in scope.

Some suggestions to add here:

1. Add to `Consensus` an atomic boolean set at `Consensus::signal_exit` which can be used by processors such as the pruning processor to exit long operations early if the app is shutting down. Another place to use this flag is `PruningProofManager::validate_pruning_point_proof`. 
2. Add `--norpc` flag support to `kaspad` cmd options
3. Metrics logs: split `perf-monitor` metrics log to two more readable and short lines. Consider printing numbers also in readable format with units such as KB,MB,GB. Change cmd option `perf_metrics_interval_sec` default value to 10. **


** Current state:
```
2023-12-20 09:50:04.076+02:00 [TRACE] [perf-monitor] metrics: CountersSnapshot { resident_set_size: 6538289152, virtual_memory_size: 15633260544, core_num: 24, cpu_usage: 0.779554540262707, fd_num: 3069, disk_io_read_bytes: 307925639168, disk_io_write_bytes: 411801882624, disk_io_read_per_sec: 22688499.00039984, disk_io_write_per_sec: 16169864.854058377 }
```
Desired state:
```
2023-12-20 09:50:04.076+02:00 [TRACE] [perf-monitor] process metrics: RSS: 6538289152 (6.53GB), VIRT: 15633260544 (15.63GB), cores: 24, cpu usage (per core): 0.779
2023-12-20 09:50:04.076+02:00 [TRACE] [perf-monitor] disk io metrics: FD: 3069, read: 307925639168 (307GB), write: 411801882624 (411GB), read rate: 22688499.00039984 (22MB/s), write rate: 16169864.854058377 (16MB/s) 
```
(the only reason to keep the long numbers as well is for log parsing)
