### PR TITLE
Implement UTXO Return Address RPC command

### DIFF
--- a/cli/src/modules/rpc.rs
+++ b/cli/src/modules/rpc.rs
@@ -258,6 +258,21 @@ impl Rpc {
                 let result = rpc.get_current_block_color_call(None, GetCurrentBlockColorRequest { hash }).await?;
                 self.println(&ctx, result);
             }
+            RpcApiOps::GetUtxoReturnAddress => {
+                if argv.is_empty() || argv.len() != 2 {
+                    return Err(Error::custom("Please specify a txid and a accepting_block_daa_score"));
+                }
+
+                let txid = argv.remove(0);
+                let txid = RpcHash::from_hex(txid.as_str())?;
+
+                let accepting_block_daa_score = argv.remove(0).parse::<u64>()?;
+
+                let result =
+                    rpc.get_utxo_return_address_call(None, GetUtxoReturnAddressRequest { txid, accepting_block_daa_score }).await?;
+
+                self.println(&ctx, result);
+            }
             _ => {
                 tprintln!(ctx, "rpc method exists but is not supported by the cli: '{op_str}'\r\n");
                 return Ok(());

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -4,7 +4,7 @@
 
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
-    api::{BlockCount, BlockValidationFutures, ConsensusApi, ConsensusStats, DynConsensus},
+    api::{BlockCount, BlockValidationFutures, ConsensusApi, ConsensusStats, DynConsensus, ReturnAddress},
     block::Block,
     blockstatus::BlockStatus,
     daa_score_timestamp::DaaScoreTimestamp,
@@ -12,7 +12,7 @@ use kaspa_consensus_core::{
     header::Header,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath, Hash,
 };
 use kaspa_utils::sync::rwlock::*;
@@ -308,12 +308,8 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(|c| c.get_chain_block_samples()).await
     }
 
