### PR TITLE
Update port handling in wRPC URL parser

### DIFF
--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -334,8 +334,16 @@ impl KaspaRpcClient {
         });
         let path_str = parse_output.path;
 
-        // Do not include port if (using SSL or the path was supplied) and the port was not explicitly supplied
-        if (scheme == "wss" || scheme == "wrpcs" || !path_str.is_empty()) && parse_output.port.is_none() {
+        // Do not automatically include port if:
+        //  1) the URL contains a scheme
+        //  2) the URL contains a path
+        //  3) explicitly specified in the URL,
+        //
+        //  This means wss://host.com or host.com/path will remain as-is
+        //  while host.com or 1.2.3.4 will be converted to host.com:port
+        //  or 1.2.3.4:port where port is based on the network type.
+        //
+        if (parse_output.scheme.is_some() || !path_str.is_empty()) && parse_output.port.is_none() {
             Ok(format!("{}://{}:{}", scheme, parse_output.host.to_string(), path_str))
         } else {
             Ok(format!("{}://{}:{}{}", scheme, parse_output.host.to_string(), port, path_str))

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -309,28 +309,37 @@ impl KaspaRpcClient {
 
     pub fn parse_url(url: String, encoding: Encoding, network_type: NetworkType) -> Result<String> {
         let parse_output = parse_host(&url).map_err(|err| Error::Custom(err.to_string()))?;
-        let scheme = parse_output.scheme.map(Ok).unwrap_or_else(|| {
-            if !application_runtime::is_web() {
-                return Ok("ws");
-            }
-            let location = window().location();
-            let protocol =
-                location.protocol().map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?;
-            if protocol == "http:" || protocol == "chrome-extension:" {
-                Ok("ws")
-            } else if protocol == "https:" {
-                Ok("wss")
-            } else {
-                Err(Error::Custom(format!("Unsupported protocol: {}", protocol)))
-            }
-        })?;
+        let scheme = parse_output
+            .scheme
+            .map(Ok)
+            .unwrap_or_else(|| {
+                if !application_runtime::is_web() {
+                    return Ok("ws");
+                }
+                let location = window().location();
+                let protocol =
+                    location.protocol().map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?;
+                if protocol == "http:" || protocol == "chrome-extension:" {
+                    Ok("ws")
+                } else if protocol == "https:" {
+                    Ok("wss")
+                } else {
+                    Err(Error::Custom(format!("Unsupported protocol: {}", protocol)))
+                }
+            })?
+            .to_lowercase();
         let port = parse_output.port.unwrap_or_else(|| match encoding {
             WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
             WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
         });
         let path_str = parse_output.path;
 
-        Ok(format!("{}://{}:{}{}", scheme, parse_output.host.to_string(), port, path_str))
+        // Do not include port if (using SSL or the path was supplied) and the port was not explicitly supplied
+        if (scheme == "wss" || scheme == "wrpcs" || !path_str.is_empty()) && parse_output.port.is_none() {
+            Ok(format!("{}://{}:{}", scheme, parse_output.host.to_string(), path_str))
+        } else {
+            Ok(format!("{}://{}:{}{}", scheme, parse_output.host.to_string(), port, path_str))
+        }
     }
 
     async fn start_rpc_ctl_service(&self) -> Result<()> {

--- a/rpc/wrpc/server/src/server.rs
+++ b/rpc/wrpc/server/src/server.rs
@@ -89,7 +89,7 @@ impl Server {
     }
 
     pub async fn connect(&self, peer: &SocketAddr, messenger: Arc<Messenger>) -> Result<Connection> {
-        log_info!("WebSocket connected: {}", peer);
+        // log_trace!("WebSocket connected: {}", peer);
         let id = self.inner.next_connection_id.fetch_add(1, Ordering::SeqCst);
 
         let grpc_client = if let Some(grpc_proxy_address) = &self.inner.options.grpc_proxy_address {
@@ -110,8 +110,6 @@ impl Server {
             // log_trace!("Creating proxy relay...");
             Some(Arc::new(grpc_client))
         } else {
-            // Provider::RpcCore
-
             None
         };
         let connection = Connection::new(id, peer, messenger, grpc_client);


### PR DESCRIPTION
Do not inject port based on network type in wRPC URL when using SSL or the URL has a path.

Current behavior always injects port unless explicitly specified, which creates interference when using WebSocket proxies (that use URL paths) requiring us to always specify ports `443` or `80`.
