### PR TITLE
Fix for the pruning proof rebuild issue (issue #444)

### DIFF
--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -294,7 +294,7 @@ impl VirtualStateProcessor {
         self.populate_mempool_transaction_in_utxo_context(mutable_tx, utxo_view)?;
 
         // For non-activated nets (mainnet, TN10) we can update mempool rules to KIP9 beta asap. For
-        // TN11 we need to hard-fork consensus first (since the new beta rules are more relaxed)
+        // TN11 we need to hard-fork consensus first (since the new beta rules are more permissive)
         let kip9_version = if self.storage_mass_activation_daa_score == u64::MAX { Kip9Version::Beta } else { Kip9Version::Alpha };
 
         // Calc the full contextual mass including storage mass

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -675,17 +675,6 @@ impl PruningProofManager {
                 let mut queue = BinaryHeap::<Reverse<SortableBlock>>::new();
                 let mut visited = BlockHashSet::new();
                 queue.push(Reverse(SortableBlock::new(root, self.ghostdag_stores[level].get_blue_work(root).unwrap())));
-                if root != block_at_depth_2m {
-                    // In rare cases DAG reachability data might be more extensive than current level relations (since
-                    // it can include information from other levels as well). This might lead to a situation where if
-                    // root is in the past or anticone of block_at_depth_2m, traversing up via level parents might miss
-                    // some blocks in the chain of block_at_depth_2m. Hence, in order to insure that the full 2M chain
-                    // is included, we explicitly add block_at_depth_2m as a traversal root as well
-                    queue.push(Reverse(SortableBlock::new(
-                        block_at_depth_2m,
-                        self.ghostdag_stores[level].get_blue_work(block_at_depth_2m).unwrap(),
-                    )));
-                }
                 while let Some(current) = queue.pop() {
                     let current = current.0.hash;
                     if !visited.insert(current) {

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -108,7 +108,7 @@ impl Default for Args {
             rpc_max_clients: 128,
             max_tracked_addresses: Tracker::DEFAULT_MAX_ADDRESSES,
             enable_unsynced_mining: false,
-            enable_mainnet_mining: false,
+            enable_mainnet_mining: true,
             testnet: false,
             testnet_suffix: 10,
             devnet: false,
@@ -308,7 +308,7 @@ pub fn cli() -> Command {
                 .long("enable-mainnet-mining")
                 .action(ArgAction::SetTrue)
                 .hide(true)
-                .help("Allow mainnet mining (do not use unless you know what you are doing)"),
+                .help("Allow mainnet mining (currently enabled by default while the flag is kept for backwards compatibility)"),
         )
         .arg(arg!(--utxoindex "Enable the UTXO index"))
         .arg(
@@ -455,6 +455,11 @@ impl Args {
             #[cfg(feature = "devnet-prealloc")]
             prealloc_amount: arg_match_unwrap_or::<u64>(&m, "prealloc-amount", defaults.prealloc_amount),
         };
+
+        if arg_match_unwrap_or::<bool>(&m, "enable-mainnet-mining", false) {
+            println!("\nNOTE: The flag --enable-mainnet-mining is deprecated and defaults to true also w/o explicit setting\n")
+        }
+
         Ok(args)
     }
 }

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -106,7 +106,7 @@ impl Default for Args {
             outbound_target: 8,
             inbound_limit: 128,
             rpc_max_clients: 128,
-            max_tracked_addresses: Tracker::DEFAULT_MAX_ADDRESSES,
+            max_tracked_addresses: 0,
             enable_unsynced_mining: false,
             enable_mainnet_mining: true,
             testnet: false,
@@ -316,8 +316,9 @@ pub fn cli() -> Command {
                 .long("max-tracked-addresses")
                 .require_equals(true)
                 .value_parser(clap::value_parser!(usize))
-                .help(format!("Max preallocated number of addresses tracking UTXO changed events (default: {}, maximum: {}). 
-Value 0 prevents the preallocation, leading to a 0 memory footprint as long as unused but then to a sub-optimal footprint when used.", Tracker::DEFAULT_MAX_ADDRESSES, Tracker::MAX_ADDRESS_UPPER_BOUND)),
+                .help(format!("Max (preallocated) number of addresses being tracked for UTXO changed events (default: {}, maximum: {}). 
+Setting to 0 prevents the preallocation and sets the maximum to {}, leading to 0 memory footprint as long as unused but to sub-optimal footprint if used.", 
+0, Tracker::MAX_ADDRESS_UPPER_BOUND, Tracker::DEFAULT_MAX_ADDRESSES)),
         )
         .arg(arg!(--testnet "Use the test network"))
         .arg(

--- a/notify/src/listener.rs
+++ b/notify/src/listener.rs
@@ -48,9 +48,9 @@ where
                 debug!(
                     "Creating a static listener {} with UtxosChanged capacity of {}",
                     connection,
-                    context.address_tracker.max_addresses().unwrap_or_default()
+                    context.address_tracker.addresses_preallocation().unwrap_or_default()
                 );
-                context.address_tracker.max_addresses()
+                context.address_tracker.addresses_preallocation()
             }
             UtxosChangedMutationPolicy::Wildcard => None,
         };

--- a/notify/src/notifier.rs
+++ b/notify/src/notifier.rs
@@ -310,7 +310,7 @@ where
             subscriber
         });
         let utxos_changed_capacity = match policies.utxo_changed {
-            UtxosChangedMutationPolicy::AddressSet => subscription_context.address_tracker.max_addresses(),
+            UtxosChangedMutationPolicy::AddressSet => subscription_context.address_tracker.addresses_preallocation(),
             UtxosChangedMutationPolicy::Wildcard => None,
         };
         Self {


### PR DESCRIPTION
The following describes the pruning bug and the fix assuming sufficient prior knowledge. 

Some notation: 
 
- High levels: block levels at which there are less than 2000 blocks since genesis (so genesis is part of that proof level). Currently this is approx around level 39 and above. 
- Low levels: block levels close to current difficulty and hence it is likely that all 2000 proof blocks are within the last day before the corresponding pruning point.
- Intermediate levels: block levels which are not that rare but are still unlikely to have more than 2000 blocks all within a single day. Hence their level proof likely has blocks **both** before and after the previous pruning point.

The bug is mostly in the case of intermediate levels. It requires that such a block is mined in the anticone of the pruning point (so the bug is likely to occur ~once in a few days, and requires that someone synced a new node exactly at that day). 

The logic missing: we did not update relations per level for the pruning point anticone (aka "trusted" blocks). 

Scenario: a "lucky" intermediate-level block `R` happened to be in the pruning point anticone. A future block `B` on that level is likely to have `R` as its only parent (for that level). Since level relations are not updated for `R`, `B` computes Ghostdag for that level over `ORIGIN` -- essentially starting from blue score 0 instead of building over the previous 2000 blocks.  When building the new proof, this segment of blocks (`S` = `B` + its future) is topologically disconnected from block `N` which is the block at depth 1000 of the next level (which is likely below the current new pruning point). So `N` becomes `root`, and the traversal starting from it never reaches `S`. Leading to a possible prune of blocks in `S` (some may be preserved via other levels)

Result: following the prune, the proof rebuild fails bcs of blocks missing from `S`. This is only a symptom of the bug, the real problem is that the level proof is literally incomplete.  

Fix: update relations per level also for trusted blocks