### PR TITLE
Mempool tweaks

### DIFF
--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -375,13 +375,12 @@ pub struct MutableTransaction<T: AsRef<Transaction> = std::sync::Arc<Transaction
     pub calculated_fee: Option<u64>,
     /// Populated compute mass (does not include the storage mass)
     pub calculated_compute_mass: Option<u64>,
-    pub estimated_size: Option<u64>,
 }
 
 impl<T: AsRef<Transaction>> MutableTransaction<T> {
     pub fn new(tx: T) -> Self {
         let num_inputs = tx.as_ref().inputs.len();
-        Self { tx, entries: vec![None; num_inputs], calculated_fee: None, calculated_compute_mass: None, estimated_size: None }
+        Self { tx, entries: vec![None; num_inputs], calculated_fee: None, calculated_compute_mass: None }
     }
 
     pub fn id(&self) -> TransactionId {
@@ -390,13 +389,7 @@ impl<T: AsRef<Transaction>> MutableTransaction<T> {
 
     pub fn with_entries(tx: T, entries: Vec<UtxoEntry>) -> Self {
         assert_eq!(tx.as_ref().inputs.len(), entries.len());
-        Self {
-            tx,
-            entries: entries.into_iter().map(Some).collect(),
-            calculated_fee: None,
-            calculated_compute_mass: None,
-            estimated_size: None,
-        }
+        Self { tx, entries: entries.into_iter().map(Some).collect(), calculated_fee: None, calculated_compute_mass: None }
     }
 
     /// Returns the tx wrapped as a [`VerifiableTransaction`]. Note that this function

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -375,12 +375,13 @@ pub struct MutableTransaction<T: AsRef<Transaction> = std::sync::Arc<Transaction
     pub calculated_fee: Option<u64>,
     /// Populated compute mass (does not include the storage mass)
     pub calculated_compute_mass: Option<u64>,
+    pub estimated_size: Option<u64>,
 }
 
 impl<T: AsRef<Transaction>> MutableTransaction<T> {
     pub fn new(tx: T) -> Self {
         let num_inputs = tx.as_ref().inputs.len();
-        Self { tx, entries: vec![None; num_inputs], calculated_fee: None, calculated_compute_mass: None }
+        Self { tx, entries: vec![None; num_inputs], calculated_fee: None, calculated_compute_mass: None, estimated_size: None }
     }
 
     pub fn id(&self) -> TransactionId {
@@ -389,7 +390,13 @@ impl<T: AsRef<Transaction>> MutableTransaction<T> {
 
     pub fn with_entries(tx: T, entries: Vec<UtxoEntry>) -> Self {
         assert_eq!(tx.as_ref().inputs.len(), entries.len());
-        Self { tx, entries: entries.into_iter().map(Some).collect(), calculated_fee: None, calculated_compute_mass: None }
+        Self {
+            tx,
+            entries: entries.into_iter().map(Some).collect(),
+            calculated_fee: None,
+            calculated_compute_mass: None,
+            estimated_size: None,
+        }
     }
 
     /// Returns the tx wrapped as a [`VerifiableTransaction`]. Note that this function

--- a/mining/errors/src/mempool.rs
+++ b/mining/errors/src/mempool.rs
@@ -33,9 +33,9 @@ pub enum RuleError {
     #[error("replace by fee found more than one double spending transaction in the mempool")]
     RejectRbfTooManyDoubleSpendingTransactions,
 
-    /// New behavior: a transaction is rejected if the mempool is full
-    #[error("number of high-priority transactions in mempool ({0}) has reached the maximum allowed ({1})")]
-    RejectMempoolIsFull(usize, u64),
+    /// a transaction is rejected if the mempool is full
+    #[error("transaction could not be added to the mempool because it's full with transactions with higher priority")]
+    RejectMempoolIsFull,
 
     /// An error emitted by mining\src\mempool\check_transaction_standard.rs
     #[error("transaction {0} is not standard: {1}")]

--- a/mining/errors/src/mempool.rs
+++ b/mining/errors/src/mempool.rs
@@ -81,9 +81,6 @@ pub enum RuleError {
 
     #[error("Rejected tx {0} from mempool due to incomputable storage mass")]
     RejectStorageMassIncomputable(TransactionId),
-
-    #[error("Rejected tx {0} from mempool because its size ({1}) is greater than the mempool size limit ({2})")]
-    RejectTxTooBig(TransactionId, usize, usize),
 }
 
 impl From<NonStandardError> for RuleError {

--- a/mining/errors/src/mempool.rs
+++ b/mining/errors/src/mempool.rs
@@ -81,6 +81,9 @@ pub enum RuleError {
 
     #[error("Rejected tx {0} from mempool due to incomputable storage mass")]
     RejectStorageMassIncomputable(TransactionId),
+
+    #[error("Rejected tx {0} from mempool because its size ({1}) is greater than the mempool size limit ({2})")]
+    RejectTxTooBig(TransactionId, usize, usize),
 }
 
 impl From<NonStandardError> for RuleError {

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -836,6 +836,11 @@ impl MiningManager {
     pub fn unknown_transactions(&self, transactions: Vec<TransactionId>) -> Vec<TransactionId> {
         self.mempool.read().unknown_transactions(transactions)
     }
+
+    // For tests
+    pub(crate) fn get_total_compute_mass(&self) -> u64 {
+        self.mempool.read().get_total_compute_mass()
+    }
 }
 
 /// Async proxy for the mining manager

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -837,7 +837,7 @@ impl MiningManager {
         self.mempool.read().unknown_transactions(transactions)
     }
 
-    // For tests
+    #[cfg(test)]
     pub(crate) fn get_total_compute_mass(&self) -> u64 {
         self.mempool.read().get_total_compute_mass()
     }

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -838,8 +838,8 @@ impl MiningManager {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_total_compute_mass(&self) -> u64 {
-        self.mempool.read().get_total_compute_mass()
+    pub(crate) fn get_estimated_size(&self) -> usize {
+        self.mempool.read().get_estimated_size()
     }
 }
 

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1134,7 +1134,7 @@ mod tests {
             validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), tx).unwrap();
             assert!(!mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.is_empty());
         }
-        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize);
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT);
 
         let heavy_tx = {
             let mut heavy_tx = create_transaction_with_utxo_entry(TX_COUNT as u32, 0);
@@ -1144,9 +1144,9 @@ mod tests {
             heavy_tx.calculated_fee = Some(500_000);
             heavy_tx
         };
-        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize);
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT);
         validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), heavy_tx.clone()).unwrap();
-        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize - 5);
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT - 5);
         assert!(mining_manager.get_estimated_size() <= size_limit);
     }
 

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -26,7 +26,7 @@ mod tests {
         subnets::SUBNETWORK_ID_NATIVE,
         tx::{
             scriptvec, MutableTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
-            TransactionOutput, UtxoEntry, VerifiableTransaction,
+            TransactionOutput, UtxoEntry,
         },
     };
     use kaspa_hashes::Hash;
