### PR TITLE
Generalized KIP9--storage mass plurality (Crescendo)

### DIFF
--- a/consensus/client/src/utxo.rs
+++ b/consensus/client/src/utxo.rs
@@ -12,6 +12,7 @@ use crate::imports::*;
 use crate::outpoint::{TransactionOutpoint, TransactionOutpointInner};
 use crate::result::Result;
 use kaspa_addresses::Address;
+use kaspa_consensus_core::mass::UtxoPlurality;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_UTXO_ENTRY: &'static str = r#"
@@ -215,6 +216,12 @@ impl UtxoEntryReference {
     #[inline(always)]
     pub fn transaction_id_as_ref(&self) -> &TransactionId {
         self.utxo.outpoint.transaction_id_as_ref()
+    }
+}
+
+impl UtxoPlurality for UtxoEntryReference {
+    fn plurality(&self) -> u64 {
+        self.utxo.script_public_key.plurality()
     }
 }
 

--- a/consensus/client/src/utxo.rs
+++ b/consensus/client/src/utxo.rs
@@ -12,7 +12,7 @@ use crate::imports::*;
 use crate::outpoint::{TransactionOutpoint, TransactionOutpointInner};
 use crate::result::Result;
 use kaspa_addresses::Address;
-use kaspa_consensus_core::mass::UtxoPlurality;
+use kaspa_consensus_core::mass::{UtxoCell, UtxoPlurality};
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_UTXO_ENTRY: &'static str = r#"
@@ -219,12 +219,6 @@ impl UtxoEntryReference {
     }
 }
 
