### PR TITLE
CachedDbAccess insert functions should first write to rocksDB then to cache

### DIFF
--- a/database/src/access.rs
+++ b/database/src/access.rs
@@ -90,8 +90,8 @@ where
         TData: Serialize,
     {
         let bin_data = bincode::serialize(&data)?;
-        self.cache.insert(key.clone(), data);
         writer.put(DbKey::new(&self.prefix, key), bin_data)?;
+        self.cache.insert(key.clone(), data);
         Ok(())
     }
 
@@ -105,11 +105,11 @@ where
         TData: Serialize,
     {
         let iter_clone = iter.clone();
-        self.cache.insert_many(iter);
         for (key, data) in iter_clone {
             let bin_data = bincode::serialize(&data)?;
             writer.put(DbKey::new(&self.prefix, key.clone()), bin_data)?;
         }
+        self.cache.insert_many(iter);
         Ok(())
     }
 


### PR DESCRIPTION
Hi : )

I'm new to this project and slowly reading up the code and see if there are some contributions I can make. 

Here in general it is a good practice to first add the data to the permanent store before storing it in the cache. In case somewhere the insertion throws an error and this error is caught somewhere, then you'd have inconsistency between the cache and the store.