@@ -1121,43 +1121,43 @@ mod tests {
         let consensus = Arc::new(ConsensusMock::new());
         let counters = Arc::new(MiningCounters::default());
         const TX_COUNT: u32 = 10;
-        const MASS_LIMIT: u64 = 1_000_000;
+        const MASS_LIMIT: u64 = 10_000;
         let mut config = Config::build_default(TARGET_TIME_PER_BLOCK, false, MASS_LIMIT);
-        config.mempool_compute_mass_limit = TX_COUNT as u64;
+        config.mempool_compute_mass_limit = MASS_LIMIT;
         let mining_manager = MiningManager::with_config(config, None, counters);
         let txs = (0..TX_COUNT)
             .map(|i| {
-                let tx = create_transaction_with_utxo_entry(i, 0).as_verifiable().tx().clone();
+                let mut tx = create_transaction_with_utxo_entry(i, 0);
+                tx.calculated_compute_mass = Some(1000);
                 tx
+                // let tx = create_transaction_with_utxo_entry(i, 0).as_verifiable().tx().clone();
+                // tx
             })
             .collect_vec();
 
         for tx in txs {
-            validate_and_insert_transaction(&mining_manager, consensus.as_ref(), tx.clone()).unwrap();
+            validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), tx).unwrap();
+            // validate_and_insert_transaction(&mining_manager, consensus.as_ref(), tx.clone()).unwrap();
+            assert!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len() != 0);
         }
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize);
 
