### PR TITLE
Fix rustc 1.77 issues and lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -1154,6 +1155,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1923,6 +1960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2019,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1986,6 +2030,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3315,6 +3360,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "serde_with",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4892,6 +4938,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+dependencies = [
+ "base64 0.21.5",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
 ]
 
 [workspace.package]
+rust-version = "1.77.0"
 version = "0.13.5"
 authors = ["Kaspa developers"]
 license = "MIT/Apache-2.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kaspa-cli"
 description = "Kaspa CLI"
 keywords = ["kaspa", "wallet", "cli", "rpc"]
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/components/addressmanager/Cargo.toml
+++ b/components/addressmanager/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-addressmanager"
 description = "Kaspa address manager"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/components/connectionmanager/Cargo.toml
+++ b/components/connectionmanager/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-connectionmanager"
 description = "Kaspa connection manager"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/components/consensusmanager/Cargo.toml
+++ b/components/consensusmanager/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-consensusmanager"
 description = "Kaspa consensus library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -23,9 +23,9 @@ pub use tokio::task::spawn_blocking;
 use crate::BlockProcessingBatch;
 
 #[derive(Clone)]
-pub struct SessionOwnedReadGuard(Arc<RfRwLockOwnedReadGuard>);
+pub struct SessionOwnedReadGuard(pub Arc<RfRwLockOwnedReadGuard>);
 
-pub struct SessionReadGuard<'a>(RfRwLockReadGuard<'a>);
+pub struct SessionReadGuard<'a>(pub RfRwLockReadGuard<'a>);
 
 pub struct SessionWriteGuard<'a>(RfRwLockWriteGuard<'a>);
 

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -22,10 +22,12 @@ pub use tokio::task::spawn_blocking;
 
 use crate::BlockProcessingBatch;
 
+#[allow(dead_code)]
 #[derive(Clone)]
-pub struct SessionOwnedReadGuard(pub Arc<RfRwLockOwnedReadGuard>);
+pub struct SessionOwnedReadGuard(Arc<RfRwLockOwnedReadGuard>);
 
-pub struct SessionReadGuard<'a>(pub RfRwLockReadGuard<'a>);
+#[allow(dead_code)]
+pub struct SessionReadGuard<'a>(RfRwLockReadGuard<'a>);
 
 pub struct SessionWriteGuard<'a>(RfRwLockWriteGuard<'a>);
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-consensus"
 description = "Kaspa consensus library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-consensus-core"
 description = "Kaspa consensus core"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/consensus/core/src/api/stats.rs
