### PR TITLE
expanded rpc api to add `MempoolSizeChanged`

### DIFF
--- a/consensus/notify/src/notification.rs
+++ b/consensus/notify/src/notification.rs
@@ -42,6 +42,9 @@ pub enum Notification {
 
     #[display(fmt = "NewBlockTemplate notification")]
     NewBlockTemplate(NewBlockTemplateNotification),
+
+    #[display(fmt = "MempoolSizeChanged notification: size {}", "_0.network_mempool_size")]
+    MempoolSizeChanged(MempoolSizeChangedNotification),
 }
 }
 
@@ -181,3 +184,14 @@ pub struct PruningPointUtxoSetOverrideNotification {}
 
 #[derive(Debug, Clone)]
 pub struct NewBlockTemplateNotification {}
+
+#[derive(Debug, Clone)]
+pub struct MempoolSizeChangedNotification {
+    pub network_mempool_size: u64,
+}
+
+impl MempoolSizeChangedNotification {
+    pub fn new(network_mempool_size: u64) -> Self {
+        Self { network_mempool_size }
+    }
+}

--- a/notify/src/events.rs
+++ b/notify/src/events.rs
@@ -51,10 +51,11 @@ event_type_enum! {
         VirtualDaaScoreChanged,
         PruningPointUtxoSetOverride,
         NewBlockTemplate,
+        MempoolSizeChanged,
     }
 }
 
-pub const EVENT_COUNT: usize = 9;
+pub const EVENT_COUNT: usize = 10;
 
 impl FromStr for EventType {
     type Err = Error;
@@ -70,6 +71,7 @@ impl FromStr for EventType {
             "virtual-daa-score-changed" => Ok(EventType::VirtualDaaScoreChanged),
             "pruning-point-utxo-set-override" => Ok(EventType::PruningPointUtxoSetOverride),
             "new-block-template" => Ok(EventType::NewBlockTemplate),
+            "mempool-size-changed" => Ok(EventType::MempoolSizeChanged),
             _ => Err(Error::InvalidEventType(s.to_string())),
         }
     }

--- a/notify/src/scope.rs
+++ b/notify/src/scope.rs
@@ -45,6 +45,7 @@ pub enum Scope {
     VirtualDaaScoreChanged,
     PruningPointUtxoSetOverride,
     NewBlockTemplate,
+    MempoolSizeChanged,
 }
 }
 
@@ -261,6 +262,23 @@ impl Serializer for NewBlockTemplateScope {
 }
 
 impl Deserializer for NewBlockTemplateScope {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        Ok(Self {})
+    }
+}
+
+#[derive(Clone, Display, Debug, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct MempoolSizeChangedScope {}
+
+impl Serializer for MempoolSizeChangedScope {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for MempoolSizeChangedScope {
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u16, reader)?;
         Ok(Self {})

--- a/rpc/core/src/api/notifications.rs
+++ b/rpc/core/src/api/notifications.rs
@@ -48,6 +48,9 @@ pub enum Notification {
 
     #[display(fmt = "NewBlockTemplate notification")]
     NewBlockTemplate(NewBlockTemplateNotification),
+
+    #[display(fmt = "MempoolSizeChanged notification: size {}", "_0.network_mempool_size")]
+    MempoolSizeChanged(MempoolSizeChangedNotification),
 }
 }
 
@@ -64,6 +67,7 @@ impl Notification {
             Notification::VirtualDaaScoreChanged(v) => to_value(&v),
             Notification::SinkBlueScoreChanged(v) => to_value(&v),
             Notification::VirtualChainChanged(v) => to_value(&v),
+            Notification::MempoolSizeChanged(v) => to_value(&v),
         }
     }
 }
@@ -157,6 +161,10 @@ impl Serializer for Notification {
                 store!(u16, &8, writer)?;
                 serialize!(NewBlockTemplateNotification, notification, writer)?;
             }
+            Notification::MempoolSizeChanged(notification) => {
+                store!(u16, &9, writer)?;
+                serialize!(MempoolSizeChangedNotification, notification, writer)?;
+            }
         }
         Ok(())
     }
