### PR TITLE
Feature gate MiMalloc use in MacOS

### DIFF
--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -12,3 +12,4 @@ mimalloc.workspace = true
 
 [features]
 heap = []
+mimalloc = []

--- a/utils/alloc/src/lib.rs
+++ b/utils/alloc/src/lib.rs
@@ -1,11 +1,11 @@
 #[cfg(not(feature = "heap"))]
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 extern "C" {
     fn mi_option_set_enabled(_: mi_option_e, val: bool);
 }
 
 #[cfg(not(feature = "heap"))]
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
 #[repr(C)]
@@ -42,14 +42,17 @@ enum mi_option_e {
 }
 
 #[cfg(not(feature = "heap"))]
+#[cfg(not(target_os = "macos"))]
 use mimalloc::MiMalloc;
 #[cfg(not(feature = "heap"))]
+#[cfg(not(target_os = "macos"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn init_allocator_with_default_settings() {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[cfg(not(feature = "heap"))]
+    #[cfg(not(target_os = "macos"))]
     unsafe {
         // Empirical tests show that this option results in the smallest RSS.
         mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)

--- a/utils/alloc/src/lib.rs
+++ b/utils/alloc/src/lib.rs
@@ -1,11 +1,9 @@
-#[cfg(not(feature = "heap"))]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(all(not(feature = "heap"), any(target_os = "linux", target_os = "windows", feature = "mimalloc")))]
 extern "C" {
     fn mi_option_set_enabled(_: mi_option_e, val: bool);
 }
 
-#[cfg(not(feature = "heap"))]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(all(not(feature = "heap"), any(target_os = "linux", target_os = "windows", feature = "mimalloc")))]
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
 #[repr(C)]
@@ -41,18 +39,14 @@ enum mi_option_e {
     _mi_option_last,
 }
 
-#[cfg(not(feature = "heap"))]
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(feature = "heap"), any(not(target_os = "macos"), feature = "mimalloc")))]
 use mimalloc::MiMalloc;
-#[cfg(not(feature = "heap"))]
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(feature = "heap"), any(not(target_os = "macos"), feature = "mimalloc")))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn init_allocator_with_default_settings() {
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[cfg(not(feature = "heap"))]
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(not(feature = "heap"), any(target_os = "linux", target_os = "windows", feature = "mimalloc")))]
     unsafe {
         // Empirical tests show that this option results in the smallest RSS.
         mi_option_set_enabled(mi_option_e::mi_option_purge_decommits, false)


### PR DESCRIPTION
MiMalloc will still be the default to use for `linux` and `windows` regardless of whether the `mimalloc` feature is set or not.

However, for `macos`, MiMalloc will only be used if the feature `mimalloc` is specified. This is to alleviate the recent segfaulting issue found in mac related to mimalloc.