### PR TITLE
Crescendo-related RAM optimizations & miscellaneous  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2295,14 +2295,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "borsh",
  "bs58",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ahash",
  "cfg-if 1.0.0",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "duration-string",
  "futures",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "borsh",
  "criterion",
@@ -2816,14 +2816,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion",
  "futures-util",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "secp256k1",
  "thiserror",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aes",
  "ahash",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "faster-hex",
  "hexplay",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ctrlc",
  "futures",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ahash",
  "async-std",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "clap 4.5.19",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.82.0"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -80,61 +80,61 @@ include = [
 ]
 
 [workspace.dependencies]
-# kaspa-testing-integration = { version = "0.17.0", path = "testing/integration" }
-kaspa-addresses = { version = "0.17.0", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "0.17.0", path = "components/addressmanager" }
-kaspa-bip32 = { version = "0.17.0", path = "wallet/bip32" }
-kaspa-cli = { version = "0.17.0", path = "cli" }
-kaspa-connectionmanager = { version = "0.17.0", path = "components/connectionmanager" }
-kaspa-consensus = { version = "0.17.0", path = "consensus" }
-kaspa-consensus-core = { version = "0.17.0", path = "consensus/core" }
-kaspa-consensus-client = { version = "0.17.0", path = "consensus/client" }
-kaspa-consensus-notify = { version = "0.17.0", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "0.17.0", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "0.17.0", path = "components/consensusmanager" }
-kaspa-core = { version = "0.17.0", path = "core" }
-kaspa-daemon = { version = "0.17.0", path = "daemon" }
-kaspa-database = { version = "0.17.0", path = "database" }
-kaspa-grpc-client = { version = "0.17.0", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "0.17.0", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "0.17.0", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "0.17.0", path = "crypto/hashes" }
-kaspa-index-core = { version = "0.17.0", path = "indexes/core" }
-kaspa-index-processor = { version = "0.17.0", path = "indexes/processor" }
-kaspa-math = { version = "0.17.0", path = "math" }
-kaspa-merkle = { version = "0.17.0", path = "crypto/merkle" }
-kaspa-metrics-core = { version = "0.17.0", path = "metrics/core" }
-kaspa-mining = { version = "0.17.0", path = "mining" }
-kaspa-mining-errors = { version = "0.17.0", path = "mining/errors" }
-kaspa-muhash = { version = "0.17.0", path = "crypto/muhash" }
-kaspa-notify = { version = "0.17.0", path = "notify" }
-kaspa-p2p-flows = { version = "0.17.0", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "0.17.0", path = "protocol/p2p" }
-kaspa-perf-monitor = { version = "0.17.0", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "0.17.0", path = "consensus/pow" }
-kaspa-rpc-core = { version = "0.17.0", path = "rpc/core" }
-kaspa-rpc-macros = { version = "0.17.0", path = "rpc/macros" }
-kaspa-rpc-service = { version = "0.17.0", path = "rpc/service" }
-kaspa-txscript = { version = "0.17.0", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "0.17.0", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "0.17.0", path = "utils" }
-kaspa-utils-tower = { version = "0.17.0", path = "utils/tower" }
-kaspa-utxoindex = { version = "0.17.0", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "0.17.0", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "0.17.0", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "0.17.0", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "0.17.0", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "0.17.0", path = "wallet/core" }
-kaspa-wallet-macros = { version = "0.17.0", path = "wallet/macros" }
-kaspa-wasm = { version = "0.17.0", path = "wasm" }
-kaspa-wasm-core = { version = "0.17.0", path = "wasm/core" }
-kaspa-wrpc-client = { version = "0.17.0", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "0.17.0", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "0.17.0", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "0.17.0", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "0.17.0", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "0.17.0", path = "kaspad" }
-kaspa-alloc = { version = "0.17.0", path = "utils/alloc" }
+# kaspa-testing-integration = { version = "0.17.1", path = "testing/integration" }
+kaspa-addresses = { version = "0.17.1", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "0.17.1", path = "components/addressmanager" }
+kaspa-bip32 = { version = "0.17.1", path = "wallet/bip32" }
+kaspa-cli = { version = "0.17.1", path = "cli" }
+kaspa-connectionmanager = { version = "0.17.1", path = "components/connectionmanager" }
+kaspa-consensus = { version = "0.17.1", path = "consensus" }
+kaspa-consensus-core = { version = "0.17.1", path = "consensus/core" }
+kaspa-consensus-client = { version = "0.17.1", path = "consensus/client" }
+kaspa-consensus-notify = { version = "0.17.1", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "0.17.1", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "0.17.1", path = "components/consensusmanager" }
+kaspa-core = { version = "0.17.1", path = "core" }
+kaspa-daemon = { version = "0.17.1", path = "daemon" }
+kaspa-database = { version = "0.17.1", path = "database" }
+kaspa-grpc-client = { version = "0.17.1", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "0.17.1", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "0.17.1", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "0.17.1", path = "crypto/hashes" }
+kaspa-index-core = { version = "0.17.1", path = "indexes/core" }
+kaspa-index-processor = { version = "0.17.1", path = "indexes/processor" }
+kaspa-math = { version = "0.17.1", path = "math" }
+kaspa-merkle = { version = "0.17.1", path = "crypto/merkle" }
+kaspa-metrics-core = { version = "0.17.1", path = "metrics/core" }
+kaspa-mining = { version = "0.17.1", path = "mining" }
+kaspa-mining-errors = { version = "0.17.1", path = "mining/errors" }
+kaspa-muhash = { version = "0.17.1", path = "crypto/muhash" }
+kaspa-notify = { version = "0.17.1", path = "notify" }
+kaspa-p2p-flows = { version = "0.17.1", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "0.17.1", path = "protocol/p2p" }
+kaspa-perf-monitor = { version = "0.17.1", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "0.17.1", path = "consensus/pow" }
+kaspa-rpc-core = { version = "0.17.1", path = "rpc/core" }
+kaspa-rpc-macros = { version = "0.17.1", path = "rpc/macros" }
+kaspa-rpc-service = { version = "0.17.1", path = "rpc/service" }
+kaspa-txscript = { version = "0.17.1", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "0.17.1", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "0.17.1", path = "utils" }
+kaspa-utils-tower = { version = "0.17.1", path = "utils/tower" }
+kaspa-utxoindex = { version = "0.17.1", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "0.17.1", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "0.17.1", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "0.17.1", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "0.17.1", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "0.17.1", path = "wallet/core" }
+kaspa-wallet-macros = { version = "0.17.1", path = "wallet/macros" }
+kaspa-wasm = { version = "0.17.1", path = "wasm" }
+kaspa-wasm-core = { version = "0.17.1", path = "wasm/core" }
+kaspa-wrpc-client = { version = "0.17.1", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "0.17.1", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "0.17.1", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "0.17.1", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "0.17.1", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "0.17.1", path = "kaspad" }
+kaspa-alloc = { version = "0.17.1", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -71,7 +71,8 @@ impl PruningProofManager {
         let pp_header = self.headers_store.get_header_with_block_level(pp).unwrap();
         let (ghostdag_stores, selected_tip_by_level, roots_by_level) = self.calc_gd_for_all_levels(&pp_header, temp_db);
 
-        // Pruning proof can contain many duplicate headers, so use a local cache in order to make sure we hold a single Arc per header
+        // The pruning proof can contain many duplicate headers (across levels), so we use a local cache in order
+        // to make sure we hold a single Arc per header
         let mut cache: BlockHashMap<Arc<Header>> = BlockHashMap::with_capacity(2 * self.pruning_proof_m as usize);
         let mut get_header = |hash| cache.entry(hash).or_insert_with_key(|&hash| self.headers_store.get_header(hash).unwrap()).clone();
 

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -237,14 +237,14 @@ impl PruningProofManager {
 
         // We only have the headers store (which has level 0 blue_scores) to assemble the proof data from.
         // We need to look deeper at higher levels (2x deeper every level) to find 2M (plus margin) blocks at that level
-        // TODO: uncomment when the full fix to minimize proof sizes come.
+        // TODO: uncomment when the full fix to minimize proof sizes comes.
         // let mut required_base_level_depth = self.estimated_blue_depth_at_level_0(
         //     level,
         //     required_level_depth + 100, // We take a safety margin
         //     current_dag_level,
         // );
-        // NOTE: Starting from required_level_depth (a much lower starting point than normal) will typically require N iterations
-        // for every N level higher than current dag level. This is fine since the steps per iteration are still exponential
+        // NOTE: Starting from required_level_depth (a much lower starting point than normal) will typically require O(N) iterations
+        // for level L + N where L is the current dag level. This is fine since the steps per iteration are still exponential
         // and so we will complete each level in not much more than N iterations per level.
         // We start here anyway so we can try to minimize the proof size when the current dag level goes down significantly.
         let mut required_base_level_depth = required_level_depth + 100;

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -73,7 +73,7 @@ impl PruningProofManager {
 
         // The pruning proof can contain many duplicate headers (across levels), so we use a local cache in order
         // to make sure we hold a single Arc per header
-        let mut cache: BlockHashMap<Arc<Header>> = BlockHashMap::with_capacity(2 * self.pruning_proof_m as usize);
+        let mut cache: BlockHashMap<Arc<Header>> = BlockHashMap::with_capacity(4 * self.pruning_proof_m as usize);
         let mut get_header = |hash| cache.entry(hash).or_insert_with_key(|&hash| self.headers_store.get_header(hash).unwrap()).clone();
 
         (0..=self.max_block_level)

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -383,6 +383,11 @@ impl PruningProofManager {
             }
         }
         let proof = Arc::new(self.build_pruning_point_proof(pp));
+        info!(
+            "Built headers proof with overall {} headers ({} unique)",
+            proof.iter().map(|l| l.len()).sum::<usize>(),
+            proof.iter().flatten().unique_by(|h| h.hash).count()
+        );
         cache_lock.replace(CachedPruningPointData { pruning_point: pp, data: proof.clone() });
         proof
     }

--- a/consensus/src/processes/pruning_proof/validate.rs
+++ b/consensus/src/processes/pruning_proof/validate.rs
@@ -110,12 +110,15 @@ impl PruningProofManager {
             ) {
                 let proof_level_blue_work_diff = proof_selected_tip_gd.blue_work.saturating_sub(proof_common_ancestor_gd.blue_work);
                 for parent in self.parents_manager.parents_at_level(&current_pp_header, level).iter().copied() {
-                    let parent_blue_work = current_consensus_ghostdag_stores[level_idx].get_blue_work(parent).unwrap();
-                    let parent_blue_work_diff = parent_blue_work.saturating_sub(common_ancestor_gd.blue_work);
-                    if parent_blue_work_diff.saturating_add(pruning_period_work)
-                        >= proof_level_blue_work_diff.saturating_add(prover_claimed_pruning_period_work)
+                    // Not all parents by level are guaranteed to be GD populated, but at least one of them will (the proof level selected tip)
+                    if let Some(parent_blue_work) = current_consensus_ghostdag_stores[level_idx].get_blue_work(parent).unwrap_option()
                     {
-                        return Err(PruningImportError::PruningProofInsufficientBlueWork);
+                        let parent_blue_work_diff = parent_blue_work.saturating_sub(common_ancestor_gd.blue_work);
+                        if parent_blue_work_diff.saturating_add(pruning_period_work)
+                            >= proof_level_blue_work_diff.saturating_add(prover_claimed_pruning_period_work)
+                        {
+                            return Err(PruningImportError::PruningProofInsufficientBlueWork);
+                        }
                     }
                 }
 

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -454,8 +454,9 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
     let connect_peers = args.connect_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect::<Vec<_>>();
     let add_peers = args.add_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect();
     let p2p_server_addr = args.listen.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_p2p_port());
-    // connect_peers means no DNS seeding and no outbound peers
+    // connect_peers means no DNS seeding and no outbound/inbound peers
     let outbound_target = if connect_peers.is_empty() { args.outbound_target } else { 0 };
+    let inbound_limit = if connect_peers.is_empty() { args.inbound_limit } else { 0 };
     let dns_seeders = if connect_peers.is_empty() && !args.disable_dns_seeding { config.dns_seeders } else { &[] };
 
     let grpc_server_addr = args.rpclisten.unwrap_or(ContextualNetAddress::loopback()).normalize(config.default_rpc_port());
@@ -556,7 +557,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         add_peers,
         p2p_server_addr,
         outbound_target,
-        args.inbound_limit,
+        inbound_limit,
         dns_seeders,
         config.default_p2p_port(),
         p2p_tower_counters.clone(),

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -300,16 +300,16 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
                 let headers_store = DbHeadersStore::new(consensus_db, CachePolicy::Empty, CachePolicy::Empty);
 
                 if headers_store.has(config.genesis.hash).unwrap() {
-                    info!("Genesis is found in active consensus DB. No action needed.");
+                    debug!("Genesis is found in active consensus DB. No action needed.");
                 } else {
-                    let msg = "Genesis not found in active consensus DB. This happens when Testnet 11 is restarted and your database needs to be fully deleted. Do you confirm the delete? (y/n)";
+                    let msg = "Genesis not found in active consensus DB. This happens when Testnets are restarted and your database needs to be fully deleted. Do you confirm the delete? (y/n)";
                     get_user_approval_or_exit(msg, args.yes);
 
                     is_db_reset_needed = true;
                 }
             }
             None => {
-                info!("Consensus not initialized yet. Skipping genesis check.");
+                debug!("Consensus not initialized yet. Skipping genesis check.");
             }
         }
     }

