### PR TITLE
Standartize fork activation logic

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -138,10 +138,10 @@ impl Params {
     #[inline]
     #[must_use]
     pub fn past_median_time_window_size(&self, selected_parent_daa_score: u64) -> usize {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            self.legacy_past_median_time_window_size()
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.sampled_past_median_time_window_size()
+        } else {
+            self.legacy_past_median_time_window_size()
         }
     }
 
@@ -150,10 +150,10 @@ impl Params {
     #[inline]
     #[must_use]
     pub fn timestamp_deviation_tolerance(&self, selected_parent_daa_score: u64) -> u64 {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            self.legacy_timestamp_deviation_tolerance
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.new_timestamp_deviation_tolerance
+        } else {
+            self.legacy_timestamp_deviation_tolerance
         }
     }
 
@@ -162,10 +162,10 @@ impl Params {
     #[inline]
     #[must_use]
     pub fn past_median_time_sample_rate(&self, selected_parent_daa_score: u64) -> u64 {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            1
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.past_median_time_sample_rate
+        } else {
+            1
         }
     }
 
@@ -174,10 +174,10 @@ impl Params {
     #[inline]
     #[must_use]
     pub fn difficulty_window_size(&self, selected_parent_daa_score: u64) -> usize {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            self.legacy_difficulty_window_size
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.sampled_difficulty_window_size
+        } else {
+            self.legacy_difficulty_window_size
         }
     }
 
@@ -186,10 +186,10 @@ impl Params {
     #[inline]
     #[must_use]
     pub fn difficulty_sample_rate(&self, selected_parent_daa_score: u64) -> u64 {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            1
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.difficulty_sample_rate
+        } else {
+            1
         }
     }
 
