### PR TITLE
WASM SDK: createTransaction produces "The address is invalid" error

### DIFF
--- a/consensus/client/src/utxo.rs
+++ b/consensus/client/src/utxo.rs
@@ -377,11 +377,12 @@ impl TryCastFromJs for UtxoEntryReference {
             if let Ok(utxo_entry) = UtxoEntry::try_ref_from_js_value(&value) {
                 Ok(Self::from(utxo_entry.clone()))
             } else if let Some(object) = Object::try_from(value.as_ref()) {
-                let address = object.get_cast::<Address>("address")?.into_owned();
-                let outpoint = TransactionOutpoint::try_from(object.get_value("outpoint")?.as_ref())?;
-                let utxo_entry = Object::from(object.get_value("utxoEntry")?);
+                let utxo_entry = Object::from(object.get_value("entry")?);
+                let address = utxo_entry.get_cast::<Address>("address")?.into_owned();
+                let outpoint = TransactionOutpoint::try_from(utxo_entry.get_value("outpoint")?.as_ref())?;
                 let amount = utxo_entry.get_u64("amount")?;
-                let script_public_key = ScriptPublicKey::try_owned_from(utxo_entry.get_value("scriptPublicKey")?)?;
+                let script_public_key_entry = Object::from(utxo_entry.get_value("scriptPublicKey")?);
+                let script_public_key = ScriptPublicKey::constructor(script_public_key_entry.get_u16("version")?, script_public_key_entry.get_value("script")?)?;
                 let block_daa_score = utxo_entry.get_u64("blockDaaScore")?;
                 let is_coinbase = utxo_entry.get_bool("isCoinbase")?;
 


### PR DESCRIPTION
Having the following code from example https://github.com/kaspanet/rusty-kaspa/blob/master/wasm/examples/nodejs/javascript/transactions/single-transaction-demo.js :

```
public async buildTransaction(
    api: KaspaAPI,
    to: string,
    fromAddress: string,
    amount: string,
    network: KaspaNetwork
  ): Promise<kaspa.Transaction> {
    const { kaspaToSompi, createTransaction, Transaction } = kaspa;

    const { entries: utxos } = await api.rpc.getUtxosByAddresses([fromAddress]);

    if (utxos.length === 0) {
      throw `Send some kaspa to ${to} before proceeding with the demo`;
    }

    const outputs = [
      {
        address: to,
        amount: kaspaToSompi(amount) as bigint,
      },
    ];

    return createTransaction(utxos, outputs, fromAddress, 0n, 0, 1, 1);
 }
```

This code produces "The address is invalid" error as a part of `createTransaction` call.

After deep investigation, I found the `entries` returned from `rpc.getUtxosByAddresses` have diff format from what `UtxoEntryReference.try_cast_from` expects.

This is what is returned after `rpc.getUtxosByAddresses` call:
<img width="247" alt="Screenshot 2024-08-15 at 18 21 33" src="https://github.com/user-attachments/assets/0f863af1-5e07-4c07-9175-a5d6104d31eb">

This PR address this issue