### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,17 +3563,14 @@ dependencies = [
 name = "kaspa-wrpc-proxy"
 version = "1.0.1"
 dependencies = [
- "async-trait",
  "clap 4.5.19",
  "kaspa-consensus-core",
  "kaspa-grpc-client",
  "kaspa-rpc-core",
- "kaspa-rpc-macros",
  "kaspa-wrpc-server",
  "num_cpus",
  "thiserror",
  "tokio",
- "workflow-core",
  "workflow-log",
  "workflow-rpc",
 ]

--- a/rpc/wrpc/proxy/Cargo.toml
+++ b/rpc/wrpc/proxy/Cargo.toml
@@ -10,17 +10,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-async-trait.workspace = true
 clap.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-grpc-client.workspace = true
 kaspa-rpc-core.workspace = true
-kaspa-rpc-macros.workspace = true
 kaspa-wrpc-server.workspace = true
 num_cpus.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-workflow-core.workspace = true
 workflow-log.workspace = true
 workflow-rpc.workspace = true
 


### PR DESCRIPTION
In a clean build `cargo` needs to fetch all dependencies and the existence of unused declarations slows down compilation times.