-        let mut heavy_tx = create_transaction_with_utxo_entry(TX_COUNT, 0).as_verifiable().tx().clone();
-        heavy_tx.payload = vec![0u8; 5000];
-        validate_and_insert_transaction(&mining_manager, consensus.as_ref(), heavy_tx.clone()).unwrap();
-        assert!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len() != 0);
-        assert!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len() < TX_COUNT as usize);
+        let mut heavy_tx = create_transaction_with_utxo_entry(TX_COUNT, 0);
+        heavy_tx.calculated_compute_mass = Some(5000);
+        heavy_tx.calculated_fee = Some(5000);
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize);
+        validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), heavy_tx.clone()).unwrap();
+        assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize - 4);
+        assert!(mining_manager.get_total_compute_mass() <= MASS_LIMIT);
     }
 
-    fn validate_and_insert_transaction(
+    fn validate_and_insert_mutable_transaction(
         mining_manager: &MiningManager,
         consensus: &dyn ConsensusApi,
-        tx: Transaction,
+        tx: MutableTransaction,
     ) -> Result<TransactionInsertion, MiningManagerError> {
-        mining_manager.validate_and_insert_transaction(consensus, tx, Priority::Low, Orphan::Allowed, RbfPolicy::Forbidden)
+        mining_manager.validate_and_insert_mutable_transaction(consensus, tx, Priority::Low, Orphan::Allowed, RbfPolicy::Forbidden)
     }
-
-    // fn validate_and_insert_mutable_transaction(
-    //     mining_manager: &MiningManager,
-    //     consensus: &dyn ConsensusApi,
-    //     tx: MutableTransaction,
-    // ) -> Result<TransactionInsertion, MiningManagerError> {
-    //     mining_manager.validate_and_insert_mutable_transaction(consensus, tx, Priority::Low, Orphan::Allowed, RbfPolicy::Forbidden)
-    // }
 
     fn sweep_compare_modified_template_to_built(
         consensus: &dyn ConsensusApi,

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1125,7 +1125,7 @@ mod tests {
         let consensus = Arc::new(ConsensusMock::new());
         let counters = Arc::new(MiningCounters::default());
         let mut config = Config::build_default(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS);
-        let tx_size = txs[0].tx.estimate_mem_bytes();
+        let tx_size = txs[0].mempool_estimated_bytes();
         let size_limit = TX_COUNT * tx_size;
         config.mempool_size_limit = size_limit;
         let mining_manager = MiningManager::with_config(config, None, counters);

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1130,15 +1130,12 @@ mod tests {
                 let mut tx = create_transaction_with_utxo_entry(i, 0);
                 tx.calculated_compute_mass = Some(1000);
                 tx
-                // let tx = create_transaction_with_utxo_entry(i, 0).as_verifiable().tx().clone();
-                // tx
             })
             .collect_vec();
 
         for tx in txs {
             validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), tx).unwrap();
-            // validate_and_insert_transaction(&mining_manager, consensus.as_ref(), tx.clone()).unwrap();
-            assert!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len() != 0);
+            assert!(!mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.is_empty());
         }
         assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT as usize);
 

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1117,6 +1117,11 @@ mod tests {
         // TODO: extend the test according to the golang scenario
     }
 
