### PR TITLE
Fix WASM interface typo for `normalBuckets` and `lowBuckets` in `IFeerateBucket`

### DIFF
--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1567,12 +1567,12 @@ declare! {
          * to sample enough "interesting" points on the feerate-to-time curve, so that the interpolation is meaningful.
          */
 
-        normalBucket : IFeerateBucket[];
+        normalBuckets : IFeerateBucket[];
         /**
         * An array of *low* priority feerate values. The first value of this vector is guaranteed to
         * exist and provide an estimation for sub-*hour* DAG inclusion.
         */
-        lowBucket : IFeerateBucket[];
+        lowBuckets : IFeerateBucket[];
     }
     "#,
 }


### PR DESCRIPTION
Plural is used for these two fields https://github.com/kaspanet/rusty-kaspa/blob/f335376be8d720f709f04f3d12fe27a5dea5535f/rpc/core/src/wasm/message.rs#L1602-L1603