### PR TITLE
calculate sig ops on fly

### DIFF
--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -89,7 +89,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_sequential(black_box(&cache), black_box(&tx.as_verifiable()), false).unwrap();
+                    check_scripts_sequential(black_box(&cache), black_box(&tx.as_verifiable()), false, false).unwrap();
                 })
             });
 
@@ -98,7 +98,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), false).unwrap();
+                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), false, false).unwrap();
                 })
             });
 
@@ -110,8 +110,14 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                         let cache = Cache::new(inputs_count as u64);
                         b.iter(|| {
                             cache.clear();
-                            check_scripts_par_iter_pool(black_box(&cache), black_box(&tx.as_verifiable()), black_box(&pool), false)
-                                .unwrap();
+                            check_scripts_par_iter_pool(
+                                black_box(&cache),
+                                black_box(&tx.as_verifiable()),
+                                black_box(&pool),
+                                false,
+                                false,
+                            )
+                            .unwrap();
                         })
                     });
                 }
@@ -147,7 +153,7 @@ fn benchmark_check_scripts_with_payload(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), false).unwrap();
+                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), false, false).unwrap();
                 })
             });
         }

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -133,7 +133,7 @@ pub struct Params {
 
     /// Activation rules for when to enable using the payload field in transactions
     pub payload_activation: ForkActivation,
-    pub sig_op_on_fly: ForkActivation,
+    pub runtime_sig_op_counting: ForkActivation,
 }
 
 fn unix_now() -> u64 {
@@ -412,7 +412,7 @@ pub const MAINNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
-    sig_op_on_fly: ForkActivation::never(),
+    runtime_sig_op_counting: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {
@@ -478,7 +478,7 @@ pub const TESTNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
-    sig_op_on_fly: ForkActivation::never(),
+    runtime_sig_op_counting: ForkActivation::never(),
 };
 
 pub const TESTNET11_PARAMS: Params = Params {
@@ -543,7 +543,7 @@ pub const TESTNET11_PARAMS: Params = Params {
     skip_proof_of_work: false,
     max_block_level: 250,
 
-    sig_op_on_fly: ForkActivation::never(),
+    runtime_sig_op_counting: ForkActivation::never(),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -600,7 +600,7 @@ pub const SIMNET_PARAMS: Params = Params {
     max_block_level: 250,
 
     payload_activation: ForkActivation::never(),
-    sig_op_on_fly: ForkActivation::never(),
+    runtime_sig_op_counting: ForkActivation::never(),
 };
 
 pub const DEVNET_PARAMS: Params = Params {
@@ -660,5 +660,5 @@ pub const DEVNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
-    sig_op_on_fly: ForkActivation::never(),
+    runtime_sig_op_counting: ForkActivation::never(),
 };

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -133,6 +133,7 @@ pub struct Params {
 
     /// Activation rules for when to enable using the payload field in transactions
     pub payload_activation: ForkActivation,
+    pub sig_op_on_fly: ForkActivation,
 }
 
 fn unix_now() -> u64 {
@@ -411,6 +412,7 @@ pub const MAINNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
+    sig_op_on_fly: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {
@@ -476,6 +478,7 @@ pub const TESTNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
+    sig_op_on_fly: ForkActivation::never(),
 };
 
 pub const TESTNET11_PARAMS: Params = Params {
@@ -539,6 +542,8 @@ pub const TESTNET11_PARAMS: Params = Params {
 
     skip_proof_of_work: false,
     max_block_level: 250,
+
+    sig_op_on_fly: ForkActivation::never(),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -595,6 +600,7 @@ pub const SIMNET_PARAMS: Params = Params {
     max_block_level: 250,
 
     payload_activation: ForkActivation::never(),
+    sig_op_on_fly: ForkActivation::never(),
 };
 
 pub const DEVNET_PARAMS: Params = Params {
@@ -654,4 +660,5 @@ pub const DEVNET_PARAMS: Params = Params {
     pruning_proof_m: 1000,
 
     payload_activation: ForkActivation::never(),
+    sig_op_on_fly: ForkActivation::never(),
 };

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -148,7 +148,7 @@ impl ConsensusServices {
             params.storage_mass_activation,
             params.kip10_activation,
             params.payload_activation,
-            params.sig_op_on_fly,
+            params.runtime_sig_op_counting,
         );
 
         let pruning_point_manager = PruningPointManager::new(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -148,6 +148,7 @@ impl ConsensusServices {
             params.storage_mass_activation,
             params.kip10_activation,
             params.payload_activation,
+            params.sig_op_on_fly,
         );
 
         let pruning_point_manager = PruningPointManager::new(

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -31,7 +31,7 @@ pub struct TransactionValidator {
     /// KIP-10 hardfork DAA score
     kip10_activation: ForkActivation,
     payload_activation: ForkActivation,
-    sig_op_on_fly: ForkActivation,
+    runtime_sig_op_counting: ForkActivation,
 }
 
 impl TransactionValidator {
@@ -49,7 +49,7 @@ impl TransactionValidator {
         storage_mass_activation: ForkActivation,
         kip10_activation: ForkActivation,
         payload_activation: ForkActivation,
-        sig_op_on_fly: ForkActivation,
+        runtime_sig_op_counting: ForkActivation,
     ) -> Self {
         Self {
             max_tx_inputs,
@@ -64,7 +64,7 @@ impl TransactionValidator {
             storage_mass_activation,
             kip10_activation,
             payload_activation,
-            sig_op_on_fly,
+            runtime_sig_op_counting,
         }
     }
 
@@ -91,7 +91,7 @@ impl TransactionValidator {
             storage_mass_activation: ForkActivation::never(),
             kip10_activation: ForkActivation::never(),
             payload_activation: ForkActivation::never(),
-            sig_op_on_fly: ForkActivation::never(),
+            runtime_sig_op_counting: ForkActivation::never(),
         }
     }
 }

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -31,6 +31,7 @@ pub struct TransactionValidator {
     /// KIP-10 hardfork DAA score
     kip10_activation: ForkActivation,
     payload_activation: ForkActivation,
+    sig_op_on_fly: ForkActivation,
 }
 
 impl TransactionValidator {
@@ -48,6 +49,7 @@ impl TransactionValidator {
         storage_mass_activation: ForkActivation,
         kip10_activation: ForkActivation,
         payload_activation: ForkActivation,
+        sig_op_on_fly: ForkActivation,
     ) -> Self {
         Self {
             max_tx_inputs,
@@ -62,6 +64,7 @@ impl TransactionValidator {
             storage_mass_activation,
             kip10_activation,
             payload_activation,
+            sig_op_on_fly,
         }
     }
 
@@ -88,6 +91,7 @@ impl TransactionValidator {
             storage_mass_activation: ForkActivation::never(),
             kip10_activation: ForkActivation::never(),
             payload_activation: ForkActivation::never(),
+            sig_op_on_fly: ForkActivation::never(),
         }
     }
 }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,7 +4,7 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_core::warn;
-use kaspa_txscript::{caches::Cache, get_sig_op_count, SigCacheKey, TxScriptEngine};
+use kaspa_txscript::{caches::Cache, get_sig_op_count_upper_bound, SigCacheKey, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPool;
@@ -164,7 +164,8 @@ impl TransactionValidator {
 
     fn check_sig_op_counts<T: VerifiableTransaction>(tx: &T) -> TxResult<()> {
         for (i, (input, entry)) in tx.populated_inputs().enumerate() {
-            let calculated = get_sig_op_count::<T, SigHashReusedValuesUnsync>(&input.signature_script, &entry.script_public_key);
+            let calculated =
+                get_sig_op_count_upper_bound::<T, SigHashReusedValuesUnsync>(&input.signature_script, &entry.script_public_key);
             if calculated != input.sig_op_count as u64 {
                 return Err(TxRuleError::WrongSigOpCount(i, input.sig_op_count as u64, calculated));
             }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -59,7 +59,9 @@ impl TransactionValidator {
 
         match flags {
             TxValidationFlags::Full | TxValidationFlags::SkipMassCheck => {
-                Self::check_sig_op_counts(tx)?;
+                if !self.sig_op_on_fly.is_active(pov_daa_score) {
+                    Self::check_sig_op_counts(tx)?;
+                }
                 self.check_scripts(tx, pov_daa_score)?;
             }
             TxValidationFlags::SkipScriptChecks => {}
@@ -171,7 +173,7 @@ impl TransactionValidator {
     }
 
     pub fn check_scripts(&self, tx: &(impl VerifiableTransaction + Sync), pov_daa_score: u64) -> TxResult<()> {
-        check_scripts(&self.sig_cache, tx, self.kip10_activation.is_active(pov_daa_score))
+        check_scripts(&self.sig_cache, tx, self.kip10_activation.is_active(pov_daa_score), self.sig_op_on_fly.is_active(pov_daa_score))
     }
 }
 
@@ -179,11 +181,12 @@ pub fn check_scripts(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
     kip10_enabled: bool,
+    sig_op_on_fly: bool,
 ) -> TxResult<()> {
     if tx.inputs().len() > CHECK_SCRIPTS_PARALLELISM_THRESHOLD {
-        check_scripts_par_iter(sig_cache, tx, kip10_enabled)
+        check_scripts_par_iter(sig_cache, tx, kip10_enabled, sig_op_on_fly)
     } else {
-        check_scripts_sequential(sig_cache, tx, kip10_enabled)
+        check_scripts_sequential(sig_cache, tx, kip10_enabled, sig_op_on_fly)
     }
 }
 
@@ -191,10 +194,11 @@ pub fn check_scripts_sequential(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &impl VerifiableTransaction,
     kip10_enabled: bool,
+    sig_op_on_fly: bool,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesUnsync::new();
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
-        TxScriptEngine::from_transaction_input(tx, input, i, entry, &reused_values, sig_cache, kip10_enabled)
+        TxScriptEngine::from_transaction_input(tx, input, i, entry, &reused_values, sig_cache, kip10_enabled, sig_op_on_fly)
             .execute()
             .map_err(|err| map_script_err(err, input))?;
     }
@@ -205,11 +209,12 @@ pub fn check_scripts_par_iter(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
     kip10_enabled: bool,
+    sig_op_on_fly: bool,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesSync::new();
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
-        TxScriptEngine::from_transaction_input(tx, input, idx, utxo, &reused_values, sig_cache, kip10_enabled)
+        TxScriptEngine::from_transaction_input(tx, input, idx, utxo, &reused_values, sig_cache, kip10_enabled, sig_op_on_fly)
             .execute()
             .map_err(|err| map_script_err(err, input))
     })
@@ -220,8 +225,9 @@ pub fn check_scripts_par_iter_pool(
     tx: &(impl VerifiableTransaction + Sync),
     pool: &ThreadPool,
     kip10_enabled: bool,
+    sig_op_on_fly: bool,
 ) -> TxResult<()> {
-    pool.install(|| check_scripts_par_iter(sig_cache, tx, kip10_enabled))
+    pool.install(|| check_scripts_par_iter(sig_cache, tx, kip10_enabled, sig_op_on_fly))
 }
 
 fn map_script_err(script_err: TxScriptError, input: &TransactionInput) -> TxRuleError {

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -74,7 +74,7 @@ pub enum TxScriptError {
     #[error(transparent)]
     Serialization(#[from] SerializationError),
     #[error("sig op count exceed passed limit of {1}")]
-    SigOpCountTooLow(u16, u8),
+    ExceededSigOpLimit(u16, u8),
 }
 
 #[derive(Error, PartialEq, Eq, Debug, Clone, Copy)]

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -73,6 +73,8 @@ pub enum TxScriptError {
     InvalidOutputIndex(i32, usize),
     #[error(transparent)]
     Serialization(#[from] SerializationError),
+    #[error("sig op count exceed passed limit of {1}")]
+    SigOpCountTooLow(u16, u8),
 }
 
 #[derive(Error, PartialEq, Eq, Debug, Clone, Copy)]

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -73,8 +73,8 @@ pub enum TxScriptError {
     InvalidOutputIndex(i32, usize),
     #[error(transparent)]
     Serialization(#[from] SerializationError),
-    #[error("sig op count {0} exceeds passed limit of {1}")]
-    ExceededSigOpLimit(u16, u8),
+    #[error("sig op count exceeds passed limit of {0}")]
+    ExceededSigOpLimit(u8),
 }
 
 #[derive(Error, PartialEq, Eq, Debug, Clone, Copy)]

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -73,7 +73,7 @@ pub enum TxScriptError {
     InvalidOutputIndex(i32, usize),
     #[error(transparent)]
     Serialization(#[from] SerializationError),
-    #[error("sig op count exceed passed limit of {1}")]
+    #[error("sig op count {0} exceeds passed limit of {1}")]
     ExceededSigOpLimit(u16, u8),
 }
 

--- a/crypto/txscript/examples/kip-10.rs
+++ b/crypto/txscript/examples/kip-10.rs
@@ -126,7 +126,8 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[STANDARD] Owner branch execution successful");
     }
@@ -136,7 +137,8 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         println!("[STANDARD] Checking borrower branch");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[STANDARD] Borrower branch execution successful");
     }
@@ -147,7 +149,8 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[STANDARD] Borrower branch with threshold not reached failed as expected");
     }
@@ -295,7 +298,8 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[ONE-TIME] Owner branch execution successful");
     }
@@ -305,7 +309,8 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         println!("[ONE-TIME] Checking borrower branch");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[ONE-TIME] Borrower branch execution successful");
     }
@@ -316,7 +321,8 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[ONE-TIME] Borrower branch with threshold not reached failed as expected");
     }
@@ -346,6 +352,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
             &reused_values,
             &sig_cache,
             true,
+            false,
         );
         assert_eq!(vm.execute(), Err(VerifyError));
         println!("[ONE-TIME] Borrower branch with output going to wrong address failed as expected");
@@ -455,7 +462,8 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[TWO-TIMES] Owner branch execution successful");
     }
@@ -465,7 +473,8 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         println!("[TWO-TIMES] Checking borrower branch (first borrowing)");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&two_times_script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[TWO-TIMES] Borrower branch (first borrowing) execution successful");
     }
@@ -476,7 +485,8 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[TWO-TIMES] Borrower branch with threshold not reached failed as expected");
     }
@@ -506,6 +516,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
             &reused_values,
             &sig_cache,
             true,
+            false,
         );
         assert_eq!(vm.execute(), Err(VerifyError));
         println!("[TWO-TIMES] Borrower branch with output going to wrong address failed as expected");
@@ -617,7 +628,8 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[SHARED-SECRET] Owner branch execution successful");
     }
@@ -635,7 +647,8 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Ok(()));
         println!("[SHARED-SECRET] Borrower branch with correct shared secret execution successful");
     }
@@ -653,7 +666,8 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true);
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, true, false);
         assert_eq!(vm.execute(), Err(VerifyError));
         println!("[SHARED-SECRET] Borrower branch with incorrect secret failed as expected");
     }

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -1055,11 +1055,19 @@ mod tests {
         public_key: Vec<u8>,
     }
 
+    /// Builder for constructing signature scripts with different signature types and combinations.
     enum SignatureScriptBuilder {
+        /// Multisignature script that requires multiple signatures to be valid.
+        Multisig(Vec<SignatureData>),
+
+        /// Single signature script with one signature and its corresponding public key.
         Single(SignatureData),
-        Multi(Vec<SignatureData>),
+
+        /// Mixed signature script that mix different signature types (e.g., ECDSA and Schnorr)
         Mixed(Vec<SignatureData>),
-        None, // For tests that don't need signatures
+
+        /// Empty signature script builder
+        None,
     }
 
     type SigBuilder = Box<dyn Fn(&MutableTransaction<Transaction>, &SigHashReusedValuesUnsync) -> SignatureScriptBuilder>;
@@ -1083,7 +1091,7 @@ mod tests {
                     builder.add_data(&sig_data.signature)?;
                     builder.add_data(&sig_data.public_key)?;
                 }
-                SignatureScriptBuilder::Multi(sig_data_vec) => {
+                SignatureScriptBuilder::Multisig(sig_data_vec) => {
                     for sig_data in sig_data_vec {
                         builder.add_data(&sig_data.signature)?;
                     }
@@ -1174,7 +1182,7 @@ mod tests {
                 }),
                 sig_builder: Box::new(move |tx, reused| {
                     let sig = create_schnorr_signature(tx, reused);
-                    SignatureScriptBuilder::Multi(vec![sig.clone(), sig])
+                    SignatureScriptBuilder::Multisig(vec![sig.clone(), sig])
                 }),
                 expected_sig_ops: 2,
                 sig_op_limit: 2,

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -1196,7 +1196,7 @@ mod tests {
         let test_cases = vec![
             // Basic Schnorr CheckSig
             TestCase {
-                name: "Basic Schnorr CheckSig",
+                name: "Basic Schnorr CheckSig - Single signature",
                 script_builder: Box::new(|sb| sb.add_op(OpCheckSig)),
                 sig_builder: Box::new(move |tx, reused| SignatureScriptBuilder::Single(create_schnorr_signature(tx, reused))),
                 expected_sig_ops: 1,
@@ -1205,7 +1205,7 @@ mod tests {
             },
             // Basic ECDSA CheckSig
             TestCase {
-                name: "Basic ECDSA CheckSig",
+                name: "Basic ECDSA CheckSig - Single signature",
                 script_builder: Box::new(|sb| sb.add_op(OpCheckSigECDSA)),
                 sig_builder: Box::new(move |tx, reused| SignatureScriptBuilder::Single(create_ecdsa_signature(tx, reused))),
                 expected_sig_ops: 1,
@@ -1214,7 +1214,7 @@ mod tests {
             },
             // Mixed Schnorr and ECDSA
             TestCase {
-                name: "Mixed Schnorr and ECDSA",
+                name: "Mixed Schnorr and ECDSA - Within limit",
                 script_builder: Box::new(|sb| sb.add_op(OpCheckSigVerify)?.add_op(OpCheckSigECDSA)),
                 sig_builder: Box::new(move |tx, reused| {
                     SignatureScriptBuilder::Mixed(vec![create_ecdsa_signature(tx, reused), create_schnorr_signature(tx, reused)])
@@ -1225,7 +1225,7 @@ mod tests {
             },
             // 2-of-3 MultiSig test case
             TestCase {
-                name: "2-of-3 MultiSig",
+                name: "2-of-3 MultiSig - Basic validation",
                 script_builder: Box::new(move |sb| {
                     sb.add_i64(2)?
                         .add_data(&keypair.x_only_public_key().0.serialize())?
@@ -1243,7 +1243,7 @@ mod tests {
                 should_pass: true,
             },
             TestCase {
-                name: "Mixed Schnorr and ECDSA",
+                name: "Mixed Schnorr and ECDSA - Exceeds limit",
                 script_builder: Box::new(|sb| sb.add_op(OpCheckSigVerify)?.add_op(OpCheckSigECDSA)),
                 sig_builder: Box::new(move |tx, reused| {
                     SignatureScriptBuilder::Mixed(vec![create_ecdsa_signature(tx, reused), create_schnorr_signature(tx, reused)])
@@ -1254,7 +1254,7 @@ mod tests {
             },
             // Conditional execution with sig ops
             TestCase {
-                name: "Conditional sig ops",
+                name: "Conditional sig ops - True branch execution",
                 script_builder: Box::new(|sb| sb.add_op(OpTrue)?.add_op(OpIf)?.add_op(OpCheckSigECDSA)?.add_op(OpEndIf)),
                 sig_builder: Box::new(move |tx, reused| SignatureScriptBuilder::Single(create_ecdsa_signature(tx, reused))),
                 expected_sig_ops: 1,
@@ -1263,7 +1263,7 @@ mod tests {
             },
             // Conditional execution with sig ops
             TestCase {
-                name: "Conditional sig ops (false branch)",
+                name: "Conditional sig ops - False branch skips validation",
                 script_builder: Box::new(|sb| {
                     sb.add_op(OpFalse)?.add_op(OpIf)?.add_op(OpCheckSigECDSA)?.add_op(OpVerify)?.add_op(OpEndIf)?.add_op(OpTrue)
                 }),

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -84,12 +84,15 @@ enum ScriptSource<'a, T: VerifiableTransaction> {
 #[derive(Debug, Clone)]
 pub struct RuntimeSigOpCounter {
     /// Maximum number of signature operations allowed for this input
-    pub sig_op_limit: u8,
+    sig_op_limit: u8,
     /// Remaining signature operations that can be executed
-    pub sig_op_remaining: u8,
+    sig_op_remaining: u8,
 }
 
 impl RuntimeSigOpCounter {
+    pub fn new(sig_op_limit: u8) -> Self {
+        Self { sig_op_limit, sig_op_remaining: sig_op_limit }
+    }
     /// Attempts to consume the specified number of signature operations.
     ///
     /// This method handles:
@@ -105,14 +108,11 @@ impl RuntimeSigOpCounter {
     ///
     /// # Example
     /// ```
-    /// let mut counter = kaspa_txscript::RuntimeSigOpCounter {
-    ///     sig_op_limit: 10,
-    ///     sig_op_remaining: 5
-    /// };
+    /// let mut counter = kaspa_txscript::RuntimeSigOpCounter::new(5);
     ///
     /// // Consume 3 operations
     /// counter.consume_sig_ops(3).unwrap(); // Ok(())
-    /// assert_eq!(counter.sig_op_remaining, 2);
+    /// assert_eq!(counter.sig_op_remaining(), 2);
     ///
     /// // Try to consume too many
     /// counter.consume_sig_ops(3).unwrap_err(); // Err(ExceededSigOpLimit)
@@ -122,6 +122,14 @@ impl RuntimeSigOpCounter {
             self.sig_op_remaining.checked_sub(num_sigs).ok_or(TxScriptError::ExceededSigOpLimit(self.sig_op_limit))?;
 
         Ok(())
+    }
+
+    pub fn sig_op_remaining(&self) -> u8 {
+        self.sig_op_remaining
+    }
+
+    pub fn sig_op_limit(&self) -> u8 {
+        self.sig_op_limit
     }
 }
 

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -12,6 +12,8 @@ pub mod standard;
 #[cfg(feature = "wasm32-sdk")]
 pub mod wasm;
 
+pub mod runtime_sig_op_counter;
+
 use crate::caches::Cache;
 use crate::data_stack::{DataStack, Stack};
 use crate::opcodes::{deserialize_next_opcode, OpCodeImplementation};
@@ -30,6 +32,7 @@ use script_class::ScriptClass;
 pub mod prelude {
     pub use super::standard::*;
 }
+use crate::runtime_sig_op_counter::{RuntimeSigOpCounter, SigOpConsumer};
 pub use standard::*;
 
 pub const MAX_SCRIPT_PUBLIC_KEY_VERSION: u16 = 0;
@@ -72,80 +75,6 @@ pub struct SigCacheKey {
 enum ScriptSource<'a, T: VerifiableTransaction> {
     TxInput { tx: &'a T, input: &'a TransactionInput, idx: usize, utxo_entry: &'a UtxoEntry, is_p2sh: bool },
     StandAloneScripts(Vec<&'a [u8]>),
-}
-
-/// RuntimeSigOpCounter represents the state tracking of signature operations during script execution.
-/// Unlike the static counting approach which counts all possible signature operations,
-/// this tracks only the actually executed signature operations, leading to more accurate
-/// mass calculations and potentially lower fees for conditional scripts.
-#[derive(Debug, Clone)]
-pub struct RuntimeSigOpCounter {
-    /// Maximum number of signature operations allowed for this input
-    sig_op_limit: u8,
-    /// Remaining signature operations that can be executed
-    sig_op_remaining: u8,
-}
-
-impl RuntimeSigOpCounter {
-    pub fn new(sig_op_limit: u8) -> Self {
-        Self { sig_op_limit, sig_op_remaining: sig_op_limit }
-    }
-    /// Attempts to consume the specified number of signature operations.
-    ///
-    /// This method handles:
-    /// - Checking if we have enough remaining operations
-    /// - Updating the remaining count if successful
-    ///
-    /// # Arguments
-    /// * `num_sigs` - The number of signature operations to consume
-    ///
-    /// # Returns
-    /// * `Ok(())` if the operations were successfully consumed
-    /// * `Err(TxScriptError::ExceededSigOpLimit)` if not enough operations remain
-    ///
-    /// # Example
-    /// ```
-    /// let mut counter = kaspa_txscript::RuntimeSigOpCounter::new(1);
-    ///
-    /// // Consume 3 operations
-    /// counter.consume_sig_op().unwrap(); // Ok(())
-    /// assert_eq!(counter.sig_op_remaining(), 0);
-    ///
-    /// // Try to consume too many
-    /// counter.consume_sig_op().unwrap_err(); // Err(ExceededSigOpLimit)
-    /// ```
-    pub fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
-        self.sig_op_remaining = self.sig_op_remaining.checked_sub(1).ok_or(TxScriptError::ExceededSigOpLimit(self.sig_op_limit))?;
-
-        Ok(())
-    }
-
-    pub fn sig_op_remaining(&self) -> u8 {
-        self.sig_op_remaining
-    }
-
-    pub fn sig_op_limit(&self) -> u8 {
-        self.sig_op_limit
-    }
-}
-
-pub trait SigOpConsumer {
-    fn consume_sig_op(&mut self) -> Result<(), TxScriptError>;
-}
-
-impl SigOpConsumer for RuntimeSigOpCounter {
-    fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
-        RuntimeSigOpCounter::consume_sig_op(self)
-    }
-}
-impl SigOpConsumer for Option<RuntimeSigOpCounter> {
-    fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
-        if let Some(consumer) = self {
-            consumer.consume_sig_op()
-        } else {
-            Ok(())
-        }
-    }
 }
 
 pub struct TxScriptEngine<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> {
@@ -310,14 +239,11 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
         }
     }
 
-    /// Returns the number of signature operations that were actually required during script execution.
-    /// Must only be called after script execution completes successfully.
+    /// Returns the number of signature operations used in script execution if runtime sig op counting is enabled.
     ///
-    /// Returns the difference between the input's sig_op_limit and remaining sig ops.
+    /// Returns None if runtime signature operation counting is disabled.
     pub fn used_sig_ops(&self) -> Option<u8> {
-        self.runtime_sig_op_counter
-            .as_ref()
-            .map(|RuntimeSigOpCounter { sig_op_limit, sig_op_remaining }| sig_op_limit - sig_op_remaining)
+        self.runtime_sig_op_counter.as_ref().map(|counter| counter.used_sig_ops())
     }
 
     /// Creates a new Script Engine for validating transaction input.

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -285,7 +285,8 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             cond_stack: Default::default(),
             num_ops: 0,
             kip10_enabled,
-            runtime_sig_op_counting: None, // todo?
+            // Runtime sig op counting is not needed for standalone scripts, only inputs have sig op count value
+            runtime_sig_op_counting: None,
         }
     }
 

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -525,7 +525,11 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             return Err(TxScriptError::InvalidSignatureCount(format!("more signatures than pubkeys {num_sigs} > {num_keys}")));
         }
 
-        // ensure that the number of signatures(which is <= number of keys) is less than u8::MAX
+        // Compile-time check that MAX_PUB_KEYS_PER_MUTLTISIG is within u8 range.
+        // Since num_sigs <= num_keys <= MAX_PUB_KEYS_PER_MUTLTISIG, this ensures
+        // num_sigs can be safely converted to u8.
+        // This will fail to compile if MAX_PUB_KEYS_PER_MUTLTISIG > u8::MAX (255)
+        // due to const arithmetic underflow.
         const _: usize = u8::MAX as usize - MAX_PUB_KEYS_PER_MUTLTISIG as usize;
         let num_sigs = num_sigs as u8;
         self.runtime_sig_op_counter.consume_sig_ops(num_sigs)?;

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -111,11 +111,11 @@ impl RuntimeSigOpCounter {
     /// };
     ///
     /// // Consume 3 operations
-    /// counter.consume_sig_ops(3)?; // Ok(())
+    /// counter.consume_sig_ops(3).unwrap(); // Ok(())
     /// assert_eq!(counter.sig_op_remaining, 2);
     ///
     /// // Try to consume too many
-    /// counter.consume_sig_ops(3)?; // Err(ExceededSigOpLimit)
+    /// counter.consume_sig_ops(3).unwrap_err(); // Err(ExceededSigOpLimit)
     /// ```
     pub fn consume_sig_ops(&mut self, num_sigs: u8) -> Result<(), TxScriptError> {
         self.sig_op_remaining =

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -139,7 +139,7 @@ pub fn get_sig_op_count_via_simulation<T: VerifiableTransaction, Reused: SigHash
     let mut vm =
         TxScriptEngine::from_transaction_input(&tx, &mock_input, 0, &utxo_entry, &reused_values, &sig_cache, kip10_enabled, true);
     vm.execute()?;
-    Ok(vm.sig_op_required().unwrap())
+    Ok(vm.used_sig_ops().unwrap())
 }
 
 #[must_use]
@@ -221,7 +221,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
     /// Must only be called after script execution completes successfully.
     ///
     /// Returns the difference between the input's sig_op_limit and remaining sig ops.
-    pub fn sig_op_required(&self) -> Option<u8> {
+    pub fn used_sig_ops(&self) -> Option<u8> {
         self.runtime_sig_op_counting.map(|RuntimeSigOpCounter { sig_op_limit, sig_op_remaining }| sig_op_limit - sig_op_remaining)
     }
 
@@ -1248,7 +1248,7 @@ mod tests {
             let mut vm =
                 TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, &reused_values, &sig_cache, false, true);
 
-            let result = vm.execute().map(|_| vm.sig_op_required().unwrap());
+            let result = vm.execute().map(|_| vm.used_sig_ops().unwrap());
 
             match (result, test.should_pass) {
                 (Ok(count), true) => {

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -524,8 +524,10 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
         } else if num_sigs > num_keys {
             return Err(TxScriptError::InvalidSignatureCount(format!("more signatures than pubkeys {num_sigs} > {num_keys}")));
         }
-        let num_sigs =
-            num_sigs.try_into().map_err(|_| TxScriptError::NumberTooBig("Signatures count mustn't exceed 255".to_string()))?;
+
+        // ensure that the number of signatures(which is <= number of keys) is less than u8::MAX
+        const _: usize = u8::MAX as usize - MAX_PUB_KEYS_PER_MUTLTISIG as usize;
+        let num_sigs = num_sigs as u8;
         self.runtime_sig_op_counter.consume_sig_ops(num_sigs)?;
         let num_sigs = num_sigs as usize;
         let signatures = match self.dstack.len() >= num_sigs {

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -102,7 +102,6 @@ impl RuntimeSigOpCounter {
     ///
     /// # Returns
     /// * `Ok(())` if the operations were successfully consumed
-    /// * `Err(TxScriptError::NumberTooBig)` if num_sigs > 255
     /// * `Err(TxScriptError::ExceededSigOpLimit)` if not enough operations remain
     ///
     /// # Example

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -132,7 +132,7 @@ fn parse_script<T: VerifiableTransaction, Reused: SigHashReusedValues>(
 /// * `Ok(u8)` - The exact number of signature operations executed
 /// * `Err(TxScriptError)` - If script execution fails or input index is invalid
 pub fn get_sig_op_count<T: VerifiableTransaction>(tx: &T, input_idx: usize, kip10_enabled: bool) -> Result<u8, TxScriptError> {
-    let sig_cache = Cache::new(10_000);
+    let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
     let mut vm = TxScriptEngine::from_transaction_input(
         tx,

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -107,7 +107,7 @@ impl RuntimeSigOpCounter {
     ///
     /// # Example
     /// ```
-    /// let mut counter = RuntimeSigOpCounter {
+    /// let mut counter = kaspa_txscript::RuntimeSigOpCounter {
     ///     sig_op_limit: 10,
     ///     sig_op_remaining: 5
     /// };
@@ -279,7 +279,9 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
     ///
     /// Returns the difference between the input's sig_op_limit and remaining sig ops.
     pub fn used_sig_ops(&self) -> Option<u8> {
-        self.runtime_sig_op_counter.as_ref().map(|RuntimeSigOpCounter { sig_op_limit, sig_op_remaining }| sig_op_limit - sig_op_remaining)
+        self.runtime_sig_op_counter
+            .as_ref()
+            .map(|RuntimeSigOpCounter { sig_op_limit, sig_op_remaining }| sig_op_limit - sig_op_remaining)
     }
 
     /// Creates a new Script Engine for validating transaction input.

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -93,7 +93,6 @@ impl RuntimeSigOpCounter {
     /// Attempts to consume the specified number of signature operations.
     ///
     /// This method handles:
-    /// - Converting the number of signatures to u8 (failing if > 255)
     /// - Checking if we have enough remaining operations
     /// - Updating the remaining count if successful
     ///

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -3,7 +3,7 @@ mod macros;
 
 use crate::{
     data_stack::{DataStack, Kip10I64, OpcodeData},
-    ScriptSource, SigOpConsumer, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM,
+    ScriptSource, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM,
     NO_COST_OPCODE, SEQUENCE_LOCK_TIME_DISABLED, SEQUENCE_LOCK_TIME_MASK,
 };
 use blake2b_simd::Params;
@@ -720,8 +720,6 @@ opcode_list! {
         match sig.pop() {
             Some(typ) => {
                 let hash_type = SigHashType::from_u8(typ).map_err(|e| TxScriptError::InvalidSigHashType(typ))?;
-                vm.runtime_sig_op_counter.consume_sig_ops(1)?;
-
                 match vm.check_ecdsa_signature(hash_type, key.as_slice(), sig.as_slice()) {
                     Ok(valid) => {
                         vm.dstack.push_item(valid)?;
@@ -745,7 +743,6 @@ opcode_list! {
         match sig.pop() {
             Some(typ) => {
                 let hash_type = SigHashType::from_u8(typ).map_err(|e| TxScriptError::InvalidSigHashType(typ))?;
-                vm.runtime_sig_op_counter.consume_sig_ops(1)?;
                 match vm.check_schnorr_signature(hash_type, key.as_slice(), sig.as_slice()) {
                     Ok(valid) => {
                         vm.dstack.push_item(valid)?;

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -3,8 +3,8 @@ mod macros;
 
 use crate::{
     data_stack::{DataStack, Kip10I64, OpcodeData},
-    ScriptSource, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM,
-    NO_COST_OPCODE, SEQUENCE_LOCK_TIME_DISABLED, SEQUENCE_LOCK_TIME_MASK, SigOpConsumer,
+    ScriptSource, SigOpConsumer, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM,
+    NO_COST_OPCODE, SEQUENCE_LOCK_TIME_DISABLED, SEQUENCE_LOCK_TIME_MASK,
 };
 use blake2b_simd::Params;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValues;

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -3,8 +3,8 @@ mod macros;
 
 use crate::{
     data_stack::{DataStack, Kip10I64, OpcodeData},
-    ScriptSource, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM,
-    NO_COST_OPCODE, SEQUENCE_LOCK_TIME_DISABLED, SEQUENCE_LOCK_TIME_MASK,
+    ScriptSource, SpkEncoding, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD, MAX_TX_IN_SEQUENCE_NUM, NO_COST_OPCODE,
+    SEQUENCE_LOCK_TIME_DISABLED, SEQUENCE_LOCK_TIME_MASK,
 };
 use blake2b_simd::Params;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValues;

--- a/crypto/txscript/src/runtime_sig_op_counter.rs
+++ b/crypto/txscript/src/runtime_sig_op_counter.rs
@@ -1,0 +1,77 @@
+use kaspa_txscript_errors::TxScriptError;
+
+/// RuntimeSigOpCounter represents the state tracking of signature operations during script execution.
+/// Unlike the static counting approach which counts all possible signature operations,
+/// this tracks only the actually executed signature operations, leading to more accurate
+/// mass calculations and potentially lower fees for conditional scripts.
+#[derive(Debug, Clone)]
+pub struct RuntimeSigOpCounter {
+    /// Maximum number of signature operations allowed for this input
+    sig_op_limit: u8,
+    /// Remaining signature operations that can be executed
+    sig_op_remaining: u8,
+}
+
+impl RuntimeSigOpCounter {
+    pub fn new(sig_op_limit: u8) -> Self {
+        Self { sig_op_limit, sig_op_remaining: sig_op_limit }
+    }
+    /// Attempts to consume the specified number of signature operations.
+    ///
+    /// This method handles:
+    /// - Checking if we have enough remaining operations
+    /// - Updating the remaining count if successful
+    ///
+    /// # Arguments
+    /// * `num_sigs` - The number of signature operations to consume
+    ///
+    /// # Returns
+    /// * `Ok(())` if the operations were successfully consumed
+    /// * `Err(TxScriptError::ExceededSigOpLimit)` if not enough operations remain
+    ///
+    /// # Example
+    /// ```
+    /// let mut counter = kaspa_txscript::runtime_sig_op_counter::RuntimeSigOpCounter::new(1);
+    ///
+    /// // Consume 3 operations
+    /// counter.consume_sig_op().unwrap(); // Ok(())
+    /// assert_eq!(counter.sig_op_remaining(), 0);
+    /// assert_eq!(counter.used_sig_ops(), 1);
+    /// // Try to consume too many
+    /// counter.consume_sig_op().unwrap_err(); // Err(ExceededSigOpLimit)
+    /// ```
+    pub fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
+        self.sig_op_remaining = self.sig_op_remaining.checked_sub(1).ok_or(TxScriptError::ExceededSigOpLimit(self.sig_op_limit))?;
+
+        Ok(())
+    }
+
+    pub fn sig_op_remaining(&self) -> u8 {
+        self.sig_op_remaining
+    }
+    pub fn sig_op_limit(&self) -> u8 {
+        self.sig_op_limit
+    }
+    pub fn used_sig_ops(&self) -> u8 {
+        self.sig_op_limit - self.sig_op_remaining
+    }
+}
+
+pub trait SigOpConsumer {
+    fn consume_sig_op(&mut self) -> Result<(), TxScriptError>;
+}
+
+impl SigOpConsumer for RuntimeSigOpCounter {
+    fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
+        RuntimeSigOpCounter::consume_sig_op(self)
+    }
+}
+impl SigOpConsumer for Option<RuntimeSigOpCounter> {
+    fn consume_sig_op(&mut self) -> Result<(), TxScriptError> {
+        if let Some(consumer) = self {
+            consumer.consume_sig_op()
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crypto/txscript/src/runtime_sig_op_counter.rs
+++ b/crypto/txscript/src/runtime_sig_op_counter.rs
@@ -22,9 +22,6 @@ impl RuntimeSigOpCounter {
     /// - Checking if we have enough remaining operations
     /// - Updating the remaining count if successful
     ///
-    /// # Arguments
-    /// * `num_sigs` - The number of signature operations to consume
-    ///
     /// # Returns
     /// * `Ok(())` if the operations were successfully consumed
     /// * `Err(TxScriptError::ExceededSigOpLimit)` if not enough operations remain
@@ -33,7 +30,7 @@ impl RuntimeSigOpCounter {
     /// ```
     /// let mut counter = kaspa_txscript::runtime_sig_op_counter::RuntimeSigOpCounter::new(1);
     ///
-    /// // Consume 3 operations
+    /// // Consume 1 operation
     /// counter.consume_sig_op().unwrap(); // Ok(())
     /// assert_eq!(counter.sig_op_remaining(), 0);
     /// assert_eq!(counter.used_sig_ops(), 1);

--- a/crypto/txscript/src/standard/multisig.rs
+++ b/crypto/txscript/src/standard/multisig.rs
@@ -184,7 +184,7 @@ mod tests {
         let (input, entry) = tx.populated_inputs().next().unwrap();
 
         let cache = Cache::new(10_000);
-        let mut engine = TxScriptEngine::from_transaction_input(&tx, input, 0, entry, &reused_values, &cache, false);
+        let mut engine = TxScriptEngine::from_transaction_input(&tx, input, 0, entry, &reused_values, &cache, false, false);
         assert_eq!(engine.execute().is_ok(), is_ok);
     }
     #[test]

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -8,7 +8,7 @@ use kaspa_consensus_core::{
     mass,
     tx::{MutableTransaction, PopulatedTransaction, TransactionOutput},
 };
-use kaspa_txscript::{get_sig_op_count, is_unspendable, script_class::ScriptClass};
+use kaspa_txscript::{get_sig_op_count_upper_bound, is_unspendable, script_class::ScriptClass};
 
 /// MAX_STANDARD_P2SH_SIG_OPS is the maximum number of signature operations
 /// that are considered standard in a pay-to-script-hash script.
@@ -189,7 +189,7 @@ impl Mempool {
                 ScriptClass::PubKeyECDSA => {}
                 ScriptClass::ScriptHash => {
                     // todo relax due to on fly calculation
-                    let num_sig_ops = get_sig_op_count::<PopulatedTransaction, SigHashReusedValuesUnsync>(
+                    let num_sig_ops = get_sig_op_count_upper_bound::<PopulatedTransaction, SigHashReusedValuesUnsync>(
                         &input.signature_script,
                         &entry.script_public_key,
                     );

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -188,6 +188,7 @@ impl Mempool {
                 ScriptClass::PubKey => {}
                 ScriptClass::PubKeyECDSA => {}
                 ScriptClass::ScriptHash => {
+                    // todo relax due to on fly calculation
                     let num_sig_ops = get_sig_op_count::<PopulatedTransaction, SigHashReusedValuesUnsync>(
                         &input.signature_script,
                         &entry.script_public_key,

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -845,7 +845,7 @@ impl KaspadGoParams {
             max_block_level: self.MaxBlockLevel,
             pruning_proof_m: self.PruningProofM,
             payload_activation: ForkActivation::never(),
-            sig_op_on_fly: ForkActivation::never(),
+            runtime_sig_op_counting: ForkActivation::never(),
         }
     }
 }

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -845,6 +845,7 @@ impl KaspadGoParams {
             max_block_level: self.MaxBlockLevel,
             pruning_proof_m: self.PruningProofM,
             payload_activation: ForkActivation::never(),
+            sig_op_on_fly: ForkActivation::never(),
         }
     }
 }

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -436,7 +436,7 @@ impl PSKT<Extractor> {
             let reused_values = SigHashReusedValuesUnsync::new();
 
             tx.populated_inputs().enumerate().try_for_each(|(idx, (input, entry))| {
-                TxScriptEngine::from_transaction_input(&tx, input, idx, entry, &reused_values, &cache, false).execute()?;
+                TxScriptEngine::from_transaction_input(&tx, input, idx, entry, &reused_values, &cache, false, false).execute()?;
                 <Result<(), ExtractError>>::Ok(())
             })?;
         }


### PR DESCRIPTION
# Migrate to runtime signature operation counting

Changes signature operation counting from static analysis to runtime counting during script execution for improved accuracy.

## Key changes
- Add sig_op tracking fields to TxScriptEngine
- Remove static sig_op counting functions
- Count sig_ops during script execution 
- Add runtime checks for sig_op limits
- Add new error type for sig_op limit violations
- Update transaction validation to use runtime counting

## Breaking changes
- Changes sig_op validation timing from pre-execution to during execution
- May affect transaction fee estimation

## Todo
- [x] Add tests for sig_op calculation
- [x] Add documentation for new sig_op runtime counting behavior
- [ ] Consider adding sig_op estimation helper for fee calculation

Requires manual testing and careful review of sig_op counting logic.