### PR TITLE
Make mainnet nodes always disconnect p2p v6 nodes

### DIFF
--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -782,11 +782,7 @@ impl ConnectionInitializer for FlowContext {
         debug!("protocol versions - self: {}, peer: {}", PROTOCOL_VERSION, peer_version.protocol_version);
 
         // Register all flows according to version
-        const CONNECT_ONLY_NEW_VERSIONS_THRESHOLD_MILLIS: u64 = 24 * 3600 * 1000; // one day in milliseconds
-        let daa_threshold = CONNECT_ONLY_NEW_VERSIONS_THRESHOLD_MILLIS / self.config.target_time_per_block().before();
-        let sink_daa_score = self.consensus().unguarded_session().async_get_sink_daa_score_timestamp().await.daa_score;
-        let connect_only_new_versions = self.config.net.network_type() != NetworkType::Testnet
-            && self.config.crescendo_activation.is_active(sink_daa_score + daa_threshold); // activate the protocol version constraint daa_threshold blocks ahead of time
+        let connect_only_new_versions = self.config.net.network_type() != NetworkType::Testnet;
 
         let (flows, applied_protocol_version) = if connect_only_new_versions {
             match peer_version.protocol_version {


### PR DESCRIPTION
Currently, new nodes don't know that Crescendo has already been activated, so they sometimes try to sync from old nodes, and their IBD fails when they reach the Crescendo daa score