-impl UtxoPlurality for UtxoEntryReference {
-    fn plurality(&self) -> u64 {
-        self.utxo.script_public_key.plurality()
-    }
-}
-
 impl std::hash::Hash for UtxoEntryReference {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id().hash(state);
@@ -253,6 +247,12 @@ impl From<&UtxoEntryReference> for cctx::UtxoEntry {
 impl From<UtxoEntry> for UtxoEntryReference {
     fn from(entry: UtxoEntry) -> Self {
         Self { utxo: Arc::new(entry) }
+    }
+}
+
+impl From<&UtxoEntryReference> for UtxoCell {
+    fn from(entry: &UtxoEntryReference) -> Self {
+        Self::new(entry.utxo.script_public_key.plurality(), entry.amount())
     }
 }
 

--- a/consensus/core/src/mass/mod.rs
+++ b/consensus/core/src/mass/mod.rs
@@ -112,14 +112,14 @@ impl UtxoPlurality for TransactionOutput {
 /// script public keys larger than the standard 33-byte limit. For a UTXO of byte-size
 /// `entry.size`, we define:
 ///
-/// ```text
-/// P := ceil(entry.size / UTXO_UNIT)
+/// ```ignore
+/// p := ceil(entry.size / UTXO_UNIT)
 /// ```
 ///
-/// Conceptually, we treat a large UTXO as `P` sub-entries each holding `entry.amount / P`,
+/// Conceptually, we treat a large UTXO as `p` sub-entries each holding `entry.amount / p`,
 /// preserving the total locked amount but increasing the "count" proportionally to script size.
 ///
-/// Refer to the KIP-0009 specification and related documentation for more details.
+/// Refer to the KIP-0009 specification for more details.
 #[derive(Clone, Copy)]
 pub struct UtxoCell {
     /// The plurality (number of "storage units") for this UTXO
@@ -295,8 +295,8 @@ impl MassCalculator {
 ///
 /// The core formula is:
 ///
-/// ```text
-/// max(0, C * (|O| / H(O) - |I| / A(I)))
+/// ```ignore
+///     max(0, C * (|O| / H(O) - |I| / A(I)))
 /// ```
 ///
 /// where:
@@ -308,13 +308,17 @@ impl MassCalculator {
 ///
 ///   In standard KIP-0009, one has:
 ///
+///```ignore
 ///       |O| / H(O) = Σ (1 / o)
+///```
 ///
-///   Here, each UTXO that occupies `P` "storage units" is treated as if it were `P` sub-entries,
-///   each holding `amount / P`. This effectively turns `1 / o` into `P^2 / amount`. The code
+///   Here, each UTXO that occupies `p` "storage units" is treated as if it were `p` sub-entries,
+///   each holding `amount / p`. This effectively turns `1 / o` into `p^2 / amount`. The code
 ///   thus accumulates:
 ///
-///       Σ [C * P(o)^2 / amount(o)]
+///```ignore
+///       Σ [C * p(o)^2 / amount(o)]
+///```
 ///
 /// - `A(I)` is the arithmetic mean of the inputs' amounts, similarly scaled by the total input
 ///   plurality (`|I|`), while the sum of amounts can remain unchanged.

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -307,6 +307,12 @@ pub struct PopulatedInputIterator<'a, T: VerifiableTransaction> {
     r: Range<usize>,
 }
 
+impl<T: VerifiableTransaction> Clone for PopulatedInputIterator<'_, T> {
+    fn clone(&self) -> Self {
+        Self { tx: self.tx, r: self.r.clone() }
+    }
+}
+
 impl<'a, T: VerifiableTransaction> PopulatedInputIterator<'a, T> {
     pub fn new(tx: &'a T) -> Self {
         Self { tx, r: (0..tx.inputs().len()) }

--- a/consensus/core/src/tx/script_public_key.rs
+++ b/consensus/core/src/tx/script_public_key.rs
@@ -56,14 +56,6 @@ pub struct ScriptPublicKey {
     pub(super) script: ScriptVec, // Kept private to preserve read-only semantics
 }
 
-impl ScriptPublicKey {
-    pub fn plurality(&self) -> u64 {
-        const UTXO_STORAGE: usize = 32 + 4 + 8 + 8 + 1 + 2 + 8;
-        const UTXO_UNIT: usize = 100;
-        (UTXO_STORAGE + self.script.len()).div_ceil(UTXO_UNIT) as u64
-    }
-}
-
 impl std::fmt::Debug for ScriptPublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScriptPublicKey").field("version", &self.version).field("script", &self.script.to_hex()).finish()

--- a/consensus/core/src/tx/script_public_key.rs
+++ b/consensus/core/src/tx/script_public_key.rs
@@ -56,6 +56,14 @@ pub struct ScriptPublicKey {
     pub(super) script: ScriptVec, // Kept private to preserve read-only semantics
 }
 
+impl ScriptPublicKey {
+    pub fn plurality(&self) -> u64 {
+        const UTXO_STORAGE: usize = 32 + 4 + 8 + 8 + 1 + 2 + 8;
+        const UTXO_UNIT: usize = 100;
+        (UTXO_STORAGE + self.script.len()).div_ceil(UTXO_UNIT) as u64
+    }
+}
+
 impl std::fmt::Debug for ScriptPublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScriptPublicKey").field("version", &self.version).field("script", &self.script.to_hex()).finish()

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -329,8 +329,8 @@ impl MassCalculator {
     ) -> Option<u64> {
         consensus_calc_storage_mass(
             false,
-            inputs.iter().map(|entry| entry.amount()),
-            outputs.iter().map(|out| out.value),
+            inputs.iter().map(|entry| (entry.utxo.script_public_key.plurality(), entry.amount())),
+            outputs.iter().map(|out| (out.script_public_key.plurality(), out.value)),
             self.storage_mass_parameter,
         )
     }

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::result::Result;
 use kaspa_consensus_client as kcc;
 use kaspa_consensus_client::UtxoEntryReference;
-use kaspa_consensus_core::mass::{calc_storage_mass as consensus_calc_storage_mass, UtxoPlurality};
+use kaspa_consensus_core::mass::calc_storage_mass as consensus_calc_storage_mass;
 use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput, SCRIPT_VECTOR_SIZE};
 use kaspa_consensus_core::{config::params::Params, constants::*, subnets::SUBNETWORK_ID_SIZE};
 use kaspa_hashes::HASH_SIZE;
@@ -329,8 +329,8 @@ impl MassCalculator {
     ) -> Option<u64> {
         consensus_calc_storage_mass(
             false,
-            inputs.iter().map(|entry| (entry.plurality(), entry.amount())),
-            outputs.iter().map(|out| (out.plurality(), out.value)),
+            inputs.iter().map(|entry| entry.into()),
+            outputs.iter().map(|out| out.into()),
             self.storage_mass_parameter,
         )
     }

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::result::Result;
 use kaspa_consensus_client as kcc;
 use kaspa_consensus_client::UtxoEntryReference;
-use kaspa_consensus_core::mass::calc_storage_mass as consensus_calc_storage_mass;
+use kaspa_consensus_core::mass::{calc_storage_mass as consensus_calc_storage_mass, UtxoPlurality};
 use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput, SCRIPT_VECTOR_SIZE};
 use kaspa_consensus_core::{config::params::Params, constants::*, subnets::SUBNETWORK_ID_SIZE};
 use kaspa_hashes::HASH_SIZE;
@@ -329,8 +329,8 @@ impl MassCalculator {
     ) -> Option<u64> {
         consensus_calc_storage_mass(
             false,
-            inputs.iter().map(|entry| (entry.utxo.script_public_key.plurality(), entry.amount())),
-            outputs.iter().map(|out| (out.script_public_key.plurality(), out.value)),
+            inputs.iter().map(|entry| (entry.plurality(), entry.amount())),
+            outputs.iter().map(|out| (out.plurality(), out.value)),
             self.storage_mass_parameter,
         )
     }


### PR DESCRIPTION
Generalizes KIP9 to handle the case where the UTXO script public key is larger than standard keys (max 33 bytes for ECDSA) and thus captures more (persistent) storage.

The idea is based on the following simple reduction:

- Define the base UTXO storage unit (`UTXO_UNIT=100` bytes seems a natural choice)
- For a UTXO entry, let `P := ceiling(entry.size/UTXO_UNIT)` denote the UTXO's "plurality"
- Treat the entry as `P` entries each holding `entry.amount/P` KAS value 

This directly maps the usage of such a big entry to the usage of `P` single-unit entries in a model where all entries have the same size.

The choice of `UTXO_UNIT=100` is driven by the const parts of the UTXO = 63 bytes + max standard public key which is 33 bytes.

Implementing the above reduction in the storage mass calculation is straightforward. The harmonic part of the formula is $\frac{|O|}{H(O)} = \sum_{o \in O} \frac{1}{o}$. For each entry we now generalize to $\frac{P}{o/P} = \frac{P^2}{o}$. The arithmetic part of the formula is $\frac{|I|}{A(I)} = \frac{|I|^2}{sum(I)}$, and is generalized to $\frac{sum(plurality(I))^2}{sum(I)}$ where $sum(plurality(I)) = \sum_{i \in I} plurality(i)$. Note that $sum(I)$ can remain unchanged. 