### PR TITLE
15 rc4 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "0.14.5"
+version = "0.14.7"
 dependencies = [
  "futures",
  "kaspa-rpc-core",

--- a/metrics/core/src/data.rs
+++ b/metrics/core/src/data.rs
@@ -922,7 +922,7 @@ pub fn as_data_size(bytes: f64, si: bool) -> String {
 }
 
 /// Format supplied value as a float with 2 decimal places.
-fn format_as_float(f: f64, short: bool) -> String {
+pub fn format_as_float(f: f64, short: bool) -> String {
     if short {
         if f < 1000.0 {
             format_with_precision(f)

--- a/wallet/core/src/imports.rs
+++ b/wallet/core/src/imports.rs
@@ -24,7 +24,9 @@ pub use crate::wallet::*;
 pub use crate::{storage, utils};
 
 pub use ahash::{AHashMap, AHashSet};
-pub use async_std::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
+pub use async_std::sync::{
+    Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, RwLock as AsyncRwLock, RwLockReadGuard as AsyncRwLockReadGuard,
+};
 pub use async_trait::async_trait;
 pub use borsh::{BorshDeserialize, BorshSerialize};
 pub use cfg_if::cfg_if;

--- a/wallet/core/src/utxo/processor.rs
+++ b/wallet/core/src/utxo/processor.rs
@@ -33,8 +33,6 @@ use kaspa_rpc_core::{
     notify::connection::{ChannelConnection, ChannelType},
     Notification,
 };
-// use workflow_core::task;
-// use kaspa_metrics_core::{Metrics,Metric};
 
 pub struct Inner {
     /// Coinbase UTXOs in stasis
@@ -58,7 +56,7 @@ pub struct Inner {
     sync_proc: SyncMonitor,
     multiplexer: Multiplexer<Box<Events>>,
     wallet_bus: Option<Channel<WalletBusMessage>>,
-    notification_guard: AsyncMutex<()>,
+    notification_guard: AsyncRwLock<()>,
     connect_disconnect_guard: AsyncMutex<()>,
     metrics: Arc<Metrics>,
     metrics_kinds: Mutex<Vec<MetricsUpdateKind>>,
@@ -161,8 +159,8 @@ impl UtxoProcessor {
         &self.inner.multiplexer
     }
 
-    pub async fn notification_lock(&self) -> AsyncMutexGuard<()> {
-        self.inner.notification_guard.lock().await
+    pub async fn notification_lock(&self) -> AsyncRwLockReadGuard<()> {
+        self.inner.notification_guard.read().await
     }
 
     pub fn sync_proc(&self) -> &SyncMonitor {
@@ -577,7 +575,7 @@ impl UtxoProcessor {
     }
 
     async fn handle_notification(&self, notification: Notification) -> Result<()> {
-        let _lock = self.notification_lock().await;
+        let _lock = self.inner.notification_guard.write().await;
 
         match notification {
             Notification::VirtualDaaScoreChanged(virtual_daa_score_changed_notification) => {

--- a/wallet/core/src/utxo/scan.rs
+++ b/wallet/core/src/utxo/scan.rs
@@ -96,10 +96,7 @@ impl Scan {
             yield_executor().await;
 
             if !resp.is_empty() {
-                println!("Generating UTXO references...");
-
                 let refs: Vec<UtxoEntryReference> = resp.into_iter().map(UtxoEntryReference::from).collect();
-                println!("Processing UTXO reference indexes...");
                 for utxo_ref in refs.iter() {
                     if let Some(address) = utxo_ref.utxo.address.as_ref() {
                         if let Some(utxo_address_index) = address_manager.inner().address_to_index_map.get(address) {
@@ -112,7 +109,6 @@ impl Scan {
                     }
                 }
 
-                println!("Calculating balance...");
                 let balance: Balance = refs.iter().fold(Balance::default(), |mut balance, r| {
                     let entry_balance = r.balance(params, self.current_daa_score);
                     balance.mature += entry_balance.mature;
@@ -123,10 +119,8 @@ impl Scan {
                     balance
                 });
 
-                println!("Extending from scan...");
                 utxo_context.extend_from_scan(refs, self.current_daa_score).await?;
 
-                println!("Adding balance...");
                 self.balance.add(balance);
             } else {
                 match &extent {
@@ -147,7 +141,6 @@ impl Scan {
 
         // update address manager with the last used index
         address_manager.set_index(last_address_index)?;
-        println!("Scan complete...");
 
         Ok(())
     }


### PR DESCRIPTION
- Fix an issue in the metrics client that results in the first metrics snapshot having invalid values (by skipping first snapshot).
- Fix `extend_from_scan()` functionality of the `UtxoContext` resulting in long processing times for UTXO sets containing more than 500k UTXOs.