### PR TITLE
Remove mimalloc override feature for macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,6 @@ include = [
 ]
 
 [workspace.dependencies]
-mimalloc = { version = "0.1.39", default-features = false, features = [
-    'override',
-] }
 # kaspa-testing-integration = { version = "0.13.3", path = "testing/integration" }
 kaspa-addresses = { version = "0.13.3", path = "crypto/addresses" }
 kaspa-addressmanager = { version = "0.13.3", path = "components/addressmanager" }

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -8,9 +8,12 @@ edition.workspace = true
 include.workspace = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-mimalloc.workspace = true
+mimalloc = { version = "0.1.39", default-features = false, features = [
+    'override',
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# override is unstable in MacOS and is thus excluded
 mimalloc = { version = "0.1.39", default-features = false }
 
 [features]

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -7,8 +7,11 @@ license.workspace = true
 edition.workspace = true
 include.workspace = true
 
-[dependencies]
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 mimalloc.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc = { version = "0.1.39", default-features = false }
 
 [features]
 heap = []


### PR DESCRIPTION
The `override` mimalloc feature causes instability in macos builds