### PR TITLE
windows asm support for Keccak

### DIFF
--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["keccak?/asm"]
 no-asm = ["keccak"]
 
 [dependencies]

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -25,7 +25,7 @@ sha2.workspace = true
 wasm-bindgen.workspace = true
 workflow-wasm.workspace = true
 
-[target.'cfg(any(target_os = "windows", not(target_arch = "x86_64")))'.dependencies]
+[target.'cfg(not(target_arch = "x86_64"))'.dependencies]
 keccak.workspace = true
 
 [dev-dependencies]

--- a/crypto/hashes/build.rs
+++ b/crypto/hashes/build.rs
@@ -1,16 +1,23 @@
 use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=src/keccakf1600_x86-64.s");
-    println!("cargo:rerun-if-changed=src/keccakf1600_x86-64-osx.s");
+    println!("cargo:rerun-if-changed=src/asm");
 
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    if target_arch == "x86_64" && target_os != "windows" && target_os != "macos" {
-        cc::Build::new().flag("-c").file("src/keccakf1600_x86-64.s").compile("libkeccak.a");
-    }
-    if target_arch == "x86_64" && target_os == "macos" {
-        cc::Build::new().flag("-c").file("src/keccakf1600_x86-64-osx.s").compile("libkeccak.a");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    if target_arch == "x86_64" {
+        let mut builder = cc::Build::new();
+        builder.flag("-c");
+        match target_os.as_str() {
+            "macos" => builder.file("src/asm/keccakf1600_x86-64-osx.s"),
+            "linux" => builder.file("src/asm/keccakf1600_x86-64-elf.s"),
+            "windows" if target_env == "gnu" => builder.file("src/asm/keccakf1600_x86-64-mingw64.s"),
+            "windows" if target_env == "msvc" => builder.file("src/asm/keccakf1600_x86-64-msvc.asm"),
+            _ => unimplemented!("Unsupported OS"),
+        };
+        builder.compile("libkeccak.a");
     }
     Ok(())
 }

--- a/crypto/hashes/src/asm/keccakf1600_x86-64-elf.s
+++ b/crypto/hashes/src/asm/keccakf1600_x86-64-elf.s
@@ -2,8 +2,8 @@
 
 .text
 
-
-.p2align	5
+.type	__KeccakF1600,@function
+.align	32
 __KeccakF1600:
 .cfi_startproc
 	.byte	0xf3,0x0f,0x1e,0xfa
@@ -13,10 +13,10 @@ __KeccakF1600:
 	movq	76(%rdi),%rcx
 	movq	84(%rdi),%rdx
 	movq	92(%rdi),%rbp
-	jmp	L$oop
+	jmp	.Loop
 
-.p2align	5
-L$oop:
+.align	32
+.Loop:
 	movq	-100(%rdi),%r8
 	movq	-52(%rdi),%r9
 	movq	-4(%rdi),%r10
@@ -256,17 +256,17 @@ L$oop:
 	movq	%r13,%rdx
 
 	testq	$255,%r15
-	jnz	L$oop
+	jnz	.Loop
 
 	leaq	-192(%r15),%r15
 	.byte	0xf3,0xc3
 .cfi_endproc
+.size	__KeccakF1600,.-__KeccakF1600
 
-
-.globl	_KeccakF1600
-
-.p2align	5
-_KeccakF1600:
+.globl	KeccakF1600
+.type	KeccakF1600,@function
+.align	32
+KeccakF1600:
 .cfi_startproc
 	.byte	0xf3,0x0f,0x1e,0xfa
 
@@ -294,6 +294,7 @@ _KeccakF1600:
 	subq	$200,%rsp
 .cfi_adjust_cfa_offset	200
 
+
 	notq	-92(%rdi)
 	notq	-84(%rdi)
 	notq	-36(%rdi)
@@ -314,33 +315,193 @@ _KeccakF1600:
 	notq	60(%rdi)
 	leaq	-100(%rdi),%rdi
 
-	addq	$200,%rsp
-.cfi_adjust_cfa_offset	-200
-
-	popq	%r15
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r15
-	popq	%r14
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r14
-	popq	%r13
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r13
-	popq	%r12
-.cfi_adjust_cfa_offset	-8
+	leaq	248(%rsp),%r11
+.cfi_def_cfa	%r11,8
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
 .cfi_restore	%r12
-	popq	%rbp
-.cfi_adjust_cfa_offset	-8
+.cfi_restore	%r13
+.cfi_restore	%r14
+.cfi_restore	%r15
 .cfi_restore	%rbp
-	popq	%rbx
-.cfi_adjust_cfa_offset	-8
 .cfi_restore	%rbx
 	.byte	0xf3,0xc3
 .cfi_endproc
+.size	KeccakF1600,.-KeccakF1600
+.globl	SHA3_absorb
+.type	SHA3_absorb,@function
+.align	32
+SHA3_absorb:
+.cfi_startproc
+	.byte	0xf3,0x0f,0x1e,0xfa
 
-.p2align	8
+
+	pushq	%rbx
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%rbx,-16
+	pushq	%rbp
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%rbp,-24
+	pushq	%r12
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r12,-32
+	pushq	%r13
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r13,-40
+	pushq	%r14
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r14,-48
+	pushq	%r15
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r15,-56
+
+	leaq	100(%rdi),%rdi
+	subq	$232,%rsp
+.cfi_adjust_cfa_offset	232
+
+
+	movq	%rsi,%r9
+	leaq	100(%rsp),%rsi
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	iotas(%rip),%r15
+
+	movq	%rcx,216-100(%rsi)
+
+.Loop_absorb:
+	cmpq	%rcx,%rdx
+	jc	.Ldone_absorb
+
+	shrq	$3,%rcx
+	leaq	-100(%rdi),%r8
+
+.Lblock_absorb:
+	movq	(%r9),%rax
+	leaq	8(%r9),%r9
+	xorq	(%r8),%rax
+	leaq	8(%r8),%r8
+	subq	$8,%rdx
+	movq	%rax,-8(%r8)
+	subq	$1,%rcx
+	jnz	.Lblock_absorb
+
+	movq	%r9,200-100(%rsi)
+	movq	%rdx,208-100(%rsi)
+	call	__KeccakF1600
+	movq	200-100(%rsi),%r9
+	movq	208-100(%rsi),%rdx
+	movq	216-100(%rsi),%rcx
+	jmp	.Loop_absorb
+
+.align	32
+.Ldone_absorb:
+	movq	%rdx,%rax
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	280(%rsp),%r11
+.cfi_def_cfa	%r11,8
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.cfi_restore	%r12
+.cfi_restore	%r13
+.cfi_restore	%r14
+.cfi_restore	%r15
+.cfi_restore	%rbp
+.cfi_restore	%rbx
+	.byte	0xf3,0xc3
+.cfi_endproc
+.size	SHA3_absorb,.-SHA3_absorb
+.globl	SHA3_squeeze
+.type	SHA3_squeeze,@function
+.align	32
+SHA3_squeeze:
+.cfi_startproc
+	.byte	0xf3,0x0f,0x1e,0xfa
+
+
+	pushq	%r12
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r12,-16
+	pushq	%r13
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r13,-24
+	pushq	%r14
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r14,-32
+	subq	$32,%rsp
+.cfi_adjust_cfa_offset	32
+
+
+	shrq	$3,%rcx
+	movq	%rdi,%r8
+	movq	%rsi,%r12
+	movq	%rdx,%r13
+	movq	%rcx,%r14
+	jmp	.Loop_squeeze
+
+.align	32
+.Loop_squeeze:
+	cmpq	$8,%r13
+	jb	.Ltail_squeeze
+
+	movq	(%r8),%rax
+	leaq	8(%r8),%r8
+	movq	%rax,(%r12)
+	leaq	8(%r12),%r12
+	subq	$8,%r13
+	jz	.Ldone_squeeze
+
+	subq	$1,%rcx
+	jnz	.Loop_squeeze
+
+	movq	%rdi,%rcx
+	call	KeccakF1600
+	movq	%rdi,%r8
+	movq	%r14,%rcx
+	jmp	.Loop_squeeze
+
+.Ltail_squeeze:
+	movq	%r8,%rsi
+	movq	%r12,%rdi
+	movq	%r13,%rcx
+.byte	0xf3,0xa4
+
+.Ldone_squeeze:
+	movq	32(%rsp),%r14
+	movq	40(%rsp),%r13
+	movq	48(%rsp),%r12
+	addq	$56,%rsp
+.cfi_adjust_cfa_offset	-56
+.cfi_restore	%r12
+.cfi_restore	%r13
+.cfi_restore	%r14
+	.byte	0xf3,0xc3
+.cfi_endproc
+.size	SHA3_squeeze,.-SHA3_squeeze
+.align	256
 .quad	0,0,0,0,0,0,0,0
-
+.type	iotas,@object
 iotas:
 .quad	0x0000000000000001
 .quad	0x0000000000008082
@@ -366,5 +527,12 @@ iotas:
 .quad	0x8000000000008080
 .quad	0x0000000080000001
 .quad	0x8000000080008008
-
+.size	iotas,.-iotas
 .byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+
+.section	.note.gnu.property,"a",@note
+	.long	4,2f-1f,5
+	.byte	0x47,0x4E,0x55,0
+1:	.long	0xc0000002,4,3
+.align	8
+2:

