### PR TITLE
Cleanup legacy bip39 cfg flags interfering with docs.rs documentation builds

### DIFF
--- a/wallet/bip32/src/mnemonic/mod.rs
+++ b/wallet/bip32/src/mnemonic/mod.rs
@@ -7,7 +7,6 @@ mod bits;
 mod language;
 mod phrase;
 
-//#[cfg(feature = "bip39")]
 pub(crate) mod seed;
 
 pub use self::{language::Language, phrase::Mnemonic, phrase::WordCount};

--- a/wallet/bip32/src/mnemonic/phrase.rs
+++ b/wallet/bip32/src/mnemonic/phrase.rs
@@ -229,8 +229,6 @@ impl Mnemonic {
     }
 
     /// Convert this mnemonic phrase into the BIP39 seed value.
-    //#[cfg(feature = "bip39")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
     pub fn to_seed(&self, password: &str) -> Seed {
         let salt = Zeroizing::new(format!("mnemonic{password}"));
         let mut seed = [0u8; Seed::SIZE];

--- a/wallet/bip32/src/mnemonic/seed.rs
+++ b/wallet/bip32/src/mnemonic/seed.rs
@@ -4,7 +4,6 @@ use zeroize::Zeroize;
 
 /// BIP39 seeds.
 // TODO(tarcieri): support for 32-byte seeds
-#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
 pub struct Seed(pub(crate) [u8; Seed::SIZE]);
 
 impl Seed {


### PR DESCRIPTION
Kaspa fork of the `bip32` crate inherited a `bip39` feature which has been removed as `bip39` (mnemonic handling) is an integral part of the `kaspa-bip32` crate.  However, a left-over `cfg_attr()` gate was not noticed as it was specific for `docs.rs` resulting in docs.rs build failure.  This PR cleans this up.
