### PR TITLE
Some simplification to script number types

### DIFF
--- a/crypto/txscript/src/data_stack.rs
+++ b/crypto/txscript/src/data_stack.rs
@@ -5,11 +5,46 @@ use kaspa_txscript_errors::SerializationError;
 use std::cmp::Ordering;
 use std::ops::Deref;
 
-const DEFAULT_SCRIPT_NUM_LEN: usize = 4;
-const DEFAULT_SCRIPT_NUM_LEN_KIP10: usize = 8;
-
-#[derive(PartialEq, Eq, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default, PartialOrd, Ord)]
 pub(crate) struct SizedEncodeInt<const LEN: usize>(pub(crate) i64);
+
+impl<const LEN: usize> From<i64> for SizedEncodeInt<LEN> {
+    fn from(value: i64) -> Self {
+        SizedEncodeInt(value)
+    }
+}
+
+impl<const LEN: usize> From<i32> for SizedEncodeInt<LEN> {
+    fn from(value: i32) -> Self {
+        SizedEncodeInt(value as i64)
+    }
+}
+
+impl<const LEN: usize> PartialEq<i64> for SizedEncodeInt<LEN> {
+    fn eq(&self, other: &i64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<const LEN: usize> PartialOrd<i64> for SizedEncodeInt<LEN> {
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl<const LEN: usize> Deref for SizedEncodeInt<LEN> {
+    type Target = i64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const LEN: usize> From<SizedEncodeInt<LEN>> for i64 {
+    fn from(value: SizedEncodeInt<LEN>) -> Self {
+        value.0
+    }
+}
 
 pub(crate) type Stack = Vec<Vec<u8>>;
 
@@ -111,94 +146,36 @@ fn deserialize_i64(v: &[u8]) -> Result<i64, TxScriptError> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
-#[repr(transparent)]
-pub struct Kip10I64(pub i64);
-
-impl From<Kip10I64> for i64 {
-    fn from(value: Kip10I64) -> Self {
-        value.0
-    }
-}
-
-impl PartialEq<i64> for Kip10I64 {
-    fn eq(&self, other: &i64) -> bool {
-        self.0.eq(other)
-    }
-}
-
-impl PartialOrd<i64> for Kip10I64 {
-    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
-        self.0.partial_cmp(other)
-    }
-}
-
-impl Deref for Kip10I64 {
-    type Target = i64;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl OpcodeData<Kip10I64> for Vec<u8> {
-    #[inline]
-    fn deserialize(&self) -> Result<Kip10I64, TxScriptError> {
-        match self.len() > DEFAULT_SCRIPT_NUM_LEN_KIP10 {
-            true => Err(TxScriptError::NumberTooBig(format!(
-                "numeric value encoded as {:x?} is {} bytes which exceeds the max allowed of {}",
-                self,
-                self.len(),
-                DEFAULT_SCRIPT_NUM_LEN_KIP10
-            ))),
-            false => deserialize_i64(self).map(Kip10I64),
-        }
-    }
-
-    #[inline]
-    fn serialize(from: &Kip10I64) -> Result<Self, SerializationError> {
-        if from.0 == i64::MIN {
-            return Err(SerializationError::NumberTooLong(from.0));
-        }
-        Ok(serialize_i64(&from.0))
-    }
-}
+// TODO: Rename to DefaultSizedEncodeInt when KIP-10 is activated
+pub type Kip10I64 = SizedEncodeInt<8>;
 
 impl OpcodeData<i64> for Vec<u8> {
     #[inline]
     fn deserialize(&self) -> Result<i64, TxScriptError> {
-        match self.len() > DEFAULT_SCRIPT_NUM_LEN {
-            true => Err(TxScriptError::NumberTooBig(format!(
-                "numeric value encoded as {:x?} is {} bytes which exceeds the max allowed of {}",
-                self,
-                self.len(),
-                DEFAULT_SCRIPT_NUM_LEN
-            ))),
-            false => deserialize_i64(self),
-        }
+        // TODO: Change LEN to 8 once KIP-10 is activated
+        OpcodeData::<SizedEncodeInt<4>>::deserialize(self).map(i64::from)
     }
 
     #[inline]
     fn serialize(from: &i64) -> Result<Self, SerializationError> {
-        if from == &i64::MIN {
-            return Err(SerializationError::NumberTooLong(*from));
-        }
-        Ok(serialize_i64(from))
+        // Note that serialization and deserialization use different LEN.
+        // This is because prior to KIP-10, only deserialization size was limited.
+        // It's safe to use 8 here because i32 arithmetic operations (which were the
+        // only ones that were supported prior to KIP-10) can't get to i64::MIN
+        // (the only i64 value that requires more than 8 bytes to serialize).
+        OpcodeData::<SizedEncodeInt<8>>::serialize(&(*from).into())
     }
 }
 
 impl OpcodeData<i32> for Vec<u8> {
     #[inline]
     fn deserialize(&self) -> Result<i32, TxScriptError> {
-        let res = OpcodeData::<i64>::deserialize(self)?;
-        // TODO: Consider getting rid of clamp, since the call to deserialize should return an error
-        // if the number is not in the i32 range (this should be done with proper testing)?
-        Ok(res.clamp(i32::MIN as i64, i32::MAX as i64) as i32)
+        OpcodeData::<SizedEncodeInt<4>>::deserialize(self).map(|v| i64::from(v).try_into().expect("number is within i32 range"))
     }
 
     #[inline]
     fn serialize(from: &i32) -> Result<Self, SerializationError> {
-        Ok(OpcodeData::<i64>::serialize(&(*from as i64)).expect("should never happen"))
+        OpcodeData::<SizedEncodeInt<4>>::serialize(&(*from).into())
     }
 }
 
@@ -206,7 +183,7 @@ impl<const LEN: usize> OpcodeData<SizedEncodeInt<LEN>> for Vec<u8> {
     #[inline]
     fn deserialize(&self) -> Result<SizedEncodeInt<LEN>, TxScriptError> {
         match self.len() > LEN {
-            true => Err(TxScriptError::InvalidState(format!(
+            true => Err(TxScriptError::NumberTooBig(format!(
                 "numeric value encoded as {:x?} is {} bytes which exceeds the max allowed of {}",
                 self,
                 self.len(),
@@ -218,7 +195,16 @@ impl<const LEN: usize> OpcodeData<SizedEncodeInt<LEN>> for Vec<u8> {
 
     #[inline]
     fn serialize(from: &SizedEncodeInt<LEN>) -> Result<Self, SerializationError> {
-        Ok(serialize_i64(&from.0))
+        // This is an optimzation for LEN 8. Without it, the function will fail when checking the serialized data length.
+        if LEN == 8 && from.0 == i64::MIN {
+            return Err(SerializationError::NumberTooLong(from.0));
+        }
+
+        let bytes = serialize_i64(&from.0);
+        if bytes.len() > LEN {
+            return Err(SerializationError::NumberTooLong(from.0));
+        }
+        Ok(bytes)
     }
 }
 
@@ -614,59 +600,59 @@ mod tests {
         let kip10_tests = vec![
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000008000").expect("failed parsing hex"),
-                result: Ok(Kip10I64(2147483648)),
+                result: Ok(Kip10I64::from(2147483648i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000008080").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-2147483648)),
+                result: Ok(Kip10I64::from(-2147483648i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000009000").expect("failed parsing hex"),
-                result: Ok(Kip10I64(2415919104)),
+                result: Ok(Kip10I64::from(2415919104i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000009080").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-2415919104)),
+                result: Ok(Kip10I64::from(-2415919104i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffff00").expect("failed parsing hex"),
-                result: Ok(Kip10I64(4294967295)),
+                result: Ok(Kip10I64::from(4294967295i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffff80").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-4294967295)),
+                result: Ok(Kip10I64::from(-4294967295i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000000001").expect("failed parsing hex"),
-                result: Ok(Kip10I64(4294967296)),
+                result: Ok(Kip10I64::from(4294967296i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("0000000081").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-4294967296)),
+                result: Ok(Kip10I64::from(-4294967296i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffff00").expect("failed parsing hex"),
-                result: Ok(Kip10I64(281474976710655)),
+                result: Ok(Kip10I64::from(281474976710655i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffff80").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-281474976710655)),
+                result: Ok(Kip10I64::from(-281474976710655i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffffff00").expect("failed parsing hex"),
-                result: Ok(Kip10I64(72057594037927935)),
+                result: Ok(Kip10I64::from(72057594037927935i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffffff80").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-72057594037927935)),
+                result: Ok(Kip10I64::from(-72057594037927935i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffffff7f").expect("failed parsing hex"),
-                result: Ok(Kip10I64(9223372036854775807)),
+                result: Ok(Kip10I64::from(9223372036854775807i64)),
             },
             TestCase::<Kip10I64> {
                 serialized: hex::decode("ffffffffffffffff").expect("failed parsing hex"),
-                result: Ok(Kip10I64(-9223372036854775807)),
+                result: Ok(Kip10I64::from(-9223372036854775807i64)),
             },
             // Minimally encoded values that are out of range for data that
             // is interpreted as script numbers with the minimal encoding

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -1196,16 +1196,10 @@ mod bitcoind_tests {
 
             // Read the JSON contents of the file as an instance of `User`.
             let tests: Vec<JsonTestRow> = serde_json::from_reader(reader).expect("Failed Parsing {:?}");
-            let mut had_errors = 0;
-            let total_tests = tests.len();
             for row in tests {
                 if let Err(error) = row.test_row(kip10_enabled) {
-                    println!("Test: {:?} failed: {:?}", row.clone(), error);
-                    had_errors += 1;
+                    panic!("Test: {:?} failed for {}: {:?}", row.clone(), file_name, error);
                 }
-            }
-            if had_errors > 0 {
-                panic!("{}/{} json tests failed", had_errors, total_tests)
             }
         }
     }

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -219,6 +219,7 @@ fn push_number<T: VerifiableTransaction, Reused: SigHashReusedValues>(
 /// This macro helps to avoid code duplication in numeric opcodes where the only difference
 /// between KIP10_ENABLED and disabled states is the numeric type used (Kip10I64 vs i64).
 /// KIP10I64 deserializator supports 8-byte integers
+// TODO: Remove this macro after KIP-10 activation.
 macro_rules! numeric_op {
     ($vm: expr, $pattern: pat, $count: expr, $block: expr) => {
         if $vm.kip10_enabled {

--- a/crypto/txscript/src/script_builder.rs
+++ b/crypto/txscript/src/script_builder.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use crate::{
-    data_stack::OpcodeData,
+    data_stack::{Kip10I64, OpcodeData},
     opcodes::{codes::*, OP_1_NEGATE_VAL, OP_DATA_MAX_VAL, OP_DATA_MIN_VAL, OP_SMALL_INT_MAX_VAL},
     MAX_SCRIPTS_SIZE, MAX_SCRIPT_ELEMENT_SIZE,
 };
@@ -232,7 +232,7 @@ impl ScriptBuilder {
             return Ok(self);
         }
 
-        let bytes: Vec<_> = OpcodeData::<i64>::serialize(&val)?;
+        let bytes: Vec<_> = OpcodeData::<Kip10I64>::serialize(&val.into())?;
         self.add_data(&bytes)
     }
 


### PR DESCRIPTION
Unifying `OpcodeData<i32/i64/Kip10I64>` to use `SizedEncodeInt` for serialization.

Critical lines and explanation:
1. https://github.com/someone235/rusty-kaspa/blob/976313f0f4c492061689d84811b17ee1ea73cc8b/crypto/txscript/src/data_stack.rs#L178
Here we limit any `push_item<i32>` to 4 bytes. This is fine since we nowhere use this method.
2. https://github.com/someone235/rusty-kaspa/blob/976313f0f4c492061689d84811b17ee1ea73cc8b/crypto/txscript/src/data_stack.rs#L166
Here we limit any `push_item<i64>` to 8 bytes. Explanation for safety is in the code.
3. https://github.com/someone235/rusty-kaspa/blob/976313f0f4c492061689d84811b17ee1ea73cc8b/crypto/txscript/src/data_stack.rs#L173
Here we limit any `pop_items<i32>` to 4 bytes, disallowing the use of `i32::MIN`. This is fine since in any place we use `pop_items<i32>` we also return an error if the number is negative.