### PR TITLE
Parallelize MuHash calculations

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -81,6 +81,7 @@ use kaspa_database::prelude::StoreResultExtensions;
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
 use kaspa_txscript::caches::TxScriptCacheCounters;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use std::{
     cmp::Reverse,
@@ -771,9 +772,21 @@ impl ConsensusApi for Consensus {
     fn append_imported_pruning_point_utxos(&self, utxoset_chunk: &[(TransactionOutpoint, UtxoEntry)], current_multiset: &mut MuHash) {
         let mut pruning_utxoset_write = self.pruning_utxoset_stores.write();
         pruning_utxoset_write.utxo_set.write_many(utxoset_chunk).unwrap();
-        for (outpoint, entry) in utxoset_chunk {
-            current_multiset.add_utxo(outpoint, entry);
-        }
+
+        // Parallelize processing
+        let inner_multiset = utxoset_chunk
+            .par_iter()
+            .map(|(outpoint, entry)| {
+                let mut inner_multiset = MuHash::new();
+                inner_multiset.add_utxo(outpoint, entry);
+                inner_multiset
+            })
+            .reduce(MuHash::new, |mut a, b| {
+                a.combine(&b);
+                a
+            });
+
+        current_multiset.combine(&inner_multiset);
     }
 
     fn import_pruning_point_utxo_set(&self, new_pruning_point: Hash, imported_utxo_multiset: MuHash) -> PruningImportResult<()> {

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1097,7 +1097,7 @@ impl VirtualStateProcessor {
 
         // Validate transactions of the pruning point itself
         let new_pruning_point_transactions = self.block_transactions_store.get(new_pruning_point).unwrap();
-        let (validated_transactions, _) = self.validate_transactions_in_parallel(
+        let validated_transactions = self.validate_transactions_in_parallel(
             &new_pruning_point_transactions,
             &virtual_read.utxo_set,
             new_pruning_point_header.daa_score,

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1094,7 +1094,7 @@ impl VirtualStateProcessor {
 
         // Validate transactions of the pruning point itself
         let new_pruning_point_transactions = self.block_transactions_store.get(new_pruning_point).unwrap();
-        let validated_transactions = self.validate_transactions_in_parallel(
+        let (validated_transactions, _) = self.validate_transactions_in_parallel(
             &new_pruning_point_transactions,
             &virtual_read.utxo_set,
             new_pruning_point_header.daa_score,

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -356,6 +356,8 @@ impl VirtualStateProcessor {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
+
     use super::*;
 
     #[test]
@@ -378,9 +380,9 @@ mod tests {
 
         println!("collected len: {}", collected.len());
 
-        collected.iter().enumerate().skip(1).for_each(|(idx, curr_data)| {
+        collected.iter().tuple_windows().for_each(|(prev, curr)| {
             // Data was originally sorted, so we check if they remain sorted after filtering
-            assert!(collected[idx - 1] < *curr_data);
+            assert!(prev < curr, "expected {} < {} if original sort was preserved", prev, curr);
         });
 
         let reduced: SmallVec<[u16; 2]> = data
@@ -402,9 +404,9 @@ mod tests {
 
         println!("reduced len: {}", reduced.len());
 
-        reduced.iter().enumerate().skip(1).for_each(|(idx, curr_data)| {
+        reduced.iter().tuple_windows().for_each(|(prev, curr)| {
             // Data was originally sorted, so we check if they remain sorted after filtering
-            assert!(reduced[idx - 1] < *curr_data);
+            assert!(prev < curr, "expected {} < {} if original sort was preserved", prev, curr);
         });
     }
 }


### PR DESCRIPTION
Parallelize parts of the muhash calculations (`add_utxo` and `add_transaction`) then later combine results so we can delegate the heavier work to multiple threads.