--- a/crypto/hashes/src/asm/keccakf1600_x86-64-mingw64.s
+++ b/crypto/hashes/src/asm/keccakf1600_x86-64-mingw64.s
@@ -1,0 +1,650 @@
+# Source: https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-x86_64.pl
+
+.text
+
+.def	__KeccakF1600;	.scl 3;	.type 32;	.endef
+.p2align	5
+__KeccakF1600:
+	.byte	0xf3,0x0f,0x1e,0xfa
+
+	movq	60(%rdi),%rax
+	movq	68(%rdi),%rbx
+	movq	76(%rdi),%rcx
+	movq	84(%rdi),%rdx
+	movq	92(%rdi),%rbp
+	jmp	.Loop
+
+.p2align	5
+.Loop:
+	movq	-100(%rdi),%r8
+	movq	-52(%rdi),%r9
+	movq	-4(%rdi),%r10
+	movq	44(%rdi),%r11
+
+	xorq	-84(%rdi),%rcx
+	xorq	-76(%rdi),%rdx
+	xorq	%r8,%rax
+	xorq	-92(%rdi),%rbx
+	xorq	-44(%rdi),%rcx
+	xorq	-60(%rdi),%rax
+	movq	%rbp,%r12
+	xorq	-68(%rdi),%rbp
+
+	xorq	%r10,%rcx
+	xorq	-20(%rdi),%rax
+	xorq	-36(%rdi),%rdx
+	xorq	%r9,%rbx
+	xorq	-28(%rdi),%rbp
+
+	xorq	36(%rdi),%rcx
+	xorq	20(%rdi),%rax
+	xorq	4(%rdi),%rdx
+	xorq	-12(%rdi),%rbx
+	xorq	12(%rdi),%rbp
+
+	movq	%rcx,%r13
+	rolq	$1,%rcx
+	xorq	%rax,%rcx
+	xorq	%r11,%rdx
+
+	rolq	$1,%rax
+	xorq	%rdx,%rax
+	xorq	28(%rdi),%rbx
+
+	rolq	$1,%rdx
+	xorq	%rbx,%rdx
+	xorq	52(%rdi),%rbp
+
+	rolq	$1,%rbx
+	xorq	%rbp,%rbx
+
+	rolq	$1,%rbp
+	xorq	%r13,%rbp
+	xorq	%rcx,%r9
+	xorq	%rdx,%r10
+	rolq	$44,%r9
+	xorq	%rbp,%r11
+	xorq	%rax,%r12
+	rolq	$43,%r10
+	xorq	%rbx,%r8
+	movq	%r9,%r13
+	rolq	$21,%r11
+	orq	%r10,%r9
+	xorq	%r8,%r9
+	rolq	$14,%r12
+
+	xorq	(%r15),%r9
+	leaq	8(%r15),%r15
+
+	movq	%r12,%r14
+	andq	%r11,%r12
+	movq	%r9,-100(%rsi)
+	xorq	%r10,%r12
+	notq	%r10
+	movq	%r12,-84(%rsi)
+
+	orq	%r11,%r10
+	movq	76(%rdi),%r12
+	xorq	%r13,%r10
+	movq	%r10,-92(%rsi)
+
+	andq	%r8,%r13
+	movq	-28(%rdi),%r9
+	xorq	%r14,%r13
+	movq	-20(%rdi),%r10
+	movq	%r13,-68(%rsi)
+
+	orq	%r8,%r14
+	movq	-76(%rdi),%r8
+	xorq	%r11,%r14
+	movq	28(%rdi),%r11
+	movq	%r14,-76(%rsi)
+
+
+	xorq	%rbp,%r8
+	xorq	%rdx,%r12
+	rolq	$28,%r8
+	xorq	%rcx,%r11
+	xorq	%rax,%r9
+	rolq	$61,%r12
+	rolq	$45,%r11
+	xorq	%rbx,%r10
+	rolq	$20,%r9
+	movq	%r8,%r13
+	orq	%r12,%r8
+	rolq	$3,%r10
+
+	xorq	%r11,%r8
+	movq	%r8,-36(%rsi)
+
+	movq	%r9,%r14
+	andq	%r13,%r9
+	movq	-92(%rdi),%r8
+	xorq	%r12,%r9
+	notq	%r12
+	movq	%r9,-28(%rsi)
+
+	orq	%r11,%r12
+	movq	-44(%rdi),%r9
+	xorq	%r10,%r12
+	movq	%r12,-44(%rsi)
+
+	andq	%r10,%r11
+	movq	60(%rdi),%r12
+	xorq	%r14,%r11
+	movq	%r11,-52(%rsi)
+
+	orq	%r10,%r14
+	movq	4(%rdi),%r10
+	xorq	%r13,%r14
+	movq	52(%rdi),%r11
+	movq	%r14,-60(%rsi)
+
+
+	xorq	%rbp,%r10
+	xorq	%rax,%r11
+	rolq	$25,%r10
+	xorq	%rdx,%r9
+	rolq	$8,%r11
+	xorq	%rbx,%r12
+	rolq	$6,%r9
+	xorq	%rcx,%r8
+	rolq	$18,%r12
+	movq	%r10,%r13
+	andq	%r11,%r10
+	rolq	$1,%r8
+
+	notq	%r11
+	xorq	%r9,%r10
+	movq	%r10,-12(%rsi)
+
+	movq	%r12,%r14
+	andq	%r11,%r12
+	movq	-12(%rdi),%r10
+	xorq	%r13,%r12
+	movq	%r12,-4(%rsi)
+
+	orq	%r9,%r13
+	movq	84(%rdi),%r12
+	xorq	%r8,%r13
+	movq	%r13,-20(%rsi)
+
+	andq	%r8,%r9
+	xorq	%r14,%r9
+	movq	%r9,12(%rsi)
+
+	orq	%r8,%r14
+	movq	-60(%rdi),%r9
+	xorq	%r11,%r14
+	movq	36(%rdi),%r11
+	movq	%r14,4(%rsi)
+
+
+	movq	-68(%rdi),%r8
+
+	xorq	%rcx,%r10
+	xorq	%rdx,%r11
+	rolq	$10,%r10
+	xorq	%rbx,%r9
+	rolq	$15,%r11
+	xorq	%rbp,%r12
+	rolq	$36,%r9
+	xorq	%rax,%r8
+	rolq	$56,%r12
+	movq	%r10,%r13
+	orq	%r11,%r10
+	rolq	$27,%r8
+
+	notq	%r11
+	xorq	%r9,%r10
+	movq	%r10,28(%rsi)
+
+	movq	%r12,%r14
+	orq	%r11,%r12
+	xorq	%r13,%r12
+	movq	%r12,36(%rsi)
+
+	andq	%r9,%r13
+	xorq	%r8,%r13
+	movq	%r13,20(%rsi)
+
+	orq	%r8,%r9
+	xorq	%r14,%r9
+	movq	%r9,52(%rsi)
+
+	andq	%r14,%r8
+	xorq	%r11,%r8
+	movq	%r8,44(%rsi)
+
+
+	xorq	-84(%rdi),%rdx
+	xorq	-36(%rdi),%rbp
+	rolq	$62,%rdx
+	xorq	68(%rdi),%rcx
+	rolq	$55,%rbp
+	xorq	12(%rdi),%rax
+	rolq	$2,%rcx
+	xorq	20(%rdi),%rbx
+	xchgq	%rsi,%rdi
+	rolq	$39,%rax
+	rolq	$41,%rbx
+	movq	%rdx,%r13
+	andq	%rbp,%rdx
+	notq	%rbp
+	xorq	%rcx,%rdx
+	movq	%rdx,92(%rdi)
+
+	movq	%rax,%r14
+	andq	%rbp,%rax
+	xorq	%r13,%rax
+	movq	%rax,60(%rdi)
+
+	orq	%rcx,%r13
+	xorq	%rbx,%r13
+	movq	%r13,84(%rdi)
+
+	andq	%rbx,%rcx
+	xorq	%r14,%rcx
+	movq	%rcx,76(%rdi)
+
+	orq	%r14,%rbx
+	xorq	%rbp,%rbx
+	movq	%rbx,68(%rdi)
+
+	movq	%rdx,%rbp
+	movq	%r13,%rdx
+
+	testq	$255,%r15
+	jnz	.Loop
+
+	leaq	-192(%r15),%r15
+	.byte	0xf3,0xc3
+
+
+.globl	KeccakF1600
+.def	KeccakF1600;	.scl 2;	.type 32;	.endef
+.p2align	5
+KeccakF1600:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_KeccakF1600:
+
+
+	movq	%rcx,%rdi
+	pushq	%rbx
+
+	pushq	%rbp
+
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	pushq	%r15
+
+
+	leaq	100(%rdi),%rdi
+	subq	$200,%rsp
+
+.LSEH_body_KeccakF1600:
+
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	iotas(%rip),%r15
+	leaq	100(%rsp),%rsi
+
+	call	__KeccakF1600
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	-100(%rdi),%rdi
+
+	leaq	248(%rsp),%r11
+
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.LSEH_epilogue_KeccakF1600:
+	mov	8(%r11),%rdi
+	mov	16(%r11),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_KeccakF1600:
+.globl	SHA3_absorb
+.def	SHA3_absorb;	.scl 2;	.type 32;	.endef
+.p2align	5
+SHA3_absorb:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_SHA3_absorb:
+
+
+	movq	%rcx,%rdi
+	movq	%rdx,%rsi
+	movq	%r8,%rdx
+	movq	%r9,%rcx
+	pushq	%rbx
+
+	pushq	%rbp
+
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	pushq	%r15
+
+
+	leaq	100(%rdi),%rdi
+	subq	$232,%rsp
+
+.LSEH_body_SHA3_absorb:
+
+
+	movq	%rsi,%r9
+	leaq	100(%rsp),%rsi
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	iotas(%rip),%r15
+
+	movq	%rcx,216-100(%rsi)
+
+.Loop_absorb:
+	cmpq	%rcx,%rdx
+	jc	.Ldone_absorb
+
+	shrq	$3,%rcx
+	leaq	-100(%rdi),%r8
+
+.Lblock_absorb:
+	movq	(%r9),%rax
+	leaq	8(%r9),%r9
+	xorq	(%r8),%rax
+	leaq	8(%r8),%r8
+	subq	$8,%rdx
+	movq	%rax,-8(%r8)
+	subq	$1,%rcx
+	jnz	.Lblock_absorb
+
+	movq	%r9,200-100(%rsi)
+	movq	%rdx,208-100(%rsi)
+	call	__KeccakF1600
+	movq	200-100(%rsi),%r9
+	movq	208-100(%rsi),%rdx
+	movq	216-100(%rsi),%rcx
+	jmp	.Loop_absorb
+
+.p2align	5
+.Ldone_absorb:
+	movq	%rdx,%rax
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	280(%rsp),%r11
+
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.LSEH_epilogue_SHA3_absorb:
+	mov	8(%r11),%rdi
+	mov	16(%r11),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_SHA3_absorb:
+.globl	SHA3_squeeze
+.def	SHA3_squeeze;	.scl 2;	.type 32;	.endef
+.p2align	5
+SHA3_squeeze:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_SHA3_squeeze:
+
+
+	movq	%rcx,%rdi
+	movq	%rdx,%rsi
+	movq	%r8,%rdx
+	movq	%r9,%rcx
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	subq	$32,%rsp
+
+.LSEH_body_SHA3_squeeze:
+
+
+	shrq	$3,%rcx
+	movq	%rdi,%r8
+	movq	%rsi,%r12
+	movq	%rdx,%r13
+	movq	%rcx,%r14
+	jmp	.Loop_squeeze
+
+.p2align	5
+.Loop_squeeze:
+	cmpq	$8,%r13
+	jb	.Ltail_squeeze
+
+	movq	(%r8),%rax
+	leaq	8(%r8),%r8
+	movq	%rax,(%r12)
+	leaq	8(%r12),%r12
+	subq	$8,%r13
+	jz	.Ldone_squeeze
+
+	subq	$1,%rcx
+	jnz	.Loop_squeeze
+
+	movq	%rdi,%rcx
+	call	KeccakF1600
+	movq	%rdi,%r8
+	movq	%r14,%rcx
+	jmp	.Loop_squeeze
+
+.Ltail_squeeze:
+	movq	%r8,%rsi
+	movq	%r12,%rdi
+	movq	%r13,%rcx
+.byte	0xf3,0xa4
+
+.Ldone_squeeze:
+	movq	32(%rsp),%r14
+	movq	40(%rsp),%r13
+	movq	48(%rsp),%r12
+	addq	$56,%rsp
+
+.LSEH_epilogue_SHA3_squeeze:
+	mov	8(%rsp),%rdi
+	mov	16(%rsp),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_SHA3_squeeze:
+.p2align	8
+.quad	0,0,0,0,0,0,0,0
+
+iotas:
+.quad	0x0000000000000001
+.quad	0x0000000000008082
+.quad	0x800000000000808a
+.quad	0x8000000080008000
+.quad	0x000000000000808b
+.quad	0x0000000080000001
+.quad	0x8000000080008081
+.quad	0x8000000000008009
+.quad	0x000000000000008a
+.quad	0x0000000000000088
+.quad	0x0000000080008009
+.quad	0x000000008000000a
+.quad	0x000000008000808b
+.quad	0x800000000000008b
+.quad	0x8000000000008089
+.quad	0x8000000000008003
+.quad	0x8000000000008002
+.quad	0x8000000000000080
+.quad	0x000000000000800a
+.quad	0x800000008000000a
+.quad	0x8000000080008081
+.quad	0x8000000000008080
+.quad	0x0000000080000001
+.quad	0x8000000080008008
+
+.byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+.section	.pdata
+.p2align	2
+.rva	.LSEH_begin_KeccakF1600
+.rva	.LSEH_body_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_prologue
+
+.rva	.LSEH_body_KeccakF1600
+.rva	.LSEH_epilogue_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_body
+
+.rva	.LSEH_epilogue_KeccakF1600
+.rva	.LSEH_end_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_epilogue
+
+.rva	.LSEH_begin_SHA3_absorb
+.rva	.LSEH_body_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_prologue
+
+.rva	.LSEH_body_SHA3_absorb
+.rva	.LSEH_epilogue_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_body
+
+.rva	.LSEH_epilogue_SHA3_absorb
+.rva	.LSEH_end_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_epilogue
+
+.rva	.LSEH_begin_SHA3_squeeze
+.rva	.LSEH_body_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_prologue
+
+.rva	.LSEH_body_SHA3_squeeze
+.rva	.LSEH_epilogue_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_body
+
+.rva	.LSEH_epilogue_SHA3_squeeze
+.rva	.LSEH_end_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_epilogue
+
+.section	.xdata
+.p2align	3
+.LSEH_info_KeccakF1600_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_KeccakF1600_body:
+.byte	1,0,18,0
+.byte	0x00,0xf4,0x19,0x00
+.byte	0x00,0xe4,0x1a,0x00
+.byte	0x00,0xd4,0x1b,0x00
+.byte	0x00,0xc4,0x1c,0x00
+.byte	0x00,0x54,0x1d,0x00
+.byte	0x00,0x34,0x1e,0x00
+.byte	0x00,0x74,0x20,0x00
+.byte	0x00,0x64,0x21,0x00
+.byte	0x00,0x01,0x1f,0x00
+.byte	0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+.LSEH_info_KeccakF1600_epilogue:
+.byte	1,0,5,11
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0xb3
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+
+.LSEH_info_SHA3_absorb_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_SHA3_absorb_body:
+.byte	1,0,18,0
+.byte	0x00,0xf4,0x1d,0x00
+.byte	0x00,0xe4,0x1e,0x00
+.byte	0x00,0xd4,0x1f,0x00
+.byte	0x00,0xc4,0x20,0x00
+.byte	0x00,0x54,0x21,0x00
+.byte	0x00,0x34,0x22,0x00
+.byte	0x00,0x74,0x24,0x00
+.byte	0x00,0x64,0x25,0x00
+.byte	0x00,0x01,0x23,0x00
+.byte	0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+.LSEH_info_SHA3_absorb_epilogue:
+.byte	1,0,5,11
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0xb3
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+
+.LSEH_info_SHA3_squeeze_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_SHA3_squeeze_body:
+.byte	1,0,11,0
+.byte	0x00,0xe4,0x04,0x00
+.byte	0x00,0xd4,0x05,0x00
+.byte	0x00,0xc4,0x06,0x00
+.byte	0x00,0x74,0x08,0x00
+.byte	0x00,0x64,0x09,0x00
+.byte	0x00,0x62
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.LSEH_info_SHA3_squeeze_epilogue:
+.byte	1,0,4,0
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0x00,0x00,0x00
+

