### PR TITLE
Subscription context with a network type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "futures-util",
  "h2",
  "itertools 0.11.0",
+ "kaspa-consensus-core",
  "kaspa-core",
  "kaspa-grpc-core",
  "kaspa-notify",

--- a/consensus/notify/src/notification.rs
+++ b/consensus/notify/src/notification.rs
@@ -6,7 +6,6 @@ use kaspa_notify::{
     full_featured,
     notification::Notification as NotificationTrait,
     subscription::{
-        context::SubscriptionContext,
         single::{OverallSubscription, UtxosChangedSubscription, VirtualChainChangedSubscription},
         Subscription,
     },
@@ -46,18 +45,14 @@ pub enum Notification {
 }
 
 impl NotificationTrait for Notification {
-    fn apply_overall_subscription(&self, subscription: &OverallSubscription, _context: &SubscriptionContext) -> Option<Self> {
+    fn apply_overall_subscription(&self, subscription: &OverallSubscription) -> Option<Self> {
         match subscription.active() {
             true => Some(self.clone()),
             false => None,
         }
     }
 
-    fn apply_virtual_chain_changed_subscription(
-        &self,
-        subscription: &VirtualChainChangedSubscription,
-        _context: &SubscriptionContext,
-    ) -> Option<Self> {
+    fn apply_virtual_chain_changed_subscription(&self, subscription: &VirtualChainChangedSubscription) -> Option<Self> {
         match subscription.active() {
             true => {
                 // If the subscription excludes accepted transaction ids and the notification includes some
@@ -77,11 +72,7 @@ impl NotificationTrait for Notification {
         }
     }
 
-    fn apply_utxos_changed_subscription(
-        &self,
-        _subscription: &UtxosChangedSubscription,
-        _context: &SubscriptionContext,
-    ) -> Option<Self> {
+    fn apply_utxos_changed_subscription(&self, _subscription: &UtxosChangedSubscription) -> Option<Self> {
         // No effort is made here to apply the subscription addresses.
         // This will be achieved farther along the notification backbone.
         Some(self.clone())

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -49,7 +49,7 @@ pub struct TestConsensus {
 impl TestConsensus {
     /// Creates a test consensus instance based on `config` with the provided `db` and `notification_sender`
     pub fn with_db(db: Arc<DB>, config: &Config, notification_sender: Sender<Notification>) -> Self {
-        let notification_root = Arc::new(ConsensusNotificationRoot::new(notification_sender));
+        let notification_root = Arc::new(ConsensusNotificationRoot::new(config.net.into(), notification_sender));
         let counters = Default::default();
         let tx_script_cache_counters = Default::default();
         let consensus = Arc::new(Consensus::new(
@@ -90,7 +90,7 @@ impl TestConsensus {
     pub fn new(config: &Config) -> Self {
         let (db_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
         let (dummy_notification_sender, _) = async_channel::unbounded();
-        let notification_root = Arc::new(ConsensusNotificationRoot::new(dummy_notification_sender));
+        let notification_root = Arc::new(ConsensusNotificationRoot::new(config.net.into(), dummy_notification_sender));
         let counters = Default::default();
         let tx_script_cache_counters = Default::default();
         let consensus = Arc::new(Consensus::new(

--- a/indexes/core/src/notification.rs
+++ b/indexes/core/src/notification.rs
@@ -101,8 +101,8 @@ impl UtxosChangedNotification {
             }
         } else {
             let tracker_data = subscription_data.tracker().data();
-            subscription_data.iter().for_each(|index| {
-                if let Some(script_public_key) = tracker_data.get_index(*index) {
+            subscription_data.iter_index().for_each(|index| {
+                if let Some(script_public_key) = tracker_data.get_index(index) {
                     if let Some(collection) = utxo_set.get(script_public_key) {
                         result.insert(script_public_key.clone(), collection.clone());
                     }

--- a/indexes/core/src/notification.rs
+++ b/indexes/core/src/notification.rs
@@ -88,7 +88,10 @@ impl UtxosChangedNotification {
         // and check existence over the larger set (O(1))
         let mut result = HashMap::default();
         let subscription_data = subscription.data();
-        if utxo_set.len() < subscription_data.len() {
+
+        // Compare capacities instead of lengths since iterators do also visit empty buckets,
+        // so we have O(capacity) time complexity
+        if utxo_set.capacity() < subscription_data.capacity() {
             {
                 utxo_set.iter().for_each(|(script_public_key, collection)| {
                     if subscription_data.contains(script_public_key) {

--- a/indexes/core/src/notification.rs
+++ b/indexes/core/src/notification.rs
@@ -5,7 +5,6 @@ use kaspa_notify::{
     full_featured,
     notification::Notification as NotificationTrait,
     subscription::{
-        context::SubscriptionContext,
         single::{OverallSubscription, UtxosChangedSubscription, VirtualChainChangedSubscription},
         Subscription,
     },
@@ -24,22 +23,18 @@ pub enum Notification {
 }
 
 impl NotificationTrait for Notification {
-    fn apply_overall_subscription(&self, subscription: &OverallSubscription, _context: &SubscriptionContext) -> Option<Self> {
+    fn apply_overall_subscription(&self, subscription: &OverallSubscription) -> Option<Self> {
         match subscription.active() {
             true => Some(self.clone()),
             false => None,
         }
     }
 
-    fn apply_virtual_chain_changed_subscription(
-        &self,
-        _subscription: &VirtualChainChangedSubscription,
-        _context: &SubscriptionContext,
-    ) -> Option<Self> {
+    fn apply_virtual_chain_changed_subscription(&self, _subscription: &VirtualChainChangedSubscription) -> Option<Self> {
         Some(self.clone())
     }
 
-    fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription, _: &SubscriptionContext) -> Option<Self> {
+    fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription) -> Option<Self> {
         match subscription.active() {
             true => {
                 let Self::UtxosChanged(notification) = self else { return None };

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -361,7 +361,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     let tick_service = Arc::new(TickService::new());
     let (notification_send, notification_recv) = unbounded();
     let max_tracked_addresses = if args.utxoindex && args.max_tracked_addresses > 0 { Some(args.max_tracked_addresses) } else { None };
-    let subscription_context = SubscriptionContext::with_options(max_tracked_addresses);
+    let subscription_context = SubscriptionContext::with_options(Some(config.net.into()), max_tracked_addresses);
     let notification_root = Arc::new(ConsensusNotificationRoot::with_context(notification_send, subscription_context.clone()));
     let processing_counters = Arc::new(ProcessingCounters::default());
     let mining_counters = Arc::new(MiningCounters::default());

--- a/notify/benches/bench.rs
+++ b/notify/benches/bench.rs
@@ -3,14 +3,16 @@ use kaspa_addresses::{Address, Prefix};
 use kaspa_math::Uint256;
 use kaspa_notify::{address::tracker::Indexes, subscription::context::SubscriptionContext};
 
+const ADDRESS_PREFIX: Prefix = Prefix::Mainnet;
+
 fn create_addresses(count: usize) -> Vec<Address> {
     (0..count)
-        .map(|i| Address::new(Prefix::Mainnet, kaspa_addresses::Version::PubKey, &Uint256::from_u64(i as u64).to_le_bytes()))
+        .map(|i| Address::new(ADDRESS_PREFIX, kaspa_addresses::Version::PubKey, &Uint256::from_u64(i as u64).to_le_bytes()))
         .collect()
 }
 
 fn create_and_fill_context(addresses: Vec<Address>) -> SubscriptionContext {
-    let context = SubscriptionContext::with_options(Some(ADDRESS_COUNT));
+    let context = SubscriptionContext::with_options(Some(ADDRESS_PREFIX), Some(ADDRESS_COUNT));
     let mut indexes = Indexes::new(context.address_tracker.clone());
     let _ = indexes.register(addresses);
     context

--- a/notify/benches/bench.rs
+++ b/notify/benches/bench.rs
@@ -12,7 +12,7 @@ fn create_addresses(count: usize) -> Vec<Address> {
 }
 
 fn create_and_fill_context(addresses: Vec<Address>) -> SubscriptionContext {
-    let context = SubscriptionContext::with_options(Some(ADDRESS_PREFIX), Some(ADDRESS_COUNT));
+    let context = SubscriptionContext::with_options(Some(ADDRESS_PREFIX.try_into().unwrap()), Some(ADDRESS_COUNT));
     let mut indexes = Indexes::new(context.address_tracker.clone());
     let _ = indexes.register(addresses);
     context

--- a/notify/benches/bench.rs
+++ b/notify/benches/bench.rs
@@ -12,7 +12,7 @@ fn create_addresses(count: usize) -> Vec<Address> {
 fn create_and_fill_context(addresses: Vec<Address>) -> SubscriptionContext {
     let context = SubscriptionContext::with_options(Some(ADDRESS_COUNT));
     let mut indexes = Indexes::new(context.address_tracker.clone(), vec![]);
-    let _ = context.address_tracker.register(&mut indexes, addresses);
+    let _ = indexes.register(addresses);
     context
 }
 

--- a/notify/benches/bench.rs
+++ b/notify/benches/bench.rs
@@ -10,8 +10,8 @@ fn create_addresses(count: usize) -> Vec<Address> {
 }
 
 fn create_and_fill_context(addresses: Vec<Address>) -> SubscriptionContext {
-    let mut indexes = Indexes::new(vec![]);
     let context = SubscriptionContext::with_options(Some(ADDRESS_COUNT));
+    let mut indexes = Indexes::new(context.address_tracker.clone(), vec![]);
     let _ = context.address_tracker.register(&mut indexes, addresses);
     context
 }

--- a/notify/benches/bench.rs
+++ b/notify/benches/bench.rs
@@ -11,7 +11,7 @@ fn create_addresses(count: usize) -> Vec<Address> {
 
 fn create_and_fill_context(addresses: Vec<Address>) -> SubscriptionContext {
     let context = SubscriptionContext::with_options(Some(ADDRESS_COUNT));
-    let mut indexes = Indexes::new(context.address_tracker.clone(), vec![]);
+    let mut indexes = Indexes::new(context.address_tracker.clone());
     let _ = indexes.register(addresses);
     context
 }

--- a/notify/src/address/error.rs
+++ b/notify/src/address/error.rs
@@ -1,9 +1,16 @@
+use kaspa_addresses::Address;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
 pub enum Error {
-    #[error("the address store reached the maximum capacity")]
+    #[error("the address tracker reached the maximum capacity")]
     MaxCapacityReached,
+
+    #[error("no prefix was attributed to the address tracker")]
+    NoPrefix,
+
+    #[error("address {0} does not match the address tracker prefix")]
+    PrefixMismatch(Address),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/notify/src/address/mod.rs
+++ b/notify/src/address/mod.rs
@@ -4,7 +4,9 @@ pub mod tracker;
 pub mod test_helpers {
     use kaspa_addresses::Address;
     use kaspa_addresses::{Prefix, Version};
+    use kaspa_consensus_core::network::NetworkType;
 
+    pub const NETWORK_TYPE: NetworkType = NetworkType::Mainnet;
     pub const ADDRESS_PREFIX: Prefix = Prefix::Mainnet;
 
     pub fn get_3_addresses(sorted: bool) -> Vec<Address> {

--- a/notify/src/address/tracker.rs
+++ b/notify/src/address/tracker.rs
@@ -380,9 +380,9 @@ impl Inner {
 /// This prevents inter-network duplication and optimizes UTXOs filtering efficiency.
 ///
 /// But consequently the address network prefix gets lost and must be globally provided when querying for addresses by indexes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Tracker {
-    inner: RwLock<Inner>,
+    inner: Arc<RwLock<Inner>>,
 }
 
 impl Display for Tracker {
@@ -407,12 +407,12 @@ impl Tracker {
     }
 
     pub fn new(max_addresses: Option<usize>) -> Self {
-        Self { inner: RwLock::new(Inner::new(max_addresses)) }
+        Self { inner: Arc::new(RwLock::new(Inner::new(max_addresses))) }
     }
 
     #[cfg(test)]
     pub fn with_addresses(addresses: &[Address]) -> Self {
-        let tracker = Self { inner: RwLock::new(Inner::new(None)) };
+        let tracker = Self { inner: Arc::new(RwLock::new(Inner::new(None))) };
         for chunk in addresses.chunks(Self::ADDRESS_CHUNK_SIZE) {
             let mut inner = tracker.inner.write();
             for address in chunk {

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -179,7 +179,7 @@ where
                             let event = notification.event_type();
                             for (subscription, encoding_set) in plan[event].iter() {
                                 // ... by subscription scope
-                                if let Some(applied_notification) = notification.apply_subscription(&**subscription, &context) {
+                                if let Some(applied_notification) = notification.apply_subscription(&**subscription, ) {
                                     for (encoding, connection_set) in encoding_set.iter() {
                                         // ... by message encoding
                                         let message = C::into_message(&applied_notification, encoding);

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -258,6 +258,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        address::test_helpers::ADDRESS_PREFIX,
         connection::{ChannelConnection, ChannelType},
         listener::Listener,
         notification::test_helpers::*,
@@ -287,7 +288,7 @@ mod tests {
     impl Test {
         fn new(name: &'static str, listener_count: usize, steps: Vec<Step>) -> Self {
             const IDENT: &str = "test";
-            let subscription_context = SubscriptionContext::new();
+            let subscription_context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
             let (sync_sender, sync_receiver) = unbounded();
             let (notification_sender, notification_receiver) = unbounded();
             let broadcaster =

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -326,8 +326,7 @@ mod tests {
                     if let Some(ref mutation) = mutation {
                         trace!("{} #{} - {}: L{} {:?}", self.name, step_idx, step.name, idx, mutation);
                         let event = mutation.event_type();
-                        let outcome =
-                            self.listeners[idx].mutate(mutation.clone(), Default::default(), &self.subscription_context).unwrap();
+                        let outcome = self.listeners[idx].mutate(mutation.clone(), Default::default()).unwrap();
                         if outcome.has_new_state() {
                             trace!(
                                 "{} #{} - {}: - L{} has the new state {:?}",

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -258,7 +258,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        address::test_helpers::ADDRESS_PREFIX,
+        address::test_helpers::NETWORK_TYPE,
         connection::{ChannelConnection, ChannelType},
         listener::Listener,
         notification::test_helpers::*,
@@ -288,7 +288,7 @@ mod tests {
     impl Test {
         fn new(name: &'static str, listener_count: usize, steps: Vec<Step>) -> Self {
             const IDENT: &str = "test";
-            let subscription_context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+            let subscription_context = SubscriptionContext::new(Some(NETWORK_TYPE));
             let (sync_sender, sync_receiver) = unbounded();
             let (notification_sender, notification_receiver) = unbounded();
             let broadcaster =

--- a/notify/src/broadcaster.rs
+++ b/notify/src/broadcaster.rs
@@ -297,7 +297,7 @@ mod tests {
             for i in 0..listener_count {
                 let (sender, receiver) = unbounded();
                 let connection = TestConnection::new(IDENT, sender, ChannelType::Closable);
-                let listener = Listener::new(i as ListenerId, connection);
+                let listener = Listener::new(i as ListenerId, connection, &subscription_context);
                 listeners.push(listener);
                 notification_receivers.push(receiver);
             }

--- a/notify/src/collector.rs
+++ b/notify/src/collector.rs
@@ -126,10 +126,7 @@ mod tests {
         converter::ConverterFrom,
         events::EventType,
         notifier::test_helpers::NotifyMock,
-        subscription::{
-            context::SubscriptionContext,
-            single::{OverallSubscription, UtxosChangedSubscription, VirtualChainChangedSubscription},
-        },
+        subscription::single::{OverallSubscription, UtxosChangedSubscription, VirtualChainChangedSubscription},
     };
     use derive_more::Display;
 
@@ -155,19 +152,15 @@ mod tests {
     }
 
     impl crate::notification::Notification for OutgoingNotification {
-        fn apply_overall_subscription(&self, _: &OverallSubscription, _: &SubscriptionContext) -> Option<Self> {
+        fn apply_overall_subscription(&self, _: &OverallSubscription) -> Option<Self> {
             unimplemented!()
         }
 
-        fn apply_virtual_chain_changed_subscription(
-            &self,
-            _: &VirtualChainChangedSubscription,
-            _: &SubscriptionContext,
-        ) -> Option<Self> {
+        fn apply_virtual_chain_changed_subscription(&self, _: &VirtualChainChangedSubscription) -> Option<Self> {
             unimplemented!()
         }
 
-        fn apply_utxos_changed_subscription(&self, _: &UtxosChangedSubscription, _: &SubscriptionContext) -> Option<Self> {
+        fn apply_utxos_changed_subscription(&self, _: &UtxosChangedSubscription) -> Option<Self> {
             unimplemented!()
         }
 

--- a/notify/src/listener.rs
+++ b/notify/src/listener.rs
@@ -67,14 +67,9 @@ where
     }
 
     /// Apply a mutation to the subscriptions
-    pub fn mutate(
-        &mut self,
-        mutation: Mutation,
-        policies: MutationPolicies,
-        context: &SubscriptionContext,
-    ) -> Result<MutationOutcome> {
+    pub fn mutate(&mut self, mutation: Mutation, policies: MutationPolicies) -> Result<MutationOutcome> {
         let event_type = mutation.event_type();
-        self.subscriptions[event_type].mutate(mutation, policies, context)
+        self.subscriptions[event_type].mutate(mutation, policies)
     }
 
     pub fn close(&self) {

--- a/notify/src/listener.rs
+++ b/notify/src/listener.rs
@@ -38,8 +38,12 @@ impl<C> Listener<C>
 where
     C: Connection,
 {
-    pub fn new(id: ListenerId, connection: C) -> Self {
-        Self { connection, subscriptions: ArrayBuilder::single(id, None), _lifespan: ListenerLifespan::Dynamic }
+    pub fn new(id: ListenerId, connection: C, context: &SubscriptionContext) -> Self {
+        Self {
+            connection,
+            subscriptions: ArrayBuilder::single(id, &context.address_tracker, None),
+            _lifespan: ListenerLifespan::Dynamic,
+        }
     }
 
     pub fn new_static(id: ListenerId, connection: C, context: &SubscriptionContext, policies: MutationPolicies) -> Self {
@@ -54,7 +58,7 @@ where
             }
             UtxosChangedMutationPolicy::Wildcard => None,
         };
-        let subscriptions = ArrayBuilder::single(id, capacity);
+        let subscriptions = ArrayBuilder::single(id, &context.address_tracker, capacity);
         Self { connection, subscriptions, _lifespan: ListenerLifespan::Static(policies) }
     }
 

--- a/notify/src/notification.rs
+++ b/notify/src/notification.rs
@@ -143,11 +143,7 @@ pub mod test_helpers {
             }
         }
 
-        fn apply_utxos_changed_subscription(
-            &self,
-            subscription: &UtxosChangedSubscription,
-            context: &SubscriptionContext,
-        ) -> Option<Self> {
+        fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription, _: &SubscriptionContext) -> Option<Self> {
             match subscription.active() {
                 true => {
                     if let TestNotification::UtxosChanged(ref payload) = self {
@@ -156,12 +152,8 @@ pub mod test_helpers {
                             // trace!("apply_utxos_changed_subscription: Notification payload {:?}", payload);
                             // trace!("apply_utxos_changed_subscription: Subscription content {:?}", subscription);
                             // trace!("apply_utxos_changed_subscription: Subscription Context {}", context.address_tracker);
-                            let addresses = payload
-                                .addresses
-                                .iter()
-                                .filter(|x| subscription.contains_address(x, context))
-                                .cloned()
-                                .collect::<Vec<_>>();
+                            let addresses =
+                                payload.addresses.iter().filter(|x| subscription.contains_address(x)).cloned().collect::<Vec<_>>();
                             if !addresses.is_empty() {
                                 return Some(TestNotification::UtxosChanged(UtxosChangedNotification {
                                     data: payload.data,

--- a/notify/src/notifier.rs
+++ b/notify/src/notifier.rs
@@ -316,7 +316,7 @@ where
         Self {
             enabled_events,
             listeners: Mutex::new(HashMap::new()),
-            subscriptions: Mutex::new(ArrayBuilder::compounded(utxos_changed_capacity)),
+            subscriptions: Mutex::new(ArrayBuilder::compounded(&subscription_context.address_tracker, utxos_changed_capacity)),
             started: Arc::new(AtomicBool::new(false)),
             notification_channel,
             broadcasters,
@@ -352,7 +352,7 @@ where
                 trace!("[Notifier {}] registering listener {id}", self.name);
                 let listener = match lifespan {
                     ListenerLifespan::Static(policies) => Listener::new_static(id, connection, &self.subscription_context, policies),
-                    ListenerLifespan::Dynamic => Listener::new(id, connection),
+                    ListenerLifespan::Dynamic => Listener::new(id, connection, &self.subscription_context),
                 };
                 e.insert(listener);
                 return id;

--- a/notify/src/notifier.rs
+++ b/notify/src/notifier.rs
@@ -412,7 +412,7 @@ where
         let event = scope.event_type();
         let scope_trace = format!("{scope}");
         debug!("[Notifier {}] {command} notifying about {scope_trace} to listener {id} - {}", self.name, listener.connection());
-        let outcome = listener.mutate(Mutation::new(command, scope), self.policies, &self.subscription_context)?;
+        let outcome = listener.mutate(Mutation::new(command, scope), self.policies)?;
         if outcome.has_changes() {
             trace!(
                 "[Notifier {}] {command} notifying listener {id} about {scope_trace} involves {} mutations",
@@ -433,7 +433,7 @@ where
                     self.broadcasters.iter().try_for_each(|broadcaster| broadcaster.unregister(event, id))?;
                 }
             }
-            self.apply_mutations(event, outcome.mutations, &self.subscription_context)?;
+            self.apply_mutations(event, outcome.mutations)?;
         } else {
             trace!("[Notifier {}] {command} notifying listener {id} about {scope_trace} is ignored (no mutation)", self.name);
             sync_feedback = true;
@@ -448,12 +448,12 @@ where
         Ok(())
     }
 
-    fn apply_mutations(&self, event: EventType, mutations: Vec<Mutation>, context: &SubscriptionContext) -> Result<()> {
+    fn apply_mutations(&self, event: EventType, mutations: Vec<Mutation>) -> Result<()> {
         let mut subscriptions = self.subscriptions.lock();
         // Compound mutations
         let mut compound_result = None;
         for mutation in mutations {
-            compound_result = subscriptions[event].compound(mutation, context);
+            compound_result = subscriptions[event].compound(mutation);
         }
         // Report to the parent if any
         if let Some(mutation) = compound_result {
@@ -482,7 +482,7 @@ where
     fn renew_subscriptions(&self) -> Result<()> {
         let subscriptions = self.subscriptions.lock();
         EVENT_TYPE_ARRAY.iter().copied().filter(|x| self.enabled_events[*x] && subscriptions[*x].active()).try_for_each(|x| {
-            let mutation = Mutation::new(Command::Start, subscriptions[x].scope(&self.subscription_context));
+            let mutation = Mutation::new(Command::Start, subscriptions[x].scope());
             self.subscribers.iter().try_for_each(|subscriber| subscriber.mutate(mutation.clone()))?;
             Ok(())
         })

--- a/notify/src/notifier.rs
+++ b/notify/src/notifier.rs
@@ -823,7 +823,7 @@ pub mod test_helpers {
 mod tests {
     use super::{test_helpers::*, *};
     use crate::{
-        address::test_helpers::ADDRESS_PREFIX,
+        address::test_helpers::NETWORK_TYPE,
         collector::CollectorFrom,
         connection::ChannelType,
         converter::ConverterFrom,
@@ -858,7 +858,7 @@ mod tests {
             let (subscription_sender, subscription_receiver) = unbounded();
             let collector = Arc::new(TestCollector::new(IDENT, notification_receiver, Arc::new(TestConverter::new())));
             let subscription_manager = Arc::new(SubscriptionManagerMock::new(subscription_sender));
-            let subscription_context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+            let subscription_context = SubscriptionContext::new(Some(NETWORK_TYPE));
             let subscriber =
                 Arc::new(Subscriber::new("test", EVENT_TYPE_ARRAY[..].into(), subscription_manager, SUBSCRIPTION_MANAGER_ID));
             let notifier = Arc::new(TestNotifier::with_sync(

--- a/notify/src/notifier.rs
+++ b/notify/src/notifier.rs
@@ -823,6 +823,7 @@ pub mod test_helpers {
 mod tests {
     use super::{test_helpers::*, *};
     use crate::{
+        address::test_helpers::ADDRESS_PREFIX,
         collector::CollectorFrom,
         connection::ChannelType,
         converter::ConverterFrom,
@@ -857,7 +858,7 @@ mod tests {
             let (subscription_sender, subscription_receiver) = unbounded();
             let collector = Arc::new(TestCollector::new(IDENT, notification_receiver, Arc::new(TestConverter::new())));
             let subscription_manager = Arc::new(SubscriptionManagerMock::new(subscription_sender));
-            let subscription_context = SubscriptionContext::new();
+            let subscription_context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
             let subscriber =
                 Arc::new(Subscriber::new("test", EVENT_TYPE_ARRAY[..].into(), subscription_manager, SUBSCRIPTION_MANAGER_ID));
             let notifier = Arc::new(TestNotifier::with_sync(

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use async_channel::Sender;
 use async_trait::async_trait;
+use kaspa_addresses::Prefix;
 use kaspa_core::{debug, trace};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -36,8 +37,8 @@ impl<N> Root<N>
 where
     N: Notification,
 {
-    pub fn new(sender: Sender<N>) -> Self {
-        let subscription_context = SubscriptionContext::new();
+    pub fn new(prefix: Prefix, sender: Sender<N>) -> Self {
+        let subscription_context = SubscriptionContext::new(Some(prefix));
         Self::with_context(sender, subscription_context)
     }
 

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -109,7 +109,7 @@ where
     const ROOT_LISTENER_ID: ListenerId = 1;
 
     fn new(sender: Sender<N>, subscription_context: SubscriptionContext) -> Self {
-        let subscriptions = RwLock::new(ArrayBuilder::single(Self::ROOT_LISTENER_ID, None));
+        let subscriptions = RwLock::new(ArrayBuilder::single(Self::ROOT_LISTENER_ID, &subscription_context.address_tracker, None));
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::Wildcard);
         Self { sender, subscriptions, subscription_context, policies }
     }

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -117,7 +117,7 @@ where
     fn send(&self, notification: N) -> Result<()> {
         let event = notification.event_type();
         let subscription = &self.subscriptions.read()[event];
-        if let Some(applied_notification) = notification.apply_subscription(&**subscription, &self.subscription_context) {
+        if let Some(applied_notification) = notification.apply_subscription(&**subscription) {
             self.sender.try_send(applied_notification)?;
         }
         Ok(())
@@ -138,7 +138,7 @@ where
         let event = notification.event_type();
         let subscription = &self.subscriptions.read()[event];
         if subscription.active() {
-            if let Some(applied_notification) = notification.apply_subscription(&**subscription, &self.subscription_context) {
+            if let Some(applied_notification) = notification.apply_subscription(&**subscription) {
                 self.sender.try_send(applied_notification)?;
             }
         }

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use async_channel::Sender;
 use async_trait::async_trait;
-use kaspa_addresses::Prefix;
+use kaspa_consensus_core::network::NetworkType;
 use kaspa_core::{debug, trace};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -37,8 +37,8 @@ impl<N> Root<N>
 where
     N: Notification,
 {
-    pub fn new(prefix: Prefix, sender: Sender<N>) -> Self {
-        let subscription_context = SubscriptionContext::new(Some(prefix));
+    pub fn new(network_type: NetworkType, sender: Sender<N>) -> Self {
+        let subscription_context = SubscriptionContext::new(Some(network_type));
         Self::with_context(sender, subscription_context)
     }
 

--- a/notify/src/root.rs
+++ b/notify/src/root.rs
@@ -99,7 +99,6 @@ where
 {
     sender: Sender<N>,
     subscriptions: RwLock<EventArray<DynSubscription>>,
-    subscription_context: SubscriptionContext,
     policies: MutationPolicies,
 }
 
@@ -112,7 +111,7 @@ where
     fn new(sender: Sender<N>, subscription_context: SubscriptionContext) -> Self {
         let subscriptions = RwLock::new(ArrayBuilder::single(Self::ROOT_LISTENER_ID, &subscription_context.address_tracker, None));
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::Wildcard);
-        Self { sender, subscriptions, subscription_context, policies }
+        Self { sender, subscriptions, policies }
     }
 
     fn send(&self, notification: N) -> Result<()> {
@@ -127,7 +126,7 @@ where
     pub fn execute_subscribe_command(&self, scope: Scope, command: Command) -> Result<()> {
         let mutation = Mutation::new(command, scope);
         let mut subscriptions = self.subscriptions.write();
-        subscriptions[mutation.event_type()].mutate(mutation, self.policies, &self.subscription_context)?;
+        subscriptions[mutation.event_type()].mutate(mutation, self.policies)?;
         Ok(())
     }
 

--- a/notify/src/scope.rs
+++ b/notify/src/scope.rs
@@ -151,7 +151,7 @@ impl PartialEq for UtxosChangedScope {
                     indexes.len() == other_addresses.len() && other_addresses.iter().all(|x| indexes.contains(x))
                 }
                 Self::Indexes(ref other_indexes) => {
-                    indexes.len() == other_indexes.len() && indexes.iter().all(|x| other_indexes.contains_index(*x))
+                    indexes.len() == other_indexes.len() && indexes.iter_index().all(|x| other_indexes.contains_index(x))
                 }
             },
         }

--- a/notify/src/scope.rs
+++ b/notify/src/scope.rs
@@ -1,4 +1,7 @@
-use super::events::EventType;
+use crate::{
+    address::tracker::{Indexer, Indexes},
+    events::EventType,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::Display;
 use kaspa_addresses::Address;
@@ -79,17 +82,54 @@ pub struct FinalityConflictScope {}
 #[derive(Clone, Display, Debug, PartialEq, Eq, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct FinalityConflictResolvedScope {}
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-pub struct UtxosChangedScope {
-    pub addresses: Vec<Address>,
+#[derive(Clone, Debug)]
+pub enum UtxosChangedScope {
+    Addresses(Vec<Address>),
+    Indexes(Indexes),
+}
+
+impl UtxosChangedScope {
+    pub fn new(addresses: Vec<Address>) -> Self {
+        Self::Addresses(addresses)
+    }
+
+    pub fn new_indexes(indexes: Indexes) -> Self {
+        Self::Indexes(indexes)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Addresses(ref addresses) => addresses.is_empty(),
+            Self::Indexes(ref indexes) => indexes.is_empty(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Addresses(ref addresses) => addresses.len(),
+            Self::Indexes(ref indexes) => indexes.len(),
+        }
+    }
+}
+
+impl Default for UtxosChangedScope {
+    fn default() -> Self {
+        Self::new(vec![])
+    }
 }
 
 impl std::fmt::Display for UtxosChangedScope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let addresses = match self.addresses.len() {
-            0 => "all".to_string(),
-            1 => format!("{}", self.addresses[0]),
-            n => format!("{} addresses", n),
+        let addresses = match self {
+            Self::Addresses(ref addresses) => match addresses.len() {
+                0 => "all".to_string(),
+                1 => format!("{}", addresses[0]),
+                n => format!("{} addresses", n),
+            },
+            Self::Indexes(ref indexes) => match indexes.len() {
+                0 => "all".to_string(),
+                n => format!("{} addresses", n),
+            },
         };
         write!(f, "UtxosChangedScope ({})", addresses)
     }
@@ -97,17 +137,207 @@ impl std::fmt::Display for UtxosChangedScope {
 
 impl PartialEq for UtxosChangedScope {
     fn eq(&self, other: &Self) -> bool {
-        self.addresses.len() == other.addresses.len() && self.addresses.iter().all(|x| other.addresses.contains(x))
+        match self {
+            Self::Addresses(ref addresses) => match other {
+                Self::Addresses(ref other_addresses) => {
+                    addresses.len() == other_addresses.len() && addresses.iter().all(|x| other_addresses.contains(x))
+                }
+                Self::Indexes(ref other_indexes) => {
+                    addresses.len() == other_indexes.len() && addresses.iter().all(|x| other_indexes.contains(x))
+                }
+            },
+            Self::Indexes(ref indexes) => match other {
+                Self::Addresses(ref other_addresses) => {
+                    indexes.len() == other_addresses.len() && other_addresses.iter().all(|x| indexes.contains(x))
+                }
+                Self::Indexes(ref other_indexes) => {
+                    indexes.len() == other_indexes.len() && indexes.iter().all(|x| other_indexes.contains_index(*x))
+                }
+            },
+        }
     }
 }
 
 impl Eq for UtxosChangedScope {}
 
-impl UtxosChangedScope {
-    pub fn new(addresses: Vec<Address>) -> Self {
-        Self { addresses }
+impl BorshSerialize for UtxosChangedScope
+where
+    Vec<Address>: BorshSerialize,
+{
+    fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+        match self {
+            Self::Addresses(ref addresses) => {
+                borsh::BorshSerialize::serialize(addresses, writer)?;
+            }
+            Self::Indexes(_) => {
+                todo!("Convert indexes into addresses and serialize");
+            }
+        }
+        Ok(())
     }
 }
+
+impl BorshDeserialize for UtxosChangedScope
+where
+    Vec<Address>: BorshDeserialize,
+{
+    fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+        let addresses = borsh::BorshDeserialize::deserialize(buf)?;
+        Ok(Self::new(addresses))
+    }
+}
+
+#[doc(hidden)]
+#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl _serde::Serialize for UtxosChangedScope {
+        fn serialize<__S>(&self, __serializer: __S) -> _serde::__private::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            match self {
+                Self::Addresses(ref addresses) => {
+                    let mut __serde_state =
+                        _serde::Serializer::serialize_struct(__serializer, "UtxosChangedScope", false as usize + 1)?;
+                    _serde::ser::SerializeStruct::serialize_field(&mut __serde_state, "addresses", addresses)?;
+                    _serde::ser::SerializeStruct::end(__serde_state)
+                }
+                Self::Indexes(_) => {
+                    todo!("Convert indexes into addresses and serialize");
+                }
+            }
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for UtxosChangedScope {
+        fn deserialize<__D>(__deserializer: __D) -> _serde::__private::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __ignore,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(&self, __formatter: &mut _serde::__private::Formatter) -> _serde::__private::fmt::Result {
+                    _serde::__private::Formatter::write_str(__formatter, "field identifier")
+                }
+                fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private::Ok(__Field::__field0),
+                        _ => _serde::__private::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_str<__E>(self, __value: &str) -> _serde::__private::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "addresses" => _serde::__private::Ok(__Field::__field0),
+                        _ => _serde::__private::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_bytes<__E>(self, __value: &[u8]) -> _serde::__private::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"addresses" => _serde::__private::Ok(__Field::__field0),
+                        _ => _serde::__private::Ok(__Field::__ignore),
+                    }
+                }
+            }
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(__deserializer: __D) -> _serde::__private::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private::PhantomData<UtxosChangedScope>,
+                lifetime: _serde::__private::PhantomData<&'de ()>,
+            }
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = UtxosChangedScope;
+                fn expecting(&self, __formatter: &mut _serde::__private::Formatter) -> _serde::__private::fmt::Result {
+                    _serde::__private::Formatter::write_str(__formatter, "struct UtxosChangedScope")
+                }
+                #[inline]
+                fn visit_seq<__A>(self, mut __seq: __A) -> _serde::__private::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    let __field0 = match _serde::de::SeqAccess::next_element::<Vec<Address>>(&mut __seq)? {
+                        _serde::__private::Some(__value) => __value,
+                        _serde::__private::None => {
+                            return _serde::__private::Err(_serde::de::Error::invalid_length(
+                                0usize,
+                                &"struct UtxosChangedScope with 1 element",
+                            ))
+                        }
+                    };
+                    _serde::__private::Ok(UtxosChangedScope::new(__field0))
+                }
+                #[inline]
+                fn visit_map<__A>(self, mut __map: __A) -> _serde::__private::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    let mut __field0: _serde::__private::Option<Vec<Address>> = _serde::__private::None;
+                    while let _serde::__private::Some(__key) = _serde::de::MapAccess::next_key::<__Field>(&mut __map)? {
+                        match __key {
+                            __Field::__field0 => {
+                                if _serde::__private::Option::is_some(&__field0) {
+                                    return _serde::__private::Err(<__A::Error as _serde::de::Error>::duplicate_field("addresses"));
+                                }
+                                __field0 = _serde::__private::Some(_serde::de::MapAccess::next_value::<Vec<Address>>(&mut __map)?);
+                            }
+                            _ => {
+                                let _ = _serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(&mut __map)?;
+                            }
+                        }
+                    }
+                    let __field0 = match __field0 {
+                        _serde::__private::Some(__field0) => __field0,
+                        _serde::__private::None => _serde::__private::de::missing_field("addresses")?,
+                    };
+                    _serde::__private::Ok(UtxosChangedScope::new(__field0))
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &[&str] = &["addresses"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "UtxosChangedScope",
+                FIELDS,
+                __Visitor { marker: _serde::__private::PhantomData::<UtxosChangedScope>, lifetime: _serde::__private::PhantomData },
+            )
+        }
+    }
+};
 
 #[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct SinkBlueScoreChangedScope {}

--- a/notify/src/subscription/array.rs
+++ b/notify/src/subscription/array.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_array_builder() {
-        let tracker = Tracker::new(None);
+        let tracker = Tracker::new(None, None);
         let single = ArrayBuilder::single(0, &tracker, None);
         let compounded = ArrayBuilder::compounded(&tracker, None);
         EVENT_TYPE_ARRAY.into_iter().for_each(|event| {

--- a/notify/src/subscription/compounded.rs
+++ b/notify/src/subscription/compounded.rs
@@ -254,7 +254,7 @@ mod tests {
     use super::super::*;
     use super::*;
     use crate::{
-        address::test_helpers::{get_3_addresses, ADDRESS_PREFIX},
+        address::test_helpers::{get_3_addresses, ADDRESS_PREFIX, NETWORK_TYPE},
         scope::BlockAddedScope,
     };
     use std::panic::AssertUnwindSafe;
@@ -295,7 +295,7 @@ mod tests {
         let remove = || Mutation::new(Command::Stop, Scope::BlockAdded(BlockAddedScope {}));
         let test = Test {
             name: "OverallSubscription 0 to 2 to 0",
-            context: SubscriptionContext::new(Some(ADDRESS_PREFIX)),
+            context: SubscriptionContext::new(Some(NETWORK_TYPE)),
             initial_state: none(),
             steps: vec![
                 Step { name: "add 1", mutation: add(), result: Some(add()) },
@@ -325,7 +325,7 @@ mod tests {
         let remove_all = || m(Command::Stop, true);
         let test = Test {
             name: "VirtualChainChanged",
-            context: SubscriptionContext::new(Some(ADDRESS_PREFIX)),
+            context: SubscriptionContext::new(Some(NETWORK_TYPE)),
             initial_state: none(),
             steps: vec![
                 Step { name: "add all 1", mutation: add_all(), result: Some(add_all()) },
@@ -359,7 +359,7 @@ mod tests {
     #[allow(clippy::redundant_clone)]
     fn test_utxos_changed_compounding() {
         kaspa_core::log::try_init_logger("trace,kaspa_notify=trace");
-        let context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+        let context = SubscriptionContext::new(Some(NETWORK_TYPE));
         let a_stock = get_3_addresses(true);
 
         let a = |indexes: &[usize]| indexes.iter().map(|idx| (a_stock[*idx]).clone()).collect::<Vec<_>>();

--- a/notify/src/subscription/context.rs
+++ b/notify/src/subscription/context.rs
@@ -79,7 +79,7 @@ impl Deref for SubscriptionContext {
 #[cfg(test)]
 mod tests {
     use crate::{
-        address::tracker::{CounterMap, Index, IndexSet, Indexer, RefCount, Tracker},
+        address::tracker::{CounterMap, Index, IndexSet, RefCount, Tracker},
         subscription::SubscriptionContext,
     };
     use itertools::Itertools;
@@ -235,7 +235,7 @@ mod tests {
                         let mut item = CounterMap::with_capacity(tracker.clone(), ITEM_LEN);
 
                         (0..ITEM_LEN as Index).for_each(|x| {
-                            item.insert(x);
+                            item.test_direct_insert(x);
                         });
                         item
                     })
@@ -339,7 +339,7 @@ mod tests {
                         let mut item = IndexSet::with_capacity(tracker.clone(), ITEM_LEN);
 
                         (0..ITEM_LEN as Index).for_each(|x| {
-                            item.insert(x);
+                            item.test_direct_insert(x);
                         });
                         item
                     })

--- a/notify/src/subscription/mod.rs
+++ b/notify/src/subscription/mod.rs
@@ -97,11 +97,11 @@ impl Mutation {
 pub trait Subscription {
     fn event_type(&self) -> EventType;
     fn active(&self) -> bool;
-    fn scope(&self, context: &SubscriptionContext) -> Scope;
+    fn scope(&self, context: &SubscriptionContext) -> Scope; // TODO: remove context
 }
 
 pub trait Compounded: Subscription + AsAny + DynEq + CompoundedClone + Debug + Send + Sync {
-    fn compound(&mut self, mutation: Mutation, context: &SubscriptionContext) -> Option<Mutation>;
+    fn compound(&mut self, mutation: Mutation, context: &SubscriptionContext) -> Option<Mutation>; // TODO: remove context
 }
 
 impl PartialEq for dyn Compounded {
@@ -177,7 +177,7 @@ pub trait Single: Subscription + AsAny + DynHash + DynEq + Debug + Send + Sync {
         arc_self: &Arc<dyn Single>,
         mutation: Mutation,
         policies: MutationPolicies,
-        context: &SubscriptionContext,
+        context: &SubscriptionContext, // TODO: remove context which is not used anymore
     ) -> Result<MutationOutcome>;
 }
 

--- a/notify/src/subscription/single.rs
+++ b/notify/src/subscription/single.rs
@@ -594,7 +594,7 @@ mod tests {
     use super::super::*;
     use super::*;
     use crate::{
-        address::test_helpers::{get_3_addresses, ADDRESS_PREFIX},
+        address::test_helpers::{get_3_addresses, NETWORK_TYPE},
         scope::BlockAddedScope,
     };
     use std::collections::hash_map::DefaultHasher;
@@ -657,7 +657,7 @@ mod tests {
             comparisons: Vec<Comparison>,
         }
 
-        let context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+        let context = SubscriptionContext::new(Some(NETWORK_TYPE));
         let addresses = get_3_addresses(false);
         let mut sorted_addresses = addresses.clone();
         sorted_addresses.sort();
@@ -771,7 +771,7 @@ mod tests {
 
     #[test]
     fn test_overall_mutation() {
-        let context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+        let context = SubscriptionContext::new(Some(NETWORK_TYPE));
 
         fn s(active: bool) -> DynSubscription {
             Arc::new(OverallSubscription { event_type: EventType::BlockAdded, active })
@@ -824,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_virtual_chain_changed_mutation() {
-        let context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+        let context = SubscriptionContext::new(Some(NETWORK_TYPE));
 
         fn s(active: bool, include_accepted_transaction_ids: bool) -> DynSubscription {
             Arc::new(VirtualChainChangedSubscription { active, include_accepted_transaction_ids })
@@ -936,7 +936,7 @@ mod tests {
 
     #[test]
     fn test_utxos_changed_mutation() {
-        let context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
+        let context = SubscriptionContext::new(Some(NETWORK_TYPE));
         let a_stock = get_3_addresses(true);
 
         let av = |indexes: &[usize]| indexes.iter().map(|idx| (a_stock[*idx]).clone()).collect::<Vec<_>>();

--- a/notify/src/subscription/single.rs
+++ b/notify/src/subscription/single.rs
@@ -1,5 +1,5 @@
 use crate::{
-    address::tracker::{Index, Indexes, Tracker},
+    address::tracker::{Index, Indexer, Indexes, Tracker},
     error::Result,
     events::EventType,
     listener::ListenerId,
@@ -249,8 +249,12 @@ impl UtxosChangedSubscriptionData {
         self.state = new_state;
     }
 
-    pub fn contains(&self, spk: &ScriptPublicKey, context: &SubscriptionContext) -> bool {
-        context.address_tracker.contains(&self.indexes, spk)
+    pub fn tracker(&self) -> &Tracker {
+        self.indexes.tracker()
+    }
+
+    pub fn contains(&self, spk: &ScriptPublicKey) -> bool {
+        self.indexes.contains_spk(spk)
     }
 
     pub fn len(&self) -> usize {
@@ -269,8 +273,8 @@ impl UtxosChangedSubscriptionData {
         self.indexes.iter()
     }
 
-    pub fn contains_address(&self, address: &Address, context: &SubscriptionContext) -> bool {
-        context.address_tracker.contains_address(&self.indexes, address)
+    pub fn contains_address(&self, address: &Address) -> bool {
+        self.indexes.contains(address)
     }
 
     pub fn to_addresses(&self, prefix: Prefix, context: &SubscriptionContext) -> Vec<Address> {

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -116,7 +116,7 @@ async fn main() {
     kaspa_core::log::init_logger(None, "");
     let args = Args::parse();
     let stats = Arc::new(Mutex::new(Stats { num_txs: 0, since: unix_now(), num_utxos: 0, utxos_amount: 0, num_outs: 0 }));
-    let subscription_context = SubscriptionContext::new();
+    let subscription_context = SubscriptionContext::new(Some(ADDRESS_PREFIX));
     let rpc_client = GrpcClient::connect_with_args(
         NotificationMode::Direct,
         format!("grpc://{}", args.rpc_server),

--- a/rpc/core/src/api/notifications.rs
+++ b/rpc/core/src/api/notifications.rs
@@ -5,7 +5,6 @@ use kaspa_notify::{
     events::EventType,
     notification::{full_featured, Notification as NotificationTrait},
     subscription::{
-        context::SubscriptionContext,
         single::{OverallSubscription, UtxosChangedSubscription, VirtualChainChangedSubscription},
         Subscription,
     },
@@ -65,18 +64,14 @@ impl Notification {
 }
 
 impl NotificationTrait for Notification {
-    fn apply_overall_subscription(&self, subscription: &OverallSubscription, _context: &SubscriptionContext) -> Option<Self> {
+    fn apply_overall_subscription(&self, subscription: &OverallSubscription) -> Option<Self> {
         match subscription.active() {
             true => Some(self.clone()),
             false => None,
         }
     }
 
-    fn apply_virtual_chain_changed_subscription(
-        &self,
-        subscription: &VirtualChainChangedSubscription,
-        _context: &SubscriptionContext,
-    ) -> Option<Self> {
+    fn apply_virtual_chain_changed_subscription(&self, subscription: &VirtualChainChangedSubscription) -> Option<Self> {
         match subscription.active() {
             true => {
                 if let Notification::VirtualChainChanged(ref payload) = self {
@@ -94,7 +89,7 @@ impl NotificationTrait for Notification {
         }
     }
 
-    fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription, _: &SubscriptionContext) -> Option<Self> {
+    fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription) -> Option<Self> {
         match subscription.active() {
             true => {
                 let Self::UtxosChanged(notification) = self else { return None };

--- a/rpc/core/src/api/notifications.rs
+++ b/rpc/core/src/api/notifications.rs
@@ -94,15 +94,11 @@ impl NotificationTrait for Notification {
         }
     }
 
-    fn apply_utxos_changed_subscription(
-        &self,
-        subscription: &UtxosChangedSubscription,
-        context: &SubscriptionContext,
-    ) -> Option<Self> {
+    fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription, _: &SubscriptionContext) -> Option<Self> {
         match subscription.active() {
             true => {
                 let Self::UtxosChanged(notification) = self else { return None };
-                notification.apply_utxos_changed_subscription(subscription, context).map(Self::UtxosChanged)
+                notification.apply_utxos_changed_subscription(subscription).map(Self::UtxosChanged)
             }
             false => None,
         }

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -2,7 +2,7 @@ use crate::model::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_consensus_core::api::stats::BlockCount;
 use kaspa_core::debug;
-use kaspa_notify::subscription::{context::SubscriptionContext, single::UtxosChangedSubscription, Command};
+use kaspa_notify::subscription::{single::UtxosChangedSubscription, Command};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
@@ -984,16 +984,12 @@ pub struct UtxosChangedNotification {
 }
 
 impl UtxosChangedNotification {
-    pub(crate) fn apply_utxos_changed_subscription(
-        &self,
-        subscription: &UtxosChangedSubscription,
-        context: &SubscriptionContext,
-    ) -> Option<Self> {
+    pub(crate) fn apply_utxos_changed_subscription(&self, subscription: &UtxosChangedSubscription) -> Option<Self> {
         if subscription.to_all() {
             Some(self.clone())
         } else {
-            let added = Self::filter_utxos(&self.added, subscription, context);
-            let removed = Self::filter_utxos(&self.removed, subscription, context);
+            let added = Self::filter_utxos(&self.added, subscription);
+            let removed = Self::filter_utxos(&self.removed, subscription);
             if added.is_empty() && removed.is_empty() {
                 None
             } else {
@@ -1003,13 +999,9 @@ impl UtxosChangedNotification {
         }
     }
 
-    fn filter_utxos(
-        utxo_set: &[RpcUtxosByAddressesEntry],
-        subscription: &UtxosChangedSubscription,
-        context: &SubscriptionContext,
-    ) -> Vec<RpcUtxosByAddressesEntry> {
+    fn filter_utxos(utxo_set: &[RpcUtxosByAddressesEntry], subscription: &UtxosChangedSubscription) -> Vec<RpcUtxosByAddressesEntry> {
         let subscription_data = subscription.data();
-        utxo_set.iter().filter(|x| subscription_data.contains(&x.utxo_entry.script_public_key, context)).cloned().collect()
+        utxo_set.iter().filter(|x| subscription_data.contains(&x.utxo_entry.script_public_key)).cloned().collect()
     }
 }
 

--- a/rpc/grpc/client/Cargo.toml
+++ b/rpc/grpc/client/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+kaspa-consensus-core.workspace = true
 kaspa-core.workspace = true
 kaspa-grpc-core.workspace = true
 kaspa-notify.workspace = true

--- a/rpc/grpc/client/src/error.rs
+++ b/rpc/grpc/client/src/error.rs
@@ -12,6 +12,12 @@ pub enum Error {
     #[error("GRPC invalid address schema {0}")]
     GrpcAddressSchema(String),
 
+    #[error("GRPC stream was closed by the server")]
+    ServerClosedStream,
+
+    #[error("GRPC query to GetCurrentNetwork failed")]
+    GetCurrentNetwork,
+
     #[error("GRPC client error {0}")]
     TonicStatus(#[from] tonic::Status),
 
@@ -24,6 +30,9 @@ pub enum Error {
 
     #[error("Notify error: {0}")]
     NotifyError(#[from] kaspa_notify::error::Error),
+
+    #[error("{0}")]
+    NetworkType(#[from] kaspa_consensus_core::network::NetworkTypeError),
 
     #[error("RPC: channel receive error")]
     ChannelRecvError,

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -156,7 +156,7 @@ impl GrpcClient {
             }
             NotificationMode::Direct => {
                 let collector = GrpcClientCollector::new(GRPC_CLIENT, inner.notification_channel_receiver(), converter);
-                let subscriptions = ArrayBuilder::single(Self::DIRECT_MODE_LISTENER_ID, None);
+                let subscriptions = ArrayBuilder::single(Self::DIRECT_MODE_LISTENER_ID, &subscription_context.address_tracker, None);
                 (None, Some(Arc::new(collector)), Some(Arc::new(Mutex::new(subscriptions))))
             }
         };

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -29,8 +29,7 @@ use kaspa_notify::{
 };
 use kaspa_rpc_core::{
     api::rpc::RpcApi,
-    error::RpcError,
-    error::RpcResult,
+    error::{RpcError, RpcResult},
     model::message::*,
     notify::{collector::RpcCoreConverter, connection::ChannelConnection, mode::NotificationMode},
     Notification,
@@ -137,7 +136,7 @@ impl GrpcClient {
         .await?;
         let converter = Arc::new(RpcCoreConverter::new());
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
-        let subscription_context = subscription_context.unwrap_or_default();
+        let subscription_context = subscription_context.unwrap_or_else(|| SubscriptionContext::new(None)); // FIXME
         let (notifier, collector, subscriptions) = match notification_mode {
             NotificationMode::MultiListeners => {
                 let enabled_events = EVENT_TYPE_ARRAY[..].into();

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -7,11 +7,14 @@ use async_trait::async_trait;
 pub use client_pool::ClientPool;
 use connection_event::ConnectionEvent;
 use futures::{future::FutureExt, pin_mut, select};
+use kaspa_consensus_core::network::NetworkTypeError;
 use kaspa_core::{debug, error, trace};
 use kaspa_grpc_core::{
     channel::NotificationChannel,
     ops::KaspadPayloadOps,
-    protowire::{kaspad_request, rpc_client::RpcClient, GetInfoRequestMessage, KaspadRequest, KaspadResponse},
+    protowire::{
+        kaspad_request, rpc_client::RpcClient, GetCurrentNetworkRequestMessage, GetInfoRequestMessage, KaspadRequest, KaspadResponse,
+    },
     RPC_MAX_MESSAGE_SIZE,
 };
 use kaspa_notify::{
@@ -74,8 +77,6 @@ pub struct GrpcClient {
     /// In direct mode, a Collector relaying incoming notifications via a channel (see `self.notification_channel_receiver()`)
     collector: Option<Arc<GrpcClientCollector>>,
     subscriptions: Option<Arc<DirectSubscriptions>>,
-    subscription_context: SubscriptionContext,
-    policies: MutationPolicies,
     notification_mode: NotificationMode,
 }
 
@@ -126,8 +127,15 @@ impl GrpcClient {
         if !schema.is_match(&url) {
             return Err(Error::GrpcAddressSchema(url));
         }
+
+        // If not provided, create a subscription context without network type and let the first connection query it from the server
+        let subscription_context = subscription_context.unwrap_or_else(|| SubscriptionContext::new(None));
+        let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
+
         let inner = Inner::connect(
             url,
+            subscription_context,
+            policies,
             connection_event_sender,
             override_handle_stop_notify,
             timeout_duration.unwrap_or(REQUEST_TIMEOUT_DURATION),
@@ -135,8 +143,6 @@ impl GrpcClient {
         )
         .await?;
         let converter = Arc::new(RpcCoreConverter::new());
-        let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
-        let subscription_context = subscription_context.unwrap_or_else(|| SubscriptionContext::new(None)); // FIXME
         let (notifier, collector, subscriptions) = match notification_mode {
             NotificationMode::MultiListeners => {
                 let enabled_events = EVENT_TYPE_ARRAY[..].into();
@@ -147,7 +153,7 @@ impl GrpcClient {
                     enabled_events,
                     vec![collector],
                     vec![subscriber],
-                    subscription_context.clone(),
+                    inner.subscription_context.clone(),
                     3,
                     policies,
                 );
@@ -155,17 +161,18 @@ impl GrpcClient {
             }
             NotificationMode::Direct => {
                 let collector = GrpcClientCollector::new(GRPC_CLIENT, inner.notification_channel_receiver(), converter);
-                let subscriptions = ArrayBuilder::single(Self::DIRECT_MODE_LISTENER_ID, &subscription_context.address_tracker, None);
+                let subscriptions =
+                    ArrayBuilder::single(Self::DIRECT_MODE_LISTENER_ID, &inner.subscription_context.address_tracker, None);
                 (None, Some(Arc::new(collector)), Some(Arc::new(Mutex::new(subscriptions))))
             }
         };
 
         if reconnect {
             // Start the connection monitor
-            inner.clone().spawn_connection_monitor(notifier.clone(), subscriptions.clone(), subscription_context.clone());
+            inner.clone().spawn_connection_monitor(notifier.clone(), subscriptions.clone());
         }
 
-        Ok(Self { inner, notifier, collector, subscriptions, subscription_context, policies, notification_mode })
+        Ok(Self { inner, notifier, collector, subscriptions, notification_mode })
     }
 
     #[inline(always)]
@@ -310,8 +317,8 @@ impl RpcApi for GrpcClient {
                     let event = scope.event_type();
                     self.subscriptions.as_ref().unwrap().lock().await[event].mutate(
                         Mutation::new(Command::Start, scope.clone()),
-                        self.policies,
-                        &self.subscription_context,
+                        self.inner.policies,
+                        &self.inner.subscription_context,
                     )?;
                 }
                 self.inner.start_notify_to_client(scope).await?;
@@ -332,8 +339,8 @@ impl RpcApi for GrpcClient {
                         let event = scope.event_type();
                         self.subscriptions.as_ref().unwrap().lock().await[event].mutate(
                             Mutation::new(Command::Stop, scope.clone()),
-                            self.policies,
-                            &self.subscription_context,
+                            self.inner.policies,
+                            &self.inner.subscription_context,
                         )?;
                     }
                     self.inner.stop_notify_to_client(scope).await?;
@@ -398,6 +405,8 @@ struct Inner {
     url: String,
 
     server_features: ServerFeatures,
+    subscription_context: SubscriptionContext,
+    policies: MutationPolicies,
 
     // Pushing incoming notifications forward
     notification_channel: NotificationChannel,
@@ -438,6 +447,8 @@ impl Inner {
     fn new(
         url: String,
         server_features: ServerFeatures,
+        subscription_context: SubscriptionContext,
+        policies: MutationPolicies,
         request_sender: KaspadRequestSender,
         request_receiver: KaspadRequestReceiver,
         connection_event_sender: Option<Sender<ConnectionEvent>>,
@@ -453,6 +464,8 @@ impl Inner {
         Self {
             url,
             server_features,
+            subscription_context,
+            policies,
             notification_channel,
             request_sender,
             request_receiver,
@@ -475,6 +488,8 @@ impl Inner {
     // TODO - remove the override (discuss how to handle this in relation to the golang client)
     async fn connect(
         url: String,
+        subscription_context: SubscriptionContext,
+        policies: MutationPolicies,
         connection_event_sender: Option<Sender<ConnectionEvent>>,
         override_handle_stop_notify: bool,
         timeout_duration: u64,
@@ -484,14 +499,22 @@ impl Inner {
         let (request_sender, request_receiver) = async_channel::unbounded();
 
         // Try to connect to the server
-        let (stream, server_features) =
-            Inner::try_connect(url.clone(), request_sender.clone(), request_receiver.clone(), timeout_duration, counters.clone())
-                .await?;
+        let (stream, server_features) = Inner::try_connect(
+            url.clone(),
+            &subscription_context,
+            request_sender.clone(),
+            request_receiver.clone(),
+            timeout_duration,
+            counters.clone(),
+        )
+        .await?;
 
         // create the inner object
         let inner = Arc::new(Inner::new(
             url,
             server_features,
+            subscription_context,
+            policies,
             request_sender,
             request_receiver,
             connection_event_sender,
@@ -513,6 +536,7 @@ impl Inner {
     #[allow(unused_variables)]
     async fn try_connect(
         url: String,
+        subscription_context: &SubscriptionContext,
         request_sender: KaspadRequestSender,
         request_receiver: KaspadRequestReceiver,
         request_timeout: u64,
@@ -569,6 +593,7 @@ impl Inner {
 
         // Actual KaspadRequest to KaspadResponse stream
         let mut stream: Streaming<KaspadResponse> = client.message_stream(request_stream).await?.into_inner();
+        let mut closed: bool = false;
 
         // Collect server capabilities as stated in GetInfoResponse
         let mut server_features = ServerFeatures::default();
@@ -583,9 +608,35 @@ impl Inner {
                 }
             }
             None => {
-                debug!("GRPC client: try_connect - stream closed by the server");
-                return Err(Error::String("GRPC stream was closed by the server".to_string()));
+                closed = true;
             }
+        }
+
+        // Get current network type
+        request_sender.send(GetCurrentNetworkRequestMessage {}.into()).await?;
+        match stream.message().await? {
+            Some(ref msg) => {
+                trace!("GRPC client: try_connect - GetCurrentNetwork got a response");
+                let response: RpcResult<GetCurrentNetworkResponse> = msg.try_into();
+                if let Ok(response) = response {
+                    // Try to set the subscription context network type.
+                    // This always succeeds when not defined in the context yet.
+                    if !subscription_context.set_network_type(response.network) {
+                        return Err(NetworkTypeError::InvalidNetworkType(response.network.to_string()).into());
+                    }
+                } else {
+                    debug!("GRPC client: try_connect - stream closed since the query to GetCurrentNetwork failed");
+                    return Err(Error::GetCurrentNetwork);
+                }
+            }
+            None => {
+                closed = true;
+            }
+        }
+
+        if closed {
+            debug!("GRPC client: try_connect - stream closed by the server");
+            return Err(Error::ServerClosedStream);
         }
 
         Ok((stream, server_features))
@@ -607,6 +658,7 @@ impl Inner {
         // Try to connect to the server
         let (stream, _) = Inner::try_connect(
             self.url.clone(),
+            &self.subscription_context,
             self.request_sender.clone(),
             self.request_receiver.clone(),
             self.timeout_duration,
@@ -809,7 +861,6 @@ impl Inner {
         self: Arc<Self>,
         notifier: Option<Arc<GrpcClientNotifier>>,
         subscriptions: Option<Arc<DirectSubscriptions>>,
-        subscription_context: SubscriptionContext,
     ) {
         // Note: self is a cloned Arc here so that it can be used in the spawned task.
 
@@ -832,7 +883,7 @@ impl Inner {
                     _ = delay => {
                         trace!("GRPC client: connection monitor task - running");
                         if !self.is_connected() {
-                            match self.clone().reconnect(notifier.clone(), subscriptions.clone(), &subscription_context).await {
+                            match self.clone().reconnect(notifier.clone(), subscriptions.clone(), &self.subscription_context).await {
                                 Ok(_) => {
                                     trace!("GRPC client: reconnection to server succeeded");
                                 },

--- a/rpc/grpc/core/src/ext/kaspad.rs
+++ b/rpc/grpc/core/src/ext/kaspad.rs
@@ -1,4 +1,7 @@
-use kaspa_notify::{scope::Scope, subscription::Command};
+use kaspa_notify::{
+    scope::{Scope, UtxosChangedScope},
+    subscription::Command,
+};
 
 use crate::protowire::{
     kaspad_request, kaspad_response, KaspadRequest, KaspadResponse, NotifyBlockAddedRequestMessage,
@@ -46,7 +49,10 @@ impl kaspad_request::Payload {
                 })
             }
             Scope::UtxosChanged(ref scope) => kaspad_request::Payload::NotifyUtxosChangedRequest(NotifyUtxosChangedRequestMessage {
-                addresses: scope.addresses.iter().map(|x| x.into()).collect::<Vec<String>>(),
+                addresses: match scope {
+                    UtxosChangedScope::Addresses(ref addresses) => addresses.iter().map(|x| x.into()).collect::<Vec<String>>(),
+                    UtxosChangedScope::Indexes(_) => todo!("Convert indexes into addresses into strings and collect"),
+                },
                 command: command.into(),
             }),
             Scope::SinkBlueScoreChanged(_) => {

--- a/rpc/grpc/server/src/tests/client_server.rs
+++ b/rpc/grpc/server/src/tests/client_server.rs
@@ -3,16 +3,18 @@ use crate::{adaptor::Adaptor, manager::Manager};
 use kaspa_core::info;
 use kaspa_grpc_client::GrpcClient;
 use kaspa_notify::scope::{NewBlockTemplateScope, Scope};
-use kaspa_rpc_core::api::rpc::RpcApi;
+use kaspa_rpc_core::{api::rpc::RpcApi, RpcNetworkType};
 use kaspa_utils::networking::{ContextualNetAddress, NetAddress};
 use std::sync::Arc;
+
+pub const NETWORK_TYPE: RpcNetworkType = RpcNetworkType::Mainnet;
 
 #[tokio::test]
 async fn test_client_server_sanity_check() {
     kaspa_core::log::try_init_logger("info, kaspa_grpc_core=trace, kaspa_grpc_server=trace, kaspa_grpc_client=trace");
 
     // Create and start a fake core service
-    let rpc_core_service = Arc::new(RpcCoreMock::new());
+    let rpc_core_service = Arc::new(RpcCoreMock::new(NETWORK_TYPE));
     rpc_core_service.start();
 
     // Create and start the server
@@ -55,7 +57,7 @@ async fn test_client_server_connections() {
             info!("{}", self.name);
 
             // Create and start a fake core service
-            let rpc_core_service = Arc::new(RpcCoreMock::new());
+            let rpc_core_service = Arc::new(RpcCoreMock::new(NETWORK_TYPE));
             rpc_core_service.start();
 
             // Create and start the server
@@ -153,7 +155,7 @@ async fn test_client_server_notifications() {
     kaspa_core::log::try_init_logger("info, kaspa_grpc_core=trace, kaspa_grpc_server=trace, kaspa_grpc_client=trace");
 
     // Create and start a fake core service
-    let rpc_core_service = Arc::new(RpcCoreMock::new());
+    let rpc_core_service = Arc::new(RpcCoreMock::new(NETWORK_TYPE));
     rpc_core_service.start();
 
     // Create and start the server

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -95,7 +95,7 @@ impl RpcApi for RpcCoreMock {
     }
 
     async fn get_current_network_call(&self, _request: GetCurrentNetworkRequest) -> RpcResult<GetCurrentNetworkResponse> {
-        Err(RpcError::NotImplemented)
+        Ok(GetCurrentNetworkResponse::new(self.core_notifier.subscription_context().network_type().unwrap()))
     }
 
     async fn submit_block_call(&self, _request: SubmitBlockRequest) -> RpcResult<SubmitBlockResponse> {

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -21,7 +21,7 @@ impl RpcCoreMock {
     pub(super) fn new(network: RpcNetworkType) -> Self {
         let (sync_sender, sync_receiver) = unbounded();
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
-        let subscription_context = SubscriptionContext::new(Some(network.into()));
+        let subscription_context = SubscriptionContext::new(Some(network));
         let core_notifier: Arc<RpcCoreNotifier> = Arc::new(Notifier::with_sync(
             "rpc-core",
             EVENT_TYPE_ARRAY[..].into(),

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -18,10 +18,10 @@ pub(super) struct RpcCoreMock {
 }
 
 impl RpcCoreMock {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(network: RpcNetworkType) -> Self {
         let (sync_sender, sync_receiver) = unbounded();
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
-        let subscription_context = SubscriptionContext::new();
+        let subscription_context = SubscriptionContext::new(Some(network.into()));
         let core_notifier: Arc<RpcCoreNotifier> = Arc::new(Notifier::with_sync(
             "rpc-core",
             EVENT_TYPE_ARRAY[..].into(),

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -913,7 +913,7 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
     /// Start sending notifications of some type to a listener.
     async fn start_notify(&self, id: ListenerId, scope: Scope) -> RpcResult<()> {
         match scope {
-            Scope::UtxosChanged(ref utxos_changed_scope) if !self.config.unsafe_rpc && utxos_changed_scope.addresses.is_empty() => {
+            Scope::UtxosChanged(ref utxos_changed_scope) if !self.config.unsafe_rpc && utxos_changed_scope.is_empty() => {
                 // The subscription to blanket UtxosChanged notifications is restricted to unsafe mode only
                 // since the notifications yielded are highly resource intensive.
                 //

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -200,7 +200,7 @@ impl KaspaRpcClient {
                 enabled_events,
                 vec![collector],
                 vec![subscriber],
-                subscription_context.unwrap_or_default(),
+                subscription_context.unwrap_or_else(|| SubscriptionContext::new(None)), // FIXME
                 3,
                 policies,
             )))

--- a/rpc/wrpc/client/src/wasm.rs
+++ b/rpc/wrpc/client/src/wasm.rs
@@ -41,7 +41,7 @@ impl RpcClient {
         let url = if let Some(network_type) = network_type { Self::parse_url(url, encoding, network_type)? } else { url.to_string() };
 
         let rpc_client = RpcClient {
-            client: Arc::new(KaspaRpcClient::new(encoding, url.as_str(), None).unwrap_or_else(|err| panic!("{err}"))),
+            client: Arc::new(KaspaRpcClient::new(encoding, url.as_str()).unwrap_or_else(|err| panic!("{err}"))),
             inner: Arc::new(Inner {
                 notification_task: AtomicBool::new(false),
                 notification_ctl: DuplexChannel::oneshot(),

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -211,7 +211,7 @@ fn main_impl(mut args: Args) {
             (false, _) => load_existing_db!(input_dir, conn_builder),
         };
         let (dummy_notification_sender, _) = unbounded();
-        let notification_root = Arc::new(ConsensusNotificationRoot::new(dummy_notification_sender));
+        let notification_root = Arc::new(ConsensusNotificationRoot::new(config.net.into(), dummy_notification_sender));
         let consensus = Arc::new(Consensus::new(
             db,
             config.clone(),
@@ -247,7 +247,7 @@ fn main_impl(mut args: Args) {
     // Benchmark the DAG validation time
     let (_lifetime2, db2) = create_temp_db!(ConnBuilder::default().with_parallelism(num_cpus::get()).with_files_limit(default_fd));
     let (dummy_notification_sender, _) = unbounded();
-    let notification_root = Arc::new(ConsensusNotificationRoot::new(dummy_notification_sender));
+    let notification_root = Arc::new(ConsensusNotificationRoot::new(config.net.into(), dummy_notification_sender));
     let consensus2 = Arc::new(Consensus::new(
         db2,
         config.clone(),

--- a/simpa/src/simulator/network.rs
+++ b/simpa/src/simulator/network.rs
@@ -76,7 +76,7 @@ impl KaspaNetworkSimulator {
             };
 
             let (dummy_notification_sender, _) = unbounded();
-            let notification_root = Arc::new(ConsensusNotificationRoot::new(dummy_notification_sender));
+            let notification_root = Arc::new(ConsensusNotificationRoot::new(self.config.net.into(), dummy_notification_sender));
             let consensus = Arc::new(Consensus::new(
                 db,
                 self.config.clone(),

--- a/testing/integration/src/common/daemon.rs
+++ b/testing/integration/src/common/daemon.rs
@@ -31,7 +31,7 @@ pub struct ClientManager {
 impl ClientManager {
     pub fn new(args: Args) -> Self {
         let network = args.network();
-        let context = SubscriptionContext::with_options(None);
+        let context = SubscriptionContext::with_options(Some(network.into()), None);
         let rpc_port = args.rpclisten.unwrap().normalize(0).port;
         let p2p_port = args.listen.unwrap().normalize(0).port;
         let args = RwLock::new(args);

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -940,7 +940,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
 
     let tick_service = Arc::new(TickService::default());
     let (notification_send, notification_recv) = unbounded();
-    let subscription_context = SubscriptionContext::new();
+    let subscription_context = SubscriptionContext::new(Some(config.net.into()));
     let tc = Arc::new(TestConsensus::with_notifier(&config, notification_send, subscription_context.clone()));
     let notify_service = Arc::new(NotifyService::new(tc.notification_root(), notification_recv, subscription_context.clone()));
 
@@ -1729,7 +1729,7 @@ async fn staging_consensus_test() {
     let meta_db = kaspa_database::prelude::ConnBuilder::default().with_db_path(meta_db_dir).with_files_limit(5).build().unwrap();
 
     let (notification_send, _notification_recv) = unbounded();
-    let notification_root = Arc::new(ConsensusNotificationRoot::new(notification_send));
+    let notification_root = Arc::new(ConsensusNotificationRoot::new(config.net.into(), notification_send));
     let counters = Arc::new(ProcessingCounters::default());
     let tx_script_cache_counters = Arc::new(TxScriptCacheCounters::default());
 

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -28,7 +28,7 @@ pub struct RpcCoreMock {
 }
 
 impl RpcCoreMock {
-    pub fn new() -> Self {
+    pub fn new(network: NetworkType) -> Self {
         let (sync_sender, sync_receiver) = unbounded();
         let policies = MutationPolicies::new(UtxosChangedMutationPolicy::AddressSet);
         let core_notifier: Arc<RpcCoreNotifier> = Arc::new(Notifier::with_sync(
@@ -36,7 +36,7 @@ impl RpcCoreMock {
             EVENT_TYPE_ARRAY[..].into(),
             vec![],
             vec![],
-            SubscriptionContext::new(),
+            SubscriptionContext::new(Some(network.into())),
             10,
             policies,
             Some(sync_sender),
@@ -71,12 +71,6 @@ impl RpcCoreMock {
 
     pub fn ctl(&self) -> RpcCtl {
         self.ctl.clone()
-    }
-}
-
-impl Default for RpcCoreMock {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -36,7 +36,7 @@ impl RpcCoreMock {
             EVENT_TYPE_ARRAY[..].into(),
             vec![],
             vec![],
-            SubscriptionContext::new(Some(network.into())),
+            SubscriptionContext::new(Some(network)),
             10,
             policies,
             Some(sync_sender),

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -106,7 +106,7 @@ impl RpcApi for RpcCoreMock {
     }
 
     async fn get_current_network_call(&self, _request: GetCurrentNetworkRequest) -> RpcResult<GetCurrentNetworkResponse> {
-        Err(RpcError::NotImplemented)
+        Ok(GetCurrentNetworkResponse::new(self.core_notifier.subscription_context().network_type().unwrap()))
     }
 
     async fn submit_block_call(&self, _request: SubmitBlockRequest) -> RpcResult<SubmitBlockResponse> {

--- a/wallet/core/src/utxo/test.rs
+++ b/wallet/core/src/utxo/test.rs
@@ -9,7 +9,7 @@ use crate::utxo::*;
 #[tokio::test]
 async fn test_utxo_subsystem_bootstrap() -> Result<()> {
     let network_id = NetworkId::with_suffix(NetworkType::Testnet, 10);
-    let rpc_api_mock = Arc::new(RpcCoreMock::new());
+    let rpc_api_mock = Arc::new(RpcCoreMock::new(network_id.into()));
     let processor = UtxoProcessor::new(Some(rpc_api_mock.clone().into()), Some(network_id), None, None);
     let _context = UtxoContext::new(&processor, UtxoContextBinding::default());
 


### PR DESCRIPTION
Adds a network type to the subscription context and a corresponding address prefix to the address tracker.

The tracker prefix is used for validating addresses in register/unregister operations. It also allows a fully contextualized conversion of indexes to addresses.

The dependency between `Tracker` and the indexers `CounterMap` and `Indexes` is reversed by encapsulating a reference to the tracker in every indexer. The new architecture is much more robust. It guarantees an accurate index reference counting in the tracker, notably on indexers `Clone` and `Drop` and alleviates the need to carry a subscription context in many functions dealing with indexers.

It remained some rare cases of `UtxosChangedScope` mutations where a back and forth conversion of indexes to addresses could occur. This is now optimized by refactoring `UtxosChangedScope` into an enum accepting either addresses or indexes which removes the need for those costly and redundant conversions.

Both gRPC and wRPC clients, when configured with a subscription context, query the network type of the server they connect to and configure their context accordingly. Note that this operation may fail if the subscription context of the client has already a defined network type and the server provides a different type.

This PR addresses the technological debts intentionally left behind in #427 ([see](https://github.com/kaspanet/rusty-kaspa/pull/427#pullrequestreview-1988587444))