### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,9 @@ jobs:
       # Clean unnecessary files to save disk space
       - name: clean unnecessary files to save space
         run: |
-          docker rmi `docker images -q`
+          if [ "$(docker images -q)" ]; then
+            docker rmi $(docker images -q)
+          fi
           sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/sudo apt/sources.list.d
           sudo apt -y autoremove --purge
           sudo apt -y autoclean

--- a/musl-toolchain/build.sh
+++ b/musl-toolchain/build.sh
@@ -17,7 +17,7 @@ source preset.sh
 if [ ! -d "$HOME/x-tools" ] || [ ! -f "$PRESET_HASH_FILE" ] || [ "$(cat $PRESET_HASH_FILE)" != "$CURRENT_PRESET_HASH" ]; then
   # Install dependencies
   sudo apt-get update
-  sudo apt-get install -y autoconf automake libtool  libtool-bin unzip help2man python3.10-dev gperf bison flex texinfo gawk libncurses5-dev
+  sudo apt-get install -y autoconf automake libtool  libtool-bin unzip help2man python3-dev gperf bison flex texinfo gawk libncurses5-dev
   
   # Clone crosstool-ng
   git clone https://github.com/crosstool-ng/crosstool-ng


### PR DESCRIPTION
- Update Python dev package name from python3.10-dev to python3-dev for Ubuntu 24.04 compatibility
- Fix Docker image cleanup to handle empty image list case

The PR adapts the build process for Ubuntu 24.04, which is now the default for ubuntu-latest runners. Fixes failing builds by:

Using the generic python3-dev package which maps to system Python version
Adding condition to check for Docker images before removal