@@ -201,6 +209,10 @@ impl Deserializer for Notification {
             8 => {
                 let notification = deserialize!(NewBlockTemplateNotification, reader)?;
                 Ok(Notification::NewBlockTemplate(notification))
+            }
+            9 => {
+                let notification = deserialize!(MempoolSizeChangedNotification, reader)?;
+                Ok(Notification::MempoolSizeChanged(notification))
             }
             _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid variant")),
         }

--- a/rpc/core/src/api/ops.rs
+++ b/rpc/core/src/api/ops.rs
@@ -40,6 +40,7 @@ pub enum RpcApiOps {
     NotifyVirtualDaaScoreChanged = 16,
     NotifyVirtualChainChanged = 17,
     NotifySinkBlueScoreChanged = 18,
+    NotifyMempoolSizeChanged = 19,
 
     // Notification ops required by wRPC
 
@@ -54,6 +55,7 @@ pub enum RpcApiOps {
     VirtualDaaScoreChangedNotification = 66,
     PruningPointUtxoSetOverrideNotification = 67,
     NewBlockTemplateNotification = 68,
+    MempoolSizeChangedNotification = 69,
 
     // RPC methods
     /// Ping the node to check if connection is alive
@@ -153,6 +155,7 @@ impl RpcApiOps {
                 | RpcApiOps::NotifyFinalityConflictResolved
                 | RpcApiOps::NotifySinkBlueScoreChanged
                 | RpcApiOps::NotifyVirtualDaaScoreChanged
+                | RpcApiOps::NotifyMempoolSizeChanged
                 | RpcApiOps::Subscribe
                 | RpcApiOps::Unsubscribe
         )
@@ -177,6 +180,7 @@ impl From<EventType> for RpcApiOps {
             EventType::UtxosChanged => RpcApiOps::UtxosChangedNotification,
             EventType::SinkBlueScoreChanged => RpcApiOps::SinkBlueScoreChangedNotification,
             EventType::VirtualDaaScoreChanged => RpcApiOps::VirtualDaaScoreChangedNotification,
+            EventType::MempoolSizeChanged => RpcApiOps::MempoolSizeChangedNotification,
             EventType::PruningPointUtxoSetOverride => RpcApiOps::PruningPointUtxoSetOverrideNotification,
             EventType::NewBlockTemplate => RpcApiOps::NewBlockTemplateNotification,
         }

--- a/rpc/core/src/convert/notification.rs
+++ b/rpc/core/src/convert/notification.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     convert::utxo::utxo_set_into_rpc, BlockAddedNotification, FinalityConflictNotification, FinalityConflictResolvedNotification,
-    NewBlockTemplateNotification, Notification, PruningPointUtxoSetOverrideNotification, RpcAcceptedTransactionIds,
-    SinkBlueScoreChangedNotification, UtxosChangedNotification, VirtualChainChangedNotification, VirtualDaaScoreChangedNotification,
+    MempoolSizeChangedNotification, NewBlockTemplateNotification, Notification, PruningPointUtxoSetOverrideNotification,
+    RpcAcceptedTransactionIds, SinkBlueScoreChangedNotification, UtxosChangedNotification, VirtualChainChangedNotification,
+    VirtualDaaScoreChangedNotification,
 };
 use kaspa_consensus_notify::notification as consensus_notify;
 use kaspa_index_core::notification as index_notify;
@@ -31,6 +32,7 @@ impl From<&consensus_notify::Notification> for Notification {
             consensus_notify::Notification::VirtualDaaScoreChanged(msg) => Notification::VirtualDaaScoreChanged(msg.into()),
             consensus_notify::Notification::PruningPointUtxoSetOverride(msg) => Notification::PruningPointUtxoSetOverride(msg.into()),
             consensus_notify::Notification::NewBlockTemplate(msg) => Notification::NewBlockTemplate(msg.into()),
+            consensus_notify::Notification::MempoolSizeChanged(msg) => Notification::MempoolSizeChanged(msg.into()),
         }
     }
 }
