### PR TITLE
fix deterministic.rs 'seal changed -was: 0xa7a4 now 0x544d'

### DIFF
--- a/wallet/core/src/deterministic.rs
+++ b/wallet/core/src/deterministic.rs
@@ -56,7 +56,7 @@ impl std::fmt::Display for AccountId {
     }
 }
 
-seal! { 0xa7a4, {
+seal! { 0x544d, {
     // IMPORTANT: This data structure is meant to be deterministic
     // so it can not contain any new fields or be changed.
     #[derive(BorshSerialize)]


### PR DESCRIPTION
fix issue: https://github.com/kaspanet/rusty-kaspa/issues/437 

reason:
seal changed -was: 0xa7a4 now 0x544d