### PR TITLE
TN11 bug fix: activate mass hashing when modifying a cached block template  

### DIFF
--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -190,6 +190,10 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
+    fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], pov_daa_score: u64) -> Hash {
+        unimplemented!()
+    }
+
     fn validate_pruning_proof(&self, proof: &PruningPointProof) -> PruningImportResult<()> {
         unimplemented!()
     }

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -5,6 +5,7 @@ use crate::{
     BlueWorkType,
 };
 use kaspa_hashes::Hash;
+use kaspa_utils::mem_size::MemSizeEstimator;
 use std::sync::Arc;
 
 /// A mutable block structure where header and transactions within can still be mutated.
@@ -65,6 +66,20 @@ impl Block {
     /// WARNING: To be used for test purposes only
     pub fn from_precomputed_hash(hash: Hash, parents: Vec<Hash>) -> Block {
         Block::from_header(Header::from_precomputed_hash(hash, parents))
+    }
+
+    pub fn asses_for_cache(&self) -> Option<()> {
+        (self.estimate_mem_bytes() < 1_000_000).then_some(())
+    }
+}
+
+impl MemSizeEstimator for Block {
+    fn estimate_mem_bytes(&self) -> usize {
+        // Calculates mem bytes of the block (for cache tracking purposes)
+        size_of::<Self>()
+            + self.header.estimate_mem_bytes()
+            + size_of::<Vec<Transaction>>()
+            + self.transactions.iter().map(Transaction::estimate_mem_bytes).sum::<usize>()
     }
 }
 

--- a/consensus/core/src/config/genesis.rs
+++ b/consensus/core/src/config/genesis.rs
@@ -231,7 +231,7 @@ mod tests {
     fn test_genesis_hashes() {
         [GENESIS, TESTNET_GENESIS, TESTNET11_GENESIS, SIMNET_GENESIS, DEVNET_GENESIS].into_iter().for_each(|genesis| {
             let block: Block = (&genesis).into();
-            assert_hashes_eq(calc_hash_merkle_root(block.transactions.iter()), block.header.hash_merkle_root);
+            assert_hashes_eq(calc_hash_merkle_root(block.transactions.iter(), false), block.header.hash_merkle_root);
             assert_hashes_eq(block.hash(), genesis.hash);
         });
     }

--- a/consensus/core/src/errors/tx.rs
+++ b/consensus/core/src/errors/tx.rs
@@ -1,4 +1,5 @@
 use crate::constants::MAX_SOMPI;
+use crate::subnets::SubnetworkId;
 use crate::tx::TransactionOutpoint;
 use kaspa_txscript_errors::TxScriptError;
 use thiserror::Error;
@@ -91,6 +92,9 @@ pub enum TxRuleError {
 
     #[error("calculated contextual mass (including storage mass) {0} is not equal to the committed mass field {1}")]
     WrongMass(u64, u64),
+
+    #[error("transaction subnetwork id {0} is neither native nor coinbase")]
+    SubnetworksDisabled(SubnetworkId),
 
     /// [`TxRuleError::FeerateTooLow`] is not a consensus error but a mempool error triggered by the
     /// fee/mass RBF validation rule

--- a/consensus/core/src/header.rs
+++ b/consensus/core/src/header.rs
@@ -1,6 +1,7 @@
 use crate::{hashing, BlueWorkType};
 use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_hashes::Hash;
+use kaspa_utils::mem_size::MemSizeEstimator;
 use serde::{Deserialize, Serialize};
 
 /// @category Consensus
@@ -89,6 +90,12 @@ impl Header {
             blue_score: 0,
             pruning_point: Default::default(),
         }
+    }
+}
+
+impl MemSizeEstimator for Header {
+    fn estimate_mem_bytes(&self) -> usize {
+        size_of::<Self>() + self.parents_by_level.iter().map(|l| l.len()).sum::<usize>() * size_of::<Hash>()
     }
 }
 

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -6,6 +6,7 @@ pub fn calc_hash_merkle_root_with_options<'a>(txs: impl ExactSizeIterator<Item =
     calc_merkle_root(txs.map(|tx| hashing::tx::hash(tx, include_mass_field)))
 }
 