--- a/crypto/hashes/src/asm/keccakf1600_x86-64-msvc.asm
+++ b/crypto/hashes/src/asm/keccakf1600_x86-64-msvc.asm
@@ -1,0 +1,661 @@
+OPTION	DOTNAME
+.text$	SEGMENT ALIGN(256) 'CODE'
+
+
+ALIGN	32
+__KeccakF1600	PROC PRIVATE
+	DB	243,15,30,250
+
+	mov	rax,QWORD PTR[60+rdi]
+	mov	rbx,QWORD PTR[68+rdi]
+	mov	rcx,QWORD PTR[76+rdi]
+	mov	rdx,QWORD PTR[84+rdi]
+	mov	rbp,QWORD PTR[92+rdi]
+	jmp	$L$oop
+
+ALIGN	32
+$L$oop::
+	mov	r8,QWORD PTR[((-100))+rdi]
+	mov	r9,QWORD PTR[((-52))+rdi]
+	mov	r10,QWORD PTR[((-4))+rdi]
+	mov	r11,QWORD PTR[44+rdi]
+
+	xor	rcx,QWORD PTR[((-84))+rdi]
+	xor	rdx,QWORD PTR[((-76))+rdi]
+	xor	rax,r8
+	xor	rbx,QWORD PTR[((-92))+rdi]
+	xor	rcx,QWORD PTR[((-44))+rdi]
+	xor	rax,QWORD PTR[((-60))+rdi]
+	mov	r12,rbp
+	xor	rbp,QWORD PTR[((-68))+rdi]
+
+	xor	rcx,r10
+	xor	rax,QWORD PTR[((-20))+rdi]
+	xor	rdx,QWORD PTR[((-36))+rdi]
+	xor	rbx,r9
+	xor	rbp,QWORD PTR[((-28))+rdi]
+
+	xor	rcx,QWORD PTR[36+rdi]
+	xor	rax,QWORD PTR[20+rdi]
+	xor	rdx,QWORD PTR[4+rdi]
+	xor	rbx,QWORD PTR[((-12))+rdi]
+	xor	rbp,QWORD PTR[12+rdi]
+
+	mov	r13,rcx
+	rol	rcx,1
+	xor	rcx,rax
+	xor	rdx,r11
+
+	rol	rax,1
+	xor	rax,rdx
+	xor	rbx,QWORD PTR[28+rdi]
+
+	rol	rdx,1
+	xor	rdx,rbx
+	xor	rbp,QWORD PTR[52+rdi]
+
+	rol	rbx,1
+	xor	rbx,rbp
+
+	rol	rbp,1
+	xor	rbp,r13
+	xor	r9,rcx
+	xor	r10,rdx
+	rol	r9,44
+	xor	r11,rbp
+	xor	r12,rax
+	rol	r10,43
+	xor	r8,rbx
+	mov	r13,r9
+	rol	r11,21
+	or	r9,r10
+	xor	r9,r8
+	rol	r12,14
+
+	xor	r9,QWORD PTR[r15]
+	lea	r15,QWORD PTR[8+r15]
+
+	mov	r14,r12
+	and	r12,r11
+	mov	QWORD PTR[((-100))+rsi],r9
+	xor	r12,r10
+	not	r10
+	mov	QWORD PTR[((-84))+rsi],r12
+
+	or	r10,r11
+	mov	r12,QWORD PTR[76+rdi]
+	xor	r10,r13
+	mov	QWORD PTR[((-92))+rsi],r10
+
+	and	r13,r8
+	mov	r9,QWORD PTR[((-28))+rdi]
+	xor	r13,r14
+	mov	r10,QWORD PTR[((-20))+rdi]
+	mov	QWORD PTR[((-68))+rsi],r13
+
+	or	r14,r8
+	mov	r8,QWORD PTR[((-76))+rdi]
+	xor	r14,r11
+	mov	r11,QWORD PTR[28+rdi]
+	mov	QWORD PTR[((-76))+rsi],r14
+
+
+	xor	r8,rbp
+	xor	r12,rdx
+	rol	r8,28
+	xor	r11,rcx
+	xor	r9,rax
+	rol	r12,61
+	rol	r11,45
+	xor	r10,rbx
+	rol	r9,20
+	mov	r13,r8
+	or	r8,r12
+	rol	r10,3
+
+	xor	r8,r11
+	mov	QWORD PTR[((-36))+rsi],r8
+
+	mov	r14,r9
+	and	r9,r13
+	mov	r8,QWORD PTR[((-92))+rdi]
+	xor	r9,r12
+	not	r12
+	mov	QWORD PTR[((-28))+rsi],r9
+
+	or	r12,r11
+	mov	r9,QWORD PTR[((-44))+rdi]
+	xor	r12,r10
+	mov	QWORD PTR[((-44))+rsi],r12
+
+	and	r11,r10
+	mov	r12,QWORD PTR[60+rdi]
+	xor	r11,r14
+	mov	QWORD PTR[((-52))+rsi],r11
+
+	or	r14,r10
+	mov	r10,QWORD PTR[4+rdi]
+	xor	r14,r13
+	mov	r11,QWORD PTR[52+rdi]
+	mov	QWORD PTR[((-60))+rsi],r14
+
+
+	xor	r10,rbp
+	xor	r11,rax
+	rol	r10,25
+	xor	r9,rdx
+	rol	r11,8
+	xor	r12,rbx
+	rol	r9,6
+	xor	r8,rcx
+	rol	r12,18
+	mov	r13,r10
+	and	r10,r11
+	rol	r8,1
+
+	not	r11
+	xor	r10,r9
+	mov	QWORD PTR[((-12))+rsi],r10
+
+	mov	r14,r12
+	and	r12,r11
+	mov	r10,QWORD PTR[((-12))+rdi]
+	xor	r12,r13
+	mov	QWORD PTR[((-4))+rsi],r12
+
+	or	r13,r9
+	mov	r12,QWORD PTR[84+rdi]
+	xor	r13,r8
+	mov	QWORD PTR[((-20))+rsi],r13
+
+	and	r9,r8
+	xor	r9,r14
+	mov	QWORD PTR[12+rsi],r9
+
+	or	r14,r8
+	mov	r9,QWORD PTR[((-60))+rdi]
+	xor	r14,r11
+	mov	r11,QWORD PTR[36+rdi]
+	mov	QWORD PTR[4+rsi],r14
+
+
+	mov	r8,QWORD PTR[((-68))+rdi]
+
+	xor	r10,rcx
+	xor	r11,rdx
+	rol	r10,10
+	xor	r9,rbx
+	rol	r11,15
+	xor	r12,rbp
+	rol	r9,36
+	xor	r8,rax
+	rol	r12,56
+	mov	r13,r10
+	or	r10,r11
+	rol	r8,27
+
+	not	r11
+	xor	r10,r9
+	mov	QWORD PTR[28+rsi],r10
+
+	mov	r14,r12
+	or	r12,r11
+	xor	r12,r13
+	mov	QWORD PTR[36+rsi],r12
+
+	and	r13,r9
+	xor	r13,r8
+	mov	QWORD PTR[20+rsi],r13
+
+	or	r9,r8
+	xor	r9,r14
+	mov	QWORD PTR[52+rsi],r9
+
+	and	r8,r14
+	xor	r8,r11
+	mov	QWORD PTR[44+rsi],r8
+
+
+	xor	rdx,QWORD PTR[((-84))+rdi]
+	xor	rbp,QWORD PTR[((-36))+rdi]
+	rol	rdx,62
+	xor	rcx,QWORD PTR[68+rdi]
+	rol	rbp,55
+	xor	rax,QWORD PTR[12+rdi]
+	rol	rcx,2
+	xor	rbx,QWORD PTR[20+rdi]
+	xchg	rdi,rsi
+	rol	rax,39
+	rol	rbx,41
+	mov	r13,rdx
+	and	rdx,rbp
+	not	rbp
+	xor	rdx,rcx
+	mov	QWORD PTR[92+rdi],rdx
+
+	mov	r14,rax
+	and	rax,rbp
+	xor	rax,r13
+	mov	QWORD PTR[60+rdi],rax
+
+	or	r13,rcx
+	xor	r13,rbx
+	mov	QWORD PTR[84+rdi],r13
+
+	and	rcx,rbx
+	xor	rcx,r14
+	mov	QWORD PTR[76+rdi],rcx
+
+	or	rbx,r14
+	xor	rbx,rbp
+	mov	QWORD PTR[68+rdi],rbx
+
+	mov	rbp,rdx
+	mov	rdx,r13
+
+	test	r15,255
+	jnz	$L$oop
+
+	lea	r15,QWORD PTR[((-192))+r15]
+	DB	0F3h,0C3h		;repret
+__KeccakF1600	ENDP
+
+PUBLIC	KeccakF1600
+
+ALIGN	32
+KeccakF1600	PROC PUBLIC
+	DB	243,15,30,250
+	mov	QWORD PTR[8+rsp],rdi	;WIN64 prologue
+	mov	QWORD PTR[16+rsp],rsi
+	mov	r11,rsp
+$L$SEH_begin_KeccakF1600::
+
+
+	mov	rdi,rcx
+	push	rbx
+
+	push	rbp
+
+	push	r12
+
+	push	r13
+
+	push	r14
+
+	push	r15
+
+
+	lea	rdi,QWORD PTR[100+rdi]
+	sub	rsp,200
+
+$L$SEH_body_KeccakF1600::
+
+
+	not	QWORD PTR[((-92))+rdi]
+	not	QWORD PTR[((-84))+rdi]
+	not	QWORD PTR[((-36))+rdi]
+	not	QWORD PTR[((-4))+rdi]
+	not	QWORD PTR[36+rdi]
+	not	QWORD PTR[60+rdi]
+
+	lea	r15,QWORD PTR[iotas]
+	lea	rsi,QWORD PTR[100+rsp]
+
+	call	__KeccakF1600
+
+	not	QWORD PTR[((-92))+rdi]
+	not	QWORD PTR[((-84))+rdi]
+	not	QWORD PTR[((-36))+rdi]
+	not	QWORD PTR[((-4))+rdi]
+	not	QWORD PTR[36+rdi]
+	not	QWORD PTR[60+rdi]
+	lea	rdi,QWORD PTR[((-100))+rdi]
+
+	lea	r11,QWORD PTR[248+rsp]
+
+	mov	r15,QWORD PTR[((-48))+r11]
+	mov	r14,QWORD PTR[((-40))+r11]
+	mov	r13,QWORD PTR[((-32))+r11]
+	mov	r12,QWORD PTR[((-24))+r11]
+	mov	rbp,QWORD PTR[((-16))+r11]
+	mov	rbx,QWORD PTR[((-8))+r11]
+	lea	rsp,QWORD PTR[r11]
+$L$SEH_epilogue_KeccakF1600::
+	mov	rdi,QWORD PTR[8+r11]	;WIN64 epilogue
+	mov	rsi,QWORD PTR[16+r11]
+
+	DB	0F3h,0C3h		;repret
+
+$L$SEH_end_KeccakF1600::
+KeccakF1600	ENDP
+PUBLIC	SHA3_absorb
+
+ALIGN	32
+SHA3_absorb	PROC PUBLIC
+	DB	243,15,30,250
+	mov	QWORD PTR[8+rsp],rdi	;WIN64 prologue
+	mov	QWORD PTR[16+rsp],rsi
+	mov	r11,rsp
+$L$SEH_begin_SHA3_absorb::
+
+
+	mov	rdi,rcx
+	mov	rsi,rdx
+	mov	rdx,r8
+	mov	rcx,r9
+	push	rbx
+
+	push	rbp
+
+	push	r12
+
+	push	r13
+
+	push	r14
+
+	push	r15
+
+
+	lea	rdi,QWORD PTR[100+rdi]
+	sub	rsp,232
+
+$L$SEH_body_SHA3_absorb::
+
+
+	mov	r9,rsi
+	lea	rsi,QWORD PTR[100+rsp]
+
+	not	QWORD PTR[((-92))+rdi]
+	not	QWORD PTR[((-84))+rdi]
+	not	QWORD PTR[((-36))+rdi]
+	not	QWORD PTR[((-4))+rdi]
+	not	QWORD PTR[36+rdi]
+	not	QWORD PTR[60+rdi]
+	lea	r15,QWORD PTR[iotas]
+
+	mov	QWORD PTR[((216-100))+rsi],rcx
+
+$L$oop_absorb::
+	cmp	rdx,rcx
+	jc	$L$done_absorb
+
+	shr	rcx,3
+	lea	r8,QWORD PTR[((-100))+rdi]
+
+$L$block_absorb::
+	mov	rax,QWORD PTR[r9]
+	lea	r9,QWORD PTR[8+r9]
+	xor	rax,QWORD PTR[r8]
+	lea	r8,QWORD PTR[8+r8]
+	sub	rdx,8
+	mov	QWORD PTR[((-8))+r8],rax
+	sub	rcx,1
+	jnz	$L$block_absorb
+
+	mov	QWORD PTR[((200-100))+rsi],r9
+	mov	QWORD PTR[((208-100))+rsi],rdx
+	call	__KeccakF1600
+	mov	r9,QWORD PTR[((200-100))+rsi]
+	mov	rdx,QWORD PTR[((208-100))+rsi]
+	mov	rcx,QWORD PTR[((216-100))+rsi]
+	jmp	$L$oop_absorb
+
+ALIGN	32
+$L$done_absorb::
+	mov	rax,rdx
+
+	not	QWORD PTR[((-92))+rdi]
+	not	QWORD PTR[((-84))+rdi]
+	not	QWORD PTR[((-36))+rdi]
+	not	QWORD PTR[((-4))+rdi]
+	not	QWORD PTR[36+rdi]
+	not	QWORD PTR[60+rdi]
+
+	lea	r11,QWORD PTR[280+rsp]
+
+	mov	r15,QWORD PTR[((-48))+r11]
+	mov	r14,QWORD PTR[((-40))+r11]
+	mov	r13,QWORD PTR[((-32))+r11]
+	mov	r12,QWORD PTR[((-24))+r11]
+	mov	rbp,QWORD PTR[((-16))+r11]
+	mov	rbx,QWORD PTR[((-8))+r11]
+	lea	rsp,QWORD PTR[r11]
+$L$SEH_epilogue_SHA3_absorb::
+	mov	rdi,QWORD PTR[8+r11]	;WIN64 epilogue
+	mov	rsi,QWORD PTR[16+r11]
+
+	DB	0F3h,0C3h		;repret
+
+$L$SEH_end_SHA3_absorb::
+SHA3_absorb	ENDP
+PUBLIC	SHA3_squeeze
+
+ALIGN	32
+SHA3_squeeze	PROC PUBLIC
+	DB	243,15,30,250
+	mov	QWORD PTR[8+rsp],rdi	;WIN64 prologue
+	mov	QWORD PTR[16+rsp],rsi
+	mov	r11,rsp
+$L$SEH_begin_SHA3_squeeze::
+
+
+	mov	rdi,rcx
+	mov	rsi,rdx
+	mov	rdx,r8
+	mov	rcx,r9
+	push	r12
+
+	push	r13
+
+	push	r14
+
+	sub	rsp,32
+
+$L$SEH_body_SHA3_squeeze::
+
+
+	shr	rcx,3
+	mov	r8,rdi
+	mov	r12,rsi
+	mov	r13,rdx
+	mov	r14,rcx
+	jmp	$L$oop_squeeze
+
+ALIGN	32
+$L$oop_squeeze::
+	cmp	r13,8
+	jb	$L$tail_squeeze
+
+	mov	rax,QWORD PTR[r8]
+	lea	r8,QWORD PTR[8+r8]
+	mov	QWORD PTR[r12],rax
+	lea	r12,QWORD PTR[8+r12]
+	sub	r13,8
+	jz	$L$done_squeeze
+
+	sub	rcx,1
+	jnz	$L$oop_squeeze
+
+	mov	rcx,rdi
+	call	KeccakF1600
+	mov	r8,rdi
+	mov	rcx,r14
+	jmp	$L$oop_squeeze
+
+$L$tail_squeeze::
+	mov	rsi,r8
+	mov	rdi,r12
+	mov	rcx,r13
+DB	0f3h,0a4h
+
+$L$done_squeeze::
+	mov	r14,QWORD PTR[32+rsp]
+	mov	r13,QWORD PTR[40+rsp]
+	mov	r12,QWORD PTR[48+rsp]
+	add	rsp,56
+
+$L$SEH_epilogue_SHA3_squeeze::
+	mov	rdi,QWORD PTR[8+rsp]	;WIN64 epilogue
+	mov	rsi,QWORD PTR[16+rsp]
+
+	DB	0F3h,0C3h		;repret
+
+$L$SEH_end_SHA3_squeeze::
+SHA3_squeeze	ENDP
+ALIGN	256
+	DQ	0,0,0,0,0,0,0,0
+
+iotas::
+	DQ	00000000000000001h
+	DQ	00000000000008082h
+	DQ	0800000000000808ah
+	DQ	08000000080008000h
+	DQ	0000000000000808bh
+	DQ	00000000080000001h
+	DQ	08000000080008081h
+	DQ	08000000000008009h
+	DQ	0000000000000008ah
+	DQ	00000000000000088h
+	DQ	00000000080008009h
+	DQ	0000000008000000ah
+	DQ	0000000008000808bh
+	DQ	0800000000000008bh
+	DQ	08000000000008089h
+	DQ	08000000000008003h
+	DQ	08000000000008002h
+	DQ	08000000000000080h
+	DQ	0000000000000800ah
+	DQ	0800000008000000ah
+	DQ	08000000080008081h
+	DQ	08000000000008080h
+	DQ	00000000080000001h
+	DQ	08000000080008008h
+
+DB	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111
+DB	114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102
+DB	111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84
+DB	79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64
+DB	111,112,101,110,115,115,108,46,111,114,103,62,0
+.text$	ENDS
+.pdata	SEGMENT READONLY ALIGN(4)
+ALIGN	4
+	DD	imagerel $L$SEH_begin_KeccakF1600
+	DD	imagerel $L$SEH_body_KeccakF1600
+	DD	imagerel $L$SEH_info_KeccakF1600_prologue
+
+	DD	imagerel $L$SEH_body_KeccakF1600
+	DD	imagerel $L$SEH_epilogue_KeccakF1600
+	DD	imagerel $L$SEH_info_KeccakF1600_body
+
+	DD	imagerel $L$SEH_epilogue_KeccakF1600
+	DD	imagerel $L$SEH_end_KeccakF1600
+	DD	imagerel $L$SEH_info_KeccakF1600_epilogue
+
+	DD	imagerel $L$SEH_begin_SHA3_absorb
+	DD	imagerel $L$SEH_body_SHA3_absorb
+	DD	imagerel $L$SEH_info_SHA3_absorb_prologue
+
+	DD	imagerel $L$SEH_body_SHA3_absorb
+	DD	imagerel $L$SEH_epilogue_SHA3_absorb
+	DD	imagerel $L$SEH_info_SHA3_absorb_body
+
+	DD	imagerel $L$SEH_epilogue_SHA3_absorb
+	DD	imagerel $L$SEH_end_SHA3_absorb
+	DD	imagerel $L$SEH_info_SHA3_absorb_epilogue
+
+	DD	imagerel $L$SEH_begin_SHA3_squeeze
+	DD	imagerel $L$SEH_body_SHA3_squeeze
+	DD	imagerel $L$SEH_info_SHA3_squeeze_prologue
+
+	DD	imagerel $L$SEH_body_SHA3_squeeze
+	DD	imagerel $L$SEH_epilogue_SHA3_squeeze
+	DD	imagerel $L$SEH_info_SHA3_squeeze_body
+
+	DD	imagerel $L$SEH_epilogue_SHA3_squeeze
+	DD	imagerel $L$SEH_end_SHA3_squeeze
+	DD	imagerel $L$SEH_info_SHA3_squeeze_epilogue
+
+.pdata	ENDS
+.xdata	SEGMENT READONLY ALIGN(8)
+ALIGN	8
+$L$SEH_info_KeccakF1600_prologue::
+DB	1,0,5,00bh
+DB	0,074h,1,0
+DB	0,064h,2,0
+DB	0,0b3h
+DB	0,0
+	DD	0,0
+$L$SEH_info_KeccakF1600_body::
+DB	1,0,18,0
+DB	000h,0f4h,019h,000h
+DB	000h,0e4h,01ah,000h
+DB	000h,0d4h,01bh,000h
+DB	000h,0c4h,01ch,000h
+DB	000h,054h,01dh,000h
+DB	000h,034h,01eh,000h
+DB	000h,074h,020h,000h
+DB	000h,064h,021h,000h
+DB	000h,001h,01fh,000h
+DB	000h,000h,000h,000h
+DB	000h,000h,000h,000h
+$L$SEH_info_KeccakF1600_epilogue::
+DB	1,0,5,11
+DB	000h,074h,001h,000h
+DB	000h,064h,002h,000h
+DB	000h,0b3h
+DB	000h,000h,000h,000h,000h,000h
+DB	000h,000h,000h,000h
+
+$L$SEH_info_SHA3_absorb_prologue::
+DB	1,0,5,00bh
+DB	0,074h,1,0
+DB	0,064h,2,0
+DB	0,0b3h
+DB	0,0
+	DD	0,0
+$L$SEH_info_SHA3_absorb_body::
+DB	1,0,18,0
+DB	000h,0f4h,01dh,000h
+DB	000h,0e4h,01eh,000h
+DB	000h,0d4h,01fh,000h
+DB	000h,0c4h,020h,000h
+DB	000h,054h,021h,000h
+DB	000h,034h,022h,000h
+DB	000h,074h,024h,000h
+DB	000h,064h,025h,000h
+DB	000h,001h,023h,000h
+DB	000h,000h,000h,000h
+DB	000h,000h,000h,000h
+$L$SEH_info_SHA3_absorb_epilogue::
+DB	1,0,5,11
+DB	000h,074h,001h,000h
+DB	000h,064h,002h,000h
+DB	000h,0b3h
+DB	000h,000h,000h,000h,000h,000h
+DB	000h,000h,000h,000h
+
+$L$SEH_info_SHA3_squeeze_prologue::
+DB	1,0,5,00bh
+DB	0,074h,1,0
+DB	0,064h,2,0
+DB	0,0b3h
+DB	0,0
+	DD	0,0
+$L$SEH_info_SHA3_squeeze_body::
+DB	1,0,11,0
+DB	000h,0e4h,004h,000h
+DB	000h,0d4h,005h,000h
+DB	000h,0c4h,006h,000h
+DB	000h,074h,008h,000h
+DB	000h,064h,009h,000h
+DB	000h,062h
+DB	000h,000h,000h,000h,000h,000h
+$L$SEH_info_SHA3_squeeze_epilogue::
+DB	1,0,4,0
+DB	000h,074h,001h,000h
+DB	000h,064h,002h,000h
+DB	000h,000h,000h,000h
+
+
+.xdata	ENDS
+END