-    pub async fn async_get_utxo_return_script_public_key(
-        &self,
-        txid: Hash,
-        accepting_block_daa_score: u64,
-    ) -> Option<ScriptPublicKey> {
-        self.clone().spawn_blocking(move |c| c.get_utxo_return_script_public_key(txid, accepting_block_daa_score)).await
+    pub async fn async_get_utxo_return_script_public_key(&self, txid: Hash, accepting_block_daa_score: u64) -> ReturnAddress {
+        self.clone().spawn_blocking(move |c| c.get_utxo_return_address(txid, accepting_block_daa_score)).await
     }
 
     /// Returns the antipast of block `hash` from the POV of `context`, i.e. `antipast(hash) ∩ past(context)`.

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -12,7 +12,7 @@ use kaspa_consensus_core::{
     header::Header,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath, Hash,
 };
 use kaspa_utils::sync::rwlock::*;
@@ -306,6 +306,10 @@ impl ConsensusSessionOwned {
 
     pub async fn async_get_chain_block_samples(&self) -> Vec<DaaScoreTimestamp> {
         self.clone().spawn_blocking(|c| c.get_chain_block_samples()).await
+    }
+
+    pub async fn async_get_utxo_return_address(&self, txid: Hash, accepting_block_daa_score: u64) -> Option<ScriptPublicKey> {
+        self.clone().spawn_blocking(move |c| c.get_utxo_return_address(txid, accepting_block_daa_score)).await
     }
 
     /// Returns the antipast of block `hash` from the POV of `context`, i.e. `antipast(hash) ∩ past(context)`.

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -308,8 +308,12 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(|c| c.get_chain_block_samples()).await
     }
 
-    pub async fn async_get_utxo_return_address(&self, txid: Hash, accepting_block_daa_score: u64) -> Option<ScriptPublicKey> {
-        self.clone().spawn_blocking(move |c| c.get_utxo_return_address(txid, accepting_block_daa_score)).await
+    pub async fn async_get_utxo_return_script_public_key(
+        &self,
+        txid: Hash,
+        accepting_block_daa_score: u64,
+    ) -> Option<ScriptPublicKey> {
+        self.clone().spawn_blocking(move |c| c.get_utxo_return_script_public_key(txid, accepting_block_daa_score)).await
     }
 
     /// Returns the antipast of block `hash` from the POV of `context`, i.e. `antipast(hash) ∩ past(context)`.

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -1,6 +1,10 @@
 use futures_util::future::BoxFuture;
+use kaspa_addresses::Address;
 use kaspa_muhash::MuHash;
-use std::sync::Arc;
+use std::{
+    fmt::{Display, Formatter},
+    sync::Arc,
+};
 
 use crate::{
     acceptance_data::AcceptanceData,
@@ -19,7 +23,7 @@ use crate::{
     header::Header,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath,
 };
 use kaspa_hashes::Hash;
@@ -41,6 +45,31 @@ pub struct BlockValidationFutures {
     /// (exceptions are header-only blocks and trusted blocks which have the future completed before virtual
     /// processing along with the [`block_task`])
     pub virtual_state_task: BlockValidationFuture,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReturnAddress {
+    Found(Address),
+    AlreadyPruned,
+    TxFromCoinbase,
+    NoTxAtScore,
+    NonStandard,
+    NotFound(String),
+}
+
+impl Display for ReturnAddress {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ReturnAddress::AlreadyPruned => "Transaction is already pruned".to_string(),
+            ReturnAddress::NoTxAtScore => "Transaction not found at given accepting daa score".to_string(),
+            ReturnAddress::NonStandard => "Transaction was found but not standard".to_string(),
+            ReturnAddress::TxFromCoinbase => "Transaction return address is coinbase".to_string(),
+            ReturnAddress::NotFound(reason) => format!("Transaction return address not found: {}", reason),
+            ReturnAddress::Found(address) => address.to_string(),
+        };
+        f.write_str(&s)
+    }
 }
 
 /// Abstracts the consensus external API
@@ -165,7 +194,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn get_utxo_return_script_public_key(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
+    fn get_utxo_return_address(&self, txid: Hash, daa_score: u64) -> ReturnAddress {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -165,7 +165,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn get_utxo_return_address(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
+    fn get_utxo_return_script_public_key(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     header::Header,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath,
 };
 use kaspa_hashes::Hash;
@@ -162,6 +162,10 @@ pub trait ConsensusApi: Send + Sync {
     }
 
     fn get_chain_block_samples(&self) -> Vec<DaaScoreTimestamp> {
+        unimplemented!()
+    }
+
+    fn get_utxo_return_address(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
         unimplemented!()
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -66,7 +66,7 @@ use kaspa_consensus_core::{
     network::NetworkType,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath, HashMapCustomHasher,
 };
 use kaspa_consensus_notify::root::ConsensusNotificationRoot;
@@ -682,6 +682,69 @@ impl ConsensusApi for Consensus {
         }
 
         sample_headers
+    }
+
+    fn get_utxo_return_address(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
+        // We need consistency between the past pruning points, selected chain and header store reads
+        let _guard = self.pruning_lock.blocking_read();
+
+        let sc_read = self.selected_chain_store.read();
+
+        let low = self.pruning_point_store.read().get().unwrap().pruning_point;
+        let high = sc_read.get_tip().unwrap().1;
+
+        let mut low_index = sc_read.get_by_hash(low).unwrap();
+        let mut high_index = sc_read.get_by_hash(high).unwrap();
+
+        // let mut locator = Vec::with_capacity((high_index - low_index).ceiling_log_base_2() as usize);
+        // let mut current_index = high_index;
+        let mut matching_chain_block_hash: Option<Hash> = None;
+        while low_index < high_index {
+            let mid = low_index + (high_index - low_index) / 2;
+
+            if let Ok(hash) = sc_read.get_by_index(mid) {
+                if let Ok(compact_header) = self.headers_store.get_compact_header_data(hash) {
+                    if compact_header.daa_score == daa_score {
+                        // We found the chain block we need
+                        matching_chain_block_hash = Some(hash);
+                        break;
+                    } else if compact_header.daa_score < daa_score {
+                        low_index = mid + 1;
+                    } else {
+                        high_index = mid - 1;
+                    }
+                } else {
+                    println!("Did not find a compact header with hash {}", hash);
+                    break;
+                }
+            } else {
+                println!("Did not find a hash at index {}", mid);
+                break;
+            }
+        }
+
+        if matching_chain_block_hash.is_none() {
+            println!("No matching chain block hash found");
+            return None;
+        }
+
+        if let Ok(acceptance_data) = self.acceptance_data_store.get(matching_chain_block_hash.unwrap()) {
+            let containing_acceptance = acceptance_data
+                .iter()
+                .find(|&mbad| mbad.accepted_transactions.iter().find(|&tx| tx.transaction_id == txid).is_some())
+                .cloned();
+
+            if let Some(containing_acceptance) = containing_acceptance {
+                // I found the merged block containing the TXID
+                // let txs = self.block_transactions_store.get(containing_acceptance.block_hash).unwrap().iter().find(|tx| => )
+            } else {
+                return None;
+            }
+
+            return None;
+        } else {
+            return None;
+        };
     }
 
     fn get_virtual_parents(&self) -> BlockHashSet {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -77,6 +77,7 @@ use crossbeam_channel::{
 use itertools::Itertools;
 use kaspa_consensusmanager::{SessionLock, SessionReadGuard};
 
+use kaspa_core::{trace, warn};
 use kaspa_database::prelude::StoreResultExtensions;
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
@@ -101,6 +102,9 @@ use self::{services::ConsensusServices, storage::ConsensusStorage};
 use crate::model::stores::selected_chain::SelectedChainStoreReader;
 
 use std::cmp;
+
+use crate::model::stores::utxo_diffs::UtxoDiffsStoreReader;
+use kaspa_consensus_core::utxo::utxo_diff::ImmutableUtxoDiff;
 
 pub struct Consensus {
     // DB
@@ -684,67 +688,95 @@ impl ConsensusApi for Consensus {
         sample_headers
     }
 
-    fn get_utxo_return_address(&self, txid: Hash, daa_score: u64) -> Option<ScriptPublicKey> {
+    fn get_utxo_return_script_public_key(&self, txid: Hash, target_daa_score: u64) -> Option<ScriptPublicKey> {
         // We need consistency between the past pruning points, selected chain and header store reads
         let _guard = self.pruning_lock.blocking_read();
 
         let sc_read = self.selected_chain_store.read();
 
-        let low = self.pruning_point_store.read().get().unwrap().pruning_point;
-        let high = sc_read.get_tip().unwrap().1;
+        let pp_hash = self.pruning_point_store.read().get().unwrap().pruning_point;
+        let pp_index = sc_read.get_by_hash(pp_hash).unwrap();
+        let (tip_index, tip_hash) = sc_read.get_tip().unwrap();
+        let tip_daa_score = self.headers_store.get_compact_header_data(tip_hash).unwrap().daa_score;
 
-        let mut low_index = sc_read.get_by_hash(low).unwrap();
-        let mut high_index = sc_read.get_by_hash(high).unwrap();
+        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(pp_index);
+        let mut high_index = tip_index;
 
-        // let mut locator = Vec::with_capacity((high_index - low_index).ceiling_log_base_2() as usize);
-        // let mut current_index = high_index;
         let mut matching_chain_block_hash: Option<Hash> = None;
-        while low_index < high_index {
+        while low_index <= high_index {
             let mid = low_index + (high_index - low_index) / 2;
 
             if let Ok(hash) = sc_read.get_by_index(mid) {
                 if let Ok(compact_header) = self.headers_store.get_compact_header_data(hash) {
-                    if compact_header.daa_score == daa_score {
-                        // We found the chain block we need
-                        matching_chain_block_hash = Some(hash);
-                        break;
-                    } else if compact_header.daa_score < daa_score {
-                        low_index = mid + 1;
-                    } else {
-                        high_index = mid - 1;
+                    match compact_header.daa_score.cmp(&target_daa_score) {
+                        cmp::Ordering::Equal => {
+                            // We found the chain block we need
+                            matching_chain_block_hash = Some(hash);
+                            break;
+                        }
+                        cmp::Ordering::Greater => {
+                            high_index = mid - 1;
+                        }
+                        cmp::Ordering::Less => {
+                            low_index = mid + 1;
+                        }
                     }
                 } else {
-                    println!("Did not find a compact header with hash {}", hash);
-                    break;
+                    trace!("Did not find a compact header with hash {}", hash);
+                    return None;
                 }
             } else {
-                println!("Did not find a hash at index {}", mid);
-                break;
-            }
-        }
-
-        if matching_chain_block_hash.is_none() {
-            println!("No matching chain block hash found");
-            return None;
-        }
-
-        if let Ok(acceptance_data) = self.acceptance_data_store.get(matching_chain_block_hash.unwrap()) {
-            let containing_acceptance = acceptance_data
-                .iter()
-                .find(|&mbad| mbad.accepted_transactions.iter().find(|&tx| tx.transaction_id == txid).is_some())
-                .cloned();
-
-            if let Some(containing_acceptance) = containing_acceptance {
-                // I found the merged block containing the TXID
-                // let txs = self.block_transactions_store.get(containing_acceptance.block_hash).unwrap().iter().find(|tx| => )
-            } else {
+                trace!("Did not find a hash at index {}", mid);
                 return None;
             }
+        }
 
-            return None;
-        } else {
-            return None;
+        let matching_chain_block_hash = matching_chain_block_hash?;
+
+        if let Ok(acceptance_data) = self.acceptance_data_store.get(matching_chain_block_hash) {
+            let maybe_index_and_containing_acceptance =
+                acceptance_data.iter().find_map(|mbad| {
+                    let tx_arr_index = mbad.accepted_transactions.iter().enumerate().find_map(|(index, tx)| {
+                        if tx.transaction_id == txid {
+                            Some(index)
+                        } else {
+                            None
+                        }
+                    });
+
+                    tx_arr_index.map(|index| (index, mbad.clone()))
+                });
+
+            if let Some((index, containing_acceptance)) = maybe_index_and_containing_acceptance {
+                // Found Merged block containing the TXID
+                let tx = &self.block_transactions_store.get(containing_acceptance.block_hash).unwrap()[index];
+
+                if tx.id() != txid {
+                    // Should never happen, but do a sanity check. This would mean something went wrong with storing block transactions
+                    // Sanity check is necessary to guarantee that this function will never give back a wrong address (err on the side of None)
+                    warn!(
+                        "Expected {} to match {} when checking block_transaction_store using array index of transaction",
+                        tx.id(),
+                        txid
+                    );
+                    return None;
+                }
+
+                if tx.inputs.is_empty() {
+                    // A transaction may have no inputs (like a coinbase transaction)
+                    return None;
+                }
+
+                let first_input_prev_outpoint = &tx.inputs[0].previous_outpoint;
+                // Expected to never fail, since
+                let utxo_diff = self.utxo_diffs_store.get(matching_chain_block_hash).unwrap();
+                let removed_diffs = utxo_diff.removed();
+
+                return Some(removed_diffs.get(first_input_prev_outpoint)?.script_public_key.clone());
+            }
         };
+
+        None
     }
 
     fn get_virtual_parents(&self) -> BlockHashSet {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -46,7 +46,7 @@ use kaspa_consensus_core::{
     api::{
         args::{TransactionValidationArgs, TransactionValidationBatchArgs},
         stats::BlockCount,
-        BlockValidationFutures, ConsensusApi, ConsensusStats,
+        BlockValidationFutures, ConsensusApi, ConsensusStats, ReturnAddress,
     },
     block::{Block, BlockTemplate, TemplateBuildMode, TemplateTransactionSelector, VirtualStateApproxId},
     blockhash::BlockHashExtensions,
@@ -66,7 +66,7 @@ use kaspa_consensus_core::{
     network::NetworkType,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
     trusted::{ExternalGhostdagData, TrustedBlock},
-    tx::{MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
+    tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath, HashMapCustomHasher,
 };
 use kaspa_consensus_notify::root::ConsensusNotificationRoot;
@@ -81,7 +81,7 @@ use kaspa_core::{trace, warn};
 use kaspa_database::prelude::StoreResultExtensions;
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
-use kaspa_txscript::caches::TxScriptCacheCounters;
+use kaspa_txscript::{caches::TxScriptCacheCounters, extract_script_pub_key_address};
 
 use std::{
     cmp::Reverse,
@@ -688,13 +688,20 @@ impl ConsensusApi for Consensus {
         sample_headers
     }
 
-    fn get_utxo_return_script_public_key(&self, txid: Hash, target_daa_score: u64) -> Option<ScriptPublicKey> {
+    fn get_utxo_return_address(&self, txid: Hash, target_daa_score: u64) -> ReturnAddress {
         // We need consistency between the past pruning points, selected chain and header store reads
         let _guard = self.pruning_lock.blocking_read();
 
         let sc_read = self.selected_chain_store.read();
 
         let pp_hash = self.pruning_point_store.read().get().unwrap().pruning_point;
+
+        // Pruning Point hash is always expected to be in get_compact_header_data so unwrap should never fail
+        if target_daa_score < self.headers_store.get_compact_header_data(pp_hash).unwrap().daa_score {
+            // Early exit if target daa score is lower than that of pruning point's daa score:
+            return ReturnAddress::AlreadyPruned;
+        }
+
         let pp_index = sc_read.get_by_hash(pp_hash).unwrap();
         let (tip_index, tip_hash) = sc_read.get_tip().unwrap();
         let tip_daa_score = self.headers_store.get_compact_header_data(tip_hash).unwrap().daa_score;
@@ -708,29 +715,28 @@ impl ConsensusApi for Consensus {
             let mid = low_index + (high_index - low_index) / 2;
 
             // 1. Get the chain block hash at that index. Error if we don't find a hash at an index
-            let hash = sc_read
-                .get_by_index(mid)
-                .map_err(|err| {
+            let hash = match sc_read.get_by_index(mid) {
+                Ok(hash) => hash,
+                Err(_) => {
                     trace!("Did not find a hash at index {}", mid);
-                    err
-                })
-                .ok()?;
+                    return ReturnAddress::NotFound(format!("Did not find a hash at index {}", mid));
+                }
+            };
 
             // 2. Get the compact header so we have access to the daa_score. Error if we
-            let compact_header = self
-                .headers_store
-                .get_compact_header_data(hash)
-                .map_err(|err| {
+            let compact_header = match self.headers_store.get_compact_header_data(hash) {
+                Ok(compact_header) => compact_header,
+                Err(_) => {
                     trace!("Did not find a compact header with hash {}", hash);
-                    err
-                })
-                .ok()?;
+                    return ReturnAddress::NotFound(format!("Did not find a compact header with hash {}", hash));
+                }
+            };
 
             // 3. Compare block daa score to our target
             match compact_header.daa_score.cmp(&target_daa_score) {
                 cmp::Ordering::Equal => {
                     // We found the chain block we need
-                    break Some(hash);
+                    break hash;
                 }
                 cmp::Ordering::Greater => {
                     high_index = mid - 1;
@@ -741,30 +747,44 @@ impl ConsensusApi for Consensus {
             }
 
             if low_index > high_index {
-                break None;
+                return ReturnAddress::NoTxAtScore;
             }
-        }?;
+        };
 
-        let acceptance_data = self.acceptance_data_store.get(matching_chain_block_hash).ok()?;
-        let (index, containing_acceptance) = acceptance_data.iter().find_map(|mbad| {
+        let acceptance_data = match self.acceptance_data_store.get(matching_chain_block_hash) {
+            Ok(acceptance_data) => acceptance_data,
+            Err(_) => {
+                return ReturnAddress::NotFound("Did not find acceptance data".to_string());
+            }
+        };
+        let (index, containing_acceptance) = match acceptance_data.iter().find_map(|mbad| {
             let tx_arr_index =
                 mbad.accepted_transactions.iter().enumerate().find_map(|(index, tx)| (tx.transaction_id == txid).then_some(index));
             tx_arr_index.map(|index| (index, mbad.clone()))
-        })?;
+        }) {
+            Some((index, containing_acceptance)) => (index, containing_acceptance),
+            None => {
+                return ReturnAddress::NotFound("Did not find containing_acceptance".to_string());
+            }
+        };
 
         // Found Merged block containing the TXID
         let tx = &self.block_transactions_store.get(containing_acceptance.block_hash).unwrap()[index];
 
         if tx.id() != txid {
             // Should never happen, but do a sanity check. This would mean something went wrong with storing block transactions
-            // Sanity check is necessary to guarantee that this function will never give back a wrong address (err on the side of None)
+            // Sanity check is necessary to guarantee that this function will never give back a wrong address (err on the side of NotFound)
             warn!("Expected {} to match {} when checking block_transaction_store using array index of transaction", tx.id(), txid);
-            return None;
+            return ReturnAddress::NotFound(format!(
+                "Expected {} to match {} when checking block_transaction_store using array index of transaction",
+                tx.id(),
+                txid
+            ));
         }
 
         if tx.inputs.is_empty() {
             // A transaction may have no inputs (like a coinbase transaction)
-            return None;
+            return ReturnAddress::TxFromCoinbase;
         }
 
         let first_input_prev_outpoint = &tx.inputs[0].previous_outpoint;
@@ -772,7 +792,14 @@ impl ConsensusApi for Consensus {
         let utxo_diff = self.utxo_diffs_store.get(matching_chain_block_hash).unwrap();
         let removed_diffs = utxo_diff.removed();
 
-        Some(removed_diffs.get(first_input_prev_outpoint)?.script_public_key.clone())
+        if let Ok(address) = extract_script_pub_key_address(
+            &removed_diffs.get(first_input_prev_outpoint).unwrap().script_public_key,
+            self.config.prefix(),
+        ) {
+            ReturnAddress::Found(address)
+        } else {
+            ReturnAddress::NonStandard
+        }
     }
 
     fn get_virtual_parents(&self) -> BlockHashSet {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -694,19 +694,19 @@ impl ConsensusApi for Consensus {
 
         let sc_read = self.selected_chain_store.read();
 
-        let pp_hash = self.pruning_point_store.read().get().unwrap().pruning_point;
+        let source_hash = self.get_source();
 
         // Pruning Point hash is always expected to be in get_compact_header_data so unwrap should never fail
-        if target_daa_score < self.headers_store.get_compact_header_data(pp_hash).unwrap().daa_score {
+        if target_daa_score < self.headers_store.get_compact_header_data(source_hash).unwrap().daa_score {
             // Early exit if target daa score is lower than that of pruning point's daa score:
             return ReturnAddress::AlreadyPruned;
         }
 
-        let pp_index = sc_read.get_by_hash(pp_hash).unwrap();
+        let source_index = sc_read.get_by_hash(source_hash).unwrap();
         let (tip_index, tip_hash) = sc_read.get_tip().unwrap();
         let tip_daa_score = self.headers_store.get_compact_header_data(tip_hash).unwrap().daa_score;
 
-        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(pp_index);
+        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(source_index);
         let mut high_index = tip_index;
 
         let matching_chain_block_hash = loop {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -759,7 +759,7 @@ impl ConsensusApi for Consensus {
         };
         let (index, containing_acceptance) = match acceptance_data.iter().find_map(|mbad| {
             let tx_arr_index =
-                mbad.accepted_transactions.iter().enumerate().find_map(|(index, tx)| (tx.transaction_id == txid).then_some(index));
+                mbad.accepted_transactions.iter().find_map(|tx| (tx.transaction_id == txid).then_some(tx.index_within_block as usize));
             tx_arr_index.map(|index| (index, mbad.clone()))
         }) {
             Some((index, containing_acceptance)) => (index, containing_acceptance),

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -702,81 +702,77 @@ impl ConsensusApi for Consensus {
         let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(pp_index);
         let mut high_index = tip_index;
 
-        let mut matching_chain_block_hash: Option<Hash> = None;
-        while low_index <= high_index {
+        let matching_chain_block_hash = loop {
+            // Binary search for the chain block that matches the target_daa_score
+            // 0. Get the mid point index
             let mid = low_index + (high_index - low_index) / 2;
 
-            if let Ok(hash) = sc_read.get_by_index(mid) {
-                if let Ok(compact_header) = self.headers_store.get_compact_header_data(hash) {
-                    match compact_header.daa_score.cmp(&target_daa_score) {
-                        cmp::Ordering::Equal => {
-                            // We found the chain block we need
-                            matching_chain_block_hash = Some(hash);
-                            break;
-                        }
-                        cmp::Ordering::Greater => {
-                            high_index = mid - 1;
-                        }
-                        cmp::Ordering::Less => {
-                            low_index = mid + 1;
-                        }
-                    }
-                } else {
+            // 1. Get the chain block hash at that index. Error if we don't find a hash at an index
+            let hash = sc_read
+                .get_by_index(mid)
+                .map_err(|err| {
+                    trace!("Did not find a hash at index {}", mid);
+                    err
+                })
+                .ok()?;
+
+            // 2. Get the compact header so we have access to the daa_score. Error if we
+            let compact_header = self
+                .headers_store
+                .get_compact_header_data(hash)
+                .map_err(|err| {
                     trace!("Did not find a compact header with hash {}", hash);
-                    return None;
+                    err
+                })
+                .ok()?;
+
+            // 3. Compare block daa score to our target
+            match compact_header.daa_score.cmp(&target_daa_score) {
+                cmp::Ordering::Equal => {
+                    // We found the chain block we need
+                    break Some(hash);
                 }
-            } else {
-                trace!("Did not find a hash at index {}", mid);
-                return None;
+                cmp::Ordering::Greater => {
+                    high_index = mid - 1;
+                }
+                cmp::Ordering::Less => {
+                    low_index = mid + 1;
+                }
             }
+
+            if low_index > high_index {
+                break None;
+            }
+        }?;
+
+        let acceptance_data = self.acceptance_data_store.get(matching_chain_block_hash).ok()?;
+        let (index, containing_acceptance) = acceptance_data.iter().find_map(|mbad| {
+            let tx_arr_index =
+                mbad.accepted_transactions.iter().enumerate().find_map(|(index, tx)| (tx.transaction_id == txid).then_some(index));
+            tx_arr_index.map(|index| (index, mbad.clone()))
+        })?;
+
+        // Found Merged block containing the TXID
+        let tx = &self.block_transactions_store.get(containing_acceptance.block_hash).unwrap()[index];
+
+        if tx.id() != txid {
+            // Should never happen, but do a sanity check. This would mean something went wrong with storing block transactions
+            // Sanity check is necessary to guarantee that this function will never give back a wrong address (err on the side of None)
+            warn!("Expected {} to match {} when checking block_transaction_store using array index of transaction", tx.id(), txid);
+            return None;
         }
 
-        let matching_chain_block_hash = matching_chain_block_hash?;
+        if tx.inputs.is_empty() {
+            // A transaction may have no inputs (like a coinbase transaction)
+            return None;
+        }
 
-        if let Ok(acceptance_data) = self.acceptance_data_store.get(matching_chain_block_hash) {
-            let maybe_index_and_containing_acceptance =
-                acceptance_data.iter().find_map(|mbad| {
-                    let tx_arr_index = mbad.accepted_transactions.iter().enumerate().find_map(|(index, tx)| {
-                        if tx.transaction_id == txid {
-                            Some(index)
-                        } else {
-                            None
-                        }
-                    });
+        let first_input_prev_outpoint = &tx.inputs[0].previous_outpoint;
+        // Expected to never fail, since we found the acceptance data and therefore there must be matching diff
+        let utxo_diff = self.utxo_diffs_store.get(matching_chain_block_hash).unwrap();
+        let removed_diffs = utxo_diff.removed();
 
-                    tx_arr_index.map(|index| (index, mbad.clone()))
-                });
-
-            if let Some((index, containing_acceptance)) = maybe_index_and_containing_acceptance {
-                // Found Merged block containing the TXID
-                let tx = &self.block_transactions_store.get(containing_acceptance.block_hash).unwrap()[index];
-
-                if tx.id() != txid {
-                    // Should never happen, but do a sanity check. This would mean something went wrong with storing block transactions
-                    // Sanity check is necessary to guarantee that this function will never give back a wrong address (err on the side of None)
-                    warn!(
-                        "Expected {} to match {} when checking block_transaction_store using array index of transaction",
-                        tx.id(),
-                        txid
-                    );
-                    return None;
-                }
-
-                if tx.inputs.is_empty() {
-                    // A transaction may have no inputs (like a coinbase transaction)
-                    return None;
-                }
-
-                let first_input_prev_outpoint = &tx.inputs[0].previous_outpoint;
-                // Expected to never fail, since
-                let utxo_diff = self.utxo_diffs_store.get(matching_chain_block_hash).unwrap();
-                let removed_diffs = utxo_diff.removed();
-
-                return Some(removed_diffs.get(first_input_prev_outpoint)?.script_public_key.clone());
-            }
-        };
-
-        None
+        Some(removed_diffs.get(first_input_prev_outpoint)?.script_public_key.clone())
     }
 
     fn get_virtual_parents(&self) -> BlockHashSet {

--- a/rpc/core/src/api/ops.rs
+++ b/rpc/core/src/api/ops.rs
@@ -132,6 +132,8 @@ pub enum RpcApiOps {
     GetFeeEstimateExperimental = 148,
     /// Block color determination by iterating DAG.
     GetCurrentBlockColor = 149,
+    /// Get UTXO Return Addresses
+    GetUtxoReturnAddress = 150,
 }
 
 impl RpcApiOps {

--- a/rpc/core/src/api/rpc.rs
+++ b/rpc/core/src/api/rpc.rs
@@ -436,6 +436,18 @@ pub trait RpcApi: Sync + Send + AnySync {
         request: GetDaaScoreTimestampEstimateRequest,
     ) -> RpcResult<GetDaaScoreTimestampEstimateResponse>;
 
+    async fn get_utxo_return_address(&self, txid: RpcHash, accepting_block_daa_score: u64) -> RpcResult<Option<RpcAddress>> {
+        Ok(self
+            .get_utxo_return_address_call(None, GetUtxoReturnAddressRequest { txid, accepting_block_daa_score })
+            .await?
+            .return_address)
+    }
+    async fn get_utxo_return_address_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        request: GetUtxoReturnAddressRequest,
+    ) -> RpcResult<GetUtxoReturnAddressResponse>;
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Fee estimation API
 

--- a/rpc/core/src/error.rs
+++ b/rpc/core/src/error.rs
@@ -1,4 +1,4 @@
-use kaspa_consensus_core::{subnets::SubnetworkConversionError, tx::TransactionId};
+use kaspa_consensus_core::{api::ReturnAddress, subnets::SubnetworkConversionError, tx::TransactionId};
 use kaspa_utils::networking::IpAddress;
 use std::{net::AddrParseError, num::TryFromIntError};
 use thiserror::Error;
@@ -130,6 +130,9 @@ pub enum RpcError {
 
     #[error(transparent)]
     ConsensusClient(#[from] kaspa_consensus_client::error::Error),
+
+    #[error("utxo return address could not be found -> {0}")]
+    UtxoReturnAddressNotFound(ReturnAddress),
 }
 
 impl From<String> for RpcError {

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -2666,6 +2666,69 @@ impl Deserializer for GetCurrentBlockColorResponse {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUtxoReturnAddressRequest {
+    pub txid: RpcHash,
+    pub accepting_block_daa_score: u64,
+}
+
+impl GetUtxoReturnAddressRequest {
+    pub fn new(txid: RpcHash, accepting_block_daa_score: u64) -> Self {
+        Self { txid, accepting_block_daa_score }
+    }
+}
+
+impl Serializer for GetUtxoReturnAddressRequest {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(RpcHash, &self.txid, writer)?;
+        store!(u64, &self.accepting_block_daa_score, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetUtxoReturnAddressRequest {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let txid = load!(RpcHash, reader)?;
+        let accepting_block_daa_score = load!(u64, reader)?;
+
+        Ok(Self { txid, accepting_block_daa_score })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUtxoReturnAddressResponse {
+    pub return_address: Option<RpcAddress>,
+}
+
+impl GetUtxoReturnAddressResponse {
+    pub fn new(return_address: Option<RpcAddress>) -> Self {
+        Self { return_address }
+    }
+}
+
+impl Serializer for GetUtxoReturnAddressResponse {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(Option<RpcAddress>, &self.return_address, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetUtxoReturnAddressResponse {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let return_address = load!(Option<RpcAddress>, reader)?;
+
+        Ok(Self { return_address })
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Subscriptions & notifications
 // ----------------------------------------------------------------------------

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -277,6 +277,7 @@ impl RpcApi for GrpcClient {
     route!(get_fee_estimate_call, GetFeeEstimate);
     route!(get_fee_estimate_experimental_call, GetFeeEstimateExperimental);
     route!(get_current_block_color_call, GetCurrentBlockColor);
+    route!(get_utxo_return_address_call, GetUtxoReturnAddress);
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API

--- a/rpc/grpc/core/proto/messages.proto
+++ b/rpc/grpc/core/proto/messages.proto
@@ -65,6 +65,7 @@ message KaspadRequest {
     GetFeeEstimateRequestMessage getFeeEstimateRequest = 1106;
     GetFeeEstimateExperimentalRequestMessage getFeeEstimateExperimentalRequest = 1108;
     GetCurrentBlockColorRequestMessage getCurrentBlockColorRequest = 1110;
+    GetUtxoReturnAddressRequestMessage GetUtxoReturnAddressRequest = 1112;
   }
 }
 
@@ -130,6 +131,7 @@ message KaspadResponse {
     GetFeeEstimateResponseMessage getFeeEstimateResponse = 1107;
     GetFeeEstimateExperimentalResponseMessage getFeeEstimateExperimentalResponse = 1109;
     GetCurrentBlockColorResponseMessage getCurrentBlockColorResponse = 1111;
+    GetUtxoReturnAddressResponseMessage GetUtxoReturnAddressResponse = 1113;
   }
 }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -900,7 +900,7 @@ message GetDaaScoreTimestampEstimateRequestMessage {
   repeated uint64 daa_scores = 1;
 }
 
-message GetDaaScoreTimestampEstimateResponseMessage{
+message GetDaaScoreTimestampEstimateResponseMessage {
   repeated uint64 timestamps = 1;
   RPCError error = 1000;
 }
@@ -968,5 +968,15 @@ message GetCurrentBlockColorRequestMessage {
 message GetCurrentBlockColorResponseMessage {
   bool blue = 1;
 
+  RPCError error = 1000;
+}
+
+message GetUtxoReturnAddressRequestMessage {
+  string txid = 1;
+  uint64 accepting_block_daa_score = 2;
+}
+
+message GetUtxoReturnAddressResponseMessage {
+  string return_address = 1;
   RPCError error = 1000;
 }

--- a/rpc/grpc/core/src/convert/kaspad.rs
+++ b/rpc/grpc/core/src/convert/kaspad.rs
@@ -63,6 +63,7 @@ pub mod kaspad_request_convert {
     impl_into_kaspad_request!(GetFeeEstimate);
     impl_into_kaspad_request!(GetFeeEstimateExperimental);
     impl_into_kaspad_request!(GetCurrentBlockColor);
+    impl_into_kaspad_request!(GetUtxoReturnAddress);
 
     impl_into_kaspad_request!(NotifyBlockAdded);
     impl_into_kaspad_request!(NotifyNewBlockTemplate);
@@ -200,6 +201,7 @@ pub mod kaspad_response_convert {
     impl_into_kaspad_response!(GetFeeEstimate);
     impl_into_kaspad_response!(GetFeeEstimateExperimental);
     impl_into_kaspad_response!(GetCurrentBlockColor);
+    impl_into_kaspad_response!(GetUtxoReturnAddress);
 
     impl_into_kaspad_notify_response!(NotifyBlockAdded);
     impl_into_kaspad_notify_response!(NotifyNewBlockTemplate);

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -19,7 +19,7 @@
 //! The SubmitBlockResponse is a notable exception to this general rule.
 
 use crate::protowire::{self, submit_block_response_message::RejectReason};
-use kaspa_consensus_core::network::NetworkId;
+use kaspa_consensus_core::{network::NetworkId, Hash};
 use kaspa_core::debug;
 use kaspa_notify::subscription::Command;
 use kaspa_rpc_core::{
@@ -428,6 +428,21 @@ from!(item: &kaspa_rpc_core::GetCurrentBlockColorRequest, protowire::GetCurrentB
 });
 from!(item: RpcResult<&kaspa_rpc_core::GetCurrentBlockColorResponse>, protowire::GetCurrentBlockColorResponseMessage, {
     Self { blue: item.blue, error: None }
+});
+
+from!(item: &kaspa_rpc_core::GetUtxoReturnAddressRequest, protowire::GetUtxoReturnAddressRequestMessage, {
+    Self {
+        txid: item.txid.to_string(),
+        accepting_block_daa_score: item.accepting_block_daa_score
+    }
+});
+from!(item: RpcResult<&kaspa_rpc_core::GetUtxoReturnAddressResponse>, protowire::GetUtxoReturnAddressResponseMessage, {
+    if let Some(return_address) = &item.return_address {
+        Self { return_address: return_address.into(), error: None }
+    } else {
+        Self { return_address: String::from(""), error: None }
+    }
+
 });
 
 from!(&kaspa_rpc_core::PingRequest, protowire::PingRequestMessage);
@@ -915,6 +930,17 @@ try_from!(item: &protowire::GetCurrentBlockColorResponseMessage, RpcResult<kaspa
     Self {
         blue: item.blue
     }
+});
+try_from!(item: &protowire::GetUtxoReturnAddressRequestMessage, kaspa_rpc_core::GetUtxoReturnAddressRequest , {
+    Self {
+        txid: Hash::from_str(&item.txid).unwrap_or_default(),
+        accepting_block_daa_score: item.accepting_block_daa_score
+    }
+});
+try_from!(item: &protowire::GetUtxoReturnAddressResponseMessage, RpcResult<kaspa_rpc_core::GetUtxoReturnAddressResponse>, {
+    // Self { return_address: Some(Address::from(item.return_address)) }
+    // TODO: import Address
+    Self { return_address: None }
 });
 
 try_from!(&protowire::PingRequestMessage, kaspa_rpc_core::PingRequest);

--- a/rpc/grpc/core/src/ops.rs
+++ b/rpc/grpc/core/src/ops.rs
@@ -87,6 +87,7 @@ pub enum KaspadPayloadOps {
     GetFeeEstimate,
     GetFeeEstimateExperimental,
     GetCurrentBlockColor,
+    GetUtxoReturnAddress,
 
     // Subscription commands for starting/stopping notifications
     NotifyBlockAdded,

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -81,6 +81,7 @@ impl Factory {
                 GetFeeEstimate,
                 GetFeeEstimateExperimental,
                 GetCurrentBlockColor,
+                GetUtxoReturnAddress,
                 NotifyBlockAdded,
                 NotifyNewBlockTemplate,
                 NotifyFinalityConflict,

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -362,6 +362,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_utxo_return_address_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetUtxoReturnAddressRequest,
+    ) -> RpcResult<GetUtxoReturnAddressResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -63,6 +63,7 @@ use kaspa_rpc_core::{
     notify::connection::ChannelConnection,
     Notification, RpcError, RpcResult,
 };
+use kaspa_txscript::opcodes::codes;
 use kaspa_txscript::{extract_script_pub_key_address, pay_to_address_script};
 use kaspa_utils::expiring_cache::ExpiringCache;
 use kaspa_utils::sysinfo::SystemInfo;
@@ -786,10 +787,32 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         _connection: Option<&DynRpcConnection>,
         request: GetUtxoReturnAddressRequest,
     ) -> RpcResult<GetUtxoReturnAddressResponse> {
-        // let session = self.consensus_manager.consensus().session().await;
-        println!("{} {}", request.txid, request.accepting_block_daa_score);
-        // let mut maybe_spk = session.async_get_utxo_return_address(request.txid, request.accepting_block_daa_score).await;
-        Ok(GetUtxoReturnAddressResponse { return_address: None })
+        let session = self.consensus_manager.consensus().session().await;
+
+        let mut return_address = None;
+
+        // Convert a SPK to an Address
+        if let Some(spk) = session.async_get_utxo_return_script_public_key(request.txid, request.accepting_block_daa_score).await {
+            let script = spk.script();
+
+            // Standard Address scripts are only either 34 or 35 in length:
+            if script.len() == 34 && script[0] == codes::OpData32 && script[33] == codes::OpCheckSig {
+                // This is a standard Schnorr Address
+                return_address = Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::PubKey, &script[1..33]));
+            } else if script.len() == 35 {
+                // Could be ECDSA address OR P2SH
+                if script[0] == codes::OpData33 && script[34] == codes::OpCheckSigECDSA {
+                    // This is an standard ECDSA Address
+                    return_address =
+                        Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::PubKeyECDSA, &script[1..34]));
+                } else if script[0] == codes::OpBlake2b && script[1] == codes::OpData32 && script[34] == codes::OpEqual {
+                    // This is a standard P2SH Address
+                    return_address = Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::ScriptHash, &script[2..34]));
+                }
+            }
+        };
+
+        Ok(GetUtxoReturnAddressResponse { return_address })
     }
 
     async fn ping_call(&self, _connection: Option<&DynRpcConnection>, _: PingRequest) -> RpcResult<PingResponse> {

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -6,6 +6,7 @@ use crate::converter::{consensus::ConsensusConverter, index::IndexConverter, pro
 use crate::service::NetworkType::{Mainnet, Testnet};
 use async_trait::async_trait;
 use kaspa_consensus_core::api::counters::ProcessingCounters;
+use kaspa_consensus_core::api::ReturnAddress;
 use kaspa_consensus_core::errors::block::RuleError;
 use kaspa_consensus_core::{
     block::Block,
@@ -789,13 +790,11 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         let session = self.consensus_manager.consensus().session().await;
 
         // Convert a SPK to an Address
-        let return_address = if let Some(spk) =
-            session.async_get_utxo_return_script_public_key(request.txid, request.accepting_block_daa_score).await
-        {
-            extract_script_pub_key_address(&spk, self.config.prefix()).ok()
-        } else {
-            None
-        };
+        let return_address =
+            match session.async_get_utxo_return_script_public_key(request.txid, request.accepting_block_daa_score).await {
+                ReturnAddress::Found(address) => Some(address),
+                other => return Err(RpcError::UtxoReturnAddressNotFound(other)),
+            };
 
         Ok(GetUtxoReturnAddressResponse { return_address })
     }

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -781,6 +781,17 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         }
     }
 
+    async fn get_utxo_return_address_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        request: GetUtxoReturnAddressRequest,
+    ) -> RpcResult<GetUtxoReturnAddressResponse> {
+        // let session = self.consensus_manager.consensus().session().await;
+        println!("{} {}", request.txid, request.accepting_block_daa_score);
+        // let mut maybe_spk = session.async_get_utxo_return_address(request.txid, request.accepting_block_daa_score).await;
+        Ok(GetUtxoReturnAddressResponse { return_address: None })
+    }
+
     async fn ping_call(&self, _connection: Option<&DynRpcConnection>, _: PingRequest) -> RpcResult<PingResponse> {
         Ok(PingResponse {})
     }

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -63,7 +63,6 @@ use kaspa_rpc_core::{
     notify::connection::ChannelConnection,
     Notification, RpcError, RpcResult,
 };
-use kaspa_txscript::opcodes::codes;
 use kaspa_txscript::{extract_script_pub_key_address, pay_to_address_script};
 use kaspa_utils::expiring_cache::ExpiringCache;
 use kaspa_utils::sysinfo::SystemInfo;
@@ -789,27 +788,13 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
     ) -> RpcResult<GetUtxoReturnAddressResponse> {
         let session = self.consensus_manager.consensus().session().await;
 
-        let mut return_address = None;
-
         // Convert a SPK to an Address
-        if let Some(spk) = session.async_get_utxo_return_script_public_key(request.txid, request.accepting_block_daa_score).await {
-            let script = spk.script();
-
-            // Standard Address scripts are only either 34 or 35 in length:
-            if script.len() == 34 && script[0] == codes::OpData32 && script[33] == codes::OpCheckSig {
-                // This is a standard Schnorr Address
-                return_address = Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::PubKey, &script[1..33]));
-            } else if script.len() == 35 {
-                // Could be ECDSA address OR P2SH
-                if script[0] == codes::OpData33 && script[34] == codes::OpCheckSigECDSA {
-                    // This is an standard ECDSA Address
-                    return_address =
-                        Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::PubKeyECDSA, &script[1..34]));
-                } else if script[0] == codes::OpBlake2b && script[1] == codes::OpData32 && script[34] == codes::OpEqual {
-                    // This is a standard P2SH Address
-                    return_address = Some(RpcAddress::new(self.config.prefix(), kaspa_addresses::Version::ScriptHash, &script[2..34]));
-                }
-            }
+        let return_address = if let Some(spk) =
+            session.async_get_utxo_return_script_public_key(request.txid, request.accepting_block_daa_score).await
+        {
+            extract_script_pub_key_address(&spk, self.config.prefix()).ok()
+        } else {
+            None
         };
 
         Ok(GetUtxoReturnAddressResponse { return_address })

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -635,6 +635,7 @@ impl RpcApi for KaspaRpcClient {
             GetSubnetwork,
             GetSyncStatus,
             GetSystemInfo,
+            GetUtxoReturnAddress,
             GetUtxosByAddresses,
             GetVirtualChainFromBlock,
             ResolveFinalityConflict,

--- a/rpc/wrpc/server/src/router.rs
+++ b/rpc/wrpc/server/src/router.rs
@@ -53,7 +53,6 @@ impl Router {
                 GetFeeEstimateExperimental,
                 GetHeaders,
                 GetInfo,
-                GetInfo,
                 GetMempoolEntries,
                 GetMempoolEntriesByAddresses,
                 GetMempoolEntry,

--- a/rpc/wrpc/server/src/router.rs
+++ b/rpc/wrpc/server/src/router.rs
@@ -47,6 +47,8 @@ impl Router {
                 GetCurrentBlockColor,
                 GetCoinSupply,
                 GetConnectedPeerInfo,
+                GetDaaScoreTimestampEstimate,
+                GetUtxoReturnAddress,
                 GetCurrentNetwork,
                 GetDaaScoreTimestampEstimate,
                 GetFeeEstimate,

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -656,6 +656,23 @@ async fn sanity_test() {
                 })
             }
 
+            KaspadPayloadOps::GetUtxoReturnAddress => {
+                let rpc_client = client.clone();
+                tst!(op, {
+                    let results = rpc_client.get_utxo_return_address(RpcHash::from_bytes([0; 32]), 1000).await;
+
+                    assert!(results.is_err_and(|err| {
+                        match err {
+                            kaspa_rpc_core::RpcError::General(msg) => {
+                                info!("Expected error message: {}", msg);
+                                true
+                            }
+                            _ => false,
+                        }
+                    }));
+                })
+            }
+
             KaspadPayloadOps::NotifyBlockAdded => {
                 let rpc_client = client.clone();
                 let id = listener_id;

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -379,6 +379,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_utxo_return_address_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetUtxoReturnAddressRequest,
+    ) -> RpcResult<GetUtxoReturnAddressResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 


### PR DESCRIPTION
`GetUtxoReturnAddress`
Input: `txid` and `accepting_block_daa_score`
Output: `return_address` -> `Option<Address>`

Notes:
- When this call finds an address, it is guaranteed that the address is from the first input of the transaction that produced your UTXO. If the algorithm cannot find a return address (there are many reasons why it might not be able to), it will return `None`

Proto
```
GetUtxoReturnAddressRequestMessage getUtxoReturnAddressRequest = 1112;
GetUtxoReturnAddressResponseMessage getUtxoReturnAddressResponse = 1113;
```