+// #[cfg(test)]
 pub fn calc_hash_merkle_root<'a>(txs: impl ExactSizeIterator<Item = &'a Transaction>) -> Hash {
     calc_merkle_root(txs.map(|tx| hashing::tx::hash(tx, false)))
 }

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -2,13 +2,8 @@ use crate::{hashing, tx::Transaction};
 use kaspa_hashes::Hash;
 use kaspa_merkle::calc_merkle_root;
 
-pub fn calc_hash_merkle_root_with_options<'a>(txs: impl ExactSizeIterator<Item = &'a Transaction>, include_mass_field: bool) -> Hash {
+pub fn calc_hash_merkle_root<'a>(txs: impl ExactSizeIterator<Item = &'a Transaction>, include_mass_field: bool) -> Hash {
     calc_merkle_root(txs.map(|tx| hashing::tx::hash(tx, include_mass_field)))
-}
-
-// #[cfg(test)]
-pub fn calc_hash_merkle_root<'a>(txs: impl ExactSizeIterator<Item = &'a Transaction>) -> Hash {
-    calc_merkle_root(txs.map(|tx| hashing::tx::hash(tx, false)))
 }
 
 #[cfg(test)]
@@ -243,7 +238,7 @@ mod tests {
             ),
         ];
         assert_eq!(
-            calc_hash_merkle_root(txs.iter()),
+            calc_hash_merkle_root(txs.iter(), false),
             Hash::from_slice(&[
                 0x46, 0xec, 0xf4, 0x5b, 0xe3, 0xba, 0xca, 0x34, 0x9d, 0xfe, 0x8a, 0x78, 0xde, 0xaf, 0x05, 0x3b, 0x0a, 0xa6, 0xd5,
                 0x38, 0x97, 0x4d, 0xa5, 0x0f, 0xd6, 0xef, 0xb4, 0xd2, 0x66, 0xbc, 0x8d, 0x21,

--- a/consensus/core/src/subnets.rs
+++ b/consensus/core/src/subnets.rs
@@ -59,18 +59,21 @@ impl SubnetworkId {
         *self == SUBNETWORK_ID_COINBASE || *self == SUBNETWORK_ID_REGISTRY
     }
 
+    /// Returns true if the subnetwork is the native subnetwork
+    #[inline]
+    pub fn is_native(&self) -> bool {
+        *self == SUBNETWORK_ID_NATIVE
+    }
+
     /// Returns true if the subnetwork is the native or a built-in subnetwork
     #[inline]
     pub fn is_builtin_or_native(&self) -> bool {
-        *self == SUBNETWORK_ID_NATIVE || self.is_builtin()
+        self.is_native() || self.is_builtin()
     }
 }
 
 #[derive(Error, Debug, Clone)]
 pub enum SubnetworkConversionError {
-    #[error("Invalid bytes")]
-    InvalidBytes,
-
     #[error(transparent)]
     SliceError(#[from] std::array::TryFromSliceError),
 
@@ -83,11 +86,7 @@ impl TryFrom<&[u8]> for SubnetworkId {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let bytes = <[u8; SUBNETWORK_ID_SIZE]>::try_from(value)?;
-        if bytes != Self::from_byte(0).0 && bytes != Self::from_byte(1).0 {
-            Err(Self::Error::InvalidBytes)
-        } else {
-            Ok(Self(bytes))
-        }
+        Ok(Self(bytes))
     }
 }
 
@@ -115,11 +114,7 @@ impl FromStr for SubnetworkId {
     fn from_str(hex_str: &str) -> Result<Self, Self::Err> {
         let mut bytes = [0u8; SUBNETWORK_ID_SIZE];
         faster_hex::hex_decode(hex_str.as_bytes(), &mut bytes)?;
-        if bytes != Self::from_byte(0).0 && bytes != Self::from_byte(1).0 {
-            Err(Self::Err::InvalidBytes)
-        } else {
-            Ok(Self(bytes))
-        }
+        Ok(Self(bytes))
     }
 }
 
@@ -128,11 +123,7 @@ impl FromHex for SubnetworkId {
     fn from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let mut bytes = [0u8; SUBNETWORK_ID_SIZE];
         faster_hex::hex_decode(hex_str.as_bytes(), &mut bytes)?;
-        if bytes != Self::from_byte(0).0 && bytes != Self::from_byte(1).0 {
-            Err(Self::Error::InvalidBytes)
-        } else {
-            Ok(Self(bytes))
-        }
+        Ok(Self(bytes))
     }
 }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -58,6 +58,7 @@ use kaspa_consensus_core::{
         tx::TxResult,
     },
     header::Header,
+    merkle::calc_hash_merkle_root_with_options,
     muhash::MuHashExtensions,
     network::NetworkType,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
@@ -673,6 +674,11 @@ impl ConsensusApi for Consensus {
 
     fn modify_coinbase_payload(&self, payload: Vec<u8>, miner_data: &MinerData) -> CoinbaseResult<Vec<u8>> {
         self.services.coinbase_manager.modify_coinbase_payload(payload, miner_data)
+    }
+
+    fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], pov_daa_score: u64) -> Hash {
+        let storage_mass_activated = pov_daa_score > self.config.storage_mass_activation_daa_score;
+        calc_hash_merkle_root_with_options(txs.iter(), storage_mass_activated)
     }
 
     fn validate_pruning_proof(&self, proof: &PruningPointProof) -> Result<(), PruningImportError> {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -58,7 +58,7 @@ use kaspa_consensus_core::{
         tx::TxResult,
     },
     header::Header,
-    merkle::calc_hash_merkle_root_with_options,
+    merkle::calc_hash_merkle_root,
     muhash::MuHashExtensions,
     network::NetworkType,
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
@@ -678,7 +678,7 @@ impl ConsensusApi for Consensus {
 
     fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], pov_daa_score: u64) -> Hash {
         let storage_mass_activated = pov_daa_score > self.config.storage_mass_activation_daa_score;
-        calc_hash_merkle_root_with_options(txs.iter(), storage_mass_activated)
+        calc_hash_merkle_root(txs.iter(), storage_mass_activated)
     }
 
     fn validate_pruning_proof(&self, proof: &PruningPointProof) -> Result<(), PruningImportError> {

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -176,7 +176,7 @@ impl TestConsensus {
 
         let cb = Transaction::new(TX_VERSION, vec![], vec![], 0, SUBNETWORK_ID_COINBASE, 0, cb_payload);
         txs.insert(0, cb);
-        header.hash_merkle_root = calc_hash_merkle_root(txs.iter());
+        header.hash_merkle_root = calc_hash_merkle_root(txs.iter(), false);
         MutableBlock::new(header, txs)
     }
 

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -29,9 +29,7 @@ pub struct HeaderWithBlockLevel {
 
 impl MemSizeEstimator for HeaderWithBlockLevel {
     fn estimate_mem_bytes(&self) -> usize {
-        size_of::<Header>()
-            + self.header.parents_by_level.iter().map(|l| l.len()).sum::<usize>() * size_of::<Hash>()
-            + size_of::<Self>()
+        self.header.as_ref().estimate_mem_bytes() + size_of::<Self>()
     }
 }
 

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -94,12 +94,16 @@ mod tests {
     };
     use kaspa_consensus_core::{
         api::ConsensusApi,
-        merkle::calc_hash_merkle_root,
+        merkle::calc_hash_merkle_root as calc_hash_merkle_root_with_options,
         subnets::SUBNETWORK_ID_NATIVE,
         tx::{Transaction, TransactionInput, TransactionOutpoint},
     };
     use kaspa_core::assert_match;
     use kaspa_hashes::Hash;
+
+    fn calc_hash_merkle_root<'a>(txs: impl ExactSizeIterator<Item = &'a Transaction>) -> Hash {
+        calc_hash_merkle_root_with_options(txs, false)
+    }
 
     #[tokio::test]
     async fn validate_body_in_context_test() {

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -54,7 +54,7 @@ use kaspa_consensus_core::{
     coinbase::MinerData,
     config::genesis::GenesisBlock,
     header::Header,
-    merkle::calc_hash_merkle_root_with_options,
+    merkle::calc_hash_merkle_root,
     pruning::PruningPointsList,
     tx::{MutableTransaction, Transaction},
     utxo::{
@@ -975,7 +975,7 @@ impl VirtualStateProcessor {
 
         // Hash according to hardfork activation
         let storage_mass_activated = virtual_state.daa_score > self.storage_mass_activation_daa_score;
-        let hash_merkle_root = calc_hash_merkle_root_with_options(txs.iter(), storage_mass_activated);
+        let hash_merkle_root = calc_hash_merkle_root(txs.iter(), storage_mass_activated);
 
         let accepted_id_merkle_root = kaspa_merkle::calc_merkle_root(virtual_state.accepted_tx_ids.iter().copied());
         let utxo_commitment = virtual_state.multiset.clone().finalize();

--- a/mining/src/block_template/builder.rs
+++ b/mining/src/block_template/builder.rs
@@ -3,7 +3,6 @@ use kaspa_consensus_core::{
     api::ConsensusApi,
     block::{BlockTemplate, TemplateBuildMode, TemplateTransactionSelector},
     coinbase::MinerData,
-    merkle::calc_hash_merkle_root,
     tx::COINBASE_TRANSACTION_INDEX,
 };
 use kaspa_core::time::{unix_now, Stopwatch};
@@ -106,7 +105,8 @@ impl BlockTemplateBuilder {
             coinbase_tx.outputs.last_mut().unwrap().script_public_key = new_miner_data.script_public_key.clone();
         }
         // Update the hash merkle root according to the modified transactions
-        block_template.block.header.hash_merkle_root = calc_hash_merkle_root(block_template.block.transactions.iter());
+        block_template.block.header.hash_merkle_root =
+            consensus.calc_transaction_hash_merkle_root(&block_template.block.transactions, block_template.block.header.daa_score);
         let new_timestamp = unix_now();
         if new_timestamp > block_template.block.header.timestamp {
             // Only if new time stamp is later than current, update the header. Otherwise,

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -86,7 +86,7 @@ impl ConsensusApi for ConsensusMock {
         let coinbase = coinbase_manager.expected_coinbase_transaction(miner_data.clone());
         txs.insert(0, coinbase.tx);
         let now = unix_now();
-        let hash_merkle_root = calc_hash_merkle_root(txs.iter());
+        let hash_merkle_root = self.calc_transaction_hash_merkle_root(&txs, 0);
         let header = Header::new_finalized(
             BLOCK_VERSION,
             vec![],
@@ -179,6 +179,6 @@ impl ConsensusApi for ConsensusMock {
     }
 
     fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], _pov_daa_score: u64) -> Hash {
-        calc_hash_merkle_root(txs.iter())
+        calc_hash_merkle_root(txs.iter(), false)
     }
 }

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -19,7 +19,7 @@ use kaspa_consensus_core::{
     utxo::utxo_collection::UtxoCollection,
 };
 use kaspa_core::time::unix_now;
-use kaspa_hashes::ZERO_HASH;
+use kaspa_hashes::{Hash, ZERO_HASH};
 
 use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
@@ -176,5 +176,9 @@ impl ConsensusApi for ConsensusMock {
     fn modify_coinbase_payload(&self, payload: Vec<u8>, miner_data: &MinerData) -> CoinbaseResult<Vec<u8>> {
         let coinbase_manager = CoinbaseManagerMock::new();
         Ok(coinbase_manager.modify_coinbase_payload(payload, miner_data))
+    }
+
+    fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], _pov_daa_score: u64) -> Hash {
+        calc_hash_merkle_root(txs.iter())
     }
 }

--- a/protocol/flows/src/flowcontext/orphans.rs
+++ b/protocol/flows/src/flowcontext/orphans.rs
@@ -78,7 +78,7 @@ impl OrphanBlocksPool {
         if self.orphans.contains_key(&orphan_hash) {
             return None;
         }
-
+        orphan_block.asses_for_cache()?;
         let (roots, orphan_ancestors) =
             match self.get_orphan_roots(consensus, orphan_block.header.direct_parents().iter().copied().collect()).await {
                 FindRootsOutput::Roots(roots, orphan_ancestors) => (roots, orphan_ancestors),


### PR DESCRIPTION
Fixes a TN11 bug where transaction mass field hashing was not activated when modifying a cached block template. 
This produced invalid blocks when two miners with different addresses were connected to the same node, frequently triggering this code path and resulting in many bad Merkle root blocks  