### PR TITLE
do block body `past_median_time` check lazily.

### DIFF
--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -31,20 +31,25 @@ impl BlockBodyProcessor {
             if tx.lock_time < LOCK_TIME_THRESHOLD {
                 // will only check daa score
                 if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
-                    tx, 
-                    block.header.daa_score, 
-                    pmt // we don't need the past median time for this case
+                    tx,
+                    block.header.daa_score,
+                    pmt, // we don't need the past median time for this case
                 ) {
                     return Err(RuleError::TxInContextFailed(tx.id(), e));
-            } else if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
-                tx, 
-                block.header.daa_score, 
-                // we most intialize the pmt value to the past median time of the block
-                if pmt > 0 { pmt } else { self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?.0 }) {
-                return Err(RuleError::TxInContextFailed(tx.id(), e));
+                } else if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
+                    tx,
+                    block.header.daa_score,
+                    // we most intialize the pmt value to the past median time of the block
+                    if pmt > 0 {
+                        pmt
+                    } else {
+                        self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?.0
+                    },
+                ) {
+                    return Err(RuleError::TxInContextFailed(tx.id(), e));
+                }
             }
         }
-    }
 
         Ok(())
     }

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -4,7 +4,7 @@ use crate::{
     model::stores::{ghostdag::GhostdagStoreReader, statuses::StatusesStoreReader},
     processes::window::WindowManager,
 };
-use kaspa_consensus_core::block::Block;
+use kaspa_consensus_core::{block::Block, constants::LOCK_TIME_THRESHOLD};
 use kaspa_database::prelude::StoreResultExtensions;
 use kaspa_hashes::Hash;
 use kaspa_utils::option::OptionExtensions;
@@ -25,12 +25,25 @@ impl BlockBodyProcessor {
     }
 
     fn check_block_transactions_in_context(self: &Arc<Self>, block: &Block) -> BlockProcessResult<()> {
-        let (pmt, _) = self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?;
-        for tx in block.transactions.iter() {
-            if let Err(e) = self.transaction_validator.utxo_free_tx_validation(tx, block.header.daa_score, pmt) {
+        // calculating the past median time for the block may be expensive here, so we try and avoid it if possible
+        let pmt = 0u64; // we consider 0 to be an uninitialized default value
+        for tx in block.transactions.iter().filter(|tx| tx.lock_time > 0) {
+            if tx.lock_time <= LOCK_TIME_THRESHOLD {
+                if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
+                    tx, 
+                    block.header.daa_score, 
+                    pmt // we don't need the past median time for this case
+                ) {
+                    return Err(RuleError::TxInContextFailed(tx.id(), e));
+            } else if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
+                tx, 
+                block.header.daa_score, 
+                // we most intialize the pmt value to the past median time of the block
+                if pmt != 0 { pmt } else { self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?.0 }) {
                 return Err(RuleError::TxInContextFailed(tx.id(), e));
             }
         }
+    }
 
         Ok(())
     }

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -28,7 +28,8 @@ impl BlockBodyProcessor {
         // calculating the past median time for the block may be expensive here, so we try and avoid it if possible
         let pmt = 0u64; // we consider 0 to be an uninitialized default value
         for tx in block.transactions.iter().filter(|tx| tx.lock_time > 0) {
-            if tx.lock_time <= LOCK_TIME_THRESHOLD {
+            if tx.lock_time < LOCK_TIME_THRESHOLD {
+                // will only check daa score
                 if let Err(e) = self.transaction_validator.utxo_free_tx_validation(
                     tx, 
                     block.header.daa_score, 
@@ -39,7 +40,7 @@ impl BlockBodyProcessor {
                 tx, 
                 block.header.daa_score, 
                 // we most intialize the pmt value to the past median time of the block
-                if pmt != 0 { pmt } else { self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?.0 }) {
+                if pmt > 0 { pmt } else { self.window_manager.calc_past_median_time(&self.ghostdag_store.get_data(block.hash()).unwrap())?.0 }) {
                 return Err(RuleError::TxInContextFailed(tx.id(), e));
             }
         }


### PR DESCRIPTION
Currently we do window sampling for every block body, in order to get the past_median_time, this is required to check transaction lock times. Furthermore this sampling does not benefit from window caches when syncing  as, the cache is only updated via header processing.   


This PR does the pmt check for block bodies lazily, only when required.  