@@ -109,6 +111,12 @@ impl From<&consensus_notify::PruningPointUtxoSetOverrideNotification> for Prunin
 impl From<&consensus_notify::NewBlockTemplateNotification> for NewBlockTemplateNotification {
     fn from(_: &consensus_notify::NewBlockTemplateNotification) -> Self {
         Self {}
+    }
+}
+
+impl From<&consensus_notify::MempoolSizeChangedNotification> for MempoolSizeChangedNotification {
+    fn from(item: &consensus_notify::MempoolSizeChangedNotification) -> Self {
+        Self { network_mempool_size: item.network_mempool_size }
     }
 }
 

--- a/rpc/core/src/convert/scope.rs
+++ b/rpc/core/src/convert/scope.rs
@@ -1,9 +1,9 @@
 //! Conversion of Notification Scope related types
 
 use crate::{
-    NotifyBlockAddedRequest, NotifyFinalityConflictRequest, NotifyNewBlockTemplateRequest, NotifyPruningPointUtxoSetOverrideRequest,
-    NotifySinkBlueScoreChangedRequest, NotifyUtxosChangedRequest, NotifyVirtualChainChangedRequest,
-    NotifyVirtualDaaScoreChangedRequest,
+    NotifyBlockAddedRequest, NotifyFinalityConflictRequest, NotifyMempoolSizeChangedRequest, NotifyNewBlockTemplateRequest,
+    NotifyPruningPointUtxoSetOverrideRequest, NotifySinkBlueScoreChangedRequest, NotifyUtxosChangedRequest,
+    NotifyVirtualChainChangedRequest, NotifyVirtualDaaScoreChangedRequest,
 };
 use kaspa_notify::scope::*;
 
@@ -62,3 +62,4 @@ from!(SinkBlueScoreChanged);
 from!(VirtualDaaScoreChanged);
 from!(PruningPointUtxoSetOverride);
 from!(NewBlockTemplate);
+from!(MempoolSizeChanged);

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -3321,6 +3321,81 @@ impl Deserializer for VirtualDaaScoreChangedNotification {
     }
 }
 
