### PR TITLE
Smooth transition of pruning points/samples (Crescendo)  

### DIFF
--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -219,7 +219,7 @@ pub trait ConsensusApi: Send + Sync {
         unimplemented!()
     }
 
-    fn import_pruning_points(&self, pruning_points: PruningPointsList) {
+    fn import_pruning_points(&self, pruning_points: PruningPointsList) -> PruningImportResult<()> {
         unimplemented!()
     }
 

--- a/consensus/core/src/errors/pruning.rs
+++ b/consensus/core/src/errors/pruning.rs
@@ -62,6 +62,12 @@ pub enum PruningImportError {
 
     #[error("block {0} at level {1} has invalid proof of work for level")]
     ProofOfWorkFailed(Hash, BlockLevel),
+
+    #[error("past pruning points at indices {0}, {1} have non monotonic blue score {2}, {3}")]
+    InconsistentPastPruningPoints(usize, usize, u64, u64),
+
+    #[error("past pruning points contains {0} duplications")]
+    DuplicatedPastPruningPoints(usize),
 }
 
 pub type PruningImportResult<T> = std::result::Result<T, PruningImportError>;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -766,7 +766,7 @@ impl ConsensusApi for Consensus {
         self.services.pruning_proof_manager.apply_proof(proof, trusted_set)
     }
 
-    fn import_pruning_points(&self, pruning_points: PruningPointsList) {
+    fn import_pruning_points(&self, pruning_points: PruningPointsList) -> PruningImportResult<()> {
         self.services.pruning_proof_manager.import_pruning_points(&pruning_points)
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -798,6 +798,13 @@ impl ConsensusApi for Consensus {
         if !self.services.pruning_point_manager.is_valid_pruning_point(pp_info.pruning_point, syncer_virtual_selected_parent) {
             return Err(ConsensusError::General("pruning point does not coincide with the syncer's sink (virtual selected parent)"));
         }
+        for p in (0..self.pruning_point_store.read().get().unwrap().index)
+            .map(|index| self.past_pruning_points_store.get(index).unwrap())
+            .map(|h| self.headers_store.get_header(h).unwrap())
+            .take(30)
+        {
+            println!("{} -> {} [{}]", &p.hash.to_string()[58..], &p.pruning_point.to_string()[58..], p.blue_score);
+        }
         if !self.services.pruning_point_manager.are_pruning_points_in_valid_chain(pp_info, syncer_virtual_selected_parent) {
             return Err(ConsensusError::General("past pruning points do not form a valid chain"));
         }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -845,13 +845,6 @@ impl ConsensusApi for Consensus {
         if !self.services.pruning_point_manager.is_valid_pruning_point(pp_info.pruning_point, syncer_virtual_selected_parent) {
             return Err(ConsensusError::General("pruning point does not coincide with the syncer's sink (virtual selected parent)"));
         }
-        for p in (0..self.pruning_point_store.read().get().unwrap().index)
-            .map(|index| self.past_pruning_points_store.get(index).unwrap())
-            .map(|h| self.headers_store.get_header(h).unwrap())
-            .take(30)
-        {
-            println!("{} -> {} [{}]", &p.hash.to_string()[58..], &p.pruning_point.to_string()[58..], p.blue_score);
-        }
         if !self.services.pruning_point_manager.are_pruning_points_in_valid_chain(pp_info, syncer_virtual_selected_parent) {
             return Err(ConsensusError::General("past pruning points do not form a valid chain"));
         }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -21,6 +21,8 @@ use crate::{
             headers_selected_tip::HeadersSelectedTipStoreReader,
             past_pruning_points::PastPruningPointsStoreReader,
             pruning::PruningStoreReader,
+            pruning_samples::{PruningSamplesStore, PruningSamplesStoreReader},
+            reachability::ReachabilityStoreReader,
             relations::RelationsStoreReader,
             statuses::StatusesStoreReader,
             tips::TipsStoreReader,
@@ -79,7 +81,7 @@ use crossbeam_channel::{
 use itertools::Itertools;
 use kaspa_consensusmanager::{SessionLock, SessionReadGuard};
 
-use kaspa_database::prelude::StoreResultExtensions;
+use kaspa_database::prelude::{StoreResultEmptyTuple, StoreResultExtensions};
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
 use kaspa_txscript::caches::TxScriptCacheCounters;
@@ -87,7 +89,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use std::{
     cmp::Reverse,
-    collections::BinaryHeap,
+    collections::{BinaryHeap, VecDeque},
     future::Future,
     iter::once,
     ops::Deref,
@@ -288,7 +290,7 @@ impl Consensus {
             virtual_processor.process_genesis();
         }
 
-        Self {
+        let this = Self {
             db,
             block_sender: sender,
             header_processor,
@@ -303,7 +305,52 @@ impl Consensus {
             config,
             creation_timestamp,
             is_consensus_exiting,
+        };
+
+        // Database upgrade to include pruning samples
+        this.pruning_samples_database_upgrade();
+
+        this
+    }
+
+    fn pruning_samples_database_upgrade(&self) {
+        //
+        // For the first time this version runs, make sure we populate pruning samples
+        // from pov for all qualified chain blocks in the pruning point future
+        //
+
+        let sink = self.get_sink();
+        if self.storage.pruning_samples_store.pruning_sample_from_pov(sink).unwrap_option().is_some() {
+            // Sink is populated so we assume the database is upgraded
+            return;
         }
+
+        let pruning_point = self.pruning_point();
+        let reachability = self.reachability_store.read();
+
+        // We walk up via reachability tree children so that we only iterate blocks B s.t. pruning point ∈ chain(B)
+        let mut queue = VecDeque::<Hash>::from_iter(reachability.get_children(pruning_point).unwrap().iter().copied());
+        let mut processed = 0;
+        kaspa_core::info!("Upgrading database to include and populate the pruning samples store");
+        while let Some(current) = queue.pop_front() {
+            if !self.get_block_status(current).is_some_and(|s| s == BlockStatus::StatusUTXOValid) {
+                // Skip branches of the tree which are not chain qualified.
+                // This is sufficient since we will only assume this field exists
+                // for such chain qualified blocks
+                continue;
+            }
+            queue.extend(reachability.get_children(current).unwrap().iter());
+
+            processed += 1;
+
+            // Populate the data
+            let ghostdag_data = self.ghostdag_store.get_compact_data(current).unwrap();
+            let pruning_sample_from_pov =
+                self.services.pruning_point_manager.expected_header_pruning_point_v2(ghostdag_data).pruning_sample;
+            self.pruning_samples_store.insert(current, pruning_sample_from_pov).unwrap_or_exists();
+        }
+
+        kaspa_core::info!("Done upgrading database (populated {} entries)", processed);
     }
 
     pub fn run_processors(&self) -> Vec<JoinHandle<()>> {

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -158,7 +158,6 @@ impl ConsensusServices {
         let pruning_point_manager = PruningPointManager::new(
             params.pruning_depth(),
             params.finality_depth(),
-            params.ghostdag_k(),
             params.genesis.hash,
             reachability_service.clone(),
             storage.ghostdag_store.clone(),

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -152,6 +152,7 @@ impl ConsensusServices {
         let pruning_point_manager = PruningPointManager::new(
             params.pruning_depth(),
             params.finality_depth(),
+            params.ghostdag_k(),
             params.genesis.hash,
             reachability_service.clone(),
             storage.ghostdag_store.clone(),

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -6,8 +6,8 @@ use crate::{
         stores::{
             block_window_cache::BlockWindowCacheStore, daa::DbDaaStore, depth::DbDepthStore, ghostdag::DbGhostdagStore,
             headers::DbHeadersStore, headers_selected_tip::DbHeadersSelectedTipStore, past_pruning_points::DbPastPruningPointsStore,
-            pruning::DbPruningStore, reachability::DbReachabilityStore, relations::DbRelationsStore,
-            selected_chain::DbSelectedChainStore, statuses::DbStatusesStore, DB,
+            pruning::DbPruningStore, pruning_samples::DbPruningSamplesStore, reachability::DbReachabilityStore,
+            relations::DbRelationsStore, selected_chain::DbSelectedChainStore, statuses::DbStatusesStore, DB,
         },
     },
     processes::{
@@ -38,8 +38,14 @@ pub type DbSyncManager = SyncManager<
     DbStatusesStore,
 >;
 
-pub type DbPruningPointManager =
-    PruningPointManager<DbGhostdagStore, DbReachabilityStore, DbHeadersStore, DbPastPruningPointsStore, DbHeadersSelectedTipStore>;
+pub type DbPruningPointManager = PruningPointManager<
+    DbGhostdagStore,
+    DbReachabilityStore,
+    DbHeadersStore,
+    DbPastPruningPointsStore,
+    DbHeadersSelectedTipStore,
+    DbPruningSamplesStore,
+>;
 pub type DbBlockDepthManager = BlockDepthManager<DbDepthStore, DbReachabilityStore, DbGhostdagStore, DbHeadersStore>;
 pub type DbParentsManager = ParentsManager<DbHeadersStore, DbReachabilityStore, MTRelationsService<DbRelationsStore>>;
 
@@ -159,6 +165,7 @@ impl ConsensusServices {
             storage.headers_store.clone(),
             storage.past_pruning_points_store.clone(),
             storage.headers_selected_tip_store.clone(),
+            storage.pruning_samples_store.clone(),
         );
 
         let parents_manager = ParentsManager::new(

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -11,6 +11,7 @@ use crate::{
         headers_selected_tip::DbHeadersSelectedTipStore,
         past_pruning_points::DbPastPruningPointsStore,
         pruning::DbPruningStore,
+        pruning_samples::DbPruningSamplesStore,
         pruning_utxoset::PruningUtxosetStores,
         reachability::{DbReachabilityStore, ReachabilityData},
         relations::DbRelationsStore,
@@ -56,6 +57,7 @@ pub struct ConsensusStorage {
     pub past_pruning_points_store: Arc<DbPastPruningPointsStore>,
     pub daa_excluded_store: Arc<DbDaaStore>,
     pub depth_store: Arc<DbDepthStore>,
+    pub pruning_samples_store: Arc<DbPruningSamplesStore>,
 
     // Utxo-related stores
     pub utxo_diffs_store: Arc<DbUtxoDiffsStore>,
@@ -210,6 +212,7 @@ impl ConsensusStorage {
         let pruning_point_store = Arc::new(RwLock::new(DbPruningStore::new(db.clone())));
         let past_pruning_points_store = Arc::new(DbPastPruningPointsStore::new(db.clone(), past_pruning_points_builder.build()));
         let pruning_utxoset_stores = Arc::new(RwLock::new(PruningUtxosetStores::new(db.clone(), utxo_set_builder.build())));
+        let pruning_samples_store = Arc::new(DbPruningSamplesStore::new(db.clone(), header_data_builder.build()));
 
         // Txs
         let block_transactions_store = Arc::new(DbBlockTransactionsStore::new(db.clone(), transactions_builder.build()));
@@ -253,6 +256,7 @@ impl ConsensusStorage {
             past_pruning_points_store,
             daa_excluded_store,
             depth_store,
+            pruning_samples_store,
             utxo_diffs_store,
             utxo_multisets_store,
             block_window_cache_for_difficulty,

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -117,11 +117,11 @@ impl TestConsensus {
     pub fn build_header_with_parents(&self, hash: Hash, parents: Vec<Hash>) -> Header {
         let mut header = header_from_precomputed_hash(hash, parents);
         let ghostdag_data = self.consensus.services.ghostdag_manager.ghostdag(header.direct_parents());
-        header.pruning_point = self.consensus.services.pruning_point_manager.expected_header_pruning_point(
-            ghostdag_data.to_compact(),
-            self.consensus.pruning_point_store.read().get().unwrap(),
-            None,
-        );
+        header.pruning_point = self
+            .consensus
+            .services
+            .pruning_point_manager
+            .expected_header_pruning_point__(ghostdag_data.to_compact(), self.consensus.pruning_point_store.read().get().unwrap());
         let daa_window = self.consensus.services.window_manager.block_daa_window(&ghostdag_data).unwrap();
         header.bits = self.consensus.services.window_manager.calculate_difficulty_bits(&ghostdag_data, &daa_window);
         header.daa_score = daa_window.daa_score;

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -121,7 +121,7 @@ impl TestConsensus {
             .consensus
             .services
             .pruning_point_manager
-            .expected_header_pruning_point__(ghostdag_data.to_compact(), self.consensus.pruning_point_store.read().get().unwrap());
+            .expected_header_pruning_point_v1(ghostdag_data.to_compact(), self.consensus.pruning_point_store.read().get().unwrap());
         let daa_window = self.consensus.services.window_manager.block_daa_window(&ghostdag_data).unwrap();
         header.bits = self.consensus.services.window_manager.calculate_difficulty_bits(&ghostdag_data, &daa_window);
         header.daa_score = daa_window.daa_score;

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -117,11 +117,11 @@ impl TestConsensus {
     pub fn build_header_with_parents(&self, hash: Hash, parents: Vec<Hash>) -> Header {
         let mut header = header_from_precomputed_hash(hash, parents);
         let ghostdag_data = self.consensus.services.ghostdag_manager.ghostdag(header.direct_parents());
-        header.pruning_point = self
-            .consensus
-            .services
-            .pruning_point_manager
-            .expected_header_pruning_point(ghostdag_data.to_compact(), self.consensus.pruning_point_store.read().get().unwrap());
+        header.pruning_point = self.consensus.services.pruning_point_manager.expected_header_pruning_point(
+            ghostdag_data.to_compact(),
+            self.consensus.pruning_point_store.read().get().unwrap(),
+            None,
+        );
         let daa_window = self.consensus.services.window_manager.block_daa_window(&ghostdag_data).unwrap();
         header.bits = self.consensus.services.window_manager.calculate_difficulty_bits(&ghostdag_data, &daa_window);
         header.daa_score = daa_window.daa_score;

--- a/consensus/src/model/stores/mod.rs
+++ b/consensus/src/model/stores/mod.rs
@@ -9,6 +9,7 @@ pub mod headers;
 pub mod headers_selected_tip;
 pub mod past_pruning_points;
 pub mod pruning;
+pub mod pruning_samples;
 pub mod pruning_utxoset;
 pub mod reachability;
 pub mod relations;

--- a/consensus/src/model/stores/pruning_samples.rs
+++ b/consensus/src/model/stores/pruning_samples.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use kaspa_consensus_core::BlockHasher;
+use kaspa_database::prelude::CachePolicy;
+use kaspa_database::prelude::StoreError;
+use kaspa_database::prelude::DB;
+use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DirectDbWriter};
+use kaspa_database::registry::DatabaseStorePrefixes;
+use kaspa_hashes::Hash;
+use rocksdb::WriteBatch;
+
+pub trait PruningSamplesStoreReader {
+    fn pruning_sample_from_pov(&self, hash: Hash) -> Result<Hash, StoreError>;
+}
+
+pub trait PruningSamplesStore: PruningSamplesStoreReader {
+    // This is append only
+    fn insert(&self, hash: Hash, pruning_sample_from_pov: Hash) -> Result<(), StoreError>;
+    fn delete(&self, hash: Hash) -> Result<(), StoreError>;
+}
+
+/// A DB + cache implementation of `PruningSamplesStore` trait, with concurrency support.
+#[derive(Clone)]
+pub struct DbPruningSamplesStore {
+    db: Arc<DB>,
+    access: CachedDbAccess<Hash, Hash, BlockHasher>,
+}
+
+impl DbPruningSamplesStore {
+    pub fn new(db: Arc<DB>, cache_policy: CachePolicy) -> Self {
+        Self { db: Arc::clone(&db), access: CachedDbAccess::new(db, cache_policy, DatabaseStorePrefixes::PruningSamples.into()) }
+    }
+
+    pub fn clone_with_new_cache(&self, cache_policy: CachePolicy) -> Self {
+        Self::new(Arc::clone(&self.db), cache_policy)
+    }
+
+    pub fn insert_batch(&self, batch: &mut WriteBatch, hash: Hash, pruning_sample_from_pov: Hash) -> Result<(), StoreError> {
+        if self.access.has(hash)? {
+            return Err(StoreError::HashAlreadyExists(hash));
+        }
+        self.access.write(BatchDbWriter::new(batch), hash, pruning_sample_from_pov)?;
+        Ok(())
+    }
+
+    pub fn delete_batch(&self, batch: &mut WriteBatch, hash: Hash) -> Result<(), StoreError> {
+        self.access.delete(BatchDbWriter::new(batch), hash)
+    }
+}
+
+impl PruningSamplesStoreReader for DbPruningSamplesStore {
+    fn pruning_sample_from_pov(&self, hash: Hash) -> Result<Hash, StoreError> {
+        self.access.read(hash)
+    }
+}
+
+impl PruningSamplesStore for DbPruningSamplesStore {
+    fn insert(&self, hash: Hash, pruning_sample_from_pov: Hash) -> Result<(), StoreError> {
+        if self.access.has(hash)? {
+            return Err(StoreError::HashAlreadyExists(hash));
+        }
+        self.access.write(DirectDbWriter::new(&self.db), hash, pruning_sample_from_pov)?;
+        Ok(())
+    }
+
+    fn delete(&self, hash: Hash) -> Result<(), StoreError> {
+        self.access.delete(DirectDbWriter::new(&self.db), hash)
+    }
+}

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -85,11 +85,8 @@ impl HeaderProcessor {
     pub fn check_pruning_point(&self, ctx: &mut HeaderProcessingContext, header: &Header) -> BlockProcessResult<()> {
         // [Crescendo]: changing expected pruning point check from header validity to chain qualification
         if !self.crescendo_activation.is_active(ctx.selected_parent_daa_score()) {
-            let expected = self.pruning_point_manager.expected_header_pruning_point(
-                ctx.ghostdag_data().to_compact(),
-                ctx.pruning_info,
-                Some(header.hash),
-            );
+            let expected =
+                self.pruning_point_manager.expected_header_pruning_point_v1(ctx.ghostdag_data().to_compact(), ctx.pruning_info);
             if expected != header.pruning_point {
                 return Err(RuleError::WrongHeaderPruningPoint(expected, header.pruning_point));
             }

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -85,8 +85,11 @@ impl HeaderProcessor {
     pub fn check_pruning_point(&self, ctx: &mut HeaderProcessingContext, header: &Header) -> BlockProcessResult<()> {
         // [Crescendo]: changing expected pruning point check from header validity to chain qualification
         if !self.crescendo_activation.is_active(ctx.selected_parent_daa_score()) {
-            let expected =
-                self.pruning_point_manager.expected_header_pruning_point(ctx.ghostdag_data().to_compact(), ctx.pruning_info);
+            let expected = self.pruning_point_manager.expected_header_pruning_point(
+                ctx.ghostdag_data().to_compact(),
+                ctx.pruning_info,
+                Some(header.hash),
+            );
             if expected != header.pruning_point {
                 return Err(RuleError::WrongHeaderPruningPoint(expected, header.pruning_point));
             }

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -167,7 +167,7 @@ impl PruningProcessor {
     fn advance_pruning_point_and_candidate_if_possible(&self, sink_ghostdag_data: CompactGhostdagData) {
         let pruning_point_read = self.pruning_point_store.upgradable_read();
         let current_pruning_info = pruning_point_read.get().unwrap();
-        let (new_pruning_points, new_candidate) = self.pruning_point_manager.next_pruning_points_and_candidate_by_ghostdag_data(
+        let (new_pruning_points, new_candidate) = self.pruning_point_manager.next_pruning_points(
             sink_ghostdag_data,
             current_pruning_info.candidate,
             current_pruning_info.pruning_point,

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1032,7 +1032,7 @@ impl VirtualStateProcessor {
         let _prune_guard = self.pruning_lock.blocking_read();
         let pruning_info = self.pruning_point_store.read().get().unwrap();
         let header_pruning_point =
-            self.pruning_point_manager.expected_header_pruning_point(virtual_state.ghostdag_data.to_compact(), pruning_info);
+            self.pruning_point_manager.expected_header_pruning_point(virtual_state.ghostdag_data.to_compact(), pruning_info, None);
         let coinbase = self
             .coinbase_manager
             .expected_coinbase_transaction(

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -254,17 +254,16 @@ impl VirtualStateProcessor {
         // Note that we activate here based on the selected parent DAA score thus complementing the deactivation
         // in header processor which is based on selected parent DAA score as well.
 
+        if self.crescendo_activation.is_within_range_from_activation(header.daa_score, 1000) {
+            self.crescendo_logger.report_activation();
+        }
+
         let ghostdag_data = self.ghostdag_store.get_compact_data(header.hash).unwrap();
         let selected_parent_daa_score = self.headers_store.get_daa_score(ghostdag_data.selected_parent).unwrap();
         // [Crescendo]: we need to save reply.pruning_sample to the database also prior to activation
         let reply = self.pruning_point_manager.expected_header_pruning_point_v2(ghostdag_data);
-        if self.crescendo_activation.is_active(selected_parent_daa_score) {
-            if self.crescendo_activation.is_within_range_from_activation(header.daa_score, 1000) {
-                self.crescendo_logger.report_activation();
-            }
-            if reply.pruning_point != header.pruning_point {
-                return Err(WrongHeaderPruningPoint(reply.pruning_point, header.pruning_point));
-            }
+        if self.crescendo_activation.is_active(selected_parent_daa_score) && reply.pruning_point != header.pruning_point {
+            return Err(WrongHeaderPruningPoint(reply.pruning_point, header.pruning_point));
         }
         Ok(reply)
     }

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -253,9 +253,11 @@ impl VirtualStateProcessor {
                 self.crescendo_logger.report_activation();
             }
             let pruning_info = self.pruning_point_store.read().get().unwrap();
-            let expected = self
-                .pruning_point_manager
-                .expected_header_pruning_point(self.ghostdag_store.get_compact_data(header.hash).unwrap(), pruning_info);
+            let expected = self.pruning_point_manager.expected_header_pruning_point(
+                self.ghostdag_store.get_compact_data(header.hash).unwrap(),
+                pruning_info,
+                Some(header.hash),
+            );
             if expected != header.pruning_point {
                 return Err(WrongHeaderPruningPoint(expected, header.pruning_point));
             }

--- a/consensus/src/processes/pruning.rs
+++ b/consensus/src/processes/pruning.rs
@@ -88,20 +88,15 @@ impl<
     pub fn expected_header_pruning_point(
         &self,
         ghostdag_data: CompactGhostdagData,
-        pruning_info: PruningPointInfo,
+        _pruning_info: PruningPointInfo,
         hash: Option<Hash>,
     ) -> Hash {
-        let v1 = self.expected_header_pruning_point_v1(ghostdag_data, pruning_info);
-        let v2 = self.expected_header_pruning_point_v2(ghostdag_data, hash);
+        // let v1 = self.expected_header_pruning_point_v1(ghostdag_data, pruning_info);
+        // let v2 = self.expected_header_pruning_point_v2(ghostdag_data, hash);
         // assert_eq!(v1, v2);
-        if v1 != v2 {
-            println!("{}, {}", &v1.to_string()[58..], &v2.to_string()[58..]);
-            for (key, value) in self.pruning_samples_store.lock().iter() {
-                println!("{} / {}", &key.to_string()[58..], &value.to_string()[58..]);
-            }
-            panic!()
-        }
-        v2
+        // v2
+
+        self.expected_header_pruning_point_v2(ghostdag_data, hash)
     }
 
     pub fn expected_header_pruning_point_v2(&self, ghostdag_data: CompactGhostdagData, hash: Option<Hash>) -> Hash {
@@ -173,9 +168,9 @@ impl<
         current_pruning_point: Hash,
     ) -> (Vec<Hash>, Hash) {
         let v2 = self.next_pruning_points_v2(ghostdag_data, current_pruning_point);
-        let (v1, candidate) = self.next_pruning_points_v1(ghostdag_data, current_candidate, current_pruning_point);
-        assert_eq!(v1, v2);
-        (v2, candidate)
+        // let (v1, candidate) = self.next_pruning_points_v1(ghostdag_data, current_candidate, current_pruning_point);
+        // assert_eq!(v1, v2);
+        (v2, current_candidate)
     }
 
     pub fn next_pruning_points_v2(&self, ghostdag_data: CompactGhostdagData, current_pruning_point: Hash) -> Vec<Hash> {

--- a/consensus/src/processes/pruning.rs
+++ b/consensus/src/processes/pruning.rs
@@ -94,7 +94,7 @@ impl<
         }
     }
 
-    pub fn expected_header_pruning_point__(&self, ghostdag_data: CompactGhostdagData, _pruning_info: PruningPointInfo) -> Hash {
+    fn __expected_header_pruning_point(&self, ghostdag_data: CompactGhostdagData, _pruning_info: PruningPointInfo) -> Hash {
         // let v1 = self.expected_header_pruning_point_v1(ghostdag_data, pruning_info);
         // let v2 = self.expected_header_pruning_point_v2(ghostdag_data, hash);
         // assert_eq!(v1, v2);
@@ -185,7 +185,7 @@ impl<
         }
     }
 
-    pub fn next_pruning_points_v2(&self, ghostdag_data: CompactGhostdagData, current_pruning_point: Hash) -> Vec<Hash> {
+    fn next_pruning_points_v2(&self, ghostdag_data: CompactGhostdagData, current_pruning_point: Hash) -> Vec<Hash> {
         let mut deque = VecDeque::with_capacity(self.pruning_samples_steps as usize);
 
         let mut current = self.expected_header_pruning_point_v2(ghostdag_data).pruning_point;

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -36,6 +36,7 @@ pub enum DatabaseStorePrefixes {
     UtxoMultisets = 26,
     VirtualUtxoset = 27,
     VirtualState = 28,
+    PruningSamples = 29,
 
     // ---- Decomposed reachability stores ----
     ReachabilityTreeChildren = 30,

--- a/protocol/flows/src/v5/ibd/flow.rs
+++ b/protocol/flows/src/v5/ibd/flow.rs
@@ -316,7 +316,7 @@ impl IbdFlow {
                 .spawn_blocking(move |c| {
                     let ref_proof = proof.clone();
                     c.apply_pruning_proof(proof, &trusted_set)?;
-                    c.import_pruning_points(pruning_points);
+                    c.import_pruning_points(pruning_points)?;
 
                     info!("Building the proof which was just applied (sanity test)");
                     let built_proof = c.get_pruning_point_proof();
@@ -347,7 +347,7 @@ impl IbdFlow {
                 .clone()
                 .spawn_blocking(move |c| {
                     c.apply_pruning_proof(proof, &trusted_set)?;
-                    c.import_pruning_points(pruning_points);
+                    c.import_pruning_points(pruning_points)?;
                     Result::<_, ProtocolError>::Ok(trusted_set)
                 })
                 .await?;

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -256,6 +256,10 @@ fn main_impl(mut args: Args) {
     };
 
     if args.test_pruning {
+        let hashes = topologically_ordered_hashes(&consensus, consensus.pruning_point());
+        let num_blocks = hashes.len();
+        let num_txs = print_stats(&consensus, &hashes, args.delay, args.bps, config.ghostdag_k().before());
+        info!("There are {num_blocks} blocks with {num_txs} transactions overall above the current pruning point");
         consensus.validate_pruning_points(consensus.get_sink()).unwrap();
         drop(consensus);
         return;

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -256,6 +256,7 @@ fn main_impl(mut args: Args) {
     };
 
     if args.test_pruning {
+        consensus.validate_pruning_points(consensus.get_sink()).unwrap();
         drop(consensus);
         return;
     }
@@ -324,15 +325,26 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         info!("2Dλ={}, GHOSTDAG K={}, DAA window size={}", 2.0 * args.delay * args.bps, k, params.difficulty_window_size().before());
     }
     if args.test_pruning {
+        params.crescendo_activation = ForkActivation::new(900.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
+
         params.pruning_proof_m = 16;
         params.prior_difficulty_window_size = 64;
         params.timestamp_deviation_tolerance = 16;
         params.crescendo.sampled_difficulty_window_size = params.crescendo.sampled_difficulty_window_size.min(32);
-        params.prior_finality_depth = 128;
-        params.prior_merge_depth = 128;
+
+        params.prior_ghostdag_k = 10;
+        params.prior_finality_depth = 100;
+        params.prior_merge_depth = 64;
         params.prior_mergeset_size_limit = 32;
-        params.prior_pruning_depth = params.anticone_finalization_depth().before();
-        info!("Setting pruning depth to {}", params.prior_pruning_depth);
+        params.prior_pruning_depth = 100 * 2 + 50;
+
+        params.crescendo.ghostdag_k = 20;
+        params.crescendo.finality_depth = 100 * 2;
+        params.crescendo.merge_depth = 64 * 2;
+        params.crescendo.mergeset_size_limit = 32 * 2;
+        params.crescendo.pruning_depth = 100 * 2 * 2 + 50;
+
+        info!("Setting pruning depth to {:?}", params.pruning_depth());
     }
 }
 

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -325,7 +325,7 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         info!("2Dλ={}, GHOSTDAG K={}, DAA window size={}", 2.0 * args.delay * args.bps, k, params.difficulty_window_size().before());
     }
     if args.test_pruning {
-        params.crescendo_activation = ForkActivation::never(); // ForkActivation::new(900.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
+        params.crescendo_activation = ForkActivation::new(1200.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
 
         params.pruning_proof_m = 16;
         params.prior_difficulty_window_size = 64;

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -325,7 +325,7 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         info!("2Dλ={}, GHOSTDAG K={}, DAA window size={}", 2.0 * args.delay * args.bps, k, params.difficulty_window_size().before());
     }
     if args.test_pruning {
-        params.crescendo_activation = ForkActivation::new(1200.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
+        params.crescendo_activation = ForkActivation::new(1250.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
 
         params.pruning_proof_m = 16;
         params.prior_difficulty_window_size = 64;

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -325,7 +325,7 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         info!("2Dλ={}, GHOSTDAG K={}, DAA window size={}", 2.0 * args.delay * args.bps, k, params.difficulty_window_size().before());
     }
     if args.test_pruning {
-        params.crescendo_activation = ForkActivation::new(900.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
+        params.crescendo_activation = ForkActivation::never(); // ForkActivation::new(900.min(args.target_blocks.map(|x| x / 2).unwrap_or(900)));
 
         params.pruning_proof_m = 16;
         params.prior_difficulty_window_size = 64;

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -991,7 +991,7 @@ async fn json_test(file_path: &str, concurrency: bool) {
             gzip_file_lines(&main_path.join("past-pps.json.gz")).map(|line| json_line_to_block(line).header).collect_vec();
         let pruning_point = past_pruning_points.last().unwrap().hash;
 
-        tc.import_pruning_points(past_pruning_points);
+        tc.import_pruning_points(past_pruning_points).unwrap();
 
         info!("Processing {} trusted blocks...", trusted_blocks.len());
         for tb in trusted_blocks.into_iter() {


### PR DESCRIPTION
This PR:

1. significantly simplifies the logic of finding the expected header/global pruning points, while retaining the exact current semantics of current rules; and
3. utilized the updated logic for correctly performing a smooth transition of pruning points without leaving any dangling past pruning point not pointed at  


TBD: add additional documentation and comments