--- a/crypto/hashes/src/asm/keccakf1600_x86-64-osx.s
+++ b/crypto/hashes/src/asm/keccakf1600_x86-64-osx.s
@@ -2,8 +2,8 @@
 
 .text
 
-.type	__KeccakF1600,@function
-.align	32
+
+.p2align	5
 __KeccakF1600:
 .cfi_startproc
 	.byte	0xf3,0x0f,0x1e,0xfa
@@ -13,10 +13,10 @@ __KeccakF1600:
 	movq	76(%rdi),%rcx
 	movq	84(%rdi),%rdx
 	movq	92(%rdi),%rbp
-	jmp	.Loop
+	jmp	L$oop
 
-.align	32
-.Loop:
+.p2align	5
+L$oop:
 	movq	-100(%rdi),%r8
 	movq	-52(%rdi),%r9
 	movq	-4(%rdi),%r10
@@ -256,17 +256,17 @@ __KeccakF1600:
 	movq	%r13,%rdx
 
 	testq	$255,%r15
-	jnz	.Loop
+	jnz	L$oop
 
 	leaq	-192(%r15),%r15
 	.byte	0xf3,0xc3
 .cfi_endproc
-.size	__KeccakF1600,.-__KeccakF1600
 
-.globl	KeccakF1600
-.type	KeccakF1600,@function
-.align	32
-KeccakF1600:
+
+.globl	_KeccakF1600
+
+.p2align	5
+_KeccakF1600:
 .cfi_startproc
 	.byte	0xf3,0x0f,0x1e,0xfa
 