+// NotifyMempoolSizeChangedRequest registers this connection for
+// mempoolSizeChanged notifications.
+//
+// See: MempoolSizeChangedNotification
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotifyMempoolSizeChangedRequest {
+    pub command: Command,
+}
+
+impl NotifyMempoolSizeChangedRequest {
+    pub fn new(command: Command) -> Self {
+        Self { command }
+    }
+}
+
+impl Serializer for NotifyMempoolSizeChangedRequest {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(Command, &self.command, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for NotifyMempoolSizeChangedRequest {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let command = load!(Command, reader)?;
+        Ok(Self { command })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotifyMempoolSizeChangedResponse {}
+
+impl Serializer for NotifyMempoolSizeChangedResponse {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for NotifyMempoolSizeChangedResponse {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        Ok(Self {})
+    }
+}
+
+// MempoolSizeChangedNotification is sent whenever the mempool changes.
+//
+// See NotifyMempoolSizeChangedRequest
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MempoolSizeChangedNotification {
+    pub network_mempool_size: u64,
+}
+
+impl Serializer for MempoolSizeChangedNotification {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(u64, &self.network_mempool_size, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for MempoolSizeChangedNotification {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let network_mempool_size = load!(u64, reader)?;
+        Ok(Self { network_mempool_size })
+    }
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // PruningPointUtxoSetOverrideNotification
 

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -1290,6 +1290,30 @@ mod mockery {
         }
     }
 
+    impl Mock for NotifyMempoolSizeChangedRequest {
+        fn mock() -> Self {
+            NotifyMempoolSizeChangedRequest { command: Command::Start }
+        }
+    }
+
+    test!(NotifyMempoolSizeChangedRequest);
+
+    impl Mock for NotifyMempoolSizeChangedResponse {
+        fn mock() -> Self {
+            NotifyMempoolSizeChangedResponse {}
+        }
+    }
+
+    test!(NotifyMempoolSizeChangedResponse);
+
+    impl Mock for MempoolSizeChangedNotification {
+        fn mock() -> Self {
+            MempoolSizeChangedNotification { network_mempool_size: mock() }
+        }
+    }
+
+    test!(MempoolSizeChangedNotification);
+
     test!(SubscribeResponse);
 
     impl Mock for UnsubscribeResponse {

--- a/rpc/grpc/core/proto/messages.proto
+++ b/rpc/grpc/core/proto/messages.proto
@@ -66,6 +66,7 @@ message KaspadRequest {
     GetFeeEstimateExperimentalRequestMessage getFeeEstimateExperimentalRequest = 1108;
     GetCurrentBlockColorRequestMessage getCurrentBlockColorRequest = 1110;
     GetUtxoReturnAddressRequestMessage GetUtxoReturnAddressRequest = 1112;
+    NotifyMempoolSizeChangedRequestMessage notifyMempoolSizeChangedRequest = 1114;
   }
 }
 
@@ -132,6 +133,8 @@ message KaspadResponse {
     GetFeeEstimateExperimentalResponseMessage getFeeEstimateExperimentalResponse = 1109;
     GetCurrentBlockColorResponseMessage getCurrentBlockColorResponse = 1111;
     GetUtxoReturnAddressResponseMessage GetUtxoReturnAddressResponse = 1113;
+    NotifyMempoolSizeChangedResponseMessage notifyMempoolSizeChangedResponse = 1115;
+    MempoolSizeChangedNotificationMessage mempoolSizeChangedNotification = 1117;
   }
 }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -636,6 +636,25 @@ message VirtualDaaScoreChangedNotificationMessage {
   uint64 virtualDaaScore = 1;
 }
 
+// NotifyMempoolSizeChangedRequestMessage registers this connection for
+// mempoolSizeChanged notifications.
+//
+// See: MempoolSizeChangedNotificationMessage
+message NotifyMempoolSizeChangedRequestMessage {
+  RpcNotifyCommand command = 101;
+}
+
+message NotifyMempoolSizeChangedResponseMessage {
+  RPCError error = 1000;
+}
+
+// MempoolSizeChangedNotificationMessage is sent whenever the mempool changes.
+//
+// See NotifyMempoolSizeChangedRequestMessage
+message MempoolSizeChangedNotificationMessage {
+  uint64 networkMempoolSize = 1;
+}
+
 // NotifyPruningPointUtxoSetOverrideRequestMessage registers this connection for
 // pruning point UTXO set override notifications.
 //

--- a/rpc/grpc/core/src/convert/kaspad.rs
+++ b/rpc/grpc/core/src/convert/kaspad.rs
@@ -73,6 +73,7 @@ pub mod kaspad_request_convert {
     impl_into_kaspad_request!(NotifyVirtualDaaScoreChanged);
     impl_into_kaspad_request!(NotifyVirtualChainChanged);
     impl_into_kaspad_request!(NotifySinkBlueScoreChanged);
+    impl_into_kaspad_request!(NotifyMempoolSizeChanged);
 
     macro_rules! impl_into_kaspad_request {
         ($name:tt) => {
@@ -214,6 +215,7 @@ pub mod kaspad_response_convert {
 
     impl_into_kaspad_notify_response!(NotifyUtxosChanged, StopNotifyingUtxosChanged);
     impl_into_kaspad_notify_response!(NotifyPruningPointUtxoSetOverride, StopNotifyingPruningPointUtxoSetOverride);
+    impl_into_kaspad_notify_response!(NotifyMempoolSizeChanged);
 
     macro_rules! impl_into_kaspad_response {
         ($name:tt) => {

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -559,6 +559,10 @@ from!(item: &kaspa_rpc_core::NotifySinkBlueScoreChangedRequest, protowire::Notif
     Self { command: item.command.into() }
 });
 from!(RpcResult<&kaspa_rpc_core::NotifySinkBlueScoreChangedResponse>, protowire::NotifySinkBlueScoreChangedResponseMessage);
+from!(item: &kaspa_rpc_core::NotifyMempoolSizeChangedRequest, protowire::NotifyMempoolSizeChangedRequestMessage, {
+    Self { command: item.command.into() }
+});
+from!(RpcResult<&kaspa_rpc_core::NotifyMempoolSizeChangedResponse>, protowire::NotifyMempoolSizeChangedResponseMessage);
 
 // ----------------------------------------------------------------------------
 // protowire to rpc_core
@@ -1060,6 +1064,10 @@ try_from!(item: &protowire::NotifySinkBlueScoreChangedRequestMessage, kaspa_rpc_
     Self { command: item.command.into() }
 });
 try_from!(&protowire::NotifySinkBlueScoreChangedResponseMessage, RpcResult<kaspa_rpc_core::NotifySinkBlueScoreChangedResponse>);
+try_from!(item: &protowire::NotifyMempoolSizeChangedRequestMessage, kaspa_rpc_core::NotifyMempoolSizeChangedRequest, {
+    Self { command: item.command.into() }
+});
+try_from!(&protowire::NotifyMempoolSizeChangedResponseMessage, RpcResult<kaspa_rpc_core::NotifyMempoolSizeChangedResponse>);
 
 // ----------------------------------------------------------------------------
 // Unit tests

--- a/rpc/grpc/core/src/convert/notification.rs
+++ b/rpc/grpc/core/src/convert/notification.rs
@@ -2,12 +2,13 @@ use crate::protowire::{
     kaspad_response::Payload, BlockAddedNotificationMessage, KaspadResponse, NewBlockTemplateNotificationMessage, RpcNotifyCommand,
 };
 use crate::protowire::{
-    FinalityConflictNotificationMessage, FinalityConflictResolvedNotificationMessage, NotifyPruningPointUtxoSetOverrideRequestMessage,
-    NotifyPruningPointUtxoSetOverrideResponseMessage, NotifyUtxosChangedRequestMessage, NotifyUtxosChangedResponseMessage,
-    PruningPointUtxoSetOverrideNotificationMessage, SinkBlueScoreChangedNotificationMessage,
-    StopNotifyingPruningPointUtxoSetOverrideRequestMessage, StopNotifyingPruningPointUtxoSetOverrideResponseMessage,
-    StopNotifyingUtxosChangedRequestMessage, StopNotifyingUtxosChangedResponseMessage, UtxosChangedNotificationMessage,
-    VirtualChainChangedNotificationMessage, VirtualDaaScoreChangedNotificationMessage,
+    FinalityConflictNotificationMessage, FinalityConflictResolvedNotificationMessage, MempoolSizeChangedNotificationMessage,
+    NotifyPruningPointUtxoSetOverrideRequestMessage, NotifyPruningPointUtxoSetOverrideResponseMessage,
+    NotifyUtxosChangedRequestMessage, NotifyUtxosChangedResponseMessage, PruningPointUtxoSetOverrideNotificationMessage,
+    SinkBlueScoreChangedNotificationMessage, StopNotifyingPruningPointUtxoSetOverrideRequestMessage,
+    StopNotifyingPruningPointUtxoSetOverrideResponseMessage, StopNotifyingUtxosChangedRequestMessage,
+    StopNotifyingUtxosChangedResponseMessage, UtxosChangedNotificationMessage, VirtualChainChangedNotificationMessage,
+    VirtualDaaScoreChangedNotificationMessage,
 };
 use crate::{from, try_from};
 use kaspa_notify::subscription::Command;
@@ -31,6 +32,9 @@ from!(item: &kaspa_rpc_core::Notification, Payload, {
         Notification::UtxosChanged(ref notification) => Payload::UtxosChangedNotification(notification.into()),
         Notification::SinkBlueScoreChanged(ref notification) => Payload::SinkBlueScoreChangedNotification(notification.into()),
         Notification::VirtualDaaScoreChanged(ref notification) => Payload::VirtualDaaScoreChangedNotification(notification.into()),
+        Notification::MempoolSizeChanged(ref notification) => {
+            Payload::MempoolSizeChangedNotification(notification.into())
+        }
         Notification::PruningPointUtxoSetOverride(ref notification) => {
             Payload::PruningPointUtxoSetOverrideNotification(notification.into())
         }
@@ -70,6 +74,10 @@ from!(item: &kaspa_rpc_core::SinkBlueScoreChangedNotification, SinkBlueScoreChan
 
 from!(item: &kaspa_rpc_core::VirtualDaaScoreChangedNotification, VirtualDaaScoreChangedNotificationMessage, {
     Self { virtual_daa_score: item.virtual_daa_score }
+});
+
+from!(item: &kaspa_rpc_core::MempoolSizeChangedNotification, MempoolSizeChangedNotificationMessage, {
+    Self { network_mempool_size: item.network_mempool_size }
 });
 
 from!(&kaspa_rpc_core::PruningPointUtxoSetOverrideNotification, PruningPointUtxoSetOverrideNotificationMessage);
@@ -117,6 +125,9 @@ try_from!(item: &Payload, kaspa_rpc_core::Notification, {
         Payload::PruningPointUtxoSetOverrideNotification(ref notification) => {
             Notification::PruningPointUtxoSetOverride(notification.try_into()?)
         }
+        Payload::MempoolSizeChangedNotification(ref notification) => {
+            Notification::MempoolSizeChanged(notification.try_into()?)
+        },
         _ => Err(RpcError::UnsupportedFeature)?,
     }
 });
@@ -167,6 +178,10 @@ try_from!(item: &SinkBlueScoreChangedNotificationMessage, kaspa_rpc_core::SinkBl
 
 try_from!(item: &VirtualDaaScoreChangedNotificationMessage, kaspa_rpc_core::VirtualDaaScoreChangedNotification, {
     Self { virtual_daa_score: item.virtual_daa_score }
+});
+
+try_from!(item: &MempoolSizeChangedNotificationMessage, kaspa_rpc_core::MempoolSizeChangedNotification, {
+    Self { network_mempool_size: item.network_mempool_size }
 });
 
 try_from!(&PruningPointUtxoSetOverrideNotificationMessage, kaspa_rpc_core::PruningPointUtxoSetOverrideNotification);

--- a/rpc/grpc/core/src/ext/kaspad.rs
+++ b/rpc/grpc/core/src/ext/kaspad.rs
@@ -2,9 +2,9 @@ use kaspa_notify::{scope::Scope, subscription::Command};
 
 use crate::protowire::{
     kaspad_request, kaspad_response, KaspadRequest, KaspadResponse, NotifyBlockAddedRequestMessage,
-    NotifyFinalityConflictRequestMessage, NotifyNewBlockTemplateRequestMessage, NotifyPruningPointUtxoSetOverrideRequestMessage,
-    NotifySinkBlueScoreChangedRequestMessage, NotifyUtxosChangedRequestMessage, NotifyVirtualChainChangedRequestMessage,
-    NotifyVirtualDaaScoreChangedRequestMessage,
+    NotifyFinalityConflictRequestMessage, NotifyMempoolSizeChangedRequestMessage, NotifyNewBlockTemplateRequestMessage,
+    NotifyPruningPointUtxoSetOverrideRequestMessage, NotifySinkBlueScoreChangedRequestMessage, NotifyUtxosChangedRequestMessage,
+    NotifyVirtualChainChangedRequestMessage, NotifyVirtualDaaScoreChangedRequestMessage,
 };
 
 impl KaspadRequest {
@@ -64,6 +64,11 @@ impl kaspad_request::Payload {
                     command: command.into(),
                 })
             }
+            Scope::MempoolSizeChanged(_) => {
+                kaspad_request::Payload::NotifyMempoolSizeChangedRequest(NotifyMempoolSizeChangedRequestMessage {
+                    command: command.into(),
+                })
+            }
         }
     }
 
@@ -79,6 +84,7 @@ impl kaspad_request::Payload {
                 | Payload::NotifyVirtualDaaScoreChangedRequest(_)
                 | Payload::NotifyPruningPointUtxoSetOverrideRequest(_)
                 | Payload::NotifyNewBlockTemplateRequest(_)
+                | Payload::NotifyMempoolSizeChangedRequest(_)
                 | Payload::StopNotifyingUtxosChangedRequest(_)
                 | Payload::StopNotifyingPruningPointUtxoSetOverrideRequest(_)
         )
@@ -108,6 +114,7 @@ impl kaspad_response::Payload {
             Payload::VirtualDaaScoreChangedNotification(_) => true,
             Payload::PruningPointUtxoSetOverrideNotification(_) => true,
             Payload::NewBlockTemplateNotification(_) => true,
+            Payload::MempoolSizeChangedNotification(_) => true,
             _ => false,
         }
     }

--- a/rpc/grpc/core/src/ops.rs
+++ b/rpc/grpc/core/src/ops.rs
@@ -98,6 +98,7 @@ pub enum KaspadPayloadOps {
     NotifyPruningPointUtxoSetOverride,
     NotifyVirtualDaaScoreChanged,
     NotifyVirtualChainChanged,
+    NotifyMempoolSizeChanged,
 
     // Legacy stop subscription commands
     StopNotifyingUtxosChanged,

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -90,6 +90,7 @@ impl Factory {
                 NotifyPruningPointUtxoSetOverride,
                 NotifyVirtualDaaScoreChanged,
                 NotifyVirtualChainChanged,
+                NotifyMempoolSizeChanged,
                 StopNotifyingUtxosChanged,
                 StopNotifyingPruningPointUtxoSetOverride,
             ]

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -76,6 +76,7 @@ impl Inner {
             RpcApiOps::VirtualDaaScoreChangedNotification,
             RpcApiOps::PruningPointUtxoSetOverrideNotification,
             RpcApiOps::NewBlockTemplateNotification,
+            RpcApiOps::MempoolSizeChangedNotification,
         ]
         .into_iter()
         .for_each(|notification_op| {

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -11,8 +11,8 @@ use kaspa_hashes::Hash;
 use kaspa_notify::{
     connection::{ChannelConnection, ChannelType},
     scope::{
-        BlockAddedScope, FinalityConflictScope, NewBlockTemplateScope, PruningPointUtxoSetOverrideScope, Scope,
-        SinkBlueScoreChangedScope, UtxosChangedScope, VirtualChainChangedScope, VirtualDaaScoreChangedScope,
+        BlockAddedScope, FinalityConflictScope, MempoolSizeChangedScope, NewBlockTemplateScope, PruningPointUtxoSetOverrideScope,
+        Scope, SinkBlueScoreChangedScope, UtxosChangedScope, VirtualChainChangedScope, VirtualDaaScoreChangedScope,
     },
 };
 use kaspa_rpc_core::{api::rpc::RpcApi, model::*, Notification};
@@ -732,6 +732,13 @@ async fn sanity_test() {
                         .start_notify(id, VirtualChainChangedScope { include_accepted_transaction_ids: false }.into())
                         .await
                         .unwrap();
+                })
+            }
+            KaspadPayloadOps::NotifyMempoolSizeChanged => {
+                let rpc_client = client.clone();
+                let id = listener_id;
+                tst!(op, {
+                    rpc_client.start_notify(id, MempoolSizeChangedScope {}.into()).await.unwrap();
                 })
             }
             KaspadPayloadOps::StopNotifyingUtxosChanged => {


### PR DESCRIPTION
Confirmed working with the below wrpc example subscriber:
https://github.com/kaspanet/rusty-kaspa/blob/master/rpc/wrpc/examples/subscriber/src/main.rs

`self.client().rpc_api().start_notify(listener_id, Scope::MempoolSizeChanged(MempoolSizeChangedScope {})).await?;`

```
Creating listener with options: url=Some("ws://localhost:17210"), network=testnet-10, encoding=Borsh, timeout=5000ms
Received connection event
Connected to Some("ws://localhost:17210")
Node version: 0.17.2
Network: testnet-10
Virtual DAA Score: 106173779
Node is indexing UTXOs: true
Node is synced: synced
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 535 })
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 586 })
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 543 })
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 631 })
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 568 })
Notification: MempoolSizeChanged(MempoolSizeChangedNotification { network_mempool_size: 756 })
```
---
Currently in the [kaspa socket server](https://github.com/lAmeR1/kaspa-socket-server/commit/0064253af34037957587f190eab7587fbd6a395f#diff-05852653de753d30a75d2b816fad6ea2e07a4cfbcb42adad4e2948a62bf7d731) we periodically update mempool size using `getInfoRequest`. With the [rusty-socket-server](https://github.com/IzioDev/kaspa-rusty-socket-server/tree/main) we can now use wRPC notifications to get mempool size updates directly and efficiently, replacing the full `GetInfoResponseMessage` with a more lightweight, real-time mempool size notification.