### PR TITLE
Release builds will use `lto = false` instead of thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,7 +326,6 @@ workflow-wasm = { version = "0.18.0" }
 # nw-sys = { path = "../nw-sys" }
 
 [profile.release]
-lto = "thin"
 strip = true
 overflow-checks = true
 


### PR DESCRIPTION
* breaks x86_64-pc-windows-gnullvm target on Windows as with llvm optimization it is impossible to link clang libc++ statically. The gnullvm target is needed as it will link ucrt instead of msvc and allow running it without VC runtime. In theory it should make a fix possible for: kaspanet/rusty-kaspa#417

* occasionally lead to node crashes in futures crate, especially when mixed with unsafe and C/C++ code. It is hard to reproduce, but at least with the from scratch reproduces the crash relatively often.