@@ -294,6 +294,7 @@ KeccakF1600:
 	subq	$200,%rsp
 .cfi_adjust_cfa_offset	200
 
+
 	notq	-92(%rdi)
 	notq	-84(%rdi)
 	notq	-36(%rdi)
@@ -314,33 +315,193 @@ KeccakF1600:
 	notq	60(%rdi)
 	leaq	-100(%rdi),%rdi
 
-	addq	$200,%rsp
-.cfi_adjust_cfa_offset	-200
-
-	popq	%r15
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r15
-	popq	%r14
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r14
-	popq	%r13
-.cfi_adjust_cfa_offset	-8
-.cfi_restore	%r13
-	popq	%r12
-.cfi_adjust_cfa_offset	-8
+	leaq	248(%rsp),%r11
+.cfi_def_cfa	%r11,8
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
 .cfi_restore	%r12
-	popq	%rbp
-.cfi_adjust_cfa_offset	-8
+.cfi_restore	%r13
+.cfi_restore	%r14
+.cfi_restore	%r15
 .cfi_restore	%rbp
-	popq	%rbx
-.cfi_adjust_cfa_offset	-8
 .cfi_restore	%rbx
 	.byte	0xf3,0xc3
 .cfi_endproc
-.size	KeccakF1600,.-KeccakF1600
-.align	256
+
+.globl	_SHA3_absorb
+
+.p2align	5
+_SHA3_absorb:
+.cfi_startproc
+	.byte	0xf3,0x0f,0x1e,0xfa
+
+
+	pushq	%rbx
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%rbx,-16
+	pushq	%rbp
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%rbp,-24
+	pushq	%r12
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r12,-32
+	pushq	%r13
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r13,-40
+	pushq	%r14
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r14,-48
+	pushq	%r15
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r15,-56
+
+	leaq	100(%rdi),%rdi
+	subq	$232,%rsp
+.cfi_adjust_cfa_offset	232
+
+
+	movq	%rsi,%r9
+	leaq	100(%rsp),%rsi
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	iotas(%rip),%r15
+
+	movq	%rcx,216-100(%rsi)
+
+L$oop_absorb:
+	cmpq	%rcx,%rdx
+	jc	L$done_absorb
+
+	shrq	$3,%rcx
+	leaq	-100(%rdi),%r8
+
+L$block_absorb:
+	movq	(%r9),%rax
+	leaq	8(%r9),%r9
+	xorq	(%r8),%rax
+	leaq	8(%r8),%r8
+	subq	$8,%rdx
+	movq	%rax,-8(%r8)
+	subq	$1,%rcx
+	jnz	L$block_absorb
+
+	movq	%r9,200-100(%rsi)
+	movq	%rdx,208-100(%rsi)
+	call	__KeccakF1600
+	movq	200-100(%rsi),%r9
+	movq	208-100(%rsi),%rdx
+	movq	216-100(%rsi),%rcx
+	jmp	L$oop_absorb
+
+.p2align	5
+L$done_absorb:
+	movq	%rdx,%rax
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	280(%rsp),%r11
+.cfi_def_cfa	%r11,8
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.cfi_restore	%r12
+.cfi_restore	%r13
+.cfi_restore	%r14
+.cfi_restore	%r15
+.cfi_restore	%rbp
+.cfi_restore	%rbx
+	.byte	0xf3,0xc3
+.cfi_endproc
+
+.globl	_SHA3_squeeze
+
+.p2align	5
+_SHA3_squeeze:
+.cfi_startproc
+	.byte	0xf3,0x0f,0x1e,0xfa
+
+
+	pushq	%r12
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r12,-16
+	pushq	%r13
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r13,-24
+	pushq	%r14
+.cfi_adjust_cfa_offset	8
+.cfi_offset	%r14,-32
+	subq	$32,%rsp
+.cfi_adjust_cfa_offset	32
+
+
+	shrq	$3,%rcx
+	movq	%rdi,%r8
+	movq	%rsi,%r12
+	movq	%rdx,%r13
+	movq	%rcx,%r14
+	jmp	L$oop_squeeze
+
+.p2align	5
+L$oop_squeeze:
+	cmpq	$8,%r13
+	jb	L$tail_squeeze
+
+	movq	(%r8),%rax
+	leaq	8(%r8),%r8
+	movq	%rax,(%r12)
+	leaq	8(%r12),%r12
+	subq	$8,%r13
+	jz	L$done_squeeze
+
+	subq	$1,%rcx
+	jnz	L$oop_squeeze
+
+	movq	%rdi,%rcx
+	call	_KeccakF1600
+	movq	%rdi,%r8
+	movq	%r14,%rcx
+	jmp	L$oop_squeeze
+
+L$tail_squeeze:
+	movq	%r8,%rsi
+	movq	%r12,%rdi
+	movq	%r13,%rcx
+.byte	0xf3,0xa4
+
+L$done_squeeze:
+	movq	32(%rsp),%r14
+	movq	40(%rsp),%r13
+	movq	48(%rsp),%r12
+	addq	$56,%rsp
+.cfi_adjust_cfa_offset	-56
+.cfi_restore	%r12
+.cfi_restore	%r13
+.cfi_restore	%r14
+	.byte	0xf3,0xc3
+.cfi_endproc
+
+.p2align	8
 .quad	0,0,0,0,0,0,0,0
