### PR TITLE
Add hint message for P2P reject reason block not found.

### DIFF
--- a/protocol/p2p/src/common.rs
+++ b/protocol/p2p/src/common.rs
@@ -100,6 +100,10 @@ impl ProtocolError {
     pub fn from_reject_message(reason: String) -> Self {
         if reason == LOOPBACK_CONNECTION_MESSAGE || reason == DUPLICATE_CONNECTION_MESSAGE {
             ProtocolError::IgnorableReject(reason)
+        } else if reason.contains("cannot find full block") {
+            let hint = "Hint: If this error persists, it might be due to the other peer having pruned block data after syncing headers and UTXOs. In such a case, you may need to reset the database.";
+            let detailed_reason = format!("{}. {}", reason, hint);
+            ProtocolError::Rejected(detailed_reason)
         } else {
             ProtocolError::Rejected(reason)
         }


### PR DESCRIPTION
Until this rare issue is resolved, displays a message to hint a user would need to reset the database when the P2P reject reason "block not found" persists after IBD.