+++ b/consensus/core/src/api/stats.rs
@@ -1,7 +1,7 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockCount {
     pub header_count: u64,

--- a/consensus/core/src/header.rs
+++ b/consensus/core/src/header.rs
@@ -1,5 +1,5 @@
 use crate::{hashing, BlueWorkType};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use js_sys::{Array, Object};
 use kaspa_hashes::Hash;
 use kaspa_utils::hex::ToHex;
@@ -8,7 +8,7 @@ use serde_wasm_bindgen::*;
 use wasm_bindgen::prelude::*;
 use workflow_wasm::prelude::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 #[wasm_bindgen(inspectable)]
 pub struct Header {

--- a/consensus/core/src/network.rs
+++ b/consensus/core/src/network.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_addresses::Prefix;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Debug, Display, Formatter};
@@ -15,7 +15,7 @@ pub enum NetworkTypeError {
 }
 
 u8_try_from! {
-    #[derive(Clone, Copy, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq, Eq)]
+    #[derive(Clone, Copy, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
     #[serde(rename_all = "lowercase")]
     #[wasm_bindgen]
     pub enum NetworkType {
@@ -157,7 +157,7 @@ pub enum NetworkIdError {
     InvalidNetworkId(String),
 }
 
-#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[wasm_bindgen(inspectable)]
 pub struct NetworkId {
     #[wasm_bindgen(js_name = "type")]

--- a/consensus/core/src/subnets.rs
+++ b/consensus/core/src/subnets.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::str::{self, FromStr};
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_utils::hex::{FromHex, ToHex};
 use kaspa_utils::{serde_impl_deser_fixed_bytes_ref, serde_impl_ser_fixed_bytes_ref};
 
@@ -9,7 +9,7 @@ use kaspa_utils::{serde_impl_deser_fixed_bytes_ref, serde_impl_ser_fixed_bytes_r
 pub const SUBNETWORK_ID_SIZE: usize = 20;
 
 /// The domain representation of a Subnetwork ID
-#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, BorshSerialize, BorshDeserialize)]
 pub struct SubnetworkId([u8; SUBNETWORK_ID_SIZE]);
 
 impl Debug for SubnetworkId {

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -1,6 +1,6 @@
 mod script_public_key;
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_utils::hex::ToHex;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use kaspa_utils::{serde_bytes, serde_bytes_fixed_ref};
@@ -28,7 +28,7 @@ pub type TransactionId = kaspa_hashes::Hash;
 /// set such as whether or not it was contained in a coinbase tx, the daa
 /// score of the block that accepts the tx, its public key script, and how
 /// much it pays.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 #[wasm_bindgen(inspectable, js_name = TxUtxoEntry)]
 pub struct UtxoEntry {
@@ -52,7 +52,7 @@ impl MemSizeEstimator for UtxoEntry {}
 pub type TransactionIndexType = u32;
 
 /// Represents a Kaspa transaction outpoint
-#[derive(Eq, Hash, PartialEq, Debug, Copy, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Eq, Hash, PartialEq, Debug, Copy, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionOutpoint {
     #[serde(with = "serde_bytes_fixed_ref")]
@@ -73,7 +73,7 @@ impl Display for TransactionOutpoint {
 }
 
 /// Represents a Kaspa transaction input
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionInput {
     pub previous_outpoint: TransactionOutpoint,
@@ -105,7 +105,7 @@ impl std::fmt::Debug for TransactionInput {
 }
 
 /// Represents a Kaspad transaction output
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionOutput {
     pub value: u64,

--- a/consensus/core/src/tx/script_public_key.rs
+++ b/consensus/core/src/tx/script_public_key.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use core::fmt::Formatter;
 use kaspa_utils::{
     hex::{FromHex, ToHex},
@@ -347,26 +347,6 @@ impl BorshDeserialize for ScriptPublicKey {
     fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
         // Deserialize into vec first since we have no custom smallvec support
         Ok(Self::from_vec(borsh::BorshDeserialize::deserialize(buf)?, borsh::BorshDeserialize::deserialize(buf)?))
-    }
-}
-
-impl BorshSchema for ScriptPublicKey {
-    fn add_definitions_recursively(
-        definitions: &mut std::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        let fields = borsh::schema::Fields::NamedFields(std::vec![
-            ("version".to_string(), <u16>::declaration()),
-            ("script".to_string(), <Vec<u8>>::declaration())
-        ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-        <u16>::add_definitions_recursively(definitions);
-        // `<Vec<u8>>` can be safely used as scheme definition for smallvec. See comments above.
-        <Vec<u8>>::add_definitions_recursively(definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "ScriptPublicKey".to_string()
     }
 }
 

--- a/consensus/notify/Cargo.toml
+++ b/consensus/notify/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-consensus-notify"
 description = "Kaspa consensus notifier"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/consensus/pow/Cargo.toml
+++ b/consensus/pow/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-pow"
 description = "Kaspa proof-of-work"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/consensus/wasm/Cargo.toml
+++ b/consensus/wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-consensus-wasm"
 description = "Kaspa consensus core WASM bindings"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-core"
 description = "Kaspa core"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/addresses/Cargo.toml
+++ b/crypto/addresses/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-addresses"
 description = "Kaspa address"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/addresses/src/lib.rs
+++ b/crypto/addresses/src/lib.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use js_sys::Array;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
@@ -43,9 +43,7 @@ impl From<workflow_wasm::error::Error> for AddressError {
 }
 
 /// Address prefix identifying the network type this address belongs to (such as `kaspa`, `kaspatest`, `kaspasim`, `kaspadev`).
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum Prefix {
     #[serde(rename = "kaspa")]
     Mainnet,
@@ -111,9 +109,7 @@ impl TryFrom<&str> for Prefix {
 ///
 ///  Kaspa `Address` version (`PubKey`, `PubKey ECDSA`, `ScriptHash`)
 ///
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[repr(u8)]
 #[wasm_bindgen(js_name = "AddressVersion")]
 pub enum Version {
@@ -279,28 +275,6 @@ impl BorshDeserialize for Address {
         let version: Version = borsh::BorshDeserialize::deserialize(buf)?;
         let payload: Vec<u8> = borsh::BorshDeserialize::deserialize(buf)?;
         Ok(Self::new(prefix, version, &payload))
-    }
-}
-
-impl BorshSchema for Address {
-    fn add_definitions_recursively(
-        definitions: &mut std::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        let fields = borsh::schema::Fields::NamedFields(std::vec![
-            ("prefix".to_string(), <Prefix>::declaration()),
-            ("version".to_string(), <Version>::declaration()),
-            ("payload".to_string(), <Vec<u8>>::declaration())
-        ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-        <Prefix>::add_definitions_recursively(definitions);
-        <Version>::add_definitions_recursively(definitions);
-        // `<Vec<u8>>` can be safely used as scheme definition for smallvec. See comments above.
-        <Vec<u8>>::add_definitions_recursively(definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "Address".to_string()
     }
 }
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-hashes"
 description = "Kaspa hashing functions"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/hashes/src/lib.rs
+++ b/crypto/hashes/src/lib.rs
@@ -1,7 +1,7 @@
 mod hashers;
 mod pow_hashers;
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_utils::{
     hex::{FromHex, ToHex},
     mem_size::MemSizeEstimator,
@@ -21,7 +21,7 @@ pub const HASH_SIZE: usize = 32;
 pub use hashers::*;
 
 // TODO: Check if we use hash more as an array of u64 or of bytes and change the default accordingly
-#[derive(Eq, Clone, Copy, Default, PartialOrd, Ord, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Eq, Clone, Copy, Default, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
 #[wasm_bindgen]
 pub struct Hash([u8; HASH_SIZE]);
 

--- a/crypto/merkle/Cargo.toml
+++ b/crypto/merkle/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-merkle"
 description = "Kaspa merkle tree library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/muhash/Cargo.toml
+++ b/crypto/muhash/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-muhash"
 description = "Kaspa Muhash library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-txscript"
 description = "Kaspa txscript engine library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/txscript/errors/Cargo.toml
+++ b/crypto/txscript/errors/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-txscript-errors"
 description = "Kaspa txscript errors"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -941,6 +941,7 @@ mod bitcoind_tests {
         result: Result<(), UnifiedError>,
     }
 
+    #[allow(dead_code)]
     #[derive(Deserialize, Debug, Clone)]
     #[serde(untagged)]
     enum JsonTestRow {

--- a/crypto/txscript/src/script_class.rs
+++ b/crypto/txscript/src/script_class.rs
@@ -1,5 +1,5 @@
 use crate::{opcodes, MAX_SCRIPT_PUBLIC_KEY_VERSION};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_addresses::Version;
 use kaspa_consensus_core::tx::{ScriptPublicKey, ScriptPublicKeyVersion};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ pub enum Error {
 }
 
 /// Standard classes of script payment in the blockDAG
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[repr(u8)]
 pub enum ScriptClass {
     /// None of the recognized forms

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-daemon"
 description = "Utilities for running Kaspa node and tools as a child processes"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-database"
 description = "Kaspa database"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/indexes/core/Cargo.toml
+++ b/indexes/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-index-core"
 description = "Kaspa index core"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/indexes/processor/Cargo.toml
+++ b/indexes/processor/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-index-processor"
 description = "Kaspa index processor"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/indexes/utxoindex/Cargo.toml
+++ b/indexes/utxoindex/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-utxoindex"
 description = "Kaspa UTXO index"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kaspad"
 description = "Kaspa full node daemon"
 keywords = ["kaspa", "blockdag"]
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/kos/Cargo.toml
+++ b/kos/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kaspa-os"
 description = "Kaspa Node & Wallet Manager"
 # please keep this version detached from the workspace
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-math"
 description = "Kaspa misc math library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use wasm_bindgen::JsValue;
 use workflow_core::sendable::Sendable;
 
@@ -6,7 +6,7 @@ pub mod int;
 pub mod uint;
 pub mod wasm;
 
-construct_uint!(Uint192, 3, BorshSerialize, BorshDeserialize, BorshSchema);
+construct_uint!(Uint192, 3, BorshSerialize, BorshDeserialize);
 construct_uint!(Uint256, 4);
 construct_uint!(Uint320, 5);
 construct_uint!(Uint3072, 48);

--- a/metrics/core/Cargo.toml
+++ b/metrics/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-metrics-core"
 description = "Tools for collecting and reporting Kaspa p2p node metrics"
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/metrics/perf_monitor/Cargo.toml
+++ b/metrics/perf_monitor/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-perf-monitor"
 description = "Kaspa process performance monitoring tools"
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mining/Cargo.toml
+++ b/mining/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-mining"
 description = "Kaspa mining"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/mining/errors/Cargo.toml
+++ b/mining/errors/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-mining-errors"
 description = "Kaspa mining error definitions"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -547,7 +547,7 @@ mod tests {
             }
         }
 
-        let tests = vec![
+        let tests = [
             TestStep {
                 name: "low-priority transaction into an empty orphan pool",
                 priority: Priority::Low,

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-notify"
 description = "Kaspa notification subsystem"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/notify/src/scope.rs
+++ b/notify/src/scope.rs
@@ -1,5 +1,5 @@
 use super::events::EventType;
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::Display;
 use kaspa_addresses::Address;
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ macro_rules! scope_enum {
 }
 
 scope_enum! {
-#[derive(Clone, Display, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum Scope {
     BlockAdded,
     VirtualChainChanged,
@@ -46,10 +46,10 @@ pub enum Scope {
 }
 }
 
-#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct BlockAddedScope {}
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct VirtualChainChangedScope {
     pub include_accepted_transaction_ids: bool,
 }
@@ -66,13 +66,13 @@ impl std::fmt::Display for VirtualChainChangedScope {
     }
 }
 
-#[derive(Clone, Display, Debug, PartialEq, Eq, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, PartialEq, Eq, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct FinalityConflictScope {}
 
-#[derive(Clone, Display, Debug, PartialEq, Eq, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, PartialEq, Eq, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct FinalityConflictResolvedScope {}
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct UtxosChangedScope {
     pub addresses: Vec<Address>,
 }
@@ -102,14 +102,14 @@ impl UtxosChangedScope {
     }
 }
 
-#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct SinkBlueScoreChangedScope {}
 
-#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct VirtualDaaScoreChangedScope {}
 
-#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct PruningPointUtxoSetOverrideScope {}
 
-#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct NewBlockTemplateScope {}

--- a/notify/src/subscription/mod.rs
+++ b/notify/src/subscription/mod.rs
@@ -1,5 +1,5 @@
 use super::{events::EventType, notification::Notification, scope::Scope};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::{
@@ -13,7 +13,7 @@ pub mod array;
 pub mod compounded;
 pub mod single;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum Command {
     Start = 0,
     Stop = 1,

--- a/protocol/flows/Cargo.toml
+++ b/protocol/flows/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-p2p-flows"
 description = "Kaspa p2p flows"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/protocol/p2p/Cargo.toml
+++ b/protocol/p2p/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-p2p-lib"
 description = "Kaspa p2p library"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rothschild/Cargo.toml
+++ b/rothschild/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rothschild"
 description = "Kaspa Transaction Generator"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/core/Cargo.toml
+++ b/rpc/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-rpc-core"
 description = "Kaspa RPC core"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/core/src/model/address.rs
+++ b/rpc/core/src/model/address.rs
@@ -1,11 +1,11 @@
 use crate::{RpcTransactionOutpoint, RpcUtxoEntry};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 pub type RpcAddress = kaspa_addresses::Address;
 
 ///
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcUtxosByAddressesEntry {
     pub address: Option<RpcAddress>,
@@ -14,7 +14,7 @@ pub struct RpcUtxosByAddressesEntry {
 }
 
 ///
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBalancesByAddressesEntry {
     pub address: RpcAddress,

--- a/rpc/core/src/model/block.rs
+++ b/rpc/core/src/model/block.rs
@@ -1,9 +1,9 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::{RpcHash, RpcHeader, RpcTransaction};
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlock {
     pub header: RpcHeader,
@@ -11,7 +11,7 @@ pub struct RpcBlock {
     pub verbose_data: Option<RpcBlockVerboseData>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlockVerboseData {
     pub hash: RpcHash,

--- a/rpc/core/src/model/mempool.rs
+++ b/rpc/core/src/model/mempool.rs
@@ -1,9 +1,9 @@
 use super::RpcAddress;
 use super::RpcTransaction;
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct RpcMempoolEntry {
     pub fee: u64,
     pub transaction: RpcTransaction,
@@ -16,7 +16,7 @@ impl RpcMempoolEntry {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct RpcMempoolEntryByAddress {
     pub address: RpcAddress,
     pub sending: Vec<RpcMempoolEntry>,

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -1,5 +1,5 @@
 use crate::model::*;
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_consensus_core::api::stats::BlockCount;
 use kaspa_core::debug;
 use kaspa_notify::subscription::{single::UtxosChangedSubscription, Command};
@@ -15,7 +15,7 @@ pub type RpcExtraData = Vec<u8>;
 /// Blocks are generally expected to have been generated using the getBlockTemplate call.
 ///
 /// See: [`GetBlockTemplateRequest`]
-#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitBlockRequest {
     pub block: RpcBlock,
@@ -28,7 +28,7 @@ impl SubmitBlockRequest {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SubmitBlockRejectReason {
     BlockInvalid = 1,
@@ -51,7 +51,7 @@ impl Display for SubmitBlockRejectReason {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SubmitBlockReport {
     Success,
@@ -63,7 +63,7 @@ impl SubmitBlockReport {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitBlockResponse {
     pub report: SubmitBlockReport,
@@ -73,7 +73,7 @@ pub struct SubmitBlockResponse {
 /// Callers are expected to solve the block template and submit it using the submitBlock call
 ///
 /// See: [`SubmitBlockRequest`]
-#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockTemplateRequest {
     /// Which kaspa address should the coinbase block reward transaction pay into
@@ -86,7 +86,7 @@ impl GetBlockTemplateRequest {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockTemplateResponse {
     pub block: RpcBlock,
@@ -99,7 +99,7 @@ pub struct GetBlockTemplateResponse {
 }
 
 /// GetBlockRequest requests information about a specific block
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockRequest {
     /// The hash of the requested block
@@ -114,18 +114,18 @@ impl GetBlockRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockResponse {
     pub block: RpcBlock,
 }
 
 /// GetInfoRequest returns info about the node.
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetInfoRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetInfoResponse {
     pub p2p_id: String,
@@ -137,11 +137,11 @@ pub struct GetInfoResponse {
     pub has_message_id: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCurrentNetworkRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCurrentNetworkResponse {
     pub network: RpcNetworkType,
@@ -153,11 +153,11 @@ impl GetCurrentNetworkResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPeerAddressesRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPeerAddressesResponse {
     pub known_addresses: Vec<RpcPeerAddress>,
@@ -170,11 +170,11 @@ impl GetPeerAddressesResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSinkRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSinkResponse {
     pub sink: RpcHash,
@@ -186,7 +186,7 @@ impl GetSinkResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntryRequest {
     pub transaction_id: RpcTransactionId,
@@ -201,7 +201,7 @@ impl GetMempoolEntryRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntryResponse {
     pub mempool_entry: RpcMempoolEntry,
@@ -213,7 +213,7 @@ impl GetMempoolEntryResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntriesRequest {
     pub include_orphan_pool: bool,
@@ -227,7 +227,7 @@ impl GetMempoolEntriesRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntriesResponse {
     pub mempool_entries: Vec<RpcMempoolEntry>,
@@ -239,11 +239,11 @@ impl GetMempoolEntriesResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetConnectedPeerInfoRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetConnectedPeerInfoResponse {
     pub peer_info: Vec<RpcPeerInfo>,
@@ -255,7 +255,7 @@ impl GetConnectedPeerInfoResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddPeerRequest {
     pub peer_address: RpcContextualPeerAddress,
@@ -268,11 +268,11 @@ impl AddPeerRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddPeerResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitTransactionRequest {
     pub transaction: RpcTransaction,
@@ -285,7 +285,7 @@ impl SubmitTransactionRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitTransactionResponse {
     pub transaction_id: RpcTransactionId,
@@ -297,7 +297,7 @@ impl SubmitTransactionResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSubnetworkRequest {
     pub subnetwork_id: RpcSubnetworkId,
@@ -309,7 +309,7 @@ impl GetSubnetworkRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSubnetworkResponse {
     pub gas_limit: u64,
@@ -321,7 +321,7 @@ impl GetSubnetworkResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVirtualChainFromBlockRequest {
     pub start_hash: RpcHash,
@@ -334,7 +334,7 @@ impl GetVirtualChainFromBlockRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVirtualChainFromBlockResponse {
     pub removed_chain_block_hashes: Vec<RpcHash>,
@@ -352,7 +352,7 @@ impl GetVirtualChainFromBlockResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlocksRequest {
     pub low_hash: Option<RpcHash>,
@@ -366,7 +366,7 @@ impl GetBlocksRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlocksResponse {
     pub block_hashes: Vec<RpcHash>,
@@ -379,17 +379,17 @@ impl GetBlocksResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockCountRequest {}
 
 pub type GetBlockCountResponse = BlockCount;
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockDagInfoRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockDagInfoResponse {
     pub network: RpcNetworkId,
@@ -432,7 +432,7 @@ impl GetBlockDagInfoResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveFinalityConflictRequest {
     pub finality_block_hash: RpcHash,
@@ -444,19 +444,19 @@ impl ResolveFinalityConflictRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveFinalityConflictResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ShutdownRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ShutdownResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetHeadersRequest {
     pub start_hash: RpcHash,
@@ -470,7 +470,7 @@ impl GetHeadersRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetHeadersResponse {
     pub headers: Vec<RpcHeader>,
@@ -482,7 +482,7 @@ impl GetHeadersResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBalanceByAddressRequest {
     pub address: RpcAddress,
@@ -494,7 +494,7 @@ impl GetBalanceByAddressRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBalanceByAddressResponse {
     pub balance: u64,
@@ -506,7 +506,7 @@ impl GetBalanceByAddressResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBalancesByAddressesRequest {
     pub addresses: Vec<RpcAddress>,
@@ -518,7 +518,7 @@ impl GetBalancesByAddressesRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBalancesByAddressesResponse {
     pub entries: Vec<RpcBalancesByAddressesEntry>,
@@ -530,11 +530,11 @@ impl GetBalancesByAddressesResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSinkBlueScoreRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSinkBlueScoreResponse {
     pub blue_score: u64,
@@ -546,7 +546,7 @@ impl GetSinkBlueScoreResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetUtxosByAddressesRequest {
     pub addresses: Vec<RpcAddress>,
@@ -558,7 +558,7 @@ impl GetUtxosByAddressesRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetUtxosByAddressesResponse {
     pub entries: Vec<RpcUtxosByAddressesEntry>,
@@ -570,7 +570,7 @@ impl GetUtxosByAddressesResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BanRequest {
     pub ip: RpcIpAddress,
@@ -582,11 +582,11 @@ impl BanRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BanResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnbanRequest {
     pub ip: RpcIpAddress,
@@ -598,11 +598,11 @@ impl UnbanRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnbanResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EstimateNetworkHashesPerSecondRequest {
     pub window_size: u32,
@@ -615,7 +615,7 @@ impl EstimateNetworkHashesPerSecondRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EstimateNetworkHashesPerSecondResponse {
     pub network_hashes_per_second: u64,
@@ -627,7 +627,7 @@ impl EstimateNetworkHashesPerSecondResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntriesByAddressesRequest {
     pub addresses: Vec<RpcAddress>,
@@ -642,7 +642,7 @@ impl GetMempoolEntriesByAddressesRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMempoolEntriesByAddressesResponse {
     pub entries: Vec<RpcMempoolEntryByAddress>,
@@ -654,11 +654,11 @@ impl GetMempoolEntriesByAddressesResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCoinSupplyRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCoinSupplyResponse {
     pub max_sompi: u64,
@@ -671,17 +671,17 @@ impl GetCoinSupplyResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PingRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PingResponse {}
 
 // TODO - custom wRPC commands (need review and implementation in gRPC)
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMetricsRequest {
     pub process_metrics: bool,
@@ -690,7 +690,7 @@ pub struct GetMetricsRequest {
     pub consensus_metrics: bool,
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessMetrics {
     pub resident_set_size: u64,
@@ -704,7 +704,7 @@ pub struct ProcessMetrics {
     pub disk_io_write_per_sec: f32,
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionMetrics {
     pub borsh_live_connections: u32,
@@ -717,7 +717,7 @@ pub struct ConnectionMetrics {
     pub active_peers: u32,
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BandwidthMetrics {
     pub borsh_bytes_tx: u64,
@@ -730,7 +730,7 @@ pub struct BandwidthMetrics {
     pub grpc_bytes_rx: u64,
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsensusMetrics {
     pub node_blocks_submitted_count: u64,
@@ -752,7 +752,7 @@ pub struct ConsensusMetrics {
     pub network_virtual_daa_score: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMetricsResponse {
     pub server_time: u64,
@@ -774,11 +774,11 @@ impl GetMetricsResponse {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetServerInfoRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetServerInfoResponse {
     pub rpc_api_version: [u16; 4],
@@ -789,17 +789,17 @@ pub struct GetServerInfoResponse {
     pub virtual_daa_score: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSyncStatusRequest {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSyncStatusResponse {
     pub is_synced: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetDaaScoreTimestampEstimateRequest {
     pub daa_scores: Vec<u64>,
@@ -811,7 +811,7 @@ impl GetDaaScoreTimestampEstimateRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetDaaScoreTimestampEstimateResponse {
     pub timestamps: Vec<u64>,
@@ -833,7 +833,7 @@ impl GetDaaScoreTimestampEstimateResponse {
 /// NotifyBlockAddedRequest registers this connection for blockAdded notifications.
 ///
 /// See: BlockAddedNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyBlockAddedRequest {
     pub command: Command,
@@ -844,7 +844,7 @@ impl NotifyBlockAddedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyBlockAddedResponse {}
 
@@ -865,7 +865,7 @@ pub struct BlockAddedNotification {
 // virtualDaaScoreChanged notifications.
 //
 // See: VirtualChainChangedNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyVirtualChainChangedRequest {
     pub include_accepted_transaction_ids: bool,
@@ -878,7 +878,7 @@ impl NotifyVirtualChainChangedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyVirtualChainChangedResponse {}
 
@@ -897,7 +897,7 @@ pub struct VirtualChainChangedNotification {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // FinalityConflictNotification
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyFinalityConflictRequest {
     pub command: Command,
@@ -909,7 +909,7 @@ impl NotifyFinalityConflictRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyFinalityConflictResponse {}
 
@@ -922,7 +922,7 @@ pub struct FinalityConflictNotification {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // FinalityConflictResolvedNotification
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyFinalityConflictResolvedRequest {
     pub command: Command,
@@ -934,7 +934,7 @@ impl NotifyFinalityConflictResolvedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyFinalityConflictResolvedResponse {}
 
@@ -956,7 +956,7 @@ pub struct FinalityConflictResolvedNotification {
 // This call is only available when this kaspad was started with `--utxoindex`
 //
 // See: UtxosChangedNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyUtxosChangedRequest {
     pub addresses: Vec<RpcAddress>,
@@ -969,7 +969,7 @@ impl NotifyUtxosChangedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyUtxosChangedResponse {}
 
@@ -1011,7 +1011,7 @@ impl UtxosChangedNotification {
 // sinkBlueScoreChanged notifications.
 //
 // See: SinkBlueScoreChangedNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifySinkBlueScoreChangedRequest {
     pub command: Command,
@@ -1023,7 +1023,7 @@ impl NotifySinkBlueScoreChangedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifySinkBlueScoreChangedResponse {}
 
@@ -1031,7 +1031,7 @@ pub struct NotifySinkBlueScoreChangedResponse {}
 // of the virtual's selected parent changes.
 //
 /// See: NotifySinkBlueScoreChangedRequest
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SinkBlueScoreChangedNotification {
     pub sink_blue_score: u64,
@@ -1044,7 +1044,7 @@ pub struct SinkBlueScoreChangedNotification {
 // virtualDaaScoreChanged notifications.
 //
 // See: VirtualDaaScoreChangedNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyVirtualDaaScoreChangedRequest {
     pub command: Command,
@@ -1056,7 +1056,7 @@ impl NotifyVirtualDaaScoreChangedRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyVirtualDaaScoreChangedResponse {}
 
@@ -1064,7 +1064,7 @@ pub struct NotifyVirtualDaaScoreChangedResponse {}
 // of the virtual changes.
 //
 // See NotifyVirtualDaaScoreChangedRequest
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VirtualDaaScoreChangedNotification {
     pub virtual_daa_score: u64,
@@ -1073,7 +1073,7 @@ pub struct VirtualDaaScoreChangedNotification {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // PruningPointUtxoSetOverrideNotification
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyPruningPointUtxoSetOverrideRequest {
     pub command: Command,
@@ -1085,11 +1085,11 @@ impl NotifyPruningPointUtxoSetOverrideRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyPruningPointUtxoSetOverrideResponse {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PruningPointUtxoSetOverrideNotification {}
 
@@ -1099,7 +1099,7 @@ pub struct PruningPointUtxoSetOverrideNotification {}
 /// NotifyNewBlockTemplateRequest registers this connection for blockAdded notifications.
 ///
 /// See: NewBlockTemplateNotification
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyNewBlockTemplateRequest {
     pub command: Command,
@@ -1110,7 +1110,7 @@ impl NotifyNewBlockTemplateRequest {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyNewBlockTemplateResponse {}
 
@@ -1118,14 +1118,14 @@ pub struct NotifyNewBlockTemplateResponse {}
 /// into the DAG.
 ///
 /// See: NotifyNewBlockTemplateRequest
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NewBlockTemplateNotification {}
 
 ///
 ///  wRPC response for RpcApiOps::Subscribe request
 ///
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeResponse {
     id: u64,
@@ -1140,6 +1140,6 @@ impl SubscribeResponse {
 ///
 ///  wRPC response for RpcApiOps::Unsubscribe request
 ///
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnsubscribeResponse {}

--- a/rpc/core/src/model/peer.rs
+++ b/rpc/core/src/model/peer.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_utils::networking::{ContextualNetAddress, IpAddress, NetAddress, PeerId};
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +7,7 @@ pub type RpcIpAddress = IpAddress;
 pub type RpcPeerAddress = NetAddress;
 pub type RpcContextualPeerAddress = ContextualNetAddress;
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct RpcPeerInfo {
     pub id: RpcNodeId,
     pub address: RpcPeerAddress,

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_addresses::Address;
 use kaspa_consensus_core::tx::{
     ScriptPublicKey, ScriptVec, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry,
@@ -18,7 +18,7 @@ pub type RpcUtxoEntry = UtxoEntry;
 pub type RpcTransactionOutpoint = TransactionOutpoint;
 
 /// Represents a Kaspa transaction input
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionInput {
     pub previous_outpoint: RpcTransactionOutpoint,
@@ -47,12 +47,12 @@ impl RpcTransactionInput {
 }
 
 /// Represent Kaspa transaction input verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionInputVerboseData {}
 
 /// Represents a Kaspad transaction output
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionOutput {
     pub value: u64,
@@ -73,7 +73,7 @@ impl From<TransactionOutput> for RpcTransactionOutput {
 }
 
 /// Represent Kaspa transaction output verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionOutputVerboseData {
     pub script_public_key_type: RpcScriptClass,
@@ -81,7 +81,7 @@ pub struct RpcTransactionOutputVerboseData {
 }
 
 /// Represents a Kaspa transaction
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransaction {
     pub version: u16,
@@ -96,7 +96,7 @@ pub struct RpcTransaction {
 }
 
 /// Represent Kaspa transaction verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionVerboseData {
     pub transaction_id: RpcTransactionId,
@@ -107,7 +107,7 @@ pub struct RpcTransactionVerboseData {
 }
 
 /// Represents accepted transaction ids
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAcceptedTransactionIds {
     pub accepting_block_hash: RpcHash,

--- a/rpc/grpc/client/Cargo.toml
+++ b/rpc/grpc/client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-grpc-client"
 description = "Kaspa gRPC client"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/grpc/core/Cargo.toml
+++ b/rpc/grpc/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-grpc-core"
 description = "Kaspa gRPC core"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/grpc/server/Cargo.toml
+++ b/rpc/grpc/server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-grpc-server"
 description = "Kaspa gRPC server"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/macros/Cargo.toml
+++ b/rpc/macros/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kaspa-rpc-macros"
+rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rpc/service/Cargo.toml
+++ b/rpc/service/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-rpc-service"
 description = "Kaspa RPC service"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/wrpc/client/Cargo.toml
+++ b/rpc/wrpc/client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wrpc-client"
 description = "Kaspa wRPC client"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/wrpc/proxy/Cargo.toml
+++ b/rpc/wrpc/proxy/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wrpc-proxy"
 description = "Kaspa wRPC to gRPC proxy"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/wrpc/server/Cargo.toml
+++ b/rpc/wrpc/server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wrpc-server"
 description = "Kaspa wRPC server"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/rpc/wrpc/wasm/Cargo.toml
+++ b/rpc/wrpc/wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wrpc-wasm"
 description = "Kaspa wRPC WASM client"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/simpa/Cargo.toml
+++ b/simpa/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simpa"
 description = "Kaspa Network Simulator"
 publish = false
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -142,9 +142,7 @@ impl Miner {
             .possible_unspent_outpoints
             .iter()
             .filter_map(|&outpoint| {
-                let Some(entry) = self.get_spendable_entry(virtual_utxo_view, outpoint, virtual_state.daa_score) else {
-                    return None;
-                };
+                let entry = self.get_spendable_entry(virtual_utxo_view, outpoint, virtual_state.daa_score)?;
                 let unsigned_tx = self.create_unsigned_tx(outpoint, entry.amount, multiple_outputs);
                 Some(MutableTransaction::with_entries(unsigned_tx, vec![entry]))
             })
@@ -177,9 +175,7 @@ impl Miner {
         outpoint: TransactionOutpoint,
         virtual_daa_score: u64,
     ) -> Option<UtxoEntry> {
-        let Some(entry) = utxo_view.get(&outpoint) else {
-            return None;
-        };
+        let entry = utxo_view.get(&outpoint)?;
         if entry.amount < 2
             || (entry.is_coinbase && (virtual_daa_score as i64 - entry.block_daa_score as i64) <= self.params.coinbase_maturity as i64)
         {

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-testing-integration"
 publish = false
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-utils"
 description = "Kaspa utilities"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-alloc"
 description = "Kaspa allocator wrapper"
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -1,4 +1,5 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+// #![allow(dead_code)]
+use borsh::{BorshDeserialize, BorshSerialize};
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -196,25 +197,8 @@ impl BorshDeserialize for IpAddress {
     }
 }
 
-impl BorshSchema for IpAddress {
-    fn declaration() -> borsh::schema::Declaration {
-        "IpAddress".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh::maybestd::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        #[allow(dead_code)]
-        #[derive(BorshSchema)]
-        enum IpAddress {
-            V4([u8; 4]),
-            V6([u8; 16]),
-        }
-        <IpAddress>::add_definitions_recursively(definitions);
-    }
-}
-
 /// A network address, equivalent of a [SocketAddr].
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize)]
 pub struct NetAddress {
     pub ip: IpAddress,
     pub port: u16,
@@ -259,7 +243,7 @@ impl Display for NetAddress {
 /// A network address possibly without explicit port.
 ///
 /// Use `normalize` to get a fully determined address.
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize)]
 pub struct ContextualNetAddress {
     ip: IpAddress,
     port: Option<u16>,
@@ -386,20 +370,6 @@ impl BorshDeserialize for PeerId {
     fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
         let bytes: uuid::Bytes = BorshDeserialize::deserialize(buf)?;
         Ok(Self::new(Uuid::from_bytes(bytes)))
-    }
-}
-
-impl BorshSchema for PeerId {
-    fn declaration() -> borsh::schema::Declaration {
-        "PeerId".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh::maybestd::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        let fields = borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![<uuid::Bytes>::declaration()]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-        <uuid::Bytes>::add_definitions_recursively(definitions);
     }
 }
 

--- a/utils/tower/Cargo.toml
+++ b/utils/tower/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-utils-tower"
 description = "Kaspa utilities and middleware for Tower HTTP"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/wallet/bip32/Cargo.toml
+++ b/wallet/bip32/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-bip32"
 description = "BIP32 for Kaspa"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/wallet/bip32/src/mnemonic/phrase.rs
+++ b/wallet/bip32/src/mnemonic/phrase.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::Result;
 use crate::{Error, KEY_SIZE};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_utils::hex::*;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ pub type Entropy32 = [u8; KEY_SIZE];
 pub type Entropy16 = [u8; 16];
 
 /// Word count for a BIP39 mnemonic phrase. Identifies mnemonic as 12 or 24 word variants.
-#[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum WordCount {
     #[default]

--- a/wallet/core/Cargo.toml
+++ b/wallet/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kaspa-wallet-core"
 description = "Kaspa wallet library"
 keywords = ["kaspa", "wallet"]
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/wallet/core/src/account/mod.rs
+++ b/wallet/core/src/account/mod.rs
@@ -210,7 +210,7 @@ pub trait Account: AnySync + Send + Sync + 'static {
                     None => ScanExtent::EmptyWindow,
                 };
 
-                let scans = vec![
+                let scans = [
                     Scan::new_with_address_manager(
                         derivation.receive_address_manager(),
                         &balance,

--- a/wallet/core/src/deterministic.rs
+++ b/wallet/core/src/deterministic.rs
@@ -56,7 +56,7 @@ impl std::fmt::Display for AccountId {
     }
 }
 
-seal! { 0xa7a4, {
+seal! { 0x544d, {
     // IMPORTANT: This data structure is meant to be deterministic
     // so it can not contain any new fields or be changed.
     #[derive(BorshSerialize)]

--- a/wallet/core/src/imports.rs
+++ b/wallet/core/src/imports.rs
@@ -27,7 +27,7 @@ pub use crate::{storage, utils};
 
 pub use ahash::{AHashMap, AHashSet};
 pub use async_trait::async_trait;
-pub use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+pub use borsh::{BorshDeserialize, BorshSerialize};
 pub use cfg_if::cfg_if;
 pub use dashmap::{DashMap, DashSet};
 pub use downcast::{downcast_sync, AnySync};

--- a/wallet/core/src/secret.rs
+++ b/wallet/core/src/secret.rs
@@ -2,12 +2,12 @@
 //! Secret container for sensitive data. Performs zeroization on drop.
 //!
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// Secret container for sensitive data. Performs memory zeroization on drop.
-#[derive(Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct Secret(Vec<u8>);
 
 impl Secret {

--- a/wallet/core/src/storage/hint.rs
+++ b/wallet/core/src/storage/hint.rs
@@ -5,10 +5,10 @@
 //!
 
 use crate::imports::*;
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct Hint {
     pub text: String,
 }

--- a/wallet/core/src/storage/interface.rs
+++ b/wallet/core/src/storage/interface.rs
@@ -13,7 +13,7 @@ pub struct WalletExportOptions {
     pub include_transactions: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[wasm_bindgen(inspectable)]
 pub struct WalletDescriptor {
     #[wasm_bindgen(getter_with_clone)]
@@ -28,7 +28,7 @@ impl WalletDescriptor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind", content = "meta")]
 pub enum StorageDescriptor {

--- a/wallet/core/src/wallet/args.rs
+++ b/wallet/core/src/wallet/args.rs
@@ -6,7 +6,7 @@ use crate::imports::*;
 use crate::secret::Secret;
 use crate::storage::interface::CreateArgs;
 use crate::storage::{Hint, PrvKeyDataId};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use zeroize::Zeroize;
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
@@ -37,7 +37,7 @@ impl From<WalletCreateArgs> for CreateArgs {
     }
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct WalletOpenArgs {
     /// Return account descriptors
     pub account_descriptors: bool,
@@ -59,7 +59,7 @@ impl WalletOpenArgs {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct PrvKeyDataCreateArgs {
     pub name: Option<String>,
     pub payment_secret: Option<Secret>,

--- a/wallet/core/src/wallet/mod.rs
+++ b/wallet/core/src/wallet/mod.rs
@@ -1733,6 +1733,7 @@ mod test {
 
     #[test]
     fn deser_golang_wallet_test() {
+        #[allow(dead_code)]
         #[derive(Debug)]
         enum WalletType<'a> {
             SingleV0(SingleWalletFileV0<'a, Vec<u8>>),

--- a/wallet/macros/Cargo.toml
+++ b/wallet/macros/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kaspa-wallet-macros"
+rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/wallet/native/Cargo.toml
+++ b/wallet/native/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wallet"
 description = "Kaspa wallet"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/wallet/wasm/Cargo.toml
+++ b/wallet/wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wallet-cli-wasm"
 description = "Kaspa CLI wallet for WASM"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kaspa-wasm"
 description = "KASPA WASM bindings"
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
- remove BorshSchema due to rustc 1.77 issues (BorshSchema is not used anywhere)
- fix seal macro hash error (hash changed due to different whitespace processing in rustc 1.77)
- fix all rustc 1.77 lints

This replicates #438 (unfortunately I can't merge this due to other lint errors, so if this merged #438 should be closed)