@@ -209,18 +209,18 @@ impl Params {
     }
 
     pub fn daa_window_duration_in_blocks(&self, selected_parent_daa_score: u64) -> u64 {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            self.legacy_difficulty_window_size as u64
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.difficulty_sample_rate * self.sampled_difficulty_window_size as u64
+        } else {
+            self.legacy_difficulty_window_size as u64
         }
     }
 
     fn expected_daa_window_duration_in_milliseconds(&self, selected_parent_daa_score: u64) -> u64 {
-        if !self.sampling_activation.is_active(selected_parent_daa_score) {
-            self.target_time_per_block * self.legacy_difficulty_window_size as u64
-        } else {
+        if self.sampling_activation.is_active(selected_parent_daa_score) {
             self.target_time_per_block * self.difficulty_sample_rate * self.sampled_difficulty_window_size as u64
+        } else {
+            self.target_time_per_block * self.legacy_difficulty_window_size as u64
         }
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -257,7 +257,7 @@ impl Consensus {
             pruning_lock.clone(),
             notification_root.clone(),
             counters.clone(),
-            params.storage_mass_activation_daa_score,
+            params.storage_mass_activation,
         ));
 
         let virtual_processor = Arc::new(VirtualStateProcessor::new(
@@ -753,7 +753,7 @@ impl ConsensusApi for Consensus {
     }
 
     fn calc_transaction_hash_merkle_root(&self, txs: &[Transaction], pov_daa_score: u64) -> Hash {
-        let storage_mass_activated = pov_daa_score > self.config.storage_mass_activation_daa_score;
+        let storage_mass_activated = self.config.storage_mass_activation.is_active(pov_daa_score);
         calc_hash_merkle_root(txs.iter(), storage_mass_activated)
     }
 

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -94,7 +94,7 @@ impl ConsensusServices {
             storage.block_window_cache_for_past_median_time.clone(),
             params.max_difficulty_target,
             params.target_time_per_block,
-            params.sampling_activation_daa_score,
+            params.sampling_activation,
             params.legacy_difficulty_window_size,
             params.sampled_difficulty_window_size,
             params.min_difficulty_window_len,
@@ -146,7 +146,7 @@ impl ConsensusServices {
             params.coinbase_maturity,
             tx_script_cache_counters,
             mass_calculator.clone(),
-            params.storage_mass_activation_daa_score,
+            params.storage_mass_activation,
         );
 
         let pruning_point_manager = PruningPointManager::new(

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -6,7 +6,7 @@ use kaspa_consensus_core::{block::Block, merkle::calc_hash_merkle_root, tx::Tran
 
 impl BlockBodyProcessor {
     pub fn validate_body_in_isolation(self: &Arc<Self>, block: &Block) -> BlockProcessResult<u64> {
-        let storage_mass_activated = block.header.daa_score > self.storage_mass_activation_daa_score;
+        let storage_mass_activated = self.storage_mass_activation.is_active(block.header.daa_score);
 
         Self::check_has_transactions(block)?;
         Self::check_hash_merkle_root(block, storage_mass_activated)?;

--- a/consensus/src/pipeline/body_processor/processor.rs
+++ b/consensus/src/pipeline/body_processor/processor.rs
@@ -23,7 +23,7 @@ use crossbeam_channel::{Receiver, Sender};
 use kaspa_consensus_core::{
     block::Block,
     blockstatus::BlockStatus::{self, StatusHeaderOnly, StatusInvalid},
-    config::genesis::GenesisBlock,
+    config::{genesis::GenesisBlock, params::ForkActivation},
     mass::MassCalculator,
     tx::Transaction,
 };
@@ -81,7 +81,7 @@ pub struct BlockBodyProcessor {
     counters: Arc<ProcessingCounters>,
 
     /// Storage mass hardfork DAA score
-    pub(crate) storage_mass_activation_daa_score: u64,
+    pub(crate) storage_mass_activation: ForkActivation,
 }
 
 impl BlockBodyProcessor {
@@ -108,7 +108,7 @@ impl BlockBodyProcessor {
         pruning_lock: SessionLock,
         notification_root: Arc<ConsensusNotificationRoot>,
         counters: Arc<ProcessingCounters>,
-        storage_mass_activation_daa_score: u64,
+        storage_mass_activation: ForkActivation,
     ) -> Self {
         Self {
             receiver,
@@ -131,7 +131,7 @@ impl BlockBodyProcessor {
             task_manager: BlockTaskDependencyManager::new(),
             notification_root,
             counters,
-            storage_mass_activation_daa_score,
+            storage_mass_activation,
         }
     }
 

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -52,7 +52,7 @@ use kaspa_consensus_core::{
     block::{BlockTemplate, MutableBlock, TemplateBuildMode, TemplateTransactionSelector},
     blockstatus::BlockStatus::{StatusDisqualifiedFromChain, StatusUTXOValid},
     coinbase::MinerData,
-    config::genesis::GenesisBlock,
+    config::{genesis::GenesisBlock, params::ForkActivation},
     header::Header,
     merkle::calc_hash_merkle_root,
     pruning::PruningPointsList,
@@ -159,7 +159,7 @@ pub struct VirtualStateProcessor {
     counters: Arc<ProcessingCounters>,
 
     // Storage mass hardfork DAA score
-    pub(crate) storage_mass_activation_daa_score: u64,
+    pub(crate) storage_mass_activation: ForkActivation,
 }
 
 impl VirtualStateProcessor {
@@ -220,7 +220,7 @@ impl VirtualStateProcessor {
             pruning_lock,
             notification_root,
             counters,
-            storage_mass_activation_daa_score: params.storage_mass_activation_daa_score,
+            storage_mass_activation: params.storage_mass_activation,
         }
     }
 
@@ -983,7 +983,7 @@ impl VirtualStateProcessor {
         let parents_by_level = self.parents_manager.calc_block_parents(pruning_info.pruning_point, &virtual_state.parents);
 
         // Hash according to hardfork activation
-        let storage_mass_activated = virtual_state.daa_score > self.storage_mass_activation_daa_score;
+        let storage_mass_activated = self.storage_mass_activation.is_active(virtual_state.daa_score);
         let hash_merkle_root = calc_hash_merkle_root(txs.iter(), storage_mass_activated);
 
         let accepted_id_merkle_root = kaspa_merkle::calc_merkle_root(virtual_state.accepted_tx_ids.iter().copied());

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -14,6 +14,7 @@ use kaspa_consensus_core::{
     acceptance_data::{AcceptedTxEntry, MergesetBlockAcceptanceData},
     api::args::TransactionValidationArgs,
     coinbase::*,
+    config::params::ForkActivation,
     hashing,
     header::Header,
     mass::Kip9Version,
@@ -328,7 +329,8 @@ impl VirtualStateProcessor {
 
         // For non-activated nets (mainnet, TN10) we can update mempool rules to KIP9 beta asap. For
         // TN11 we need to hard-fork consensus first (since the new beta rules are more permissive)
-        let kip9_version = if self.storage_mass_activation_daa_score == u64::MAX { Kip9Version::Beta } else { Kip9Version::Alpha };
+        let kip9_version =
+            if self.storage_mass_activation == ForkActivation::never() { Kip9Version::Beta } else { Kip9Version::Alpha };
 
         // Calc the full contextual mass including storage mass
         let contextual_mass = self

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -11,7 +11,7 @@ use kaspa_txscript::{
     SigCacheKey,
 };
 
-use kaspa_consensus_core::mass::MassCalculator;
+use kaspa_consensus_core::{config::params::ForkActivation, mass::MassCalculator};
 
 #[derive(Clone)]
 pub struct TransactionValidator {
@@ -27,7 +27,7 @@ pub struct TransactionValidator {
     pub(crate) mass_calculator: MassCalculator,
 
     /// Storage mass hardfork DAA score
-    storage_mass_activation_daa_score: u64,
+    storage_mass_activation: ForkActivation,
 }
 
 impl TransactionValidator {
@@ -41,7 +41,7 @@ impl TransactionValidator {
         coinbase_maturity: u64,
         counters: Arc<TxScriptCacheCounters>,
         mass_calculator: MassCalculator,
-        storage_mass_activation_daa_score: u64,
+        storage_mass_activation: ForkActivation,
     ) -> Self {
         Self {
             max_tx_inputs,
@@ -53,7 +53,7 @@ impl TransactionValidator {
             coinbase_maturity,
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator,
-            storage_mass_activation_daa_score,
+            storage_mass_activation,
         }
     }
 
@@ -77,7 +77,7 @@ impl TransactionValidator {
             coinbase_maturity,
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator: MassCalculator::new(0, 0, 0, 0),
-            storage_mass_activation_daa_score: u64::MAX,
+            storage_mass_activation: ForkActivation::never(),
         }
     }
 }

--- a/consensus/src/processes/transaction_validator/transaction_validator_populated.rs
+++ b/consensus/src/processes/transaction_validator/transaction_validator_populated.rs
@@ -44,13 +44,14 @@ impl TransactionValidator {
         let total_in = self.check_transaction_input_amounts(tx)?;
         let total_out = Self::check_transaction_output_values(tx, total_in)?;
         let fee = total_in - total_out;
-        if flags != TxValidationFlags::SkipMassCheck && pov_daa_score > self.storage_mass_activation_daa_score {
+        if flags != TxValidationFlags::SkipMassCheck && self.storage_mass_activation.is_active(pov_daa_score) {
             // Storage mass hardfork was activated
             self.check_mass_commitment(tx)?;
 
-            if pov_daa_score < self.storage_mass_activation_daa_score + 10 && self.storage_mass_activation_daa_score > 0 {
-                warn!("--------- Storage mass hardfork was activated successfully!!! --------- (DAA score: {})", pov_daa_score);
-            }
+            // TODO: Decide what to do here
+            // if pov_daa_score < self.storage_mass_activation + 10 && self.storage_mass_activation > 0 {
+            //     warn!("--------- Storage mass hardfork was activated successfully!!! --------- (DAA score: {})", pov_daa_score);
+            // }
         }
         Self::check_sequence_lock(tx, pov_daa_score)?;
 

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -13,7 +13,7 @@ use kaspa_consensus::{
         headers::HeaderStoreReader,
         relations::RelationsStoreReader,
     },
-    params::{Params, Testnet11Bps, DEVNET_PARAMS, NETWORK_DELAY_BOUND, TESTNET11_PARAMS},
+    params::{ForkActivation, Params, Testnet11Bps, DEVNET_PARAMS, NETWORK_DELAY_BOUND, TESTNET11_PARAMS},
 };
 use kaspa_consensus_core::{
     api::ConsensusApi, block::Block, blockstatus::BlockStatus, config::bps::calculate_ghostdag_k, errors::block::BlockProcessResult,
@@ -189,7 +189,7 @@ fn main_impl(mut args: Args) {
     }
     args.bps = if args.testnet11 { Testnet11Bps::bps() as f64 } else { args.bps };
     let mut params = if args.testnet11 { TESTNET11_PARAMS } else { DEVNET_PARAMS };
-    params.storage_mass_activation_daa_score = 400;
+    params.storage_mass_activation = ForkActivation::new(400);
     params.storage_mass_parameter = 10_000;
     let mut builder = ConfigBuilder::new(params)
         .apply_args(|config| apply_args_to_consensus_params(&args, &mut config.params))
@@ -306,12 +306,12 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
 
         if args.daa_legacy {
             // Scale DAA and median-time windows linearly with BPS
-            params.sampling_activation_daa_score = u64::MAX;
+            params.sampling_activation = ForkActivation::never();
             params.legacy_timestamp_deviation_tolerance = (params.legacy_timestamp_deviation_tolerance as f64 * args.bps) as u64;
             params.legacy_difficulty_window_size = (params.legacy_difficulty_window_size as f64 * args.bps) as usize;
         } else {
             // Use the new sampling algorithms
-            params.sampling_activation_daa_score = 0;
+            params.sampling_activation = ForkActivation::always();
             params.past_median_time_sample_rate = (10.0 * args.bps) as u64;
             params.new_timestamp_deviation_tolerance = (600.0 * args.bps) as u64;
             params.difficulty_sample_rate = (2.0 * args.bps) as u64;

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -16,7 +16,9 @@ use kaspa_consensus::model::stores::headers::HeaderStoreReader;
 use kaspa_consensus::model::stores::reachability::DbReachabilityStore;
 use kaspa_consensus::model::stores::relations::DbRelationsStore;
 use kaspa_consensus::model::stores::selected_chain::SelectedChainStoreReader;
-use kaspa_consensus::params::{Params, DEVNET_PARAMS, MAINNET_PARAMS, MAX_DIFFICULTY_TARGET, MAX_DIFFICULTY_TARGET_AS_F64};
+use kaspa_consensus::params::{
+    ForkActivation, Params, DEVNET_PARAMS, MAINNET_PARAMS, MAX_DIFFICULTY_TARGET, MAX_DIFFICULTY_TARGET_AS_F64,
+};
 use kaspa_consensus::pipeline::monitor::ConsensusMonitor;
 use kaspa_consensus::pipeline::ProcessingCounters;
 use kaspa_consensus::processes::reachability::tests::{DagBlock, DagBuilder, StoreValidationExtensions};
@@ -553,7 +555,7 @@ async fn median_time_test() {
             config: ConfigBuilder::new(MAINNET_PARAMS)
                 .skip_proof_of_work()
                 .edit_consensus_params(|p| {
-                    p.sampling_activation_daa_score = u64::MAX;
+                    p.sampling_activation = ForkActivation::never();
                 })
                 .build(),
         },
@@ -562,7 +564,7 @@ async fn median_time_test() {
             config: ConfigBuilder::new(MAINNET_PARAMS)
                 .skip_proof_of_work()
                 .edit_consensus_params(|p| {
-                    p.sampling_activation_daa_score = 0;
+                    p.sampling_activation = ForkActivation::always();
                     p.new_timestamp_deviation_tolerance = 120;
                     p.past_median_time_sample_rate = 3;
                     p.past_median_time_sampled_window_size = (2 * 120 - 1) / 3;
@@ -807,7 +809,7 @@ impl KaspadGoParams {
             past_median_time_sample_rate: 1,
             past_median_time_sampled_window_size: 2 * self.TimestampDeviationTolerance - 1,
             target_time_per_block: self.TargetTimePerBlock / 1_000_000,
-            sampling_activation_daa_score: u64::MAX,
+            sampling_activation: ForkActivation::never(),
             max_block_parents: self.MaxBlockParents,
             max_difficulty_target: MAX_DIFFICULTY_TARGET,
             max_difficulty_target_f64: MAX_DIFFICULTY_TARGET_AS_F64,
@@ -830,7 +832,7 @@ impl KaspadGoParams {
             mass_per_sig_op: self.MassPerSigOp,
             max_block_mass: self.MaxBlockMass,
             storage_mass_parameter: STORAGE_MASS_PARAMETER,
-            storage_mass_activation_daa_score: u64::MAX,
+            storage_mass_activation: ForkActivation::never(),
             deflationary_phase_daa_score: self.DeflationaryPhaseDaaScore,
             pre_deflationary_phase_base_subsidy: self.PreDeflationaryPhaseBaseSubsidy,
             coinbase_maturity: MAINNET_PARAMS.coinbase_maturity,
@@ -1388,7 +1390,7 @@ async fn difficulty_test() {
                 .edit_consensus_params(|p| {
                     p.ghostdag_k = 1;
                     p.legacy_difficulty_window_size = FULL_WINDOW_SIZE;
-                    p.sampling_activation_daa_score = u64::MAX;
+                    p.sampling_activation = ForkActivation::never();
                     // Define past median time so that calls to add_block_with_min_time create blocks
                     // which timestamps fit within the min-max timestamps found in the difficulty window
                     p.legacy_timestamp_deviation_tolerance = 60;
@@ -1404,7 +1406,7 @@ async fn difficulty_test() {
                     p.ghostdag_k = 1;
                     p.sampled_difficulty_window_size = SAMPLED_WINDOW_SIZE;
                     p.difficulty_sample_rate = SAMPLE_RATE;
-                    p.sampling_activation_daa_score = 0;
+                    p.sampling_activation = ForkActivation::always();
                     // Define past median time so that calls to add_block_with_min_time create blocks
                     // which timestamps fit within the min-max timestamps found in the difficulty window
                     p.past_median_time_sample_rate = PMT_SAMPLE_RATE;
@@ -1423,7 +1425,7 @@ async fn difficulty_test() {
                     p.target_time_per_block /= HIGH_BPS;
                     p.sampled_difficulty_window_size = HIGH_BPS_SAMPLED_WINDOW_SIZE;
                     p.difficulty_sample_rate = SAMPLE_RATE * HIGH_BPS;
-                    p.sampling_activation_daa_score = 0;
+                    p.sampling_activation = ForkActivation::always();
                     // Define past median time so that calls to add_block_with_min_time create blocks
                     // which timestamps fit within the min-max timestamps found in the difficulty window
                     p.past_median_time_sample_rate = PMT_SAMPLE_RATE * HIGH_BPS;


### PR DESCRIPTION
To avoid confusion where in one place someone will use `>=`  for fork activation logic, and in other place `>`, I introduced a newtype around uint64 to avoid such mistakes and enforce everyone to check with `is_active`