### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,16 +286,16 @@ wRPC
 
   JSON protocol:
   ```bash
-  --rpclisten-json = <interface:port>
+  --rpclisten-json=<interface:port>
   # or use the defaults for current network
-  --rpclisten-json = default
+  --rpclisten-json=default
   ```
 
   Borsh protocol:
   ```bash
-  --rpclisten-borsh = <interface:port>
+  --rpclisten-borsh=<interface:port>
   # or use the defaults for current network
-  --rpclisten-borsh = default
+  --rpclisten-borsh=default
   ```
 
   **Sidenote:**


### PR DESCRIPTION
Removed the spaces in front of and behind the "=" to ensure the wRPC commands run correctly within the command line interface.