--- a/protocol/flows/src/service.rs
+++ b/protocol/flows/src/service.rs
@@ -65,9 +65,12 @@ impl AsyncService for P2pService {
         // Prepare a shutdown signal receiver
         let shutdown_signal = self.shutdown.listener.clone();
 
-        let p2p_adaptor =
+        let p2p_adaptor = if self.inbound_limit == 0 {
+            Adaptor::client_only(self.flow_context.hub().clone(), self.flow_context.clone(), self.counters.clone())
+        } else {
             Adaptor::bidirectional(self.listen, self.flow_context.hub().clone(), self.flow_context.clone(), self.counters.clone())
-                .unwrap();
+                .unwrap()
+        };
         let connection_manager = ConnectionManager::new(
             p2p_adaptor.clone(),
             self.outbound_target,

--- a/protocol/p2p/src/convert/messages.rs
+++ b/protocol/p2p/src/convert/messages.rs
@@ -87,7 +87,7 @@ impl TryFrom<protowire::PruningPointProofMessage> for PruningPointProof {
     fn try_from(msg: protowire::PruningPointProofMessage) -> Result<Self, Self::Error> {
         // The pruning proof can contain many duplicate headers (across levels), so we use a local cache in order
         // to make sure we hold a single Arc per header
-        let mut cache: HashMap<Hash, Arc<Header>> = HashMap::with_capacity(2000);
+        let mut cache: HashMap<Hash, Arc<Header>> = HashMap::with_capacity(4000);
         msg.headers
             .into_iter()
             .map(|level| {

--- a/protocol/p2p/src/core/hub.rs
+++ b/protocol/p2p/src/core/hub.rs
@@ -39,12 +39,12 @@ impl Hub {
                     HubEvent::NewPeer(new_router) => {
                         // If peer is outbound then connection initialization was already performed as part of the connect logic
                         if new_router.is_outbound() {
-                            info!("P2P Connected to outgoing peer {}", new_router);
+                            info!("P2P Connected to outgoing peer {} (outbound: {})", new_router, self.peers_query(true) + 1);
                             self.insert_new_router(new_router).await;
                         } else {
                             match initializer.initialize_connection(new_router.clone()).await {
                                 Ok(()) => {
-                                    info!("P2P Connected to incoming peer {}", new_router);
+                                    info!("P2P Connected to incoming peer {} (inbound: {})", new_router, self.peers_query(false) + 1);
                                     self.insert_new_router(new_router).await;
                                 }
                                 Err(err) => {
@@ -180,6 +180,11 @@ impl Hub {
     /// Returns the number of currently active peers
     pub fn active_peers_len(&self) -> usize {
         self.peers.read().len()
+    }
+
+    /// Returns the number of outbound/inbound active peers (depending on the `outbound` argument)
+    pub fn peers_query(&self, outbound: bool) -> usize {
+        self.peers.read().values().filter(|r| r.is_outbound() == outbound).count()
     }
 
     /// Returns whether there are currently active peers


### PR DESCRIPTION
Optimizes memory usage of the cached pruning proof, by reusing existing Arcs and making sure each header is held in memory only once.

Additional minor additions:

1. Switch some irrelevant logs to debug
2. Disable p2p server if `--connect` is used or if `--maxinpeers=0`
3. Log inbound and outbound connection counts 
4. Fix a leftover edge case from multilevel GD upgrade
5. Bumps the version so that the memory usage patterns can be affiliated with the version    