### PR TITLE
Implement "nogrpc" flag and change default rpc listen ip

### DIFF
--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -67,6 +67,7 @@ pub struct Args {
 
     pub disable_upnp: bool,
     pub disable_dns_seeding: bool,
+    pub disable_grpc: bool,
     pub ram_scale: f64,
 }
 
@@ -115,6 +116,7 @@ impl Default for Args {
 
             disable_upnp: false,
             disable_dns_seeding: false,
+            disable_grpc: false,
             ram_scale: 1.0,
         }
     }
@@ -326,6 +328,7 @@ pub fn cli() -> Command {
         )
         .arg(arg!(--"disable-upnp" "Disable upnp"))
         .arg(arg!(--"nodnsseed" "Disable DNS seeding for peers"))
+        .arg(arg!(--"nogrpc" "Disable gRPC server"))
         .arg(
             Arg::new("ram-scale")
                 .long("ram-scale")
@@ -403,6 +406,7 @@ impl Args {
             block_template_cache_lifetime: defaults.block_template_cache_lifetime,
             disable_upnp: m.get_one::<bool>("disable-upnp").cloned().unwrap_or(defaults.disable_upnp),
             disable_dns_seeding: m.get_one::<bool>("nodnsseed").cloned().unwrap_or(defaults.disable_dns_seeding),
+            disable_grpc: m.get_one::<bool>("nogrpc").cloned().unwrap_or(defaults.disable_grpc),
             ram_scale: m.get_one::<f64>("ram-scale").cloned().unwrap_or(defaults.ram_scale),
 
             #[cfg(feature = "devnet-prealloc")]
@@ -497,5 +501,5 @@ impl Args {
       --devnet                              Use the development test network
       --override-dag-params-file=           Overrides DAG params (allowed only on devnet)
   -s, --service=                            Service command {install, remove, start, stop}
-
+      --nogrpc                              Don't initialize the gRPC server
 */

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -469,12 +469,12 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     if let Some(port_mapping_extender_svc) = port_mapping_extender_svc {
         async_runtime.register(Arc::new(port_mapping_extender_svc))
     };
+    async_runtime.register(rpc_core_service.clone());
     if !args.disable_grpc {
         let grpc_service =
             Arc::new(GrpcService::new(grpc_server_addr, config, rpc_core_service.clone(), args.rpc_max_clients, grpc_tower_counters));
         async_runtime.register(grpc_service);
     }
-    async_runtime.register(rpc_core_service.clone());
     async_runtime.register(p2p_service);
     async_runtime.register(consensus_monitor);
     async_runtime.register(mining_monitor);

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -458,8 +458,6 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         p2p_tower_counters.clone(),
         grpc_tower_counters.clone(),
     ));
-    let grpc_service =
-        Arc::new(GrpcService::new(grpc_server_addr, config, rpc_core_service.clone(), args.rpc_max_clients, grpc_tower_counters));
 
     // Create an async runtime and register the top-level async services
     let async_runtime = Arc::new(AsyncRuntime::new(args.async_threads));
@@ -471,8 +469,12 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     if let Some(port_mapping_extender_svc) = port_mapping_extender_svc {
         async_runtime.register(Arc::new(port_mapping_extender_svc))
     };
+    if !args.disable_grpc {
+        let grpc_service =
+            Arc::new(GrpcService::new(grpc_server_addr, config, rpc_core_service.clone(), args.rpc_max_clients, grpc_tower_counters));
+        async_runtime.register(grpc_service);
+    }
     async_runtime.register(rpc_core_service.clone());
-    async_runtime.register(grpc_service);
     async_runtime.register(p2p_service);
     async_runtime.register(consensus_monitor);
     async_runtime.register(mining_monitor);

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -348,7 +348,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     let outbound_target = if connect_peers.is_empty() { args.outbound_target } else { 0 };
     let dns_seeders = if connect_peers.is_empty() && !args.disable_dns_seeding { config.dns_seeders } else { &[] };
 
-    let grpc_server_addr = args.rpclisten.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_rpc_port());
+    let grpc_server_addr = args.rpclisten.unwrap_or(ContextualNetAddress::loopback()).normalize(config.default_rpc_port());
 
     let core = Arc::new(Core::new());
 


### PR DESCRIPTION
- Add nogrpc flag: When set, the gRPC service is not initialized
- Set default grpc listen to 127.0.0.1