### PR TITLE
Pruning proof minor improvements

### DIFF
--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         tx::TxResult,
     },
     header::Header,
-    pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
+    pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList, PruningProofMetadata},
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath,
@@ -203,7 +203,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn validate_pruning_proof(&self, proof: &PruningPointProof) -> PruningImportResult<()> {
+    fn validate_pruning_proof(&self, proof: &PruningPointProof, proof_metadata: &PruningProofMetadata) -> PruningImportResult<()> {
         unimplemented!()
     }
 

--- a/consensus/core/src/errors/pruning.rs
+++ b/consensus/core/src/errors/pruning.rs
@@ -59,6 +59,9 @@ pub enum PruningImportError {
 
     #[error("process exit was initiated while validating pruning point proof")]
     PruningValidationInterrupted,
+
+    #[error("block {0} at level {1} has invalid proof of work for level")]
+    ProofOfWorkFailed(Hash, BlockLevel),
 }
 
 pub type PruningImportResult<T> = std::result::Result<T, PruningImportError>;

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -41,6 +41,10 @@ pub mod utxo;
 /// overall blocks, so 2^192 is definitely a justified upper-bound.
 pub type BlueWorkType = kaspa_math::Uint192;
 
+/// The extends directly from the expectation above about having no more than
+/// 2^128 work in a single block
+pub const MAX_WORK_LEVEL: BlockLevel = 128;
+
 /// The type used to represent the GHOSTDAG K parameter
 pub type KType = u16;
 

--- a/consensus/core/src/pruning.rs
+++ b/consensus/core/src/pruning.rs
@@ -23,20 +23,12 @@ pub struct PruningPointTrustedData {
 
 #[derive(Clone, Copy)]
 pub struct PruningProofMetadata {
-    relay_block_blue_work: BlueWorkType,
+    /// The claimed work of the initial relay block (from the prover)
+    pub relay_block_blue_work: BlueWorkType,
 }
 
 impl PruningProofMetadata {
     pub fn new(relay_block_blue_work: BlueWorkType) -> Self {
         Self { relay_block_blue_work }
-    }
-
-    /// The amount of blue work since the syncer's pruning point
-    pub fn claimed_prover_relay_work(&self, pruning_point_work: BlueWorkType) -> BlueWorkType {
-        if self.relay_block_blue_work <= pruning_point_work {
-            return 0.into();
-        }
-
-        self.relay_block_blue_work - pruning_point_work
     }
 }

--- a/consensus/core/src/pruning.rs
+++ b/consensus/core/src/pruning.rs
@@ -1,6 +1,7 @@
 use crate::{
     header::Header,
     trusted::{TrustedGhostdagData, TrustedHeader},
+    BlueWorkType,
 };
 use kaspa_hashes::Hash;
 use std::sync::Arc;
@@ -18,4 +19,24 @@ pub struct PruningPointTrustedData {
 
     /// Union of GHOSTDAG data required to verify blocks in the future of the pruning point
     pub ghostdag_blocks: Vec<TrustedGhostdagData>,
+}
+
+#[derive(Clone, Copy)]
+pub struct PruningProofMetadata {
+    relay_block_blue_work: BlueWorkType,
+}
+
+impl PruningProofMetadata {
+    pub fn new(relay_block_blue_work: BlueWorkType) -> Self {
+        Self { relay_block_blue_work }
+    }
+
+    /// The amount of blue work since the syncer's pruning point
+    pub fn claimed_prover_relay_work(&self, pruning_point_work: BlueWorkType) -> BlueWorkType {
+        if self.relay_block_blue_work <= pruning_point_work {
+            return 0.into();
+        }
+
+        self.relay_block_blue_work - pruning_point_work
+    }
 }

--- a/consensus/pow/src/lib.rs
+++ b/consensus/pow/src/lib.rs
@@ -65,6 +65,11 @@ pub fn calc_block_level_check_pow(header: &Header, max_block_level: BlockLevel) 
 
     let state = State::new(header);
     let (passed, pow) = state.check_pow(header.nonce);
+    let block_level = calc_level_from_pow(pow, max_block_level);
+    (block_level, passed)
+}
+
+pub fn calc_level_from_pow(pow: Uint256, max_block_level: BlockLevel) -> BlockLevel {
     let signed_block_level = max_block_level as i64 - pow.bits() as i64;
-    (max(signed_block_level, 0) as BlockLevel, passed)
+    max(signed_block_level, 0) as BlockLevel
 }

--- a/consensus/pow/src/lib.rs
+++ b/consensus/pow/src/lib.rs
@@ -54,12 +54,17 @@ impl State {
 }
 
 pub fn calc_block_level(header: &Header, max_block_level: BlockLevel) -> BlockLevel {
+    let (block_level, _) = calc_block_level_check_pow(header, max_block_level);
+    block_level
+}
+
+pub fn calc_block_level_check_pow(header: &Header, max_block_level: BlockLevel) -> (BlockLevel, bool) {
     if header.parents_by_level.is_empty() {
-        return max_block_level; // Genesis has the max block level
+        return (max_block_level, true); // Genesis has the max block level
     }
 
     let state = State::new(header);
-    let (_, pow) = state.check_pow(header.nonce);
+    let (passed, pow) = state.check_pow(header.nonce);
     let signed_block_level = max_block_level as i64 - pow.bits() as i64;
-    max(signed_block_level, 0) as BlockLevel
+    (max(signed_block_level, 0) as BlockLevel, passed)
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -64,7 +64,7 @@ use kaspa_consensus_core::{
     merkle::calc_hash_merkle_root,
     muhash::MuHashExtensions,
     network::NetworkType,
-    pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList},
+    pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList, PruningProofMetadata},
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{MutableTransaction, Transaction, TransactionOutpoint, UtxoEntry},
     BlockHashSet, BlueWorkType, ChainPath, HashMapCustomHasher,
@@ -757,8 +757,12 @@ impl ConsensusApi for Consensus {
         calc_hash_merkle_root(txs.iter(), storage_mass_activated)
     }
 
-    fn validate_pruning_proof(&self, proof: &PruningPointProof) -> Result<(), PruningImportError> {
-        self.services.pruning_proof_manager.validate_pruning_point_proof(proof)
+    fn validate_pruning_proof(
+        &self,
+        proof: &PruningPointProof,
+        proof_metadata: &PruningProofMetadata,
+    ) -> Result<(), PruningImportError> {
+        self.services.pruning_proof_manager.validate_pruning_point_proof(proof, proof_metadata)
     }
 
     fn apply_pruning_proof(&self, proof: PruningPointProof, trusted_set: &[TrustedBlock]) -> PruningImportResult<()> {

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     processes::{
-        block_depth::BlockDepthManager, coinbase::CoinbaseManager, ghostdag::protocol::GhostdagManager,
+        block_depth::BlockDepthManager, coinbase::CoinbaseManager, difficulty::level_work, ghostdag::protocol::GhostdagManager,
         parents_builder::ParentsManager, pruning::PruningPointManager, pruning_proof::PruningProofManager, sync::SyncManager,
         transaction_validator::TransactionValidator, traversal_manager::DagTraversalManager, window::DualWindowManager,
     },
@@ -118,7 +118,7 @@ impl ConsensusServices {
             relations_services[0].clone(),
             storage.headers_store.clone(),
             reachability_service.clone(),
-            false,
+            level_work(0, config.max_block_level),
         );
 
         let coinbase_manager = CoinbaseManager::new(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     processes::{
-        block_depth::BlockDepthManager, coinbase::CoinbaseManager, difficulty::level_work, ghostdag::protocol::GhostdagManager,
+        block_depth::BlockDepthManager, coinbase::CoinbaseManager, ghostdag::protocol::GhostdagManager,
         parents_builder::ParentsManager, pruning::PruningPointManager, pruning_proof::PruningProofManager, sync::SyncManager,
         transaction_validator::TransactionValidator, traversal_manager::DagTraversalManager, window::DualWindowManager,
     },
@@ -118,7 +118,6 @@ impl ConsensusServices {
             relations_services[0].clone(),
             storage.headers_store.clone(),
             reachability_service.clone(),
-            level_work(0, config.max_block_level),
         );
 
         let coinbase_manager = CoinbaseManager::new(

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -9,7 +9,7 @@ use kaspa_consensus_core::header::Header;
 use kaspa_consensus_core::BlockLevel;
 use kaspa_core::time::unix_now;
 use kaspa_database::prelude::StoreResultExtensions;
-use std::cmp::max;
+use kaspa_pow::calc_level_from_pow;
 
 impl HeaderProcessor {
     /// Validates the header in isolation including pow check against header declared bits.
@@ -102,8 +102,7 @@ impl HeaderProcessor {
         let state = kaspa_pow::State::new(header);
         let (passed, pow) = state.check_pow(header.nonce);
         if passed || self.skip_proof_of_work {
-            let signed_block_level = self.max_block_level as i64 - pow.bits() as i64;
-            Ok(max(signed_block_level, 0) as BlockLevel)
+            Ok(calc_level_from_pow(pow, self.max_block_level))
         } else {
             Err(RuleError::InvalidPoW)
         }

--- a/consensus/src/processes/difficulty.rs
+++ b/consensus/src/processes/difficulty.rs
@@ -289,6 +289,7 @@ pub fn level_work(level: u8, max_block_level: u8) -> BlueWorkType {
     if level == 0 {
         return 0.into();
     }
+    // We use 256 here so the result corresponds to the work at the level from calc_block_level
     let exp = (level as u32) + 256 - (max_block_level as u32);
     BlueWorkType::from_u64(1) << exp.min(MAX_WORK_LEVEL)
 }

--- a/consensus/src/processes/difficulty.rs
+++ b/consensus/src/processes/difficulty.rs
@@ -287,7 +287,7 @@ pub fn level_work(level: u8, max_block_level: u8) -> BlueWorkType {
     if level == 0 {
         return 0.into();
     }
-    // We use 256 here so the result corresponds to the work at the level from calc_block_level
+    // We use 256 here so the result corresponds to the work at the level from calc_level_from_pow
     let exp = (level as u32) + 256 - (max_block_level as u32);
     BlueWorkType::from_u64(1) << exp.min(MAX_WORK_LEVEL as u32)
 }
@@ -320,10 +320,9 @@ impl Ord for DifficultyBlock {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::max;
-
     use kaspa_consensus_core::{BlockLevel, BlueWorkType, MAX_WORK_LEVEL};
     use kaspa_math::{Uint256, Uint320};
+    use kaspa_pow::calc_level_from_pow;
 
     use crate::processes::difficulty::{calc_work, level_work};
     use kaspa_utils::hex::ToHex;
@@ -335,8 +334,7 @@ mod tests {
             // required pow for level
             let level_target = (Uint320::from_u64(1) << (max_block_level - level).max(MAX_WORK_LEVEL) as u32) - Uint320::from_u64(1);
             let level_target = Uint256::from_be_bytes(level_target.to_be_bytes()[8..40].try_into().unwrap());
-            let signed_block_level = max_block_level as i64 - level_target.bits() as i64;
-            let calculated_level = max(signed_block_level, 0) as BlockLevel;
+            let calculated_level = calc_level_from_pow(level_target, max_block_level);
 
             let true_level_work = calc_work(level_target.compact_target_bits());
             let calc_level_work = level_work(level, max_block_level);

--- a/consensus/src/processes/ghostdag/protocol.rs
+++ b/consensus/src/processes/ghostdag/protocol.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use kaspa_consensus_core::{
     blockhash::{self, BlockHashExtensions, BlockHashes},
-    BlockHashMap, BlueWorkType, HashMapCustomHasher,
+    BlockHashMap, BlockLevel, BlueWorkType, HashMapCustomHasher,
 };
 use kaspa_hashes::Hash;
 use kaspa_utils::refs::Refs;
@@ -16,7 +16,7 @@ use crate::{
             relations::RelationsStoreReader,
         },
     },
-    processes::difficulty::calc_work,
+    processes::difficulty::{calc_work, level_work},
 };
 
 use super::ordering::*;
@@ -29,7 +29,15 @@ pub struct GhostdagManager<T: GhostdagStoreReader, S: RelationsStoreReader, U: R
     pub(super) relations_store: S,
     pub(super) headers_store: Arc<V>,
     pub(super) reachability_service: U,
-    expected_level_work: BlueWorkType,
+
+    /// Level work is a lower-bound for the amount of work represented by each block.
+    /// When running GD for higher-level sub-DAGs, this value should be set accordingly
+    /// to the work represented by that level, and then used as a lower bound
+    /// for the work calculated from header bits (which depends on current difficulty).
+    /// For instance, assuming level 80 (i.e., pow hash has at least 80 zeros) is always
+    /// above the difficulty target, all blocks in it should represent the same amount of
+    /// work regardless of whether current difficulty requires 20 zeros or 25 zeros.  
+    level_work: BlueWorkType,
 }
 
 impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V: HeaderStoreReader> GhostdagManager<T, S, U, V> {
@@ -40,9 +48,30 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
         relations_store: S,
         headers_store: Arc<V>,
         reachability_service: U,
-        expected_level_work: BlueWorkType,
     ) -> Self {
-        Self { genesis_hash, k, ghostdag_store, relations_store, reachability_service, headers_store, expected_level_work }
+        // For ordinary GD, always keep level_work=0 so the lower bound is ineffective
+        Self { genesis_hash, k, ghostdag_store, relations_store, reachability_service, headers_store, level_work: 0.into() }
+    }
+
+    pub fn with_level(
+        genesis_hash: Hash,
+        k: KType,
+        ghostdag_store: Arc<T>,
+        relations_store: S,
+        headers_store: Arc<V>,
+        reachability_service: U,
+        level: BlockLevel,
+        max_block_level: BlockLevel,
+    ) -> Self {
+        Self {
+            genesis_hash,
+            k,
+            ghostdag_store,
+            relations_store,
+            reachability_service,
+            headers_store,
+            level_work: level_work(level, max_block_level),
+        }
     }
 
     pub fn genesis_ghostdag_data(&self) -> GhostdagData {
@@ -115,20 +144,19 @@ impl<T: GhostdagStoreReader, S: RelationsStoreReader, U: ReachabilityService, V:
             }
         }
 
+        // Handle the special case of origin children first
+        if selected_parent.is_origin() {
+            // ORIGIN is always a single parent so both blue score and work should remain zero
+            return new_block_data;
+        }
+
         let blue_score = self.ghostdag_store.get_blue_score(selected_parent).unwrap() + new_block_data.mergeset_blues.len() as u64;
 
         let added_blue_work: BlueWorkType = new_block_data
             .mergeset_blues
             .iter()
             .cloned()
-            .map(|hash| {
-                if hash.is_origin() {
-                    0.into()
-                } else {
-                    let true_work = calc_work(self.headers_store.get_bits(hash).unwrap());
-                    true_work.max(self.expected_level_work)
-                }
-            })
+            .map(|hash| calc_work(self.headers_store.get_bits(hash).unwrap()).max(self.level_work))
             .sum();
         let blue_work: BlueWorkType = self.ghostdag_store.get_blue_work(selected_parent).unwrap() + added_blue_work;
 

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -148,7 +148,7 @@ impl PruningProofManager {
         let mut up_heap = BinaryHeap::with_capacity(capacity_estimate);
         for header in proof.iter().flatten().cloned() {
             if let Vacant(e) = dag.entry(header.hash) {
-                // TODO: Check if pow passes
+                // pow passing has already been checked during validation
                 let block_level = calc_block_level(&header, self.max_block_level);
                 self.headers_store.insert(header.hash, header.clone(), block_level).unwrap();
 

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -2,7 +2,7 @@ use std::{cmp::Reverse, collections::BinaryHeap, sync::Arc};
 
 use itertools::Itertools;
 use kaspa_consensus_core::{
-    blockhash::{BlockHashExtensions, BlockHashes, ORIGIN},
+    blockhash::{BlockHashExtensions, BlockHashes},
     header::Header,
     pruning::PruningPointProof,
     BlockHashSet, BlockLevel, HashMapCustomHasher,
@@ -342,17 +342,14 @@ impl PruningProofManager {
             self.max_block_level,
         );
 
+        // Note there is no need to initialize origin since we have a single root
         ghostdag_store.insert(root, Arc::new(gd_manager.genesis_ghostdag_data())).unwrap();
-        ghostdag_store.insert(ORIGIN, gd_manager.origin_ghostdag_data()).unwrap();
 
         let mut topological_heap: BinaryHeap<_> = Default::default();
         let mut visited = BlockHashSet::new();
         for child in relations_service.get_children(root).unwrap().read().iter().copied() {
-            topological_heap.push(Reverse(SortableBlock {
-                hash: child,
-                // It's important to use here blue work and not score so we can iterate the heap in a way that respects the topology
-                blue_work: self.headers_store.get_header(child).unwrap().blue_work,
-            }));
+            topological_heap
+                .push(Reverse(SortableBlock { hash: child, blue_work: self.headers_store.get_header(child).unwrap().blue_work }));
         }
 
         let mut has_required_block = required_block.is_some_and(|required_block| root == required_block);
@@ -379,11 +376,8 @@ impl PruningProofManager {
             ghostdag_store.insert(current_hash, Arc::new(current_gd)).unwrap_or_exists();
 
             for child in relations_service.get_children(current_hash).unwrap().read().iter().copied() {
-                topological_heap.push(Reverse(SortableBlock {
-                    hash: child,
-                    // It's important to use here blue work and not score so we can iterate the heap in a way that respects the topology
-                    blue_work: self.headers_store.get_header(child).unwrap().blue_work,
-                }));
+                topological_heap
+                    .push(Reverse(SortableBlock { hash: child, blue_work: self.headers_store.get_header(child).unwrap().blue_work }));
             }
         }
 

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -21,6 +21,7 @@ use crate::{
         },
     },
     processes::{
+        difficulty::level_work,
         ghostdag::{ordering::SortableBlock, protocol::GhostdagManager},
         pruning_proof::PruningProofManagerInternalError,
     },
@@ -338,7 +339,7 @@ impl PruningProofManager {
             relations_service.clone(),
             self.headers_store.clone(),
             self.reachability_service.clone(),
-            level != 0,
+            level_work(level, self.max_block_level),
         );
 
         ghostdag_store.insert(root, Arc::new(gd_manager.genesis_ghostdag_data())).unwrap();

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -21,7 +21,6 @@ use crate::{
         },
     },
     processes::{
-        difficulty::level_work,
         ghostdag::{ordering::SortableBlock, protocol::GhostdagManager},
         pruning_proof::PruningProofManagerInternalError,
     },
@@ -332,14 +331,15 @@ impl PruningProofManager {
             reachability_service: self.reachability_service.clone(),
             root,
         };
-        let gd_manager = GhostdagManager::new(
+        let gd_manager = GhostdagManager::with_level(
             root,
             self.ghostdag_k,
             ghostdag_store.clone(),
             relations_service.clone(),
             self.headers_store.clone(),
             self.reachability_service.clone(),
-            level_work(level, self.max_block_level),
+            level,
+            self.max_block_level,
         );
 
         ghostdag_store.insert(root, Arc::new(gd_manager.genesis_ghostdag_data())).unwrap();

--- a/consensus/src/processes/pruning_proof/validate.rs
+++ b/consensus/src/processes/pruning_proof/validate.rs
@@ -32,10 +32,7 @@ use crate::{
             relations::{DbRelationsStore, RelationsStoreReader},
         },
     },
-    processes::{
-        difficulty::level_work, ghostdag::protocol::GhostdagManager, reachability::inquirer as reachability,
-        relations::RelationsStoreExtensions,
-    },
+    processes::{ghostdag::protocol::GhostdagManager, reachability::inquirer as reachability, relations::RelationsStoreExtensions},
 };
 
 use super::{PruningProofManager, TempProofContext};
@@ -210,14 +207,15 @@ impl PruningProofManager {
             .cloned()
             .enumerate()
             .map(|(level, ghostdag_store)| {
-                GhostdagManager::new(
+                GhostdagManager::with_level(
                     self.genesis_hash,
                     self.ghostdag_k,
                     ghostdag_store,
                     relations_stores[level].clone(),
                     headers_store.clone(),
                     reachability_services[level].clone(),
-                    level_work(level as BlockLevel, self.max_block_level),
+                    level as BlockLevel,
+                    self.max_block_level,
                 )
             })
             .collect_vec();

--- a/consensus/src/processes/pruning_proof/validate.rs
+++ b/consensus/src/processes/pruning_proof/validate.rs
@@ -31,7 +31,10 @@ use crate::{
             relations::{DbRelationsStore, RelationsStoreReader},
         },
     },
-    processes::{ghostdag::protocol::GhostdagManager, reachability::inquirer as reachability, relations::RelationsStoreExtensions},
+    processes::{
+        difficulty::level_work, ghostdag::protocol::GhostdagManager, reachability::inquirer as reachability,
+        relations::RelationsStoreExtensions,
+    },
 };
 
 use super::{PruningProofManager, TempProofContext};
@@ -194,7 +197,7 @@ impl PruningProofManager {
                     relations_stores[level].clone(),
                     headers_store.clone(),
                     reachability_services[level].clone(),
-                    level != 0,
+                    level_work(level as BlockLevel, self.max_block_level),
                 )
             })
             .collect_vec();

--- a/math/src/uint.rs
+++ b/math/src/uint.rs
@@ -158,6 +158,18 @@ macro_rules! construct_uint {
                 (self, carry)
             }
 
+            #[inline]
+            pub fn saturating_sub(self, other: Self) -> Self {
+                let (sum, carry) = self.overflowing_sub(other);
+                if carry { Self::ZERO } else { sum }
+            }
+
+            #[inline]
+            pub fn saturating_add(self, other: Self) -> Self {
+                let (sum, carry) = self.overflowing_add(other);
+                if carry { Self::MAX } else { sum }
+            }
+
             /// Multiplication by u64
             #[inline]
             pub fn overflowing_mul_u64(self, other: u64) -> (Self, bool) {
@@ -1148,6 +1160,19 @@ mod tests {
                 assert_eq!(mine, Uint128::from_hex(&str_buf).unwrap());
             }
         }
+    }
+
+    #[test]
+    fn test_saturating_ops() {
+        let u1 = Uint128::from_u128(u128::MAX);
+        let u2 = Uint128::from_u64(u64::MAX);
+        // Sub
+        assert_eq!(u1.saturating_sub(u2), Uint128::from_u128(u128::MAX - u64::MAX as u128));
+        assert_eq!(u1.saturating_sub(u2).as_u128(), u128::MAX - u64::MAX as u128);
+        assert_eq!(u2.saturating_sub(u1), Uint128::ZERO);
+        // Add
+        assert_eq!(u1.saturating_add(Uint128::from_u64(1)), Uint128::MAX);
+        assert_eq!(u2.saturating_add(Uint128::from_u64(1)), Uint128::from_u128(u64::MAX as u128 + 1));
     }
 
     #[test]


### PR DESCRIPTION
## Changes
- On validating pruning proof, check pow to ensure level blocks have valid work
- Standardize level work - set a minimum amount of work per level to create a more uniform comparable blue work at higher levels
- Better pruning proof comparison between current consensus and syncer's proof