### PR TITLE
A few optimizations related to multi-level relations

### DIFF
--- a/consensus/src/model/services/reachability.rs
+++ b/consensus/src/model/services/reachability.rs
@@ -25,6 +25,7 @@ pub trait ReachabilityService {
         let mut roots = BlockHashSet::default();
         for hash in list {
             if !self.is_any_dag_ancestor(&mut roots.iter().copied(), hash) {
+                roots.retain(|&h| !self.is_dag_ancestor_of(hash, h));
                 roots.insert(hash);
             }
         }
@@ -246,9 +247,13 @@ impl<T: ReachabilityStoreReader + ?Sized> Iterator for ForwardChainIterator<T> {
 mod tests {
     use super::*;
     use crate::{
-        model::stores::reachability::MemoryReachabilityStore,
-        processes::reachability::{interval::Interval, tests::TreeBuilder},
+        model::stores::{reachability::MemoryReachabilityStore, relations::MemoryRelationsStore},
+        processes::reachability::{
+            interval::Interval,
+            tests::{DagBlock, DagBuilder, TreeBuilder},
+        },
     };
+    use blockhash::ORIGIN;
 
     #[test]
     fn test_forward_iterator() {
@@ -310,5 +315,45 @@ mod tests {
         assert!(std::iter::empty::<Hash>().eq(service.backward_chain_iterator(root, root, false)));
         assert!(std::iter::once(root).eq(service.forward_chain_iterator(root, root, true)));
         assert!(std::iter::empty::<Hash>().eq(service.forward_chain_iterator(root, root, false)));
+    }
+
+    #[test]
+    fn test_get_roots_of_set() {
+        let mut reachability = MemoryReachabilityStore::new();
+        let mut relations = MemoryRelationsStore::new();
+
+        DagBuilder::new(&mut reachability, &mut relations)
+            .init()
+            .add_block(DagBlock::new(1.into(), vec![ORIGIN]))
+            .add_block((2, [1].as_slice()).into())
+            .add_block((3, [1].as_slice()).into())
+            .add_block((4, [1].as_slice()).into())
+            .add_block((5, [1].as_slice()).into())
+            .add_block((6, [5].as_slice()).into())
+            .add_block((7, [6].as_slice()).into())
+            .add_block((8, [3, 4].as_slice()).into())
+            .add_block((9, [1].as_slice()).into())
+            .add_block((10, [8, 9].as_slice()).into())
+            .add_block((11, [9].as_slice()).into());
+
+        let service = MTReachabilityService::new(Arc::new(RwLock::new(reachability)));
+
+        let test_cases = vec![
+            // (set, expected roots)
+            (vec![6, 7, 5, 4, 3, 2], vec![5, 4, 3, 2]),
+            (vec![2, 3, 4, 5, 6, 7], vec![5, 4, 3, 2]),
+            (vec![2, 3, 4, 5], vec![5, 4, 3, 2]),
+            (vec![9, 8, 10, 11], vec![8, 9]),
+            (vec![9, 8, 3, 10, 11], vec![3, 9]),
+            ((1..=11).collect(), vec![1]),
+            ((2..=11).collect(), vec![9, 5, 4, 3, 2]),
+            ((2..=11).rev().collect(), vec![9, 5, 4, 3, 2]),
+        ];
+
+        for (i, tc) in test_cases.into_iter().enumerate() {
+            let actual_roots = service.get_roots_of_set(&mut tc.0.into_iter().map(|i| i.into()));
+            let expected_roots = BlockHashSet::from_iter(tc.1.into_iter().map(|i| i.into()));
+            assert_eq!(expected_roots, actual_roots, "{i: }");
+        }
     }
 }

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -292,6 +292,7 @@ impl PruningProcessor {
         {
             let mut counter = 0;
             let mut batch = WriteBatch::default();
+            // At this point keep_relations only holds level-0 relations which is the correct filtering criteria for primary GHOSTDAG
             for kept in keep_relations.keys().copied() {
                 let Some(ghostdag) = self.ghostdag_primary_store.get_data(kept).unwrap_option() else {
                     continue;
@@ -441,6 +442,7 @@ impl PruningProcessor {
                     }
 
                     // Delete level-x relations for blocks which only belong to higher-than-x proof levels.
+                    // This preserves the semantic that for each level, relations represent a contiguous DAG area in that level
                     for lower_level in 0..affiliated_proof_level as usize {
                         let mut staging_level_relations = StagingRelationsStore::new(&mut level_relations_write[lower_level]);
                         relations::delete_level_relations(MemoryWriter, &mut staging_level_relations, current).unwrap_option();

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -53,7 +53,7 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
         let mut origin_children_headers = None;
         let mut parents = Vec::with_capacity(self.max_block_level as usize);
 
-        for block_level in 0..self.max_block_level {
+        for block_level in 0..=self.max_block_level {
             // Direct parents are guaranteed to be in one another's anticones so add them all to
             // all the block levels they occupy.
             let mut level_candidates_to_reference_blocks = direct_parent_headers

--- a/consensus/src/processes/parents_builder.rs
+++ b/consensus/src/processes/parents_builder.rs
@@ -91,78 +91,89 @@ impl<T: HeaderStoreReader, U: ReachabilityStoreReader, V: RelationsStoreReader> 
                     .collect::<IndexSet<Hash, BlockHasher>>()
             };
 
-            for (i, parent) in grandparents.into_iter().enumerate() {
-                let has_reachability_data = self.reachability_service.has_reachability_data(parent);
+            let parents_at_level = if level_candidates_to_reference_blocks.is_empty() && first_parent_marker == grandparents.len() {
+                // Optimization: this is a common case for high levels where none of the direct parents is on the level
+                // and all direct parents have the same level parents. The condition captures this case because all grandparents
+                // will be below the first parent marker and there will be no additional grandparents. Bcs all grandparents come
+                // from a single, already validated parent, there's no need to run any additional antichain checks and we can return
+                // this set.
+                grandparents.into_iter().collect()
+            } else {
+                //
+                // Iterate through grandparents in order to find an antichain
+                for (i, parent) in grandparents.into_iter().enumerate() {
+                    let has_reachability_data = self.reachability_service.has_reachability_data(parent);
 
-                // Reference blocks are the blocks that are used in reachability queries to check if
-                // a candidate is in the future of another candidate. In most cases this is just the
-                // block itself, but in the case where a block doesn't have reachability data we need
-                // to use some blocks in its future as reference instead.
-                // If we make sure to add a parent in the future of the pruning point first, we can
-                // know that any pruned candidate that is in the past of some blocks in the pruning
-                // point anticone should be a parent (in the relevant level) of one of
-                // the origin children in the pruning point anticone. So we can check which
-                // origin children have this block as parent and use those block as
-                // reference blocks.
-                let reference_blocks = if has_reachability_data {
-                    smallvec![parent]
-                } else {
-                    // Here we explicitly declare the type because otherwise Rust would make it mutable.
-                    let origin_children_headers: &Vec<_> = origin_children_headers.get_or_insert_with(|| {
-                        self.relations_service
-                            .get_children(ORIGIN)
-                            .unwrap()
-                            .read()
-                            .iter()
-                            .copied()
-                            .map(|parent| self.headers_store.get_header(parent).unwrap())
-                            .collect_vec()
-                    });
-                    let mut reference_blocks = SmallVec::with_capacity(origin_children_headers.len());
-                    for child_header in origin_children_headers.iter() {
-                        if self.parents_at_level(child_header, block_level).contains(&parent) {
-                            reference_blocks.push(child_header.hash);
+                    // Reference blocks are the blocks that are used in reachability queries to check if
+                    // a candidate is in the future of another candidate. In most cases this is just the
+                    // block itself, but in the case where a block doesn't have reachability data we need
+                    // to use some blocks in its future as reference instead.
+                    // If we make sure to add a parent in the future of the pruning point first, we can
+                    // know that any pruned candidate that is in the past of some blocks in the pruning
+                    // point anticone should be a parent (in the relevant level) of one of
+                    // the origin children in the pruning point anticone. So we can check which
+                    // origin children have this block as parent and use those block as
+                    // reference blocks.
+                    let reference_blocks = if has_reachability_data {
+                        smallvec![parent]
+                    } else {
+                        // Here we explicitly declare the type because otherwise Rust would make it mutable.
+                        let origin_children_headers: &Vec<_> = origin_children_headers.get_or_insert_with(|| {
+                            self.relations_service
+                                .get_children(ORIGIN)
+                                .unwrap()
+                                .read()
+                                .iter()
+                                .copied()
+                                .map(|parent| self.headers_store.get_header(parent).unwrap())
+                                .collect_vec()
+                        });
+                        let mut reference_blocks = SmallVec::with_capacity(origin_children_headers.len());
+                        for child_header in origin_children_headers.iter() {
+                            if self.parents_at_level(child_header, block_level).contains(&parent) {
+                                reference_blocks.push(child_header.hash);
+                            }
                         }
+                        reference_blocks
+                    };
+
+                    // Make sure we process and insert all first parent's parents. See comments above.
+                    // Note that as parents of an already validated block, they all form an antichain,
+                    // hence no need for reachability queries yet.
+                    if i < first_parent_marker {
+                        level_candidates_to_reference_blocks.insert(parent, reference_blocks);
+                        continue;
                     }
-                    reference_blocks
-                };
 
-                // Make sure we process and insert all first parent's parents. See comments above.
-                // Note that as parents of an already validated block, they all form an antichain,
-                // hence no need for reachability queries yet.
-                if i < first_parent_marker {
-                    level_candidates_to_reference_blocks.insert(parent, reference_blocks);
-                    continue;
+                    if !has_reachability_data {
+                        continue;
+                    }
+
+                    let len_before_retain = level_candidates_to_reference_blocks.len();
+                    level_candidates_to_reference_blocks
+                        .retain(|_, refs| !self.reachability_service.is_any_dag_ancestor(&mut refs.iter().copied(), parent));
+                    let is_any_candidate_ancestor_of = level_candidates_to_reference_blocks.len() < len_before_retain;
+
+                    // We should add the block as a candidate if it's in the future of another candidate
+                    // or in the anticone of all candidates.
+                    if is_any_candidate_ancestor_of
+                        || !level_candidates_to_reference_blocks.iter().any(|(_, candidate_references)| {
+                            self.reachability_service.is_dag_ancestor_of_any(parent, &mut candidate_references.iter().copied())
+                        })
+                    {
+                        level_candidates_to_reference_blocks.insert(parent, reference_blocks);
+                    }
                 }
 
-                if !has_reachability_data {
-                    continue;
-                }
+                // After processing all grandparents, collect the successful level candidates
+                level_candidates_to_reference_blocks.keys().copied().collect_vec()
+            };
 
-                let len_before_retain = level_candidates_to_reference_blocks.len();
-                level_candidates_to_reference_blocks
-                    .retain(|_, refs| !self.reachability_service.is_any_dag_ancestor(&mut refs.iter().copied(), parent));
-                let is_any_candidate_ancestor_of = level_candidates_to_reference_blocks.len() < len_before_retain;
-
-                // We should add the block as a candidate if it's in the future of another candidate
-                // or in the anticone of all candidates.
-                if is_any_candidate_ancestor_of
-                    || !level_candidates_to_reference_blocks.iter().any(|(_, candidate_references)| {
-                        self.reachability_service.is_dag_ancestor_of_any(parent, &mut candidate_references.iter().copied())
-                    })
-                {
-                    level_candidates_to_reference_blocks.insert(parent, reference_blocks);
-                }
-            }
-
-            if block_level > 0
-                && level_candidates_to_reference_blocks.len() == 1
-                && level_candidates_to_reference_blocks.contains_key(&self.genesis_hash)
-            {
+            if block_level > 0 && parents_at_level.as_slice() == std::slice::from_ref(&self.genesis_hash) {
                 break;
             }
 
-            parents.push(level_candidates_to_reference_blocks.keys().copied().collect_vec());
+            parents.push(parents_at_level);
         }
 
         parents

--- a/consensus/src/processes/reachability/tests/mod.rs
+++ b/consensus/src/processes/reachability/tests/mod.rs
@@ -105,6 +105,12 @@ impl DagBlock {
     }
 }
 
+impl From<(u64, &[u64])> for DagBlock {
+    fn from(value: (u64, &[u64])) -> Self {
+        Self::new(value.0.into(), value.1.iter().map(|&i| i.into()).collect())
+    }
+}
+
 /// A struct with fluent API to streamline DAG building
 pub struct DagBuilder<'a, T: ReachabilityStore + ?Sized, S: RelationsStore + ChildrenStore + ?Sized> {
     reachability: &'a mut T,

--- a/utils/src/sync/semaphore.rs
+++ b/utils/src/sync/semaphore.rs
@@ -41,7 +41,7 @@ mod trace {
                 if log_time + (Duration::from_secs(10).as_micros() as u64) < now {
                     let log_value = self.log_value.load(Ordering::Relaxed);
                     debug!(
-                        "Semaphore: log interval: {:?}, readers time: {:?}, fraction: {:.2}",
+                        "Semaphore: log interval: {:?}, readers time: {:?}, fraction: {:.4}",
                         Duration::from_micros(now - log_time),
                         Duration::from_micros(readers_time - log_value),
                         (readers_time - log_value) as f64 / (now - log_time) as f64


### PR DESCRIPTION
1. In `ParentsBuilder` optimize the execution path of the common case for high levels
2. Prune relations for all levels below the affiliated proof level for block
3. Keep relations for multi-level parents of pruning point and its anticone  

(each item is in its own commit, by order)