+    // This is a sanity test for the mempool eviction policy. We check that if the mempool reached to its maximum
+    // (in bytes) a high paying transaction will evict as much transactions as needed so it can enter the
+    // mempool.
+    // TODO: Add tests to the case where the transaction doesn't have enough fee rate. We need to check that the
+    // transaction is rejected and the mempool remains untouched.
     #[test]
     fn test_evict() {
         const TX_COUNT: usize = 10;

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -1,7 +1,7 @@
 use kaspa_consensus_core::constants::TX_VERSION;
 
 pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: usize = 1_000_000;
-pub(crate) const DEFAULT_MEMPOOL_COMPUTE_MASS_LIMIT: u64 = 500_000_000; // This limits the mempool to about 500 MB.
+pub(crate) const DEFAULT_MEMPOOL_SIZE_LIMIT: u64 = 500_000_000;
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
 
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
@@ -28,7 +28,7 @@ pub(crate) const DEFAULT_MAXIMUM_STANDARD_TRANSACTION_VERSION: u16 = TX_VERSION;
 #[derive(Clone, Debug)]
 pub struct Config {
     pub maximum_transaction_count: usize,
-    pub mempool_compute_mass_limit: u64,
+    pub mempool_size_limit: u64,
     pub maximum_build_block_template_attempts: u64,
     pub transaction_expire_interval_daa_score: u64,
     pub transaction_expire_scan_interval_daa_score: u64,
@@ -52,7 +52,7 @@ impl Config {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         maximum_transaction_count: usize,
-        mempool_compute_mass_limit: u64,
+        mempool_size_limit: u64,
         maximum_build_block_template_attempts: u64,
         transaction_expire_interval_daa_score: u64,
         transaction_expire_scan_interval_daa_score: u64,
@@ -73,7 +73,7 @@ impl Config {
     ) -> Self {
         Self {
             maximum_transaction_count,
-            mempool_compute_mass_limit,
+            mempool_size_limit,
             maximum_build_block_template_attempts,
             transaction_expire_interval_daa_score,
             transaction_expire_scan_interval_daa_score,
@@ -99,7 +99,7 @@ impl Config {
     pub const fn build_default(target_milliseconds_per_block: u64, relay_non_std_transactions: bool, max_block_mass: u64) -> Self {
         Self {
             maximum_transaction_count: DEFAULT_MAXIMUM_TRANSACTION_COUNT,
-            mempool_compute_mass_limit: DEFAULT_MEMPOOL_COMPUTE_MASS_LIMIT,
+            mempool_size_limit: DEFAULT_MEMPOOL_SIZE_LIMIT,
             maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS,
             transaction_expire_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS * 1000 / target_milliseconds_per_block,
             transaction_expire_scan_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS * 1000

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -1,7 +1,7 @@
 use kaspa_consensus_core::constants::TX_VERSION;
 
 pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: usize = 1_000_000;
-pub(crate) const DEFAULT_MEMPOOL_SIZE_LIMIT: usize = 500_000_000;
+pub(crate) const DEFAULT_MEMPOOL_SIZE_LIMIT: usize = 1_000_000_000;
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
 
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 24 * 60 * 60;

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -3,7 +3,7 @@ use kaspa_consensus_core::constants::TX_VERSION;
 pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: u32 = 1_000_000;
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
 
-pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 60;
+pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS: u64 = 10;
 pub(crate) const DEFAULT_ACCEPTED_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 120;
 pub(crate) const DEFAULT_ACCEPTED_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS: u64 = 10;
@@ -11,9 +11,7 @@ pub(crate) const DEFAULT_ORPHAN_EXPIRE_INTERVAL_SECONDS: u64 = 60;
 pub(crate) const DEFAULT_ORPHAN_EXPIRE_SCAN_INTERVAL_SECONDS: u64 = 10;
 
 pub(crate) const DEFAULT_MAXIMUM_ORPHAN_TRANSACTION_MASS: u64 = 100_000;
-
-// TODO: when rusty-kaspa nodes run most of the network, consider increasing this value
-pub(crate) const DEFAULT_MAXIMUM_ORPHAN_TRANSACTION_COUNT: u64 = 50;
+pub(crate) const DEFAULT_MAXIMUM_ORPHAN_TRANSACTION_COUNT: u64 = 500;
 
 /// DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE specifies the minimum transaction fee for a transaction to be accepted to
 /// the mempool and relayed. It is specified in sompi per 1kg (or 1000 grams) of transaction mass.

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -1,6 +1,7 @@
 use kaspa_consensus_core::constants::TX_VERSION;
 
-pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: u32 = 1_000_000;
+pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: usize = 1_000_000;
+pub(crate) const DEFAULT_MEMPOOL_COMPUTE_MASS_LIMIT: u64 = 500_000_000; // This limits the mempool to about 500 MB.
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
 
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
@@ -26,7 +27,8 @@ pub(crate) const DEFAULT_MAXIMUM_STANDARD_TRANSACTION_VERSION: u16 = TX_VERSION;
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub maximum_transaction_count: u32,
+    pub maximum_transaction_count: usize,
+    pub mempool_compute_mass_limit: u64,
     pub maximum_build_block_template_attempts: u64,
     pub transaction_expire_interval_daa_score: u64,
     pub transaction_expire_scan_interval_daa_score: u64,
@@ -49,7 +51,8 @@ pub struct Config {
 impl Config {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        maximum_transaction_count: u32,
+        maximum_transaction_count: usize,
+        mempool_compute_mass_limit: u64,
         maximum_build_block_template_attempts: u64,
         transaction_expire_interval_daa_score: u64,
         transaction_expire_scan_interval_daa_score: u64,
@@ -70,6 +73,7 @@ impl Config {
     ) -> Self {
         Self {
             maximum_transaction_count,
+            mempool_compute_mass_limit,
             maximum_build_block_template_attempts,
             transaction_expire_interval_daa_score,
             transaction_expire_scan_interval_daa_score,
@@ -95,6 +99,7 @@ impl Config {
     pub const fn build_default(target_milliseconds_per_block: u64, relay_non_std_transactions: bool, max_block_mass: u64) -> Self {
         Self {
             maximum_transaction_count: DEFAULT_MAXIMUM_TRANSACTION_COUNT,
+            mempool_compute_mass_limit: DEFAULT_MEMPOOL_COMPUTE_MASS_LIMIT,
             maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS,
             transaction_expire_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS * 1000 / target_milliseconds_per_block,
             transaction_expire_scan_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS * 1000
@@ -119,7 +124,7 @@ impl Config {
     }
 
     pub fn apply_ram_scale(mut self, ram_scale: f64) -> Self {
-        self.maximum_transaction_count = (self.maximum_transaction_count as f64 * ram_scale.min(1.0)) as u32; // Allow only scaling down
+        self.maximum_transaction_count = (self.maximum_transaction_count as f64 * ram_scale.min(1.0)) as usize; // Allow only scaling down
         self
     }
 

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -1,7 +1,7 @@
 use kaspa_consensus_core::constants::TX_VERSION;
 
 pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: usize = 1_000_000;
-pub(crate) const DEFAULT_MEMPOOL_SIZE_LIMIT: u64 = 500_000_000;
+pub(crate) const DEFAULT_MEMPOOL_SIZE_LIMIT: usize = 500_000_000;
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
 
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
@@ -28,7 +28,7 @@ pub(crate) const DEFAULT_MAXIMUM_STANDARD_TRANSACTION_VERSION: u16 = TX_VERSION;
 #[derive(Clone, Debug)]
 pub struct Config {
     pub maximum_transaction_count: usize,
-    pub mempool_size_limit: u64,
+    pub mempool_size_limit: usize,
     pub maximum_build_block_template_attempts: u64,
     pub transaction_expire_interval_daa_score: u64,
     pub transaction_expire_scan_interval_daa_score: u64,
@@ -52,7 +52,7 @@ impl Config {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         maximum_transaction_count: usize,
-        mempool_size_limit: u64,
+        mempool_size_limit: usize,
         maximum_build_block_template_attempts: u64,
         transaction_expire_interval_daa_score: u64,
         transaction_expire_scan_interval_daa_score: u64,

--- a/mining/src/mempool/mod.rs
+++ b/mining/src/mempool/mod.rs
@@ -162,6 +162,11 @@ impl Mempool {
             .filter(|transaction_id| !(self.transaction_pool.has(transaction_id) || self.orphan_pool.has(transaction_id)));
         self.accepted_transactions.unaccepted(&mut not_in_pools_txs)
     }
+
+    // For tests
+    pub(crate) fn get_total_compute_mass(&self) -> u64 {
+        self.transaction_pool.get_total_compute_mass()
+    }
 }
 
 pub mod tx {

--- a/mining/src/mempool/mod.rs
+++ b/mining/src/mempool/mod.rs
@@ -164,7 +164,7 @@ impl Mempool {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_total_compute_mass(&self) -> u64 {
+    pub(crate) fn get_estimated_size(&self) -> usize {
         self.transaction_pool.get_estimated_size()
     }
 }

--- a/mining/src/mempool/mod.rs
+++ b/mining/src/mempool/mod.rs
@@ -165,7 +165,7 @@ impl Mempool {
 
     #[cfg(test)]
     pub(crate) fn get_total_compute_mass(&self) -> u64 {
-        self.transaction_pool.get_total_compute_mass()
+        self.transaction_pool.get_estimated_size()
     }
 }
 

--- a/mining/src/mempool/mod.rs
+++ b/mining/src/mempool/mod.rs
@@ -163,7 +163,7 @@ impl Mempool {
         self.accepted_transactions.unaccepted(&mut not_in_pools_txs)
     }
 
-    // For tests
+    #[cfg(test)]
     pub(crate) fn get_total_compute_mass(&self) -> u64 {
         self.transaction_pool.get_total_compute_mass()
     }

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 
 use feerate_key::FeerateTransactionKey;
-use kaspa_consensus_core::block::TemplateTransactionSelector;
+use kaspa_consensus_core::{block::TemplateTransactionSelector, tx::Transaction};
 use kaspa_core::trace;
 use rand::{distributions::Uniform, prelude::Distribution, Rng};
 use search_tree::SearchTree;
 use selectors::{SequenceSelector, SequenceSelectorInput, TakeAllSelector};
-use std::collections::HashSet;
+use std::{collections::HashSet, iter::FusedIterator, sync::Arc};
 
 pub(crate) mod feerate_key;
 pub(crate) mod search_tree;
@@ -253,6 +253,10 @@ impl Frontier {
             }
         }
         estimator
+    }
+
+    pub fn ascending_iter(&self) -> impl DoubleEndedIterator<Item = &Arc<Transaction>> + ExactSizeIterator + FusedIterator {
+        self.search_tree.ascending_iter().map(|key| &key.tx)
     }
 }
 

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -255,6 +255,7 @@ impl Frontier {
         estimator
     }
 
+    /// Returns an iterator to the transactions in the frontier in increasing feerate order
     pub fn ascending_iter(&self) -> impl DoubleEndedIterator<Item = &Arc<Transaction>> + ExactSizeIterator + FusedIterator {
         self.search_tree.ascending_iter().map(|key| &key.tx)
     }

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -21,7 +21,7 @@ use kaspa_consensus_core::{
 use kaspa_core::{time::unix_now, trace, warn};
 use std::{
     collections::{hash_map::Keys, hash_set::Iter},
-    sync::Arc,
+    sync::{atomic::AtomicU64, Arc},
 };
 
 use super::frontier::Frontier;
@@ -64,6 +64,8 @@ pub(crate) struct TransactionsPool {
     /// last expire scan time in milliseconds
     last_expire_scan_time: u64,
 
+    total_compute_mass: u64,
+
     /// Store of UTXOs
     utxo_set: MempoolUtxoSet,
 }
@@ -79,6 +81,7 @@ impl TransactionsPool {
             last_expire_scan_daa_score: 0,
             last_expire_scan_time: unix_now(),
             utxo_set: MempoolUtxoSet::new(),
+            total_compute_mass: 0,
         }
     }
 
@@ -117,6 +120,7 @@ impl TransactionsPool {
         }
 
         self.utxo_set.add_transaction(&transaction.mtx);
+        self.total_compute_mass += transaction.calculated_compute_mass().expect("we expect this field to be already calculated");
         self.all_transactions.insert(id, transaction);
         trace!("Added transaction {}", id);
         Ok(())

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -201,13 +201,12 @@ impl TransactionsPool {
         let transaction_size = transaction.tx.estimate_mem_bytes();
         let mut txs_to_remove = Vec::with_capacity(1);
         let mut selected_size = 0;
-        let mut num_selected = 0;
-        #[allow(clippy::explicit_counter_loop)]
-        for tx in self
+        for (num_selected, tx) in self
             .ready_transactions
             .ascending_iter()
             .map(|tx| self.all_transactions.get(&tx.id()).unwrap())
             .filter(|mtx| mtx.priority == Priority::Low && !mtx.is_parent_of(transaction))
+            .enumerate()
         {
             if self.len() + 1 - num_selected <= self.config.maximum_transaction_count
                 && self.estimated_size + transaction_size - selected_size <= self.config.mempool_size_limit
@@ -224,7 +223,6 @@ impl TransactionsPool {
 
             txs_to_remove.push(tx.id());
             selected_size += tx.mtx.tx.estimate_mem_bytes();
-            num_selected += 1;
         }
 
         Ok(txs_to_remove)

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -200,6 +200,7 @@ impl TransactionsPool {
         let mut txs_to_remove = Vec::with_capacity(1);
         let mut selected_mass = 0;
         let mut num_selected = 0;
+        #[allow(clippy::explicit_counter_loop)]
         for tx in self
             .ready_transactions
             .ascending_iter()

--- a/mining/src/mempool/model/tx.rs
+++ b/mining/src/mempool/model/tx.rs
@@ -27,11 +27,6 @@ impl MempoolTransaction {
         assert!(contextual_mass > 0, "expected to be called for validated txs only");
         self.mtx.calculated_fee.unwrap() as f64 / contextual_mass as f64
     }
-
-    pub(crate) fn is_parent_of(&self, transaction: &MutableTransaction) -> bool {
-        let parent_id = self.id();
-        transaction.tx.inputs.iter().any(|x| x.previous_outpoint.transaction_id == parent_id)
-    }
 }
 
 impl RbfPolicy {

--- a/mining/src/mempool/model/tx.rs
+++ b/mining/src/mempool/model/tx.rs
@@ -33,8 +33,8 @@ impl MempoolTransaction {
         transaction.tx.inputs.iter().any(|x| x.previous_outpoint.transaction_id == parent_id)
     }
 
-    pub(crate) fn calculated_compute_mass(&self) -> Option<u64> {
-        self.mtx.calculated_compute_mass
+    pub(crate) fn estimated_size(&self) -> Option<u64> {
+        self.mtx.estimated_size
     }
 }
 

--- a/mining/src/mempool/model/tx.rs
+++ b/mining/src/mempool/model/tx.rs
@@ -32,6 +32,10 @@ impl MempoolTransaction {
         let parent_id = self.id();
         transaction.tx.inputs.iter().any(|x| x.previous_outpoint.transaction_id == parent_id)
     }
+
+    pub(crate) fn calculated_compute_mass(&self) -> Option<u64> {
+        self.mtx.calculated_compute_mass
+    }
 }
 
 impl RbfPolicy {

--- a/mining/src/mempool/model/tx.rs
+++ b/mining/src/mempool/model/tx.rs
@@ -32,10 +32,6 @@ impl MempoolTransaction {
         let parent_id = self.id();
         transaction.tx.inputs.iter().any(|x| x.previous_outpoint.transaction_id == parent_id)
     }
-
-    pub(crate) fn estimated_size(&self) -> Option<u64> {
-        self.mtx.estimated_size
-    }
 }
 
 impl RbfPolicy {

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -82,26 +82,22 @@ impl Mempool {
             // smallest prefix of `ready_transactions` (sorted by ascending fee-rate)
             // that makes enough room for `transaction`, but since each call to `self.remove_transaction`
             // also removes all transactions dependant on `x` we might already have enough room.
-            #[allow(clippy::int_plus_one)]
-            if self.transaction_pool.len() + 1 <= self.config.maximum_transaction_count
+            if self.transaction_pool.len() < self.config.maximum_transaction_count
                 && self.transaction_pool.get_estimated_size() + transaction_size <= self.config.mempool_size_limit
             {
                 break;
             }
         }
 
-        #[allow(clippy::int_plus_one)]
-        {
-            assert!(
-                self.transaction_pool.len() + 1 <= self.config.maximum_transaction_count
-                    && self.transaction_pool.get_estimated_size() + transaction_size <= self.config.mempool_size_limit,
-                "Transactions in mempool: {}, max: {}, mempool size: {}, max: {}",
-                self.transaction_pool.len() + 1,
-                self.config.maximum_transaction_count,
-                self.transaction_pool.get_estimated_size() + transaction_size,
-                self.config.mempool_size_limit,
-            );
-        }
+        assert!(
+            self.transaction_pool.len() < self.config.maximum_transaction_count
+                && self.transaction_pool.get_estimated_size() + transaction_size <= self.config.mempool_size_limit,
+            "Transactions in mempool: {}, max: {}, mempool size: {}, max: {}",
+            self.transaction_pool.len() + 1,
+            self.config.maximum_transaction_count,
+            self.transaction_pool.get_estimated_size() + transaction_size,
+            self.config.mempool_size_limit,
+        );
 
         // Add the transaction to the mempool as a MempoolTransaction and return a clone of the embedded Arc<Transaction>
         let accepted_transaction =

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -83,6 +83,7 @@ impl Mempool {
             // smallest prefix of `ready_transactions` (sorted by ascending fee-rate)
             // that makes enough room for `transaction`, but since each call to `self.remove_transaction`
             // also removes all transactions dependant on `x` we might already have enough room.
+            #[allow(clippy::int_plus_one)]
             if self.transaction_pool.len() + 1 <= self.config.maximum_transaction_count
                 && self.transaction_pool.get_total_compute_mass() + transaction.calculated_compute_mass.unwrap()
                     <= self.config.mempool_compute_mass_limit
@@ -91,11 +92,14 @@ impl Mempool {
             }
         }
 
-        assert!(
-            self.transaction_pool.len() + 1 <= self.config.maximum_transaction_count
-                && self.transaction_pool.get_total_compute_mass() + transaction.calculated_compute_mass.unwrap()
-                    <= self.config.mempool_compute_mass_limit
-        );
+        #[allow(clippy::int_plus_one)]
+        {
+            assert!(
+                self.transaction_pool.len() + 1 <= self.config.maximum_transaction_count
+                    && self.transaction_pool.get_total_compute_mass() + transaction.calculated_compute_mass.unwrap()
+                        <= self.config.mempool_compute_mass_limit
+            );
+        }
 
         // Add the transaction to the mempool as a MempoolTransaction and return a clone of the embedded Arc<Transaction>
         let accepted_transaction =

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -137,11 +137,6 @@ impl Mempool {
             return Err(RuleError::RejectDuplicate(transaction_id));
         }
 
-        let tx_size = transaction.mempool_estimated_bytes();
-        if tx_size > self.config.mempool_size_limit {
-            return Err(RuleError::RejectTxTooBig(transaction_id, tx_size, self.config.mempool_size_limit));
-        }
-
         if !self.config.accept_non_standard {
             self.check_transaction_standard_in_isolation(transaction)?;
         }

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -133,11 +133,14 @@ impl ConsensusApi for ConsensusMock {
         // At this point we know all UTXO entries are populated, so we can safely calculate the fee
         let total_in: u64 = mutable_tx.entries.iter().map(|x| x.as_ref().unwrap().amount).sum();
         let total_out: u64 = mutable_tx.tx.outputs.iter().map(|x| x.value).sum();
-        let calculated_fee = total_in - total_out;
         mutable_tx
             .tx
             .set_mass(self.calculate_transaction_storage_mass(mutable_tx).unwrap() + mutable_tx.calculated_compute_mass.unwrap());
-        mutable_tx.calculated_fee = Some(calculated_fee);
+
+        if mutable_tx.calculated_fee.is_none() {
+            let calculated_fee = total_in - total_out;
+            mutable_tx.calculated_fee = Some(calculated_fee);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This PR:

* Increases mempool expiry time to 24h
* Increases orphan tx limit to 500
* Adds a compute-mass limit to the mempool (as a proxy to mempool memory size) and changing the eviction mechanism to prefer transactions with lower fee rate.