### PR TITLE
Build with debug and strip on pre-release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -83,16 +83,10 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
-            cargo build --bin kaspad --profile=heap
-            cargo build --bin simpa --profile=heap
-            cargo build --bin rothschild --profile=heap
-            cargo build --bin kaspa-wallet --profile=heap
+            cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
           else
             echo "This is a full release"
-            cargo build --bin kaspad --release
-            cargo build --bin simpa --release
-            cargo build --bin rothschild --release
-            cargo build --bin kaspa-wallet --release
+            cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release
           fi           
           mkdir bin || true
           cp target/release/kaspad.exe bin/
@@ -110,17 +104,11 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
-            cargo build --bin kaspad --profile=heap
-            cargo build --bin simpa --profile=heap
-            cargo build --bin rothschild --profile=heap
-            cargo build --bin kaspa-wallet --profile=heap
+            cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
           else
             echo "This is a full release"
-            cargo build --bin kaspad --release
-            cargo build --bin simpa --release
-            cargo build --bin rothschild --release
-            cargo build --bin kaspa-wallet --release
-          fi   
+            cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release
+          fi    
           mkdir bin || true
           cp target/release/kaspad bin/
           cp target/release/simpa bin/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,7 +63,7 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --profile=heap --target x86_64-unknown-linux-musl
-            export BUILD_DIR="heap/release"
+            export BUILD_DIR="heap"
           else
             echo "This is a full release"
             cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --release --target x86_64-unknown-linux-musl
@@ -87,7 +87,7 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
-            export BUILD_DIR="heap/release"
+            export BUILD_DIR="heap"
           else
             echo "This is a full release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release
@@ -110,7 +110,7 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
-            export BUILD_DIR="heap/release"
+            export BUILD_DIR="heap"
           else
             echo "This is a full release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -60,7 +60,13 @@ jobs:
           cd $GITHUB_WORKSPACE
           
           # Build for musl
-          cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --release --target x86_64-unknown-linux-musl
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "This is a pre-release"
+            cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --profile=heap --target x86_64-unknown-linux-musl
+          else
+            echo "This is a full release"
+            cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --release --target x86_64-unknown-linux-musl
+          fi          
           mkdir bin || true
           cp target/x86_64-unknown-linux-musl/release/kaspad bin/
           cp target/x86_64-unknown-linux-musl/release/rothschild bin/
@@ -75,10 +81,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          cargo build --bin kaspad --release
-          cargo build --bin simpa --release
-          cargo build --bin rothschild --release
-          cargo build --bin kaspa-wallet --release
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "This is a pre-release"
+            cargo build --bin kaspad --profile=heap
+            cargo build --bin simpa --profile=heap
+            cargo build --bin rothschild --profile=heap
+            cargo build --bin kaspa-wallet --profile=heap
+          else
+            echo "This is a full release"
+            cargo build --bin kaspad --release
+            cargo build --bin simpa --release
+            cargo build --bin rothschild --release
+            cargo build --bin kaspa-wallet --release
+          fi           
           mkdir bin || true
           cp target/release/kaspad.exe bin/
           cp target/release/simpa.exe bin/
@@ -93,10 +108,19 @@ jobs:
       - name: Build on MacOS
         if: runner.os == 'macOS'
         run: |
-          cargo build --bin kaspad --release
-          cargo build --bin simpa --release
-          cargo build --bin rothschild --release
-          cargo build --bin kaspa-wallet --release
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "This is a pre-release"
+            cargo build --bin kaspad --profile=heap
+            cargo build --bin simpa --profile=heap
+            cargo build --bin rothschild --profile=heap
+            cargo build --bin kaspa-wallet --profile=heap
+          else
+            echo "This is a full release"
+            cargo build --bin kaspad --release
+            cargo build --bin simpa --release
+            cargo build --bin rothschild --release
+            cargo build --bin kaspa-wallet --release
+          fi   
           mkdir bin || true
           cp target/release/kaspad bin/
           cp target/release/simpa bin/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,14 +63,17 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --profile=heap --target x86_64-unknown-linux-musl
+            export BUILD_DIR="heap/release"
           else
             echo "This is a full release"
             cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --release --target x86_64-unknown-linux-musl
-          fi          
+            export BUILD_DIR="release"
+          fi
+          
           mkdir bin || true
-          cp target/x86_64-unknown-linux-musl/release/kaspad bin/
-          cp target/x86_64-unknown-linux-musl/release/rothschild bin/
-          cp target/x86_64-unknown-linux-musl/release/kaspa-wallet bin/
+          cp target/x86_64-unknown-linux-musl/$BUILD_DIR/kaspad bin/
+          cp target/x86_64-unknown-linux-musl/$BUILD_DIR/rothschild bin/
+          cp target/x86_64-unknown-linux-musl/$BUILD_DIR/kaspa-wallet bin/
           archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
           asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
           zip -r "${archive}" ./bin/*
@@ -84,15 +87,17 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
+            export BUILD_DIR="heap/release"
           else
             echo "This is a full release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release
+            export BUILD_DIR="release"
           fi           
           mkdir bin || true
-          cp target/release/kaspad.exe bin/
-          cp target/release/simpa.exe bin/
-          cp target/release/rothschild.exe bin/
-          cp target/release/kaspa-wallet.exe bin/
+          cp target/$BUILD_DIR/kaspad.exe bin/
+          cp target/$BUILD_DIR/simpa.exe bin/
+          cp target/$BUILD_DIR/rothschild.exe bin/
+          cp target/$BUILD_DIR/kaspa-wallet.exe bin/
           archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-win64.zip"
           asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-win64.zip"
           powershell "Compress-Archive bin/* \"${archive}\""
@@ -105,15 +110,17 @@ jobs:
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             echo "This is a pre-release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --profile=heap
+            export BUILD_DIR="heap/release"
           else
             echo "This is a full release"
             cargo build --bin kaspad --bin simpa --bin rothschild --bin kaspa-wallet --release
+            export BUILD_DIR="release"
           fi    
           mkdir bin || true
-          cp target/release/kaspad bin/
-          cp target/release/simpa bin/
-          cp target/release/rothschild bin/
-          cp target/release/kaspa-wallet bin/
+          cp target/$BUILD_DIR/kaspad bin/
+          cp target/$BUILD_DIR/simpa bin/
+          cp target/$BUILD_DIR/rothschild bin/
+          cp target/$BUILD_DIR/kaspa-wallet bin/
           archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-osx.zip"
           asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-osx.zip"
           zip -r "${archive}" ./bin/*


### PR DESCRIPTION
**What is this**
This conditionally compiles RK binaries with `--profile=heap` in the case that the current release is a pre-release.

**How**
We utilize the Github API `github.event.release.prerelease` variable.

**Why**
It seems reasonable that all RC builds (pre-releases) are built with debug enabled and strip disabled. This makes it easier for us as developers to debug potential bugs, crashes etc.