### PR TITLE
Convert settings to global consts and fix TN11 conbase maturity times

### DIFF
--- a/wallet/core/src/imports.rs
+++ b/wallet/core/src/imports.rs
@@ -20,7 +20,7 @@ pub use crate::storage::*;
 pub use crate::types::*;
 pub use crate::utxo::balance::Balance;
 pub use crate::utxo::scan::{Scan, ScanExtent};
-pub use crate::utxo::{Maturity, OutgoingTransaction, UtxoContext, UtxoEntryReference, UtxoProcessor};
+pub use crate::utxo::{Maturity, NetworkParams, OutgoingTransaction, UtxoContext, UtxoEntryReference, UtxoProcessor};
 pub use crate::wallet::*;
 pub use crate::{storage, utils};
 

--- a/wallet/core/src/storage/transaction/record.rs
+++ b/wallet/core/src/storage/transaction/record.rs
@@ -68,11 +68,12 @@ impl TransactionRecord {
     }
 
     pub fn maturity(&self, current_daa_score: u64) -> Maturity {
-        // TODO - refactor @ high BPS processing
+        let params = NetworkParams::from(self.network_id);
+
         let maturity = if self.is_coinbase() {
-            crate::utxo::UTXO_MATURITY_PERIOD_COINBASE_TRANSACTION_DAA.load(Ordering::SeqCst)
+            params.coinbase_transaction_maturity_period_daa
         } else {
-            crate::utxo::UTXO_MATURITY_PERIOD_USER_TRANSACTION_DAA.load(Ordering::SeqCst)
+            params.user_transaction_maturity_period_daa
         };
 
         if current_daa_score < self.block_daa_score() + maturity {
@@ -121,10 +122,11 @@ impl TransactionRecord {
     // a progress value based on the pending period. It is assumed
     // that transactions in stasis are not visible to the user.
     pub fn maturity_progress(&self, current_daa_score: u64) -> Option<f64> {
+        let params = NetworkParams::from(self.network_id);
         let maturity = if self.is_coinbase() {
-            crate::utxo::UTXO_MATURITY_PERIOD_COINBASE_TRANSACTION_DAA.load(Ordering::SeqCst)
+            params.coinbase_transaction_maturity_period_daa
         } else {
-            crate::utxo::UTXO_MATURITY_PERIOD_USER_TRANSACTION_DAA.load(Ordering::SeqCst)
+            params.user_transaction_maturity_period_daa
         };
 
         if current_daa_score < self.block_daa_score + maturity {

--- a/wallet/core/src/utxo/context.rs
+++ b/wallet/core/src/utxo/context.rs
@@ -11,7 +11,7 @@ use crate::result::Result;
 use crate::storage::TransactionRecord;
 use crate::tx::PendingTransaction;
 use crate::utxo::{
-    Maturity, OutgoingTransaction, PendingUtxoEntryReference, UtxoContextBinding, UtxoEntryId, UtxoEntryReference,
+    Maturity, NetworkParams, OutgoingTransaction, PendingUtxoEntryReference, UtxoContextBinding, UtxoEntryId, UtxoEntryReference,
     UtxoEntryReferenceExtension, UtxoProcessor,
 };
 use kaspa_hashes::Hash;
@@ -304,7 +304,8 @@ impl UtxoContext {
             if force_maturity {
                 context.mature.sorted_insert_binary_asc_by_key(utxo_entry.clone(), |entry| entry.amount_as_ref());
             } else {
-                match utxo_entry.maturity(current_daa_score) {
+                let params = NetworkParams::from(self.processor().network_id()?);
+                match utxo_entry.maturity(&params, current_daa_score) {
                     Maturity::Stasis => {
                         context.stasis.insert(utxo_entry.id().clone(), utxo_entry.clone());
                         self.processor()
@@ -428,10 +429,12 @@ impl UtxoContext {
             let mut pending = vec![];
             let mut mature = vec![];
 
+            let params = NetworkParams::from(self.processor().network_id()?);
+
             for utxo_entry in utxo_entries.into_iter() {
                 if let std::collections::hash_map::Entry::Vacant(e) = context.map.entry(utxo_entry.id()) {
                     e.insert(utxo_entry.clone());
-                    match utxo_entry.maturity(current_daa_score) {
+                    match utxo_entry.maturity(&params, current_daa_score) {
                         Maturity::Stasis => {
                             context.stasis.insert(utxo_entry.id().clone(), utxo_entry.clone());
                             self.processor()
@@ -517,6 +520,8 @@ impl UtxoContext {
     pub(crate) async fn handle_utxo_added(&self, utxos: Vec<UtxoEntryReference>, current_daa_score: u64) -> Result<()> {
         // add UTXOs to account set
 
+        let params = NetworkParams::from(self.processor().network_id()?);
+
         let mut accepted_outgoing_transactions = AHashSet::new();
 
         let added = HashMap::group_from(utxos.into_iter().map(|utxo| (utxo.transaction_id(), utxo)));
@@ -527,7 +532,7 @@ impl UtxoContext {
 
             let force_maturity_if_outgoing = outgoing_transaction.is_some();
             let is_coinbase_stasis =
-                utxos.first().map(|utxo| matches!(utxo.maturity(current_daa_score), Maturity::Stasis)).unwrap_or_default();
+                utxos.first().map(|utxo| matches!(utxo.maturity(&params, current_daa_score), Maturity::Stasis)).unwrap_or_default();
 
             for utxo in utxos.iter() {
                 if let Err(err) = self.insert(utxo.clone(), current_daa_score, force_maturity_if_outgoing).await {

--- a/wallet/core/src/utxo/pending.rs
+++ b/wallet/core/src/utxo/pending.rs
@@ -47,8 +47,8 @@ impl PendingUtxoEntryReference {
     }
 
     #[inline(always)]
-    pub fn maturity(&self, current_daa_score: u64) -> Maturity {
-        self.inner().entry.maturity(current_daa_score)
+    pub fn maturity(&self, params: &NetworkParams, current_daa_score: u64) -> Maturity {
+        self.inner().entry.maturity(params, current_daa_score)
     }
 }
 

--- a/wallet/core/src/utxo/scan.rs
+++ b/wallet/core/src/utxo/scan.rs
@@ -62,6 +62,8 @@ impl Scan {
     }
 
     pub async fn scan_with_address_manager(&self, address_manager: &Arc<AddressManager>, utxo_context: &UtxoContext) -> Result<()> {
+        let params = utxo_context.processor().network_params()?;
+
         let window_size = self.window_size.unwrap_or(DEFAULT_WINDOW_SIZE) as u32;
         let extent = self.extent.expect("address manager requires an extent");
 
@@ -105,7 +107,7 @@ impl Scan {
                 }
 
                 let balance: Balance = refs.iter().fold(Balance::default(), |mut balance, r| {
-                    let entry_balance = r.balance(self.current_daa_score);
+                    let entry_balance = r.balance(params, self.current_daa_score);
                     balance.mature += entry_balance.mature;
                     balance.pending += entry_balance.pending;
                     balance.mature_utxo_count += entry_balance.mature_utxo_count;
@@ -141,6 +143,7 @@ impl Scan {
     }
 
     pub async fn scan_with_address_set(&self, address_set: &HashSet<Address>, utxo_context: &UtxoContext) -> Result<()> {
+        let params = utxo_context.processor().network_params()?;
         let address_vec = address_set.iter().cloned().collect::<Vec<_>>();
 
         utxo_context.register_addresses(&address_vec).await?;
@@ -148,7 +151,7 @@ impl Scan {
         let refs: Vec<UtxoEntryReference> = resp.into_iter().map(UtxoEntryReference::from).collect();
 
         let balance: Balance = refs.iter().fold(Balance::default(), |mut balance, r| {
-            let entry_balance = r.balance(self.current_daa_score);
+            let entry_balance = r.balance(params, self.current_daa_score);
             balance.mature += entry_balance.mature;
             balance.pending += entry_balance.pending;
             balance.mature_utxo_count += entry_balance.mature_utxo_count;

--- a/wallet/core/src/utxo/test.rs
+++ b/wallet/core/src/utxo/test.rs
@@ -8,7 +8,7 @@ use crate::utxo::*;
 
 #[tokio::test]
 async fn test_utxo_subsystem_bootstrap() -> Result<()> {
-    let network_id = NetworkId::with_suffix(NetworkType::Testnet, 0);
+    let network_id = NetworkId::with_suffix(NetworkType::Testnet, 10);
     let rpc_api_mock = Arc::new(RpcCoreMock::new());
     let processor = UtxoProcessor::new(Some(rpc_api_mock.clone().into()), Some(network_id), None, None);
     let _context = UtxoContext::new(&processor, UtxoContextBinding::default());


### PR DESCRIPTION
Convert wallet network settings to global consts introducing `NetworkParams` in the wallet framework similar to consensus `Params`.  For now this contains confirmation periods but is also intended to be used to statically configure various options for txgen per-network fee processing.