### PR TITLE
Add support for IP only for --rpclisten-borsh/json (#402)

### DIFF
--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -366,7 +366,7 @@ Setting to 0 prevents the preallocation and sets the maximum to {}, leading to 0
                 .long("ram-scale")
                 .require_equals(true)
                 .value_parser(clap::value_parser!(f64))
-                .help("Apply a scale factor to memory allocation bounds. Nodes with limited RAM (~4-8GB) should set this to ~0.3-0.5 respectively. Nodes with 
+                .help("Apply a scale factor to memory allocation bounds. Nodes with limited RAM (~4-8GB) should set this to ~0.3-0.5 respectively. Nodes with
 a large RAM (~64GB) can set this value to ~3.0-4.0 and gain superior performance especially for syncing peers faster"),
         )
         ;

--- a/rpc/wrpc/server/src/address.rs
+++ b/rpc/wrpc/server/src/address.rs
@@ -29,7 +29,17 @@ impl WrpcNetAddress {
                 };
                 format!("0.0.0.0:{port}").parse().unwrap()
             }
-            WrpcNetAddress::Custom(address) => *address,
+            WrpcNetAddress::Custom(address) => {
+                if address.port_not_specified() {
+                    let port = match encoding {
+                        WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
+                        WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
+                    };
+                    address.with_port(port)
+                } else {
+                    *address
+                }
+            }
         }
     }
 }
@@ -61,5 +71,33 @@ impl TryFrom<String> for WrpcNetAddress {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         WrpcNetAddress::from_str(&s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_utils::networking::IpAddress;
+
+    #[test]
+    fn test_wrpc_net_address_from_str() {
+        // Addresses
+        let port: u16 = 8080;
+        let addr = format!("1.2.3.4:{port}").parse::<WrpcNetAddress>().unwrap();
+        let addr_without_port = "1.2.3.4".parse::<WrpcNetAddress>().unwrap();
+        let ip_addr = "1.2.3.4".parse::<IpAddress>().unwrap();
+        // Test
+        for schema in WrpcEncoding::iter() {
+            for network in NetworkType::iter() {
+                let expected_port = match schema {
+                    WrpcEncoding::Borsh => Some(network.default_borsh_rpc_port()),
+                    WrpcEncoding::SerdeJson => Some(network.default_json_rpc_port()),
+                };
+                // Custom address with port
+                assert_eq!(addr.to_address(&network, &schema), ContextualNetAddress::new(ip_addr, Some(port)));
+                // Custom address without port
+                assert_eq!(addr_without_port.to_address(&network, &schema), ContextualNetAddress::new(ip_addr, expected_port))
+            }
+        }
     }
 }

--- a/rpc/wrpc/server/src/address.rs
+++ b/rpc/wrpc/server/src/address.rs
@@ -94,9 +94,9 @@ mod tests {
                     WrpcEncoding::SerdeJson => Some(network.default_json_rpc_port()),
                 };
                 // Custom address with port
-                assert_eq!(addr.to_address(&network, &schema), ContextualNetAddress::new(ip_addr, Some(port)));
+                assert_eq!(addr.to_address(&network, schema), ContextualNetAddress::new(ip_addr, Some(port)));
                 // Custom address without port
-                assert_eq!(addr_without_port.to_address(&network, &schema), ContextualNetAddress::new(ip_addr, expected_port))
+                assert_eq!(addr_without_port.to_address(&network, schema), ContextualNetAddress::new(ip_addr, expected_port))
             }
         }
     }

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -34,7 +34,7 @@ const TS_IP_ADDRESS: &'static str = r#"
 /// A bucket based on an ip's prefix bytes.
 /// for ipv4 it consists of 6 leading zero bytes, and the first two octets,
 /// for ipv6 it consists of the first 8 octets,
-/// encoded into a big endian u64.  
+/// encoded into a big endian u64.
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub struct PrefixBucket(u64);
 
@@ -271,7 +271,7 @@ pub struct ContextualNetAddress {
 }
 
 impl ContextualNetAddress {
-    fn new(ip: IpAddress, port: Option<u16>) -> Self {
+    pub fn new(ip: IpAddress, port: Option<u16>) -> Self {
         Self { ip, port }
     }
 
@@ -285,6 +285,14 @@ impl ContextualNetAddress {
 
     pub fn loopback() -> Self {
         Self { ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).into(), port: None }
+    }
+
+    pub fn port_not_specified(&self) -> bool {
+        self.port.is_none()
+    }
+
+    pub fn with_port(&self, port: u16) -> Self {
+        Self { ip: self.ip, port: Some(port) }
     }
 }
 


### PR DESCRIPTION
Adds support for IP only for the --rpclisten-borsh/json flags.
If a port is not provided a default port for a given network would be used.