### PR TITLE
kaspa-wallet (cli) updates (using latest resolver APIs + guide cleanup)

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -8,7 +8,7 @@ use crate::result::Result;
 use kaspa_daemon::{DaemonEvent, DaemonKind, Daemons};
 use kaspa_wallet_core::rpc::DynRpcApi;
 use kaspa_wallet_core::storage::{IdT, PrvKeyDataInfo};
-use kaspa_wrpc_client::KaspaRpcClient;
+use kaspa_wrpc_client::{KaspaRpcClient, Resolver};
 use workflow_core::channel::*;
 use workflow_core::time::Instant;
 use workflow_log::*;
@@ -102,7 +102,7 @@ impl KaspaCli {
     }
 
     pub async fn try_new_arc(options: Options) -> Result<Arc<Self>> {
-        let wallet = Arc::new(Wallet::try_new(Wallet::local_store()?, None, None)?);
+        let wallet = Arc::new(Wallet::try_new(Wallet::local_store()?, Some(Resolver::default()), None)?);
 
         let kaspa_cli = Arc::new(KaspaCli {
             term: Arc::new(Mutex::new(None)),

--- a/cli/src/modules/connect.rs
+++ b/cli/src/modules/connect.rs
@@ -1,5 +1,4 @@
 use crate::imports::*;
-use kaspa_wrpc_client::Resolver;
 
 #[derive(Default, Handler)]
 #[help("Connect to a Kaspa network")]
@@ -12,36 +11,31 @@ impl Connect {
             let network_id = ctx.wallet().network_id()?;
 
             let arg_or_server_address = argv.first().cloned().or_else(|| ctx.wallet().settings().get(WalletSettings::Server));
-            let (is_public, url) = match arg_or_server_address.as_deref() {
-                Some("public") => {
+            let url = match arg_or_server_address.as_deref() {
+                Some("public") | Some("resolver") => {
                     tprintln!(ctx, "Connecting to a public node");
-                    (true, Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url)
+                    None
                 }
                 None => {
                     tprintln!(ctx, "No server set, connecting to a public node");
-                    (true, Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url)
+                    None
                 }
                 Some(url) => {
-                    (false, wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?)
+                    Some(wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?)
                 }
             };
 
-            if is_public {
+            if url.is_none() {
                 tpara!(
                     ctx,
-                    "Please note that default public nodes are community-operated and \
-                    accessing them may expose your IP address to different node providers. \
+                    "Please note that public node infrastructure is community-operated and \
+                    accessing it may expose your IP address to different node providers. \
                     Consider running your own node for better privacy. \
                     ",
                 );
             }
 
-            let options = ConnectOptions {
-                block_async_connect: true,
-                strategy: ConnectStrategy::Fallback,
-                url: Some(url),
-                ..Default::default()
-            };
+            let options = ConnectOptions { block_async_connect: true, strategy: ConnectStrategy::Fallback, url, ..Default::default() };
             wrpc_client.connect(Some(options)).await.map_err(|e| e.to_string())?;
         } else {
             terrorln!(ctx, "Unable to connect with non-wRPC client");

--- a/cli/src/modules/guide.txt
+++ b/cli/src/modules/guide.txt
@@ -1,43 +1,17 @@
-Please note - this is an alpha version of the softeware, not all features are currently functional.
-
-If using a dekstop or a web version of this software, you can use Ctrl+'+' or Ctrl+'-' (Command on MacOS) to
-change the terminal font size.
-
-If using a desktop version, you can use Ctrl+M (Command on MacOS) to bring up metrics.
-
-Type `help` to see the complete list of commands. `exit` to exit this application.
-On Windows you can use `Alt+F4` and on MacOS `Command+Q` to exit.
-
----
-
 Before you start, you must configure the default network setting.  There are currently
-3 networks available.  `mainnet`, `testnet-10` and `testnet-11`.  While this software
-is in alpha stage, you should not use it on the mainnet.  If you wish to experiment,
-you should select `testnet-10` by entering `network testnet-10`
+3 networks available.  `mainnet`, `testnet-10` and `testnet-11`.  If you wish to experiment,
+you should select `testnet-11` by entering `network testnet-11`
 
 The `server` command configures the target server.  You can connect to any Rusty Kaspa
-node that has User RPC enabled with `--rpclisten-borsh=public`. If you are running the node
-from within KOS, it is locked to listen to a local IP address.
+node that has wRPC enabled with `--rpclisten-borsh=0.0.0.0`. If the server setting 
+is set to 'public' the node will connect to the public node infrastructure.
 
 Both network and server values are stored in the application settings and are 
 used when running a local node or connecting to a remote node.
 
 ---
 
-You can use `node start` to start the node.  Type `node` to see an overview of commands.
-`node mute` toggles node log output (you can also use `node logs`).  `node select` allows 
-you to choose between locally installed flavors (if running in the development environment).
-You can also specify an absolute path by typing `node select <path to rusty kaspa binary>`.
-
-For developers: `node select` scans 'target' folder for the debug and release builds
-so you can switch between builds at runtime using the `node select` command.
-
-Once you node is running, you can connect to it using the `connect` command.
-
-When starting the node and the `server` setting is configured to your local host, 
-the `connect` action will occure automatically.
-
-`wallet create [<name>]` Use theis command to create a local wallet. The <name> argument 
+`wallet create [<name>]` Use this command to create a local wallet. The <name> argument 
 is optional (the default wallet name is "kaspa") and allows you to create multiple 
 named wallets.  Only one wallet can be opened at a time. Keep in mind that a wallet can have multiple
 accounts, as such you only need one wallet, unless, for example, you want to separate wallets for 
@@ -55,9 +29,6 @@ testnet KAS.
 `account create bip32 [<name>]` - Allows you to create additional HD wallet accounts linked to the default private key of your wallet.
 
 `address` - shows your selected account address
-
-Note - you can click on the address to copy it to the clipboard.  (When on mainnet, Ctrl+Click on addresses, transactions and 
-block hashes will open a new browser window with an explorer.)
 
 Before you transact: `mute` option (enabled by default) toggles mute on/off. Mute enables terminal
 output of internal framework events.  Rust and JavaScript/TypeScript applications integrating with this platform 
@@ -77,11 +48,6 @@ the selected account to an account named 'pete' (starts with a 'p' letter)
 `history list` - Shows previous account transactions.
 
 `history details` - Show previous account transactions with extended information.
-
-Once your node is synced, you can start the CPU miner.
-
-`miner start` - Starts the miner. The miner will mine to your currently selected account. (So you need to have a wallet open and an 
-account selected to start the miner)
 
 `monitor` - A test screen environment that periodically updates account balances.
 

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -222,7 +222,7 @@ impl RpcResolver for Inner {
             self.node_descriptor.lock().unwrap().replace(Arc::new(node));
             url
         } else {
-            panic!("RpcClient resolver configuration error (expecting Some(Resolver))")
+            panic!("RpcClient resolver configuration error (expecting `url` or `resolver` as `Some(Resolver))`")
         };
 
         self.rpc_ctl.set_descriptor(Some(url.clone()));
@@ -406,9 +406,7 @@ impl KaspaRpcClient {
         let mut options = options.unwrap_or_default();
         let strategy = options.strategy;
 
-        if let Some(url) = options.url.take() {
-            self.set_url(Some(&url))?;
-        }
+        self.set_url(options.url.take().as_deref())?;
 
         // 1Gb message and frame size limits (on native and NodeJs platforms)
         let ws_config = WebSocketConfig {


### PR DESCRIPTION
Minor updates to the `kaspa-cli` crate (used by `kaspa-wallet`):
- Update CLI to use the latest `Resolver` API (enables automatic reconnect and node hopping on connection failure).
- Clean up the CLI `guide` command to remove old references to the `KOS` functionality.

This improves functionality when the `server` is set to `public` (default) allowing `kaspa-wallet` to connect to a random public node.