### PR TITLE
Implement Retention Period Support

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -255,8 +255,8 @@ impl ConsensusSessionOwned {
     }
 
     /// source refers to the earliest block from which the current node has full header & block data  
-    pub async fn async_get_source(&self) -> Hash {
-        self.clone().spawn_blocking(|c| c.get_source()).await
+    pub async fn async_get_retention_root(&self) -> Hash {
+        self.clone().spawn_blocking(|c| c.get_retention_root()).await
     }
 
     pub async fn async_estimate_block_count(&self) -> BlockCount {

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -254,7 +254,7 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(move |c| c.get_current_block_color(hash)).await
     }
 
-    /// source refers to the earliest block from which the current node has full header & block data  
+    /// retention root refers to the earliest block from which the current node has full header & block data  
     pub async fn async_get_retention_root(&self) -> Hash {
         self.clone().spawn_blocking(|c| c.get_retention_root()).await
     }

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -254,7 +254,7 @@ impl ConsensusSessionOwned {
         self.clone().spawn_blocking(move |c| c.get_current_block_color(hash)).await
     }
 
-    /// retention root refers to the earliest block from which the current node has full header & block data  
+    /// retention period root refers to the earliest block from which the current node has full header & block data  
     pub async fn async_get_retention_period_root(&self) -> Hash {
         self.clone().spawn_blocking(|c| c.get_retention_period_root()).await
     }

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -255,8 +255,8 @@ impl ConsensusSessionOwned {
     }
 
     /// retention root refers to the earliest block from which the current node has full header & block data  
-    pub async fn async_get_retention_root(&self) -> Hash {
-        self.clone().spawn_blocking(|c| c.get_retention_root()).await
+    pub async fn async_get_retention_period_root(&self) -> Hash {
+        self.clone().spawn_blocking(|c| c.get_retention_period_root()).await
     }
 
     pub async fn async_estimate_block_count(&self) -> BlockCount {

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -144,7 +144,7 @@ pub trait ConsensusApi: Send + Sync {
     }
 
     /// source refers to the earliest block from which the current node has full header & block data  
-    fn get_source(&self) -> Hash {
+    fn get_retention_root(&self) -> Hash {
         unimplemented!()
     }
 

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -143,7 +143,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    /// source refers to the earliest block from which the current node has full header & block data  
+    /// retention root refers to the earliest block from which the current node has full header & block data  
     fn get_retention_root(&self) -> Hash {
         unimplemented!()
     }

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -143,8 +143,8 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    /// retention root refers to the earliest block from which the current node has full header & block data  
-    fn get_retention_root(&self) -> Hash {
+    /// retention period root refers to the earliest block from which the current node has full header & block data  
+    fn get_retention_period_root(&self) -> Hash {
         unimplemented!()
     }
 

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -68,6 +68,9 @@ pub struct Config {
 
     /// A scale factor to apply to memory allocation bounds
     pub ram_scale: f64,
+
+    /// The number of days to keep data for
+    pub retention_period_days: f64,
 }
 
 impl Config {
@@ -95,6 +98,7 @@ impl Config {
             initial_utxo_set: Default::default(),
             disable_upnp: false,
             ram_scale: 1.0,
+            retention_period_days: 3.0,
         }
     }
 

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -98,7 +98,7 @@ impl Config {
             initial_utxo_set: Default::default(),
             disable_upnp: false,
             ram_scale: 1.0,
-            retention_period_days: 3.0,
+            retention_period_days: 0.0,
         }
     }
 

--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -70,7 +70,7 @@ pub struct Config {
     pub ram_scale: f64,
 
     /// The number of days to keep data for
-    pub retention_period_days: f64,
+    pub retention_period_days: Option<f64>,
 }
 
 impl Config {
@@ -98,7 +98,7 @@ impl Config {
             initial_utxo_set: Default::default(),
             disable_upnp: false,
             ram_scale: 1.0,
-            retention_period_days: 0.0,
+            retention_period_days: None,
         }
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -623,9 +623,7 @@ impl ConsensusApi for Consensus {
 
     fn get_retention_root(&self) -> Hash {
         let pruning_point_read = self.pruning_point_store.read();
-        pruning_point_read
-            .retention_period_root()
-            .unwrap_or(pruning_point_read.history_root().unwrap_or(pruning_point_read.pruning_point().unwrap()))
+        pruning_point_read.retention_period_root().unwrap_or(pruning_point_read.pruning_point().unwrap())
     }
 
     /// Estimates number of blocks and headers stored in the node

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -634,7 +634,7 @@ impl ConsensusApi for Consensus {
     /// as such, it does not include non-daa blocks, and does not include headers stored as part of the pruning proof.  
     fn estimate_block_count(&self) -> BlockCount {
         // PRUNE SAFETY: node is either archival or source is the pruning point which its header is kept permanently
-        let source_score = self.headers_store.get_compact_header_data(self.get_retention_root()).unwrap().daa_score;
+        let retention_root_score = self.headers_store.get_compact_header_data(self.get_retention_root()).unwrap().daa_score;
         let virtual_score = self.get_virtual_daa_score();
         let header_count = self
             .headers_store
@@ -643,8 +643,8 @@ impl ConsensusApi for Consensus {
             .map(|h| h.daa_score)
             .unwrap_or(virtual_score)
             .max(virtual_score)
-            - source_score;
-        let block_count = virtual_score - source_score;
+            - retention_root_score;
+        let block_count = virtual_score - retention_root_score;
         BlockCount { header_count, block_count }
     }
 
@@ -667,7 +667,7 @@ impl ConsensusApi for Consensus {
         // Verify that the block exists
         self.validate_block_exists(low)?;
 
-        // Verify that source is on chain(block)
+        // Verify that retention root is on chain(block)
         self.services
             .reachability_service
             .is_chain_ancestor_of(self.get_retention_root(), low)

--- a/consensus/src/model/stores/pruning.rs
+++ b/consensus/src/model/stores/pruning.rs
@@ -39,10 +39,16 @@ pub trait PruningStoreReader {
     fn get(&self) -> StoreResult<PruningPointInfo>;
 
     /// Represent the point after which data is fully held (i.e., history is consecutive from this point and up to virtual).
-    /// This is usually the pruning point, though it might lag a bit behind until data prune completes (and for archival
-    /// nodes it will remain the initial syncing point or the last pruning point before turning to an archive)
-    fn history_root(&self) -> StoreResult<Hash>;
+    /// This is usually a pruning point that is at or below the retention period requirement (and for archival
+    /// nodes it will remain the initial syncing point or the last pruning point before turning to an archive).
+    /// At every pruning point movement, this is adjusted to the next pruning point sample that satisfies the required
+    /// retention period.
     fn retention_period_root(&self) -> StoreResult<Hash>;
+
+    // During pruning, this is a reference to the retention root before the pruning point move.
+    // After pruning, this is updated to point to the retention period root.
+    // This checkpoint used to determine if pruning has successfully completed.
+    fn retention_checkpoint(&self) -> StoreResult<Hash>;
 }
 
 pub trait PruningStore: PruningStoreReader {
@@ -54,7 +60,7 @@ pub trait PruningStore: PruningStoreReader {
 pub struct DbPruningStore {
     db: Arc<DB>,
     access: CachedDbItem<PruningPointInfo>,
-    history_root_access: CachedDbItem<Hash>,
+    retention_checkpoint_access: CachedDbItem<Hash>,
     retention_period_root_access: CachedDbItem<Hash>,
 }
 
@@ -63,7 +69,7 @@ impl DbPruningStore {
         Self {
             db: Arc::clone(&db),
             access: CachedDbItem::new(db.clone(), DatabaseStorePrefixes::PruningPoint.into()),
-            history_root_access: CachedDbItem::new(db.clone(), DatabaseStorePrefixes::HistoryRoot.into()),
+            retention_checkpoint_access: CachedDbItem::new(db.clone(), DatabaseStorePrefixes::RetentionCheckpoint.into()),
             retention_period_root_access: CachedDbItem::new(db, DatabaseStorePrefixes::RetentionPeriodRoot.into()),
         }
     }
@@ -76,8 +82,8 @@ impl DbPruningStore {
         self.access.write(BatchDbWriter::new(batch), &PruningPointInfo { pruning_point, candidate, index })
     }
 
-    pub fn set_history_root(&mut self, batch: &mut WriteBatch, history_root: Hash) -> StoreResult<()> {
-        self.history_root_access.write(BatchDbWriter::new(batch), &history_root)
+    pub fn set_retention_checkpoint(&mut self, batch: &mut WriteBatch, retention_checkpoint: Hash) -> StoreResult<()> {
+        self.retention_checkpoint_access.write(BatchDbWriter::new(batch), &retention_checkpoint)
     }
 
     pub fn set_retention_period_root(&mut self, batch: &mut WriteBatch, retention_period_root: Hash) -> StoreResult<()> {
@@ -102,8 +108,8 @@ impl PruningStoreReader for DbPruningStore {
         self.access.read()
     }
 
-    fn history_root(&self) -> StoreResult<Hash> {
-        self.history_root_access.read()
+    fn retention_checkpoint(&self) -> StoreResult<Hash> {
+        self.retention_checkpoint_access.read()
     }
 
     fn retention_period_root(&self) -> StoreResult<Hash> {

--- a/consensus/src/model/stores/pruning.rs
+++ b/consensus/src/model/stores/pruning.rs
@@ -47,7 +47,7 @@ pub trait PruningStoreReader {
 
     // During pruning, this is a reference to the retention root before the pruning point move.
     // After pruning, this is updated to point to the retention period root.
-    // This checkpoint used to determine if pruning has successfully completed.
+    // This checkpoint is used to determine if pruning has successfully completed.
     fn retention_checkpoint(&self) -> StoreResult<Hash>;
 }
 

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -569,10 +569,10 @@ impl PruningProcessor {
                     retention_period_root_ts_target,
                 );
 
-                while retention_period_root != new_retention_period_root {
+                while self.reachability_service.is_dag_ancestor_of(retention_period_root, new_retention_period_root) {
                     let block = new_retention_period_root;
 
-                    let timestamp = self.headers_store.get_compact_header_data(block).unwrap().timestamp;
+                    let timestamp = self.headers_store.get_timestamp(block).unwrap();
                     trace!("block | timestamp = {} | {}", block, timestamp);
                     if timestamp < retention_period_root_ts_target {
                         trace!("block {} timestamp {} >= {}", block, timestamp, retention_period_root_ts_target);

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -542,8 +542,8 @@ impl PruningProcessor {
         }
     }
 
-    /// Adjusts the retention period root forward until the maximum chain block is reached that covers the retention period.
-    /// This is the last chain block B such that B.timestamp < retention_period_days_ago. This may return the old hash if
+    /// Adjusts the retention period root to latest pruning point sample that covers the retention period.
+    /// This is the pruning point sample B such that B.timestamp <= retention_period_days_ago. This may return the old hash if
     /// the retention period cannot be covered yet with the node's current history.
     ///
     /// This function is expected to be called only when a new pruning point is determined and right before
@@ -574,7 +574,7 @@ impl PruningProcessor {
 
                     let timestamp = self.headers_store.get_timestamp(block).unwrap();
                     trace!("block | timestamp = {} | {}", block, timestamp);
-                    if timestamp < retention_period_root_ts_target {
+                    if timestamp <= retention_period_root_ts_target {
                         trace!("block {} timestamp {} >= {}", block, timestamp, retention_period_root_ts_target);
                         // We are now at a pruning point that is at or below our retention period target
                         break;

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -533,7 +533,7 @@ impl PruningProcessor {
         }
 
         {
-            // Set the history root to the new pruning point only after we successfully pruned its past
+            // Set the retention checkpoint to the new retention root only after we successfully pruned its past
             let mut pruning_point_write = self.pruning_point_store.write();
             let mut batch = WriteBatch::default();
             pruning_point_write.set_retention_checkpoint(&mut batch, retention_period_root).unwrap();

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -182,14 +182,8 @@ impl PruningProcessor {
         );
 
         if !new_pruning_points.is_empty() {
-            let retention_period_root = if let Ok(retention_period_root) = pruning_point_read.retention_period_root() {
-                retention_period_root
-            } else if let Ok(history_root) = pruning_point_read.history_root() {
-                history_root
-            } else {
-                // pruning point always exist
-                pruning_point_read.pruning_point().unwrap()
-            };
+            let retention_period_root =
+                pruning_point_read.retention_period_root().unwrap_or(pruning_point_read.pruning_point().unwrap());
 
             // Update past pruning points and pruning point stores
             let mut batch = WriteBatch::default();

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -176,7 +176,7 @@ impl PruningProcessor {
             current_pruning_info.pruning_point,
         );
 
-        if !new_pruning_points.is_empty() {
+        if let Some(new_pruning_point) = new_pruning_points.last().copied() {
             let retention_period_root = pruning_point_read.retention_period_root().unwrap();
 
             // Update past pruning points and pruning point stores
@@ -186,7 +186,7 @@ impl PruningProcessor {
                 self.past_pruning_points_store.insert_batch(&mut batch, current_pruning_info.index + i as u64 + 1, past_pp).unwrap();
             }
             let new_pp_index = current_pruning_info.index + new_pruning_points.len() as u64;
-            let new_pruning_point = *new_pruning_points.last().unwrap();
+            
             let adjusted_retention_period_root = self.advance_retention_period_root(retention_period_root, new_pruning_point);
             pruning_point_write.set_batch(&mut batch, new_pruning_point, new_candidate, new_pp_index).unwrap();
             pruning_point_write.set_retention_period_root(&mut batch, adjusted_retention_period_root).unwrap();

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -547,44 +547,54 @@ impl PruningProcessor {
     /// the retention period cannot be covered yet with the node's current history.
     ///
     /// This function is expected to be called only when a new pruning point is determined and right before
-    /// doing any pruning.
+    /// doing any pruning. Pruning point must be the new pruning point this node is advancing to.
     ///
     /// retention_period_root is guaranteed to be in the past(pruning_point)
     fn advance_retention_period_root(&self, retention_period_root: Hash, pruning_point: Hash) -> Hash {
-        // The retention period in milliseconds we need to cover
-        let retention_period_ms = (self.config.retention_period_days * 86400.0 * 1000.0).ceil() as u64;
+        match self.config.retention_period_days {
+            // If the retention period wasn't set, immediately default to the pruning point.
+            None => pruning_point,
+            Some(retention_period_days) => {
+                // The retention period in milliseconds we need to cover
+                // Note: If retention period is set to an amount lower than what the new pruning point would cover
+                // this function will simply return the new pruning point. The new pruning point passed as an argument
+                // to this function serves as a clamp.
+                let retention_period_ms = (retention_period_days * 86400.0 * 1000.0).ceil() as u64;
 
-        let retention_period_root_ts_target = unix_now().saturating_sub(retention_period_ms);
-        let mut new_retention_period_root = pruning_point;
+                let retention_period_root_ts_target = unix_now().saturating_sub(retention_period_ms);
+                let mut new_retention_period_root = pruning_point;
 
-        trace!(
-            "Adjusting the retention period root to cover the required retention period. Target timestamp: {}",
-            retention_period_root_ts_target,
-        );
+                trace!(
+                    "Adjusting the retention period root to cover the required retention period. Target timestamp: {}",
+                    retention_period_root_ts_target,
+                );
 
-        while retention_period_root != new_retention_period_root {
-            let block = new_retention_period_root;
+                while retention_period_root != new_retention_period_root {
+                    let block = new_retention_period_root;
 
-            let timestamp = self.headers_store.get_compact_header_data(block).unwrap().timestamp;
-            trace!("block | timestamp = {} | {}", block, timestamp);
-            if timestamp < retention_period_root_ts_target {
-                trace!("block {} timestamp {} >= {}", block, timestamp, retention_period_root_ts_target);
-                // We are now at a pruning point that is at or below our retention period target
-                break;
+                    let timestamp = self.headers_store.get_compact_header_data(block).unwrap().timestamp;
+                    trace!("block | timestamp = {} | {}", block, timestamp);
+                    if timestamp < retention_period_root_ts_target {
+                        trace!("block {} timestamp {} >= {}", block, timestamp, retention_period_root_ts_target);
+                        // We are now at a pruning point that is at or below our retention period target
+                        break;
+                    }
+
+                    new_retention_period_root =
+                        self.pruning_samples_store.pruning_sample_from_pov(block).unwrap_or(retention_period_root);
+                }
+
+                // We may be at a pruning sample that's in the past or anticone of current retention_period_root. Clamp to retention_period_root here.
+                // Happens when the node is newly started and retention_period_root itself still doesn't cover the full retention period.
+                let is_new_root_in_future_of_old =
+                    self.reachability_service.is_dag_ancestor_of(retention_period_root, new_retention_period_root);
+                if !is_new_root_in_future_of_old {
+                    new_retention_period_root = retention_period_root;
+                }
+
+                new_retention_period_root
             }
-
-            new_retention_period_root = self.pruning_samples_store.pruning_sample_from_pov(block).unwrap_or(retention_period_root);
         }
-
-        // We may be at a pruning sample that's in the past or anticone of current retention_period_root. Clamp to retention_period_root here.
-        // Happens when the node is newly started and retention_period_root itself still doesn't cover the full retention period.
-        let is_new_root_in_future_of_old =
-            self.reachability_service.is_dag_ancestor_of(retention_period_root, new_retention_period_root);
-        if !is_new_root_in_future_of_old {
-            new_retention_period_root = retention_period_root;
-        }
-
-        new_retention_period_root
     }
 
     fn past_pruning_points(&self) -> BlockHashSet {

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1115,6 +1115,7 @@ impl VirtualStateProcessor {
             self.past_pruning_points_store.insert_batch(&mut batch, 0, self.genesis.hash).unwrap_or_exists();
             pruning_point_write.set_batch(&mut batch, self.genesis.hash, self.genesis.hash, 0).unwrap();
             pruning_point_write.set_history_root(&mut batch, self.genesis.hash).unwrap();
+            pruning_point_write.set_retention_period_root(&mut batch, self.genesis.hash).unwrap();
             pruning_utxoset_write.set_utxoset_position(&mut batch, self.genesis.hash).unwrap();
             self.db.write(batch).unwrap();
             drop(pruning_point_write);

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1114,7 +1114,7 @@ impl VirtualStateProcessor {
             let mut batch = WriteBatch::default();
             self.past_pruning_points_store.insert_batch(&mut batch, 0, self.genesis.hash).unwrap_or_exists();
             pruning_point_write.set_batch(&mut batch, self.genesis.hash, self.genesis.hash, 0).unwrap();
-            pruning_point_write.set_history_root(&mut batch, self.genesis.hash).unwrap();
+            pruning_point_write.set_retention_checkpoint(&mut batch, self.genesis.hash).unwrap();
             pruning_point_write.set_retention_period_root(&mut batch, self.genesis.hash).unwrap();
             pruning_utxoset_write.set_utxoset_position(&mut batch, self.genesis.hash).unwrap();
             self.db.write(batch).unwrap();

--- a/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
@@ -24,21 +24,21 @@ impl VirtualStateProcessor {
         &self,
         txid: Hash,
         accepting_block_daa_score: u64,
-        retention_root_hash: Hash,
+        retention_period_root_hash: Hash,
     ) -> Result<SignableTransaction, UtxoInquirerError> {
-        let retention_root_daa_score = self
+        let retention_period_root_daa_score = self
             .headers_store
-            .get_compact_header_data(retention_root_hash)
+            .get_compact_header_data(retention_period_root_hash)
             .map(|compact_header| compact_header.daa_score)
-            .map_err(|_| UtxoInquirerError::MissingCompactHeaderForBlockHash(retention_root_hash))?;
+            .map_err(|_| UtxoInquirerError::MissingCompactHeaderForBlockHash(retention_period_root_hash))?;
 
-        if accepting_block_daa_score < retention_root_daa_score {
+        if accepting_block_daa_score < retention_period_root_daa_score {
             // Early exit if target daa score is lower than that of pruning point's daa score:
             return Err(UtxoInquirerError::AlreadyPruned);
         }
 
         let (matching_chain_block_hash, acceptance_data) =
-            self.find_accepting_chain_block_hash_at_daa_score(accepting_block_daa_score, retention_root_hash)?;
+            self.find_accepting_chain_block_hash_at_daa_score(accepting_block_daa_score, retention_period_root_hash)?;
 
         // Expected to never fail, since we found the acceptance data and therefore there must be matching diff
         let utxo_diff = self
@@ -86,12 +86,13 @@ impl VirtualStateProcessor {
     fn find_accepting_chain_block_hash_at_daa_score(
         &self,
         target_daa_score: u64,
-        retention_root_hash: Hash,
+        retention_period_root_hash: Hash,
     ) -> Result<(Hash, Arc<AcceptanceData>), UtxoInquirerError> {
         let sc_read = self.selected_chain_store.read();
 
-        let retention_root_index =
-            sc_read.get_by_hash(retention_root_hash).map_err(|_| UtxoInquirerError::MissingIndexForHash(retention_root_hash))?;
+        let retention_period_root_index = sc_read
+            .get_by_hash(retention_period_root_hash)
+            .map_err(|_| UtxoInquirerError::MissingIndexForHash(retention_period_root_hash))?;
         let (tip_index, tip_hash) = sc_read.get_tip().map_err(|_| UtxoInquirerError::MissingTipData)?;
         let tip_daa_score = self
             .headers_store
@@ -102,7 +103,7 @@ impl VirtualStateProcessor {
         // For a chain segment it holds that len(segment) <= daa_score(segment end) - daa_score(segment start). This is true
         // because each chain block increases the daa score by at least one. Hence we can lower bound our search by high index
         // minus the daa score gap as done below
-        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(retention_root_index);
+        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(retention_period_root_index);
         let mut high_index = tip_index;
 
         let matching_chain_block_hash = loop {

--- a/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
@@ -24,21 +24,21 @@ impl VirtualStateProcessor {
         &self,
         txid: Hash,
         accepting_block_daa_score: u64,
-        source_hash: Hash,
+        retention_root_hash: Hash,
     ) -> Result<SignableTransaction, UtxoInquirerError> {
-        let source_daa_score = self
+        let retention_root_daa_score = self
             .headers_store
-            .get_compact_header_data(source_hash)
+            .get_compact_header_data(retention_root_hash)
             .map(|compact_header| compact_header.daa_score)
-            .map_err(|_| UtxoInquirerError::MissingCompactHeaderForBlockHash(source_hash))?;
+            .map_err(|_| UtxoInquirerError::MissingCompactHeaderForBlockHash(retention_root_hash))?;
 
-        if accepting_block_daa_score < source_daa_score {
+        if accepting_block_daa_score < retention_root_daa_score {
             // Early exit if target daa score is lower than that of pruning point's daa score:
             return Err(UtxoInquirerError::AlreadyPruned);
         }
 
         let (matching_chain_block_hash, acceptance_data) =
-            self.find_accepting_chain_block_hash_at_daa_score(accepting_block_daa_score, source_hash)?;
+            self.find_accepting_chain_block_hash_at_daa_score(accepting_block_daa_score, retention_root_hash)?;
 
         // Expected to never fail, since we found the acceptance data and therefore there must be matching diff
         let utxo_diff = self
@@ -86,11 +86,12 @@ impl VirtualStateProcessor {
     fn find_accepting_chain_block_hash_at_daa_score(
         &self,
         target_daa_score: u64,
-        source_hash: Hash,
+        retention_root_hash: Hash,
     ) -> Result<(Hash, Arc<AcceptanceData>), UtxoInquirerError> {
         let sc_read = self.selected_chain_store.read();
 
-        let source_index = sc_read.get_by_hash(source_hash).map_err(|_| UtxoInquirerError::MissingIndexForHash(source_hash))?;
+        let retention_root_index =
+            sc_read.get_by_hash(retention_root_hash).map_err(|_| UtxoInquirerError::MissingIndexForHash(retention_root_hash))?;
         let (tip_index, tip_hash) = sc_read.get_tip().map_err(|_| UtxoInquirerError::MissingTipData)?;
         let tip_daa_score = self
             .headers_store
@@ -101,7 +102,7 @@ impl VirtualStateProcessor {
         // For a chain segment it holds that len(segment) <= daa_score(segment end) - daa_score(segment start). This is true
         // because each chain block increases the daa score by at least one. Hence we can lower bound our search by high index
         // minus the daa score gap as done below
-        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(source_index);
+        let mut low_index = tip_index.saturating_sub(tip_daa_score.saturating_sub(target_daa_score)).max(retention_root_index);
         let mut high_index = tip_index;
 
         let matching_chain_block_hash = loop {

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -225,6 +225,7 @@ impl PruningProofManager {
         let mut batch = WriteBatch::default();
         pruning_point_write.set_batch(&mut batch, new_pruning_point, new_pruning_point, (pruning_points.len() - 1) as u64).unwrap();
         pruning_point_write.set_history_root(&mut batch, new_pruning_point).unwrap();
+        pruning_point_write.set_retention_period_root(&mut batch, new_pruning_point).unwrap();
         self.db.write(batch).unwrap();
         drop(pruning_point_write);
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -224,7 +224,7 @@ impl PruningProofManager {
         let mut pruning_point_write = self.pruning_point_store.write();
         let mut batch = WriteBatch::default();
         pruning_point_write.set_batch(&mut batch, new_pruning_point, new_pruning_point, (pruning_points.len() - 1) as u64).unwrap();
-        pruning_point_write.set_history_root(&mut batch, new_pruning_point).unwrap();
+        pruning_point_write.set_retention_checkpoint(&mut batch, new_pruning_point).unwrap();
         pruning_point_write.set_retention_period_root(&mut batch, new_pruning_point).unwrap();
         self.db.write(batch).unwrap();
         drop(pruning_point_write);

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -46,6 +46,9 @@ pub enum DatabaseStorePrefixes {
     TempGhostdag = 40,
     TempGhostdagCompact = 41,
 
+    // ---- Retention Period Root ----
+    RetentionPeriodRoot = 50,
+
     // ---- Metadata ----
     MultiConsensusMetadata = 124,
     ConsensusEntries = 125,

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -21,7 +21,7 @@ pub enum DatabaseStorePrefixes {
     PruningUtxoset = 11,
     PruningUtxosetPosition = 12,
     PruningPoint = 13,
-    HistoryRoot = 14,
+    RetentionCheckpoint = 14,
     Reachability = 15,
     ReachabilityReindexRoot = 16,
     ReachabilityRelations = 17,

--- a/docs/testnet10-transition.md
+++ b/docs/testnet10-transition.md
@@ -4,7 +4,7 @@ Kaspa is about to take a significant leap with the **Crescendo Hardfork**, as de
 
 
 **Important Note:**  
-- Version [0.17.0](https://github.com/kaspanet/rusty-kaspa/releases/tag/v0.17.0) does **not** support TN11. Some participants should keep TN11 nodes running on the latest stable release or `stable` branch until TN10’s performance is proven stable.
+- Version [0.17.1](https://github.com/kaspanet/rusty-kaspa/releases/tag/v0.17.1) does **not** support TN11. Some participants should keep TN11 nodes running on the latest stable release or `stable` branch until TN10’s performance is proven stable.
 
 ---
 
@@ -29,8 +29,8 @@ While the minimum specs suffice to sync and maintain a TN10 node with the accele
 
 ## 1. Install & Run Your TN10 Node
 
-1. **Obtain Kaspa 0.17.0 binaries**  
-   Download and extract the official [0.17.0 release](https://github.com/kaspanet/rusty-kaspa/releases/tag/v0.17.0), or build from the `master` branch by following the instructions in the project README.
+1. **Obtain Kaspa 0.17.1 binaries**  
+   Download and extract the official [0.17.1 release](https://github.com/kaspanet/rusty-kaspa/releases/tag/v0.17.1), or build from the `master` branch by following the instructions in the project README.
 
 2. **Launch the Node**  
    While TN10 is the default netsuffix, specifying it explicitly is recommended:

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -90,6 +90,7 @@ pub struct Args {
     #[serde(rename = "nogrpc")]
     pub disable_grpc: bool,
     pub ram_scale: f64,
+    pub retention_period_days: f64,
 }
 
 impl Default for Args {
@@ -140,6 +141,7 @@ impl Default for Args {
             disable_dns_seeding: false,
             disable_grpc: false,
             ram_scale: 1.0,
+            retention_period_days: 3.0,
         }
     }
 }
@@ -159,6 +161,7 @@ impl Args {
         config.p2p_listen_address = self.listen.unwrap_or(ContextualNetAddress::unspecified());
         config.externalip = self.externalip.map(|v| v.normalize(config.default_p2p_port()));
         config.ram_scale = self.ram_scale;
+        config.retention_period_days = self.retention_period_days;
 
         #[cfg(feature = "devnet-prealloc")]
         if let Some(num_prealloc_utxos) = self.num_prealloc_utxos {
@@ -369,6 +372,13 @@ Setting to 0 prevents the preallocation and sets the maximum to {}, leading to 0
                 .help("Apply a scale factor to memory allocation bounds. Nodes with limited RAM (~4-8GB) should set this to ~0.3-0.5 respectively. Nodes with
 a large RAM (~64GB) can set this value to ~3.0-4.0 and gain superior performance especially for syncing peers faster"),
         )
+        .arg(
+            Arg::new("retention-period-days")
+                .long("retention-period-days")
+                .require_equals(true)
+                .value_parser(clap::value_parser!(f64))
+                .help("The number of total days of data to keep.")
+        )
         ;
 
     #[cfg(feature = "devnet-prealloc")]
@@ -448,6 +458,7 @@ impl Args {
             disable_dns_seeding: arg_match_unwrap_or::<bool>(&m, "nodnsseed", defaults.disable_dns_seeding),
             disable_grpc: arg_match_unwrap_or::<bool>(&m, "nogrpc", defaults.disable_grpc),
             ram_scale: arg_match_unwrap_or::<f64>(&m, "ram-scale", defaults.ram_scale),
+            retention_period_days: arg_match_unwrap_or::<f64>(&m, "retention-period-days", defaults.retention_period_days),
 
             #[cfg(feature = "devnet-prealloc")]
             num_prealloc_utxos: m.get_one::<u64>("num-prealloc-utxos").cloned(),

--- a/kaspad/src/args.rs
+++ b/kaspad/src/args.rs
@@ -90,7 +90,7 @@ pub struct Args {
     #[serde(rename = "nogrpc")]
     pub disable_grpc: bool,
     pub ram_scale: f64,
-    pub retention_period_days: f64,
+    pub retention_period_days: Option<f64>,
 }
 
 impl Default for Args {
@@ -141,7 +141,7 @@ impl Default for Args {
             disable_dns_seeding: false,
             disable_grpc: false,
             ram_scale: 1.0,
-            retention_period_days: 3.0,
+            retention_period_days: None,
         }
     }
 }
@@ -458,7 +458,7 @@ impl Args {
             disable_dns_seeding: arg_match_unwrap_or::<bool>(&m, "nodnsseed", defaults.disable_dns_seeding),
             disable_grpc: arg_match_unwrap_or::<bool>(&m, "nogrpc", defaults.disable_grpc),
             ram_scale: arg_match_unwrap_or::<f64>(&m, "ram-scale", defaults.ram_scale),
-            retention_period_days: arg_match_unwrap_or::<f64>(&m, "retention-period-days", defaults.retention_period_days),
+            retention_period_days: m.get_one::<f64>("retention-period-days").cloned().or(defaults.retention_period_days),
 
             #[cfg(feature = "devnet-prealloc")]
             num_prealloc_utxos: m.get_one::<u64>("num-prealloc-utxos").cloned(),


### PR DESCRIPTION
### Notes

- New configuration usage `--retention-period-days=N` - set this to some number to keep that many days of data. If this is smaller than the pruning period duration, a pruning period duration amount of data will be kept still.
- Implementation detail - this goes through the selected parent chain to find the first block that is past the N days threshold. There is no extra logic that ensures the anticone of the last SPC block found is also retained as such those will still be pruned.