### PR TITLE
Proper tracking of the accumulative circulating supply store value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2295,14 +2295,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "borsh",
  "bs58",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "ahash",
  "cfg-if 1.0.0",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "duration-string",
  "futures",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "cfg-if 1.0.0",
  "ctrlc",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -2815,14 +2815,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "futures-util",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror",
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "secp256k1",
  "thiserror",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes",
  "ahash",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "faster-hex",
  "hexplay",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "ctrlc",
  "futures",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "ahash",
  "async-std",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "clap 4.5.19",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.82.0"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -80,61 +80,61 @@ include = [
 ]
 
 [workspace.dependencies]
-# kaspa-testing-integration = { version = "0.16.0", path = "testing/integration" }
-kaspa-addresses = { version = "0.16.0", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "0.16.0", path = "components/addressmanager" }
-kaspa-bip32 = { version = "0.16.0", path = "wallet/bip32" }
-kaspa-cli = { version = "0.16.0", path = "cli" }
-kaspa-connectionmanager = { version = "0.16.0", path = "components/connectionmanager" }
-kaspa-consensus = { version = "0.16.0", path = "consensus" }
-kaspa-consensus-core = { version = "0.16.0", path = "consensus/core" }
-kaspa-consensus-client = { version = "0.16.0", path = "consensus/client" }
-kaspa-consensus-notify = { version = "0.16.0", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "0.16.0", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "0.16.0", path = "components/consensusmanager" }
-kaspa-core = { version = "0.16.0", path = "core" }
-kaspa-daemon = { version = "0.16.0", path = "daemon" }
-kaspa-database = { version = "0.16.0", path = "database" }
-kaspa-grpc-client = { version = "0.16.0", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "0.16.0", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "0.16.0", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "0.16.0", path = "crypto/hashes" }
-kaspa-index-core = { version = "0.16.0", path = "indexes/core" }
-kaspa-index-processor = { version = "0.16.0", path = "indexes/processor" }
-kaspa-math = { version = "0.16.0", path = "math" }
-kaspa-merkle = { version = "0.16.0", path = "crypto/merkle" }
-kaspa-metrics-core = { version = "0.16.0", path = "metrics/core" }
-kaspa-mining = { version = "0.16.0", path = "mining" }
-kaspa-mining-errors = { version = "0.16.0", path = "mining/errors" }
-kaspa-muhash = { version = "0.16.0", path = "crypto/muhash" }
-kaspa-notify = { version = "0.16.0", path = "notify" }
-kaspa-p2p-flows = { version = "0.16.0", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "0.16.0", path = "protocol/p2p" }
-kaspa-perf-monitor = { version = "0.16.0", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "0.16.0", path = "consensus/pow" }
-kaspa-rpc-core = { version = "0.16.0", path = "rpc/core" }
-kaspa-rpc-macros = { version = "0.16.0", path = "rpc/macros" }
-kaspa-rpc-service = { version = "0.16.0", path = "rpc/service" }
-kaspa-txscript = { version = "0.16.0", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "0.16.0", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "0.16.0", path = "utils" }
-kaspa-utils-tower = { version = "0.16.0", path = "utils/tower" }
-kaspa-utxoindex = { version = "0.16.0", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "0.16.0", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "0.16.0", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "0.16.0", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "0.16.0", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "0.16.0", path = "wallet/core" }
-kaspa-wallet-macros = { version = "0.16.0", path = "wallet/macros" }
-kaspa-wasm = { version = "0.16.0", path = "wasm" }
-kaspa-wasm-core = { version = "0.16.0", path = "wasm/core" }
-kaspa-wrpc-client = { version = "0.16.0", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "0.16.0", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "0.16.0", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "0.16.0", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "0.16.0", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "0.16.0", path = "kaspad" }
-kaspa-alloc = { version = "0.16.0", path = "utils/alloc" }
+# kaspa-testing-integration = { version = "0.16.1", path = "testing/integration" }
+kaspa-addresses = { version = "0.16.1", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "0.16.1", path = "components/addressmanager" }
+kaspa-bip32 = { version = "0.16.1", path = "wallet/bip32" }
+kaspa-cli = { version = "0.16.1", path = "cli" }
+kaspa-connectionmanager = { version = "0.16.1", path = "components/connectionmanager" }
+kaspa-consensus = { version = "0.16.1", path = "consensus" }
+kaspa-consensus-core = { version = "0.16.1", path = "consensus/core" }
+kaspa-consensus-client = { version = "0.16.1", path = "consensus/client" }
+kaspa-consensus-notify = { version = "0.16.1", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "0.16.1", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "0.16.1", path = "components/consensusmanager" }
+kaspa-core = { version = "0.16.1", path = "core" }
+kaspa-daemon = { version = "0.16.1", path = "daemon" }
+kaspa-database = { version = "0.16.1", path = "database" }
+kaspa-grpc-client = { version = "0.16.1", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "0.16.1", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "0.16.1", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "0.16.1", path = "crypto/hashes" }
+kaspa-index-core = { version = "0.16.1", path = "indexes/core" }
+kaspa-index-processor = { version = "0.16.1", path = "indexes/processor" }
+kaspa-math = { version = "0.16.1", path = "math" }
+kaspa-merkle = { version = "0.16.1", path = "crypto/merkle" }
+kaspa-metrics-core = { version = "0.16.1", path = "metrics/core" }
+kaspa-mining = { version = "0.16.1", path = "mining" }
+kaspa-mining-errors = { version = "0.16.1", path = "mining/errors" }
+kaspa-muhash = { version = "0.16.1", path = "crypto/muhash" }
+kaspa-notify = { version = "0.16.1", path = "notify" }
+kaspa-p2p-flows = { version = "0.16.1", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "0.16.1", path = "protocol/p2p" }
+kaspa-perf-monitor = { version = "0.16.1", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "0.16.1", path = "consensus/pow" }
+kaspa-rpc-core = { version = "0.16.1", path = "rpc/core" }
+kaspa-rpc-macros = { version = "0.16.1", path = "rpc/macros" }
+kaspa-rpc-service = { version = "0.16.1", path = "rpc/service" }
+kaspa-txscript = { version = "0.16.1", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "0.16.1", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "0.16.1", path = "utils" }
+kaspa-utils-tower = { version = "0.16.1", path = "utils/tower" }
+kaspa-utxoindex = { version = "0.16.1", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "0.16.1", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "0.16.1", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "0.16.1", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "0.16.1", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "0.16.1", path = "wallet/core" }
+kaspa-wallet-macros = { version = "0.16.1", path = "wallet/macros" }
+kaspa-wasm = { version = "0.16.1", path = "wasm" }
+kaspa-wasm-core = { version = "0.16.1", path = "wasm/core" }
+kaspa-wrpc-client = { version = "0.16.1", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "0.16.1", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "0.16.1", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "0.16.1", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "0.16.1", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "0.16.1", path = "kaspad" }
+kaspa-alloc = { version = "0.16.1", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/indexes/utxoindex/src/index.rs
+++ b/indexes/utxoindex/src/index.rs
@@ -88,11 +88,11 @@ impl UtxoIndexApi for UtxoIndex {
         // Commit changed utxo state to db
         self.store.update_utxo_state(&utxoindex_changes.utxo_changes.added, &utxoindex_changes.utxo_changes.removed, false)?;
 
-        // Commit circulating supply change (if monotonic) to db.
-        if utxoindex_changes.supply_change > 0 {
-            //we force monotonic here
-            let _circulating_supply =
-                self.store.update_circulating_supply(utxoindex_changes.supply_change as CirculatingSupply, false)?;
+        // Update the stored circulating supply with the accumulated delta of the changes
+        let updated_circulating_supply = self.store.update_circulating_supply(utxoindex_changes.supply_change, false)?;
+
+
+        
         }
 
         // Commit new consensus virtual tips.

--- a/indexes/utxoindex/src/index.rs
+++ b/indexes/utxoindex/src/index.rs
@@ -28,14 +28,20 @@ const RESYNC_CHUNK_SIZE: usize = 2048; //Increased from 1k (used in go-kaspad), 
 pub struct UtxoIndex {
     consensus_manager: Arc<ConsensusManager>,
     store: Store,
+    /// A runtime value holding a monotonic supply value. Used to prevent supply fluctuations due
+    /// to the single round gap between fee deduction and its payment to miners
+    monotonic_circulating_supply: CirculatingSupply,
 }
 
 impl UtxoIndex {
     /// Creates a new [`UtxoIndex`] within a [`RwLock`]
     pub fn new(consensus_manager: Arc<ConsensusManager>, db: Arc<DB>) -> UtxoIndexResult<Arc<RwLock<Self>>> {
-        let mut utxoindex = Self { consensus_manager: consensus_manager.clone(), store: Store::new(db) };
+        let mut utxoindex =
+            Self { consensus_manager: consensus_manager.clone(), store: Store::new(db), monotonic_circulating_supply: 0 };
         if !utxoindex.is_synced()? {
             utxoindex.resync()?;
+        } else {
+            utxoindex.monotonic_circulating_supply = utxoindex.store.get_circulating_supply()?;
         }
         let utxoindex = Arc::new(RwLock::new(utxoindex));
         consensus_manager.register_consensus_reset_handler(Arc::new(UtxoIndexConsensusResetHandler::new(Arc::downgrade(&utxoindex))));
@@ -48,7 +54,7 @@ impl UtxoIndexApi for UtxoIndex {
     fn get_circulating_supply(&self) -> StoreResult<u64> {
         trace!("[{0}] retrieving circulating supply", IDENT);
 
-        self.store.get_circulating_supply()
+        Ok(self.monotonic_circulating_supply)
     }
 
     /// Retrieve utxos by script public keys from the utxoindex db.
@@ -91,8 +97,9 @@ impl UtxoIndexApi for UtxoIndex {
         // Update the stored circulating supply with the accumulated delta of the changes
         let updated_circulating_supply = self.store.update_circulating_supply(utxoindex_changes.supply_change, false)?;
 
-
-        
+        // Update the monotonic runtime value
+        if updated_circulating_supply > self.monotonic_circulating_supply {
+            self.monotonic_circulating_supply = updated_circulating_supply;
         }
 
         // Commit new consensus virtual tips.
@@ -175,6 +182,7 @@ impl UtxoIndexApi for UtxoIndex {
 
         trace!("[{0}] committing circulating supply {1} from consensus db", IDENT, circulating_supply);
         self.store.insert_circulating_supply(circulating_supply, true)?;
+        self.monotonic_circulating_supply = circulating_supply;
 
         trace!("[{0}] committing consensus tips {consensus_tips:?} from consensus db", IDENT);
         self.store.set_tips(consensus_tips, true)?;

--- a/indexes/utxoindex/src/stores/store_manager.rs
+++ b/indexes/utxoindex/src/stores/store_manager.rs
@@ -75,7 +75,7 @@ impl Store {
         self.circulating_supply_store.get()
     }
 
-    pub fn update_circulating_supply(&mut self, circulating_supply_diff: u64, try_reset_on_err: bool) -> StoreResult<u64> {
+    pub fn update_circulating_supply(&mut self, circulating_supply_diff: i64, try_reset_on_err: bool) -> StoreResult<u64> {
         let res = self.circulating_supply_store.update_circulating_supply(circulating_supply_diff);
         if try_reset_on_err && res.is_err() {
             self.delete_all()?;

--- a/indexes/utxoindex/src/stores/store_manager.rs
+++ b/indexes/utxoindex/src/stores/store_manager.rs
@@ -53,6 +53,8 @@ impl Store {
         to_remove: &UtxoSetByScriptPublicKey,
         try_reset_on_err: bool,
     ) -> StoreResult<()> {
+        // A UTXO entry can appear both in removed and in added (if the DAA score of the entry changed). Thus
+        // we must first apply removals and then additions (so it will be re-added in the addition phase)
         let mut res = self.utxos_by_script_public_key_store.remove_utxo_entries(to_remove);
 
         if res.is_err() {
@@ -62,6 +64,7 @@ impl Store {
             return res;
         }
 
+        // Now apply additions
         res = self.utxos_by_script_public_key_store.add_utxo_entries(to_add);
 
         if try_reset_on_err && res.is_err() {

--- a/indexes/utxoindex/src/update_container.rs
+++ b/indexes/utxoindex/src/update_container.rs
@@ -27,12 +27,9 @@ impl UtxoIndexChanges {
 
     /// Add a [`UtxoDiff`] the [`UtxoIndexChanges`] struct.
     pub fn update_utxo_diff(&mut self, utxo_diff: UtxoDiff) {
-        let (to_add, mut to_remove) = (utxo_diff.add, utxo_diff.remove);
+        let (to_add, to_remove) = (utxo_diff.add, utxo_diff.remove);
 
         for (transaction_outpoint, utxo_entry) in to_add.into_iter() {
-            if to_remove.remove(&transaction_outpoint).is_some() {
-                continue;
-            }; // We try and remove from `utxo_diff.remove`, if we do, discard utxo.
             self.supply_change += utxo_entry.amount as CirculatingSupplyDiff;
 
             self.utxo_changes.added.insert_into_nested(

--- a/indexes/utxoindex/src/update_container.rs
+++ b/indexes/utxoindex/src/update_container.rs
@@ -33,7 +33,7 @@ impl UtxoIndexChanges {
             if to_remove.remove(&transaction_outpoint).is_some() {
                 continue;
             }; // We try and remove from `utxo_diff.remove`, if we do, discard utxo.
-            self.supply_change += utxo_entry.amount as CirculatingSupplyDiff; // TODO: Using `virtual_state.mergeset_rewards` might be a better way to extract this.
+            self.supply_change += utxo_entry.amount as CirculatingSupplyDiff;
 
             self.utxo_changes.added.insert_into_nested(
                 utxo_entry.script_public_key,
@@ -43,7 +43,7 @@ impl UtxoIndexChanges {
         }
 
         for (transaction_outpoint, utxo_entry) in to_remove.into_iter() {
-            self.supply_change -= utxo_entry.amount as CirculatingSupplyDiff; // TODO: Using `virtual_state.mergeset_rewards` might be a better way to extract this.
+            self.supply_change -= utxo_entry.amount as CirculatingSupplyDiff;
 
             self.utxo_changes.removed.insert_into_nested(
                 utxo_entry.script_public_key,


### PR DESCRIPTION
The circulating supply value is tracked as a single DB entry within the UTXO index store (external to consensus). 
This value was not tracked properly when mergeset fees exceeded new block rewards, resulting in an accumulating error to the tracked value. Note that the actual sum of supply in the UTXO set is always accurate.  

This PR fixes the tracked store value to always be updated with the exact delta also when negative, and still provides a monotonic RPC value by keeping a separate monotonic runtime value. 