### PR TITLE
Fix yield duration of readers-preferred rwlock

### DIFF
--- a/utils/src/sync/rwlock.rs
+++ b/utils/src/sync/rwlock.rs
@@ -122,23 +122,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_writer_reentrance() {
-        let l = Arc::new(RfRwLock::new());
-        let (tx, rx) = oneshot::channel();
-        let l_clone = l.clone();
-        let h = std::thread::spawn(move || {
-            let mut write = l_clone.blocking_write();
-            tx.send(()).unwrap();
-            for _ in 0..20 {
-                std::thread::sleep(Duration::from_millis(2));
-                write.blocking_yield();
-            }
-        });
-        rx.await.unwrap();
-        // Make sure the reader acquires the lock during writer yields. We give the test a few chances to acquire
-        // in order to make sure it passes also in slow CI environments where the OS thread-scheduler might take its time
-        let read = timeout(Duration::from_millis(20), l.read()).await.unwrap();
-        drop(read);
-        timeout(Duration::from_millis(1000), tokio::task::spawn_blocking(move || h.join())).await.unwrap().unwrap().unwrap();
+        for i in 0..64 {
+            let l = Arc::new(RfRwLock::new());
+            let (tx, rx) = oneshot::channel();
+            let l_clone = l.clone();
+            let h = std::thread::spawn(move || {
+                let mut write = l_clone.blocking_write();
+                tx.send(()).unwrap();
+                for _ in 0..5 {
+                    std::thread::sleep(Duration::from_millis(2));
+                    write.blocking_yield();
+                }
+            });
+            rx.await.unwrap();
+            // Make sure the reader acquires the lock during writer yields. We give the test a few chances to acquire
+            // in order to make sure it passes also in slow CI environments where the OS thread-scheduler might take its time
+            let read = timeout(Duration::from_millis(3), l.read()).await.unwrap_or_else(|_| panic!("failed at iteration {i}"));
+            drop(read);
+            timeout(Duration::from_millis(100), tokio::task::spawn_blocking(move || h.join())).await.unwrap().unwrap().unwrap();
+        }
     }
 
     #[tokio::test]

--- a/utils/src/sync/rwlock.rs
+++ b/utils/src/sync/rwlock.rs
@@ -137,7 +137,7 @@ mod tests {
             rx.await.unwrap();
             // Make sure the reader acquires the lock during writer yields. We give the test a few chances to acquire
             // in order to make sure it passes also in slow CI environments where the OS thread-scheduler might take its time
-            let read = timeout(Duration::from_millis(3), l.read()).await.unwrap_or_else(|_| panic!("failed at iteration {i}"));
+            let read = timeout(Duration::from_millis(5), l.read()).await.unwrap_or_else(|_| panic!("failed at iteration {i}"));
             drop(read);
             timeout(Duration::from_millis(100), tokio::task::spawn_blocking(move || h.join())).await.unwrap().unwrap().unwrap();
         }

--- a/utils/src/sync/semaphore.rs
+++ b/utils/src/sync/semaphore.rs
@@ -92,7 +92,7 @@ impl Semaphore {
         // will most likely recapture the emptied slot before they wake up.
         //
         // Tests and benchmarks show that 30 microseconds are sufficient for allowing other threads to capture the lock
-        // (Windows: ~10 micros, Linux: ~30 micros, Macos: untested yet)
+        // (Windows: ~10 micros, Linux: 30 micros, Macos: 30 micros always worked with 2 yields which is sufficient for our needs)
         self.signal.listen().wait_timeout(Duration::from_micros(30));
         self.blocking_acquire(permits)
     }

--- a/utils/src/sync/semaphore.rs
+++ b/utils/src/sync/semaphore.rs
@@ -90,7 +90,10 @@ impl Semaphore {
         // which will awake us.
         // Avoiding the wait all together is harmful in the case there are listeners, since this thread
         // will most likely recapture the emptied slot before they wake up.
-        self.signal.listen().wait_timeout(Duration::from_micros(1));
+        //
+        // Tests and benchmarks show that 30 microseconds are sufficient for allowing other threads to capture the lock
+        // (Windows: ~10 micros, Linux: ~30 micros, Macos: untested yet)
+        self.signal.listen().wait_timeout(Duration::from_micros(30));
         self.blocking_acquire(permits)
     }
 }


### PR DESCRIPTION
Readers-Preferred RwLock (aka pruning lock): Increase the semaphore yield duration to 30 micros + tighten the test (so that w/o this fix it would fail with certainty)