### PR TITLE
Changes applied during crate publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-os"
-version = "0.0.2"
+version = "0.13.4"
 dependencies = [
  "async-trait",
  "borsh",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "kaspa-cli"
-description = "Kaspa CLI library"
+description = "Kaspa CLI"
+keywords = ["kaspa", "wallet", "cli", "rpc"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 include = [
     "src/**/*.rs",
     "src/**/*.txt",

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 borsh.workspace = true

--- a/components/connectionmanager/Cargo.toml
+++ b/components/connectionmanager/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 duration-string.workspace = true

--- a/components/consensusmanager/Cargo.toml
+++ b/components/consensusmanager/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 duration-string.workspace = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 arc-swap.workspace = true

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/consensus/notify/Cargo.toml
+++ b/consensus/notify/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-channel.workspace = true

--- a/consensus/pow/Cargo.toml
+++ b/consensus/pow/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
-
+repository.workspace = true
 
 [dependencies]
 js-sys.workspace = true

--- a/consensus/wasm/Cargo.toml
+++ b/consensus/wasm/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-consensus-core.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 cfg-if.workspace = true

--- a/crypto/addresses/Cargo.toml
+++ b/crypto/addresses/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 borsh.workspace = true

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 no-asm = ["keccak"]

--- a/crypto/merkle/Cargo.toml
+++ b/crypto/merkle/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-hashes.workspace = true

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-hashes.workspace = true

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 blake2b_simd.workspace = true

--- a/crypto/txscript/errors/Cargo.toml
+++ b/crypto/txscript/errors/Cargo.toml
@@ -6,9 +6,10 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 thiserror.workspace = true
-secp256k1 = { version = "0.24" }
+secp256k1.workspace = true

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 bincode.workspace = true

--- a/indexes/core/Cargo.toml
+++ b/indexes/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-channel.workspace = true

--- a/indexes/processor/Cargo.toml
+++ b/indexes/processor/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-consensus-core.workspace = true

--- a/indexes/utxoindex/Cargo.toml
+++ b/indexes/utxoindex/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 futures.workspace = true

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspad"
 description = "Kaspa full node daemon"
+keywords = ["kaspa", "blockdag"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/kos/Cargo.toml
+++ b/kos/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-repository = "https://github.com/kaspanet/rusty-kaspa"
+repository.workspace = true
 include = [
     "src/**/*.rs",
     "src/**/*.txt",

--- a/kos/Cargo.toml
+++ b/kos/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kaspa-os"
 description = "Kaspa Node & Wallet Manager"
 # please keep this version detached from the workspace
-version = "0.0.2"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 include.workspace = true
+repository.workspace = true
 
 [dependencies]
 borsh.workspace = true

--- a/metrics/core/Cargo.toml
+++ b/metrics/core/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 include.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/metrics/core/Cargo.toml
+++ b/metrics/core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kaspa-metrics-core"
+description = "Tools for collecting and reporting Kaspa p2p node metrics"
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/metrics/perf_monitor/Cargo.toml
+++ b/metrics/perf_monitor/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 include.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-core.workspace = true

--- a/mining/Cargo.toml
+++ b/mining/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-addresses.workspace = true

--- a/mining/errors/Cargo.toml
+++ b/mining/errors/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-channel.workspace = true

--- a/protocol/flows/Cargo.toml
+++ b/protocol/flows/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-core.workspace = true

--- a/protocol/p2p/Cargo.toml
+++ b/protocol/p2p/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 path = "./src/lib.rs"

--- a/rothschild/Cargo.toml
+++ b/rothschild/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-core.workspace = true

--- a/rpc/core/Cargo.toml
+++ b/rpc/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-addresses.workspace = true

--- a/rpc/grpc/client/Cargo.toml
+++ b/rpc/grpc/client/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-core.workspace = true

--- a/rpc/grpc/core/Cargo.toml
+++ b/rpc/grpc/core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-consensus-core.workspace = true

--- a/rpc/grpc/server/Cargo.toml
+++ b/rpc/grpc/server/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-consensus-core.workspace = true

--- a/rpc/macros/Cargo.toml
+++ b/rpc/macros/Cargo.toml
@@ -4,6 +4,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+repository.workspace = true
 keywords = ["rpc"]
 categories = []
 exclude = ["/.*", "/test"]

--- a/rpc/service/Cargo.toml
+++ b/rpc/service/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-addresses.workspace = true

--- a/rpc/wrpc/client/Cargo.toml
+++ b/rpc/wrpc/client/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 no-unsafe-eval = ["workflow-core/no-unsafe-eval","workflow-rpc/no-unsafe-eval"]

--- a/rpc/wrpc/proxy/Cargo.toml
+++ b/rpc/wrpc/proxy/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/rpc/wrpc/server/Cargo.toml
+++ b/rpc/wrpc/server/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/rpc/wrpc/wasm/Cargo.toml
+++ b/rpc/wrpc/wasm/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/simpa/Cargo.toml
+++ b/simpa/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-alloc.workspace = true            # This changes the global allocator for all of the next dependencies so should be kept first 

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 kaspa-alloc.workspace = true            # This changes the global allocator for all of the next dependencies so should be kept first

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 parking_lot.workspace = true

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 include.workspace = true
+repository.workspace = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 mimalloc = { version = "0.1.39", default-features = false, features = [

--- a/utils/tower/Cargo.toml
+++ b/utils/tower/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 cfg-if.workspace = true

--- a/wallet/bip32/Cargo.toml
+++ b/wallet/bip32/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 # include *.txt files for word lists
 include = ["src/**/*.rs", "Cargo.toml", "src/**/*.txt"]
 # include.workspace = true

--- a/wallet/core/Cargo.toml
+++ b/wallet/core/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "kaspa-wallet-core"
 description = "Kaspa wallet library"
+keywords = ["kaspa", "wallet"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 no-unsafe-eval = ["workflow-core/no-unsafe-eval","workflow-rpc/no-unsafe-eval"]

--- a/wallet/macros/Cargo.toml
+++ b/wallet/macros/Cargo.toml
@@ -4,6 +4,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+repository.workspace = true
 keywords = ["rpc"]
 categories = []
 exclude = ["/.*", "/test"]

--- a/wallet/native/Cargo.toml
+++ b/wallet/native/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 default = []

--- a/wallet/wasm/Cargo.toml
+++ b/wallet/wasm/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
Please do not merge until publishing is complete.

- Added `package.repository.workspace = true` flag to all crate manifests.
- Added some basic keywords to `kaspad`,`kaspa-cli`,`kaspa-wallet-core`
- Changed `secp256k1` version to `workspace.true` in `kaspa-txscript-errors` crate (benign change, actual version was matching the workspace and its for error refs only)