-.type	iotas,@object
+
 iotas:
 .quad	0x0000000000000001
 .quad	0x0000000000008082
@@ -366,12 +527,5 @@ iotas:
 .quad	0x8000000000008080
 .quad	0x0000000080000001
 .quad	0x8000000080008008
-.size	iotas,.-iotas
-.byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
 
-.section	.note.gnu.property,"a",@note
-	.long	4,2f-1f,5
-	.byte	0x47,0x4E,0x55,0
-1:	.long	0xc0000002,4,3
-.align	8
-2:
+.byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0

--- a/crypto/hashes/src/asm/keccakf1600_x86-64-win64.s
+++ b/crypto/hashes/src/asm/keccakf1600_x86-64-win64.s
@@ -1,0 +1,650 @@
+# Source: https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-x86_64.pl
+
+.text
+
+.def	__KeccakF1600;	.scl 3;	.type 32;	.endef
+.p2align	5
+__KeccakF1600:
+	.byte	0xf3,0x0f,0x1e,0xfa
+
+	movq	60(%rdi),%rax
+	movq	68(%rdi),%rbx
+	movq	76(%rdi),%rcx
+	movq	84(%rdi),%rdx
+	movq	92(%rdi),%rbp
+	jmp	.Loop
+
+.p2align	5
+.Loop:
+	movq	-100(%rdi),%r8
+	movq	-52(%rdi),%r9
+	movq	-4(%rdi),%r10
+	movq	44(%rdi),%r11
+
+	xorq	-84(%rdi),%rcx
+	xorq	-76(%rdi),%rdx
+	xorq	%r8,%rax
+	xorq	-92(%rdi),%rbx
+	xorq	-44(%rdi),%rcx
+	xorq	-60(%rdi),%rax
+	movq	%rbp,%r12
+	xorq	-68(%rdi),%rbp
+
+	xorq	%r10,%rcx
+	xorq	-20(%rdi),%rax
+	xorq	-36(%rdi),%rdx
+	xorq	%r9,%rbx
+	xorq	-28(%rdi),%rbp
+
+	xorq	36(%rdi),%rcx
+	xorq	20(%rdi),%rax
+	xorq	4(%rdi),%rdx
+	xorq	-12(%rdi),%rbx
+	xorq	12(%rdi),%rbp
+
+	movq	%rcx,%r13
+	rolq	$1,%rcx
+	xorq	%rax,%rcx
+	xorq	%r11,%rdx
+
+	rolq	$1,%rax
+	xorq	%rdx,%rax
+	xorq	28(%rdi),%rbx
+
+	rolq	$1,%rdx
+	xorq	%rbx,%rdx
+	xorq	52(%rdi),%rbp
+
+	rolq	$1,%rbx
+	xorq	%rbp,%rbx
+
+	rolq	$1,%rbp
+	xorq	%r13,%rbp
+	xorq	%rcx,%r9
+	xorq	%rdx,%r10
+	rolq	$44,%r9
+	xorq	%rbp,%r11
+	xorq	%rax,%r12
+	rolq	$43,%r10
+	xorq	%rbx,%r8
+	movq	%r9,%r13
+	rolq	$21,%r11
+	orq	%r10,%r9
+	xorq	%r8,%r9
+	rolq	$14,%r12
+
+	xorq	(%r15),%r9
+	leaq	8(%r15),%r15
+
+	movq	%r12,%r14
+	andq	%r11,%r12
+	movq	%r9,-100(%rsi)
+	xorq	%r10,%r12
+	notq	%r10
+	movq	%r12,-84(%rsi)
+
+	orq	%r11,%r10
+	movq	76(%rdi),%r12
+	xorq	%r13,%r10
+	movq	%r10,-92(%rsi)
+
+	andq	%r8,%r13
+	movq	-28(%rdi),%r9
+	xorq	%r14,%r13
+	movq	-20(%rdi),%r10
+	movq	%r13,-68(%rsi)
+
+	orq	%r8,%r14
+	movq	-76(%rdi),%r8
+	xorq	%r11,%r14
+	movq	28(%rdi),%r11
+	movq	%r14,-76(%rsi)
+
+
+	xorq	%rbp,%r8
+	xorq	%rdx,%r12
+	rolq	$28,%r8
+	xorq	%rcx,%r11
+	xorq	%rax,%r9
+	rolq	$61,%r12
+	rolq	$45,%r11
+	xorq	%rbx,%r10
+	rolq	$20,%r9
+	movq	%r8,%r13
+	orq	%r12,%r8
+	rolq	$3,%r10
+
+	xorq	%r11,%r8
+	movq	%r8,-36(%rsi)
+
+	movq	%r9,%r14
+	andq	%r13,%r9
+	movq	-92(%rdi),%r8
+	xorq	%r12,%r9
+	notq	%r12
+	movq	%r9,-28(%rsi)
+
+	orq	%r11,%r12
+	movq	-44(%rdi),%r9
+	xorq	%r10,%r12
+	movq	%r12,-44(%rsi)
+
+	andq	%r10,%r11
+	movq	60(%rdi),%r12
+	xorq	%r14,%r11
+	movq	%r11,-52(%rsi)
+
+	orq	%r10,%r14
+	movq	4(%rdi),%r10
+	xorq	%r13,%r14
+	movq	52(%rdi),%r11
+	movq	%r14,-60(%rsi)
+
+
+	xorq	%rbp,%r10
+	xorq	%rax,%r11
+	rolq	$25,%r10
+	xorq	%rdx,%r9
+	rolq	$8,%r11
+	xorq	%rbx,%r12
+	rolq	$6,%r9
+	xorq	%rcx,%r8
+	rolq	$18,%r12
+	movq	%r10,%r13
+	andq	%r11,%r10
+	rolq	$1,%r8
+
+	notq	%r11
+	xorq	%r9,%r10
+	movq	%r10,-12(%rsi)
+
+	movq	%r12,%r14
+	andq	%r11,%r12
+	movq	-12(%rdi),%r10
+	xorq	%r13,%r12
+	movq	%r12,-4(%rsi)
+
+	orq	%r9,%r13
+	movq	84(%rdi),%r12
+	xorq	%r8,%r13
+	movq	%r13,-20(%rsi)
+
+	andq	%r8,%r9
+	xorq	%r14,%r9
+	movq	%r9,12(%rsi)
+
+	orq	%r8,%r14
+	movq	-60(%rdi),%r9
+	xorq	%r11,%r14
+	movq	36(%rdi),%r11
+	movq	%r14,4(%rsi)
+
+
+	movq	-68(%rdi),%r8
+
+	xorq	%rcx,%r10
+	xorq	%rdx,%r11
+	rolq	$10,%r10
+	xorq	%rbx,%r9
+	rolq	$15,%r11
+	xorq	%rbp,%r12
+	rolq	$36,%r9
+	xorq	%rax,%r8
+	rolq	$56,%r12
+	movq	%r10,%r13
+	orq	%r11,%r10
+	rolq	$27,%r8
+
+	notq	%r11
+	xorq	%r9,%r10
+	movq	%r10,28(%rsi)
+
+	movq	%r12,%r14
+	orq	%r11,%r12
+	xorq	%r13,%r12
+	movq	%r12,36(%rsi)
+
+	andq	%r9,%r13
+	xorq	%r8,%r13
+	movq	%r13,20(%rsi)
+
+	orq	%r8,%r9
+	xorq	%r14,%r9
+	movq	%r9,52(%rsi)
+
+	andq	%r14,%r8
+	xorq	%r11,%r8
+	movq	%r8,44(%rsi)
+
+
+	xorq	-84(%rdi),%rdx
+	xorq	-36(%rdi),%rbp
+	rolq	$62,%rdx
+	xorq	68(%rdi),%rcx
+	rolq	$55,%rbp
+	xorq	12(%rdi),%rax
+	rolq	$2,%rcx
+	xorq	20(%rdi),%rbx
+	xchgq	%rsi,%rdi
+	rolq	$39,%rax
+	rolq	$41,%rbx
+	movq	%rdx,%r13
+	andq	%rbp,%rdx
+	notq	%rbp
+	xorq	%rcx,%rdx
+	movq	%rdx,92(%rdi)
+
+	movq	%rax,%r14
+	andq	%rbp,%rax
+	xorq	%r13,%rax
+	movq	%rax,60(%rdi)
+
+	orq	%rcx,%r13
+	xorq	%rbx,%r13
+	movq	%r13,84(%rdi)
+
+	andq	%rbx,%rcx
+	xorq	%r14,%rcx
+	movq	%rcx,76(%rdi)
+
+	orq	%r14,%rbx
+	xorq	%rbp,%rbx
+	movq	%rbx,68(%rdi)
+
+	movq	%rdx,%rbp
+	movq	%r13,%rdx
+
+	testq	$255,%r15
+	jnz	.Loop
+
+	leaq	-192(%r15),%r15
+	.byte	0xf3,0xc3
+
+
+.globl	KeccakF1600
+.def	KeccakF1600;	.scl 2;	.type 32;	.endef
+.p2align	5
+KeccakF1600:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_KeccakF1600:
+
+
+	movq	%rcx,%rdi
+	pushq	%rbx
+
+	pushq	%rbp
+
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	pushq	%r15
+
+
+	leaq	100(%rdi),%rdi
+	subq	$200,%rsp
+
+.LSEH_body_KeccakF1600:
+
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	iotas(%rip),%r15
+	leaq	100(%rsp),%rsi
+
+	call	__KeccakF1600
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	-100(%rdi),%rdi
+
+	leaq	248(%rsp),%r11
+
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.LSEH_epilogue_KeccakF1600:
+	mov	8(%r11),%rdi
+	mov	16(%r11),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_KeccakF1600:
+.globl	SHA3_absorb
+.def	SHA3_absorb;	.scl 2;	.type 32;	.endef
+.p2align	5
+SHA3_absorb:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_SHA3_absorb:
+
+
+	movq	%rcx,%rdi
+	movq	%rdx,%rsi
+	movq	%r8,%rdx
+	movq	%r9,%rcx
+	pushq	%rbx
+
+	pushq	%rbp
+
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	pushq	%r15
+
+
+	leaq	100(%rdi),%rdi
+	subq	$232,%rsp
+
+.LSEH_body_SHA3_absorb:
+
+
+	movq	%rsi,%r9
+	leaq	100(%rsp),%rsi
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+	leaq	iotas(%rip),%r15
+
+	movq	%rcx,216-100(%rsi)
+
+.Loop_absorb:
+	cmpq	%rcx,%rdx
+	jc	.Ldone_absorb
+
+	shrq	$3,%rcx
+	leaq	-100(%rdi),%r8
+
+.Lblock_absorb:
+	movq	(%r9),%rax
+	leaq	8(%r9),%r9
+	xorq	(%r8),%rax
+	leaq	8(%r8),%r8
+	subq	$8,%rdx
+	movq	%rax,-8(%r8)
+	subq	$1,%rcx
+	jnz	.Lblock_absorb
+
+	movq	%r9,200-100(%rsi)
+	movq	%rdx,208-100(%rsi)
+	call	__KeccakF1600
+	movq	200-100(%rsi),%r9
+	movq	208-100(%rsi),%rdx
+	movq	216-100(%rsi),%rcx
+	jmp	.Loop_absorb
+
+.p2align	5
+.Ldone_absorb:
+	movq	%rdx,%rax
+
+	notq	-92(%rdi)
+	notq	-84(%rdi)
+	notq	-36(%rdi)
+	notq	-4(%rdi)
+	notq	36(%rdi)
+	notq	60(%rdi)
+
+	leaq	280(%rsp),%r11
+
+	movq	-48(%r11),%r15
+	movq	-40(%r11),%r14
+	movq	-32(%r11),%r13
+	movq	-24(%r11),%r12
+	movq	-16(%r11),%rbp
+	movq	-8(%r11),%rbx
+	leaq	(%r11),%rsp
+.LSEH_epilogue_SHA3_absorb:
+	mov	8(%r11),%rdi
+	mov	16(%r11),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_SHA3_absorb:
+.globl	SHA3_squeeze
+.def	SHA3_squeeze;	.scl 2;	.type 32;	.endef
+.p2align	5
+SHA3_squeeze:
+	.byte	0xf3,0x0f,0x1e,0xfa
+	movq	%rdi,8(%rsp)
+	movq	%rsi,16(%rsp)
+	movq	%rsp,%r11
+.LSEH_begin_SHA3_squeeze:
+
+
+	movq	%rcx,%rdi
+	movq	%rdx,%rsi
+	movq	%r8,%rdx
+	movq	%r9,%rcx
+	pushq	%r12
+
+	pushq	%r13
+
+	pushq	%r14
+
+	subq	$32,%rsp
+
+.LSEH_body_SHA3_squeeze:
+
+
+	shrq	$3,%rcx
+	movq	%rdi,%r8
+	movq	%rsi,%r12
+	movq	%rdx,%r13
+	movq	%rcx,%r14
+	jmp	.Loop_squeeze
+
+.p2align	5
+.Loop_squeeze:
+	cmpq	$8,%r13
+	jb	.Ltail_squeeze
+
+	movq	(%r8),%rax
+	leaq	8(%r8),%r8
+	movq	%rax,(%r12)
+	leaq	8(%r12),%r12
+	subq	$8,%r13
+	jz	.Ldone_squeeze
+
+	subq	$1,%rcx
+	jnz	.Loop_squeeze
+
+	movq	%rdi,%rcx
+	call	KeccakF1600
+	movq	%rdi,%r8
+	movq	%r14,%rcx
+	jmp	.Loop_squeeze
+
+.Ltail_squeeze:
+	movq	%r8,%rsi
+	movq	%r12,%rdi
+	movq	%r13,%rcx
+.byte	0xf3,0xa4
+
+.Ldone_squeeze:
+	movq	32(%rsp),%r14
+	movq	40(%rsp),%r13
+	movq	48(%rsp),%r12
+	addq	$56,%rsp
+
+.LSEH_epilogue_SHA3_squeeze:
+	mov	8(%rsp),%rdi
+	mov	16(%rsp),%rsi
+
+	.byte	0xf3,0xc3
+
+.LSEH_end_SHA3_squeeze:
+.p2align	8
+.quad	0,0,0,0,0,0,0,0
+
+iotas:
+.quad	0x0000000000000001
+.quad	0x0000000000008082
+.quad	0x800000000000808a
+.quad	0x8000000080008000
+.quad	0x000000000000808b
+.quad	0x0000000080000001
+.quad	0x8000000080008081
+.quad	0x8000000000008009
+.quad	0x000000000000008a
+.quad	0x0000000000000088
+.quad	0x0000000080008009
+.quad	0x000000008000000a
+.quad	0x000000008000808b
+.quad	0x800000000000008b
+.quad	0x8000000000008089
+.quad	0x8000000000008003
+.quad	0x8000000000008002
+.quad	0x8000000000000080
+.quad	0x000000000000800a
+.quad	0x800000008000000a
+.quad	0x8000000080008081
+.quad	0x8000000000008080
+.quad	0x0000000080000001
+.quad	0x8000000080008008
+
+.byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+.section	.pdata
+.p2align	2
+.rva	.LSEH_begin_KeccakF1600
+.rva	.LSEH_body_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_prologue
+
+.rva	.LSEH_body_KeccakF1600
+.rva	.LSEH_epilogue_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_body
+
+.rva	.LSEH_epilogue_KeccakF1600
+.rva	.LSEH_end_KeccakF1600
+.rva	.LSEH_info_KeccakF1600_epilogue
+
+.rva	.LSEH_begin_SHA3_absorb
+.rva	.LSEH_body_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_prologue
+
+.rva	.LSEH_body_SHA3_absorb
+.rva	.LSEH_epilogue_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_body
+
+.rva	.LSEH_epilogue_SHA3_absorb
+.rva	.LSEH_end_SHA3_absorb
+.rva	.LSEH_info_SHA3_absorb_epilogue
+
+.rva	.LSEH_begin_SHA3_squeeze
+.rva	.LSEH_body_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_prologue
+
+.rva	.LSEH_body_SHA3_squeeze
+.rva	.LSEH_epilogue_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_body
+
+.rva	.LSEH_epilogue_SHA3_squeeze
+.rva	.LSEH_end_SHA3_squeeze
+.rva	.LSEH_info_SHA3_squeeze_epilogue
+
+.section	.xdata
+.p2align	3
+.LSEH_info_KeccakF1600_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_KeccakF1600_body:
+.byte	1,0,18,0
+.byte	0x00,0xf4,0x19,0x00
+.byte	0x00,0xe4,0x1a,0x00
+.byte	0x00,0xd4,0x1b,0x00
+.byte	0x00,0xc4,0x1c,0x00
+.byte	0x00,0x54,0x1d,0x00
+.byte	0x00,0x34,0x1e,0x00
+.byte	0x00,0x74,0x20,0x00
+.byte	0x00,0x64,0x21,0x00
+.byte	0x00,0x01,0x1f,0x00
+.byte	0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+.LSEH_info_KeccakF1600_epilogue:
+.byte	1,0,5,11
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0xb3
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+
+.LSEH_info_SHA3_absorb_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_SHA3_absorb_body:
+.byte	1,0,18,0
+.byte	0x00,0xf4,0x1d,0x00
+.byte	0x00,0xe4,0x1e,0x00
+.byte	0x00,0xd4,0x1f,0x00
+.byte	0x00,0xc4,0x20,0x00
+.byte	0x00,0x54,0x21,0x00
+.byte	0x00,0x34,0x22,0x00
+.byte	0x00,0x74,0x24,0x00
+.byte	0x00,0x64,0x25,0x00
+.byte	0x00,0x01,0x23,0x00
+.byte	0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+.LSEH_info_SHA3_absorb_epilogue:
+.byte	1,0,5,11
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0xb3
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.byte	0x00,0x00,0x00,0x00
+
+.LSEH_info_SHA3_squeeze_prologue:
+.byte	1,0,5,0x0b
+.byte	0,0x74,1,0
+.byte	0,0x64,2,0
+.byte	0,0xb3
+.byte	0,0
+.long	0,0
+.LSEH_info_SHA3_squeeze_body:
+.byte	1,0,11,0
+.byte	0x00,0xe4,0x04,0x00
+.byte	0x00,0xd4,0x05,0x00
+.byte	0x00,0xc4,0x06,0x00
+.byte	0x00,0x74,0x08,0x00
+.byte	0x00,0x64,0x09,0x00
+.byte	0x00,0x62
+.byte	0x00,0x00,0x00,0x00,0x00,0x00
+.LSEH_info_SHA3_squeeze_epilogue:
+.byte	1,0,4,0
+.byte	0x00,0x74,0x01,0x00
+.byte	0x00,0x64,0x02,0x00
+.byte	0x00,0x00,0x00,0x00
+

