### PR TITLE
Retain index data up to retention period root

### DIFF
--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -383,7 +383,7 @@ impl PruningProcessor {
 
             // Prune the selected chain index below the pruning point
             let mut selected_chain_write = self.selected_chain_store.write();
-            selected_chain_write.prune_below_pruning_point(BatchDbWriter::new(&mut batch), new_pruning_point).unwrap();
+            selected_chain_write.prune_below_pruning_point(BatchDbWriter::new(&mut batch), retention_period_root).unwrap();
 
             // Flush the batch to the DB
             self.db.write(batch).unwrap();

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -124,6 +124,8 @@ struct Args {
     rocksdb_mem_budget: Option<usize>,
     #[arg(long, default_value_t = false)]
     long_payload: bool,
+    #[arg(long)]
+    retention_period_days: Option<f64>,
 }
 
 #[cfg(feature = "heap")]
@@ -198,7 +200,10 @@ fn main_impl(mut args: Args) {
         .apply_args(|config| apply_args_to_consensus_params(&args, &mut config.params))
         .apply_args(|config| apply_args_to_perf_params(&args, &mut config.perf))
         .adjust_perf_params_to_consensus_params()
-        .apply_args(|config| config.ram_scale = args.ram_scale)
+        .apply_args(|config| {
+            config.ram_scale = args.ram_scale;
+            config.retention_period_days = args.retention_period_days;
+        })
         .skip_proof_of_work()
         .enable_sanity_checks();
     if !args.test_pruning {
@@ -260,7 +265,36 @@ fn main_impl(mut args: Args) {
         let num_blocks = hashes.len();
         let num_txs = print_stats(&consensus, &hashes, args.delay, args.bps, config.ghostdag_k().before());
         info!("There are {num_blocks} blocks with {num_txs} transactions overall above the current pruning point");
+
+        if args.retention_period_days.is_some() {
+            let hashes_retention = topologically_ordered_hashes(&consensus, consensus.get_retention_period_root());
+            info!("There are {} blocks above the retention period root", hashes_retention.len());
+        }
+
         consensus.validate_pruning_points(consensus.get_sink()).unwrap();
+
+        // Test whether we can still retrieve a populated transaction given a txid and the accepting block daa score.
+        for hash in hashes.iter().cloned() {
+            if !consensus.is_chain_block(hash).unwrap() {
+                // only chain blocks are worth checking the acceptance data of
+                continue;
+            }
+
+            if let Ok(block_acceptance_data) = consensus.get_block_acceptance_data(hash) {
+                block_acceptance_data.iter().for_each(|cbad| {
+                    let block = consensus.get_block(hash).unwrap();
+                    cbad.accepted_transactions.iter().for_each(|ate| {
+                        assert!(
+                            consensus.get_populated_transaction(ate.transaction_id, block.header.daa_score).is_ok(),
+                            "Expected to find find tx {} at accepted daa {} via get_populated_transaction",
+                            ate.transaction_id,
+                            block.header.daa_score
+                        );
+                    });
+                });
+            }
+        }
+
         drop(consensus);
         return;
     }


### PR DESCRIPTION
Index data needs to retain data up to retention period root for calls that require the index of it (such as get_utxo_return_address) to work.

Additional changes:
- adds support for retention_period_days in simpa
  - sink timestamp is used as `now` for retention period time calculations

Testing with retention:

```
cargo run --release --bin simpa -- -n=6000 -t=1 --test-pruning --loglevel=info --retention-period-days=0.01
```

Testing original case:
```
cargo run --release --bin simpa -- -n=6000 -t=1 --test-pruning --loglevel=info
```