### PR TITLE
feat: Make devnet crescendo.

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -651,6 +651,56 @@ pub const DEVNET_PARAMS: Params = Params {
     dns_seeders: &[],
     net: NetworkId::new(NetworkType::Devnet),
     genesis: DEVNET_GENESIS,
+    timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,
+    max_difficulty_target: MAX_DIFFICULTY_TARGET,
+    max_difficulty_target_f64: MAX_DIFFICULTY_TARGET_AS_F64,
+    prior_difficulty_window_size: LEGACY_DIFFICULTY_WINDOW_SIZE,
+    min_difficulty_window_size: MIN_DIFFICULTY_WINDOW_SIZE,
+
+    //
+    // ~~~~~~~~~~~~~~~~~~ BPS dependent constants ~~~~~~~~~~~~~~~~~~
+    //
+    // Note we use a 10 BPS configuration for devnet
+    prior_ghostdag_k: TenBps::ghostdag_k(),
+    prior_target_time_per_block: TenBps::target_time_per_block(),
+    prior_max_block_parents: TenBps::max_block_parents(),
+    prior_mergeset_size_limit: TenBps::mergeset_size_limit(),
+    prior_merge_depth: TenBps::merge_depth_bound(),
+    prior_finality_depth: TenBps::finality_depth(),
+    prior_pruning_depth: TenBps::pruning_depth(),
+    deflationary_phase_daa_score: TenBps::deflationary_phase_daa_score(),
+    pre_deflationary_phase_base_subsidy: TenBps::pre_deflationary_phase_base_subsidy(),
+    prior_coinbase_maturity: TenBps::coinbase_maturity(),
+
+    coinbase_payload_script_public_key_max_len: 150,
+    max_coinbase_payload_len: 204,
+
+    prior_max_tx_inputs: 10_000,
+    prior_max_tx_outputs: 10_000,
+    prior_max_signature_script_len: 1_000_000,
+    prior_max_script_public_key_len: 1_000_000,
+
+    mass_per_tx_byte: 1,
+    mass_per_script_pub_key_byte: 10,
+    mass_per_sig_op: 1000,
+    max_block_mass: 500_000,
+
+    storage_mass_parameter: STORAGE_MASS_PARAMETER,
+
+    skip_proof_of_work: false,
+    max_block_level: 250,
+    pruning_proof_m: PRUNING_PROOF_M,
+
+    crescendo: CRESCENDO,
+    crescendo_activation: ForkActivation::always(),
+};
+
+// Some tests depend on a pre-crescendo devnet.
+// To keep these tests intact we keep the devnet params pre-crescendo
+pub const PRE_CRESCENDO_DEVNET_PARAMS: Params = Params {
+    dns_seeders: &[],
+    net: NetworkId::new(NetworkType::Devnet),
+    genesis: DEVNET_GENESIS,
     prior_ghostdag_k: LEGACY_DEFAULT_GHOSTDAG_K,
     timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,
     prior_target_time_per_block: 1000,

--- a/consensus/src/pipeline/body_processor/body_validation_in_context.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_context.rs
@@ -109,7 +109,6 @@ impl BlockBodyProcessor {
 
 #[cfg(test)]
 mod tests {
-
     use crate::{
         config::ConfigBuilder,
         consensus::test_consensus::TestConsensus,
@@ -157,8 +156,8 @@ mod tests {
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
 
-            assert_match!(
-                consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 50000000000);
+            assert_match!(  // Pre-deflationary emission is 50_000_000_000 per second. At 10 bps block subsidy is 5_000_000_000.
+                consensus.validate_and_insert_block(block.clone().to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 5_000_000_000);
 
             // The second time we send an invalid block we expect it to be a known invalid.
             assert_match!(
@@ -196,7 +195,8 @@ mod tests {
             let mut block = consensus.build_block_with_parents_and_transactions(7.into(), vec![6.into()], vec![]);
             block.transactions[0].payload[8..16].copy_from_slice(&(5_u64).to_le_bytes());
             block.header.hash_merkle_root = calc_hash_merkle_root(block.transactions.iter());
-            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 44000000000);
+            // Post-deflationary emission is 44_000_000_000 per second. At 10 bps block subsidy is 4_400_000_000.
+            assert_match!(consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await, Err(RuleError::WrongSubsidy(expected,_)) if expected == 4_400_000_000);
         }
 
         {

--- a/consensus/src/processes/coinbase.rs
+++ b/consensus/src/processes/coinbase.rs
@@ -433,8 +433,8 @@ mod tests {
 
     #[test]
     fn subsidy_test() {
-        const PRE_DEFLATIONARY_PHASE_BASE_SUBSIDY: u64 = 50000000000;
-        const DEFLATIONARY_PHASE_INITIAL_SUBSIDY: u64 = 44000000000;
+        const PRE_DEFLATIONARY_PHASE_BASE_SUBSIDY: u64 = 50_000_000_000;
+        const DEFLATIONARY_PHASE_INITIAL_SUBSIDY: u64 = 44_000_000_000;
         const SECONDS_PER_MONTH: u64 = 2629800;
         const SECONDS_PER_HALVING: u64 = SECONDS_PER_MONTH * 12;
 
@@ -500,7 +500,6 @@ mod tests {
                     expected: 0,
                 },
             ];
-
             for t in tests {
                 assert_eq!(cbm.calc_block_subsidy(t.daa_score), t.expected, "{} test '{}' failed", network_id, t.name);
                 if bps == 1 {

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -53,6 +53,7 @@ use crate::common;
 use flate2::read::GzDecoder;
 use futures_util::future::try_join_all;
 use itertools::Itertools;
+use kaspa_consensus_core::config::params::PRE_CRESCENDO_DEVNET_PARAMS;
 use kaspa_consensus_core::errors::tx::TxRuleError;
 use kaspa_consensus_core::hashing::sighash::calc_schnorr_signature_hash;
 use kaspa_consensus_core::merkle::calc_hash_merkle_root;
@@ -930,13 +931,13 @@ async fn json_test(file_path: &str, concurrency: bool) {
         if !proof_exists {
             let second_line = lines.next().unwrap();
             let genesis_block = json_line_to_block(second_line);
-            params.genesis = (genesis_block.header.as_ref(), DEVNET_PARAMS.genesis.coinbase_payload).into();
+            params.genesis = (genesis_block.header.as_ref(), PRE_CRESCENDO_DEVNET_PARAMS.genesis.coinbase_payload).into();
         }
         params.min_difficulty_window_size = params.prior_difficulty_window_size;
         params
     } else {
         let genesis_block = json_line_to_block(first_line);
-        let mut params = DEVNET_PARAMS;
+        let mut params = PRE_CRESCENDO_DEVNET_PARAMS;
         params.genesis = (genesis_block.header.as_ref(), params.genesis.coinbase_payload).into();
         params.min_difficulty_window_size = params.prior_difficulty_window_size;
         params
@@ -1261,7 +1262,7 @@ fn hex_decode(src: &str) -> Vec<u8> {
 #[tokio::test]
 async fn bounded_merge_depth_test() {
     init_allocator_with_default_settings();
-    let config = ConfigBuilder::new(DEVNET_PARAMS)
+    let config = ConfigBuilder::new(PRE_CRESCENDO_DEVNET_PARAMS)
         .skip_proof_of_work()
         .edit_consensus_params(|p| {
             p.prior_ghostdag_k = 5;


### PR DESCRIPTION
This changes devnet to have `crescendo_activation: ForkActivation::always()`, and updates the rest of it's params to support that.

To accommodate tests that depend on a devnet pre-crescendo I have added another const PRE_CRESCENDO_DEVNET_PARAMS, which is a copy of the old DEVNET_PARAMS.
