### PR TITLE
Start the pruning proof per level search at the lowest required depth

### DIFF
--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -216,7 +216,7 @@ impl PruningProofManager {
         &self,
         pp_header: &HeaderWithBlockLevel,
         level: BlockLevel,
-        current_dag_level: BlockLevel,
+        _current_dag_level: BlockLevel,
         required_block: Option<Hash>,
         temp_db: Arc<DB>,
     ) -> PruningProofManagerInternalResult<(Arc<DbGhostdagStore>, Hash, Hash)> {
@@ -232,11 +232,17 @@ impl PruningProofManager {
 
         // We only have the headers store (which has level 0 blue_scores) to assemble the proof data from.
         // We need to look deeper at higher levels (2x deeper every level) to find 2M (plus margin) blocks at that level
-        let mut required_base_level_depth = self.estimated_blue_depth_at_level_0(
-            level,
-            required_level_depth + 100, // We take a safety margin
-            current_dag_level,
-        );
+        // TODO: uncomment when the full fix to minimize proof sizes come.
+        // let mut required_base_level_depth = self.estimated_blue_depth_at_level_0(
+        //     level,
+        //     required_level_depth + 100, // We take a safety margin
+        //     current_dag_level,
+        // );
+        // NOTE: Starting from required_level_depth (a much lower starting point than normal) will typically require N iterations
+        // for every N level higher than current dag level. This is fine since the steps per iteration are still exponential
+        // and so we will complete each level in not much more than N iterations per level.
+        // We start here anyway so we can try to minimize the proof size when the current dag level goes down significantly.
+        let mut required_base_level_depth = required_level_depth + 100;
 
         let mut is_last_level_header;
         let mut tries = 0;


### PR DESCRIPTION
Improves proof size per level especially when DAG level drops significantly like it does in testnet. This services as a simpler fix for the short-term that allows us to improve on the proof sizes already. https://github.com/kaspanet/rusty-kaspa/pull/627 should still be reviewed and merged post Crescendo.

See the attached image for a comparison in latest TN10 where a GPU came on the net (left side is new result from this PR)

![Screenshot 2025-03-09 at 12 10 35 AM](https://github.com/user-attachments/assets/9204aa45-b91e-421c-a44d-6aee1929c25f)


