### PR TITLE
Initialize pruning point depth store -- minor bug fix

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -91,7 +91,7 @@ impl ConsensusInstance {
 
     /// Returns an unguarded *blocking* consensus session. There's no guarantee that data will not be pruned between
     /// two sequential consensus calls. This session doesn't hold the consensus pruning lock, so it should
-    /// be preferred upon [`session`] when data consistency is not important.
+    /// be preferred upon [`session_blocking`] when data consistency is not important.
     pub fn unguarded_session_blocking(&self) -> ConsensusSessionBlocking<'static> {
         ConsensusSessionBlocking::new_without_session_guard(self.consensus.clone())
     }

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -89,6 +89,13 @@ impl ConsensusInstance {
         ConsensusSessionBlocking::new(g, self.consensus.clone())
     }
 
+    /// Returns an unguarded *blocking* consensus session. There's no guarantee that data will not be pruned between
+    /// two sequential consensus calls. This session doesn't hold the consensus pruning lock, so it should
+    /// be preferred upon [`session`] when data consistency is not important.
+    pub fn unguarded_session_blocking(&self) -> ConsensusSessionBlocking<'static> {
+        ConsensusSessionBlocking::new_without_session_guard(self.consensus.clone())
+    }
+
     /// Returns a consensus session for accessing consensus operations in a bulk. The user can safely assume
     /// that consensus state is consistent between operations, that is, no pruning was performed between the calls.
     /// The returned object is an *owned* consensus session type which can be cloned and shared across threads.
@@ -109,13 +116,17 @@ impl ConsensusInstance {
 }
 
 pub struct ConsensusSessionBlocking<'a> {
-    _session_guard: SessionReadGuard<'a>,
+    _session_guard: Option<SessionReadGuard<'a>>,
     consensus: DynConsensus,
 }
 
 impl<'a> ConsensusSessionBlocking<'a> {
     pub fn new(session_guard: SessionReadGuard<'a>, consensus: DynConsensus) -> Self {
-        Self { _session_guard: session_guard, consensus }
+        Self { _session_guard: Some(session_guard), consensus }
+    }
+
+    pub fn new_without_session_guard(consensus: DynConsensus) -> Self {
+        Self { _session_guard: None, consensus }
     }
 }
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -189,7 +189,7 @@ impl PruningProofManager {
         }
 
         let new_pruning_point = pruning_points.last().unwrap().hash;
-        info!("Setting {new_pruning_point} as the current pruning point");
+        info!("Setting {new_pruning_point} as the staging pruning point");
 
         let mut pruning_point_write = self.pruning_point_store.write();
         let mut batch = WriteBatch::default();

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -281,6 +281,7 @@ impl PruningProofManager {
             .set_batch(&mut batch, SortableBlock { hash: pruning_point, blue_work: pruning_point_header.blue_work })
             .unwrap();
         self.selected_chain_store.write().init_with_pruning_point(&mut batch, pruning_point).unwrap();
+        self.depth_store.insert_batch(&mut batch, pruning_point, ORIGIN, ORIGIN).unwrap();
         self.db.write(batch).unwrap();
 
         Ok(())

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -294,6 +294,7 @@ impl IbdFlow {
         let mut trusted_set = pkg.build_trusted_subdag(entries)?;
 
         if self.ctx.config.enable_sanity_checks {
+            let con = self.ctx.consensus().unguarded_session_blocking();
             trusted_set = staging
                 .clone()
                 .spawn_blocking(move |c| {
@@ -314,7 +315,8 @@ impl IbdFlow {
                     }
                     if mismatch_detected {
                         info!("Validating the locally built proof (sanity test fallback #2)");
-                        if let Err(err) = c.validate_pruning_proof(&built_proof) {
+                        // Note: the proof is validated in the context of *current* consensus
+                        if let Err(err) = con.validate_pruning_proof(&built_proof) {
                             panic!("Locally built proof failed validation: {}", err);
                         }
                         info!("Locally built proof was validated successfully");


### PR DESCRIPTION
Initialize the pruning point depth store for the rare case where the pruning point is the first sink during initial IBD (virtual processor calls the depth store for each new sink)