--- a/crypto/hashes/src/pow_hashers.rs
+++ b/crypto/hashes/src/pow_hashers.rs
@@ -60,13 +60,13 @@ impl KHeavyHash {
 }
 
 mod keccak256 {
-    #[cfg(any(not(target_arch = "x86_64"), feature = "no-asm", target_os = "windows"))]
+    #[cfg(any(not(target_arch = "x86_64"), feature = "no-asm"))]
     #[inline(always)]
     pub(super) fn f1600(state: &mut [u64; 25]) {
         keccak::f1600(state);
     }
 
-    #[cfg(all(target_arch = "x86_64", not(feature = "no-asm"), not(target_os = "windows")))]
+    #[cfg(all(target_arch = "x86_64", not(feature = "no-asm")))]
     #[inline(always)]
     pub(super) fn f1600(state: &mut [u64; 25]) {
         extern "C" {


### PR DESCRIPTION
It follows the same approach used in https://github.com/elichai/kaspa-miner/commit/f759ce3c6e680a8b2dbd88a38e7edb601b91c638 by @elichai adapted for the hashes crate.

Benchmarks with:
`cargo bench -p kaspa-hashes --features no-asm` and `cargo bench -p kaspa-hashes`

```
PoWHash including timestamp
                        time:   [225.16 ns 225.50 ns 225.86 ns]
                        change: [-20.500% -20.193% -19.890%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

PoWHash without timestamp
                        time:   [220.29 ns 220.71 ns 221.19 ns]
                        change: [-21.103% -20.809% -20.508%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
KHeavyHash              time:   [215.44 ns 215.73 ns 216.02 ns]
                        change: [-20.636% -20.326% -19.935%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
```