### PR TITLE
fix(rpc): Comprehensive safety improvements for RPC domain

### DIFF
--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -55,7 +55,10 @@ impl ConsensusConverter {
     ) -> RpcResult<RpcBlock> {
         let hash = block.hash();
         let ghostdag_data = consensus.async_get_ghostdag_data(hash).await?;
-        let block_status = consensus.async_get_block_status(hash).await.unwrap();
+        let block_status = consensus
+            .async_get_block_status(hash)
+            .await
+            .ok_or_else(|| kaspa_rpc_core::RpcError::General(format!("Block status not found for hash: {}", hash)))?;
         let children = consensus.async_get_block_children(hash).await.unwrap_or_default();
         let is_chain_block = consensus.async_is_chain_block(hash).await?;
         let verbose_data = Some(RpcBlockVerboseData {
@@ -164,7 +167,9 @@ impl ConsensusConverter {
         chain_path: &ChainPath,
         merged_blocks_limit: Option<usize>,
     ) -> RpcResult<Vec<RpcAcceptedTransactionIds>> {
-        let acceptance_data = consensus.async_get_blocks_acceptance_data(chain_path.added.clone(), merged_blocks_limit).await.unwrap();
+        let acceptance_data = consensus
+            .async_get_blocks_acceptance_data(chain_path.added.clone(), merged_blocks_limit)
+            .await?;
         Ok(chain_path
             .added
             .iter()

--- a/rpc/service/src/converter/protocol.rs
+++ b/rpc/service/src/converter/protocol.rs
@@ -19,7 +19,7 @@ impl ProtocolConverter {
             id: peer.identity(),
             address: peer.net_address().into(),
             is_outbound: peer.is_outbound(),
-            is_ibd_peer: ibd_peer_key.is_some() && peer.key() == *ibd_peer_key.as_ref().unwrap(),
+            is_ibd_peer: ibd_peer_key.as_ref().map_or(false, |key| peer.key() == *key),
             last_ping_duration: peer.last_ping_duration(),
             time_offset: properties.time_offset,
             user_agent: properties.user_agent.clone(),

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -690,7 +690,8 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
                 let sink_blue_score = session.async_get_sink_blue_score().await;
 
                 while !virtual_chain_batch.added.is_empty() {
-                    let vc_last_accepted_block_hash = virtual_chain_batch.added.last().unwrap();
+                    let vc_last_accepted_block_hash = virtual_chain_batch.added.last()
+                        .ok_or_else(|| RpcError::General("Virtual chain batch is empty".to_string()))?;
                     let vc_last_accepted_block = session.async_get_block(*vc_last_accepted_block_hash).await?;
 
                     let distance = sink_blue_score.saturating_sub(vc_last_accepted_block.header.blue_score);
@@ -816,7 +817,11 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         //
         // TODO: optimize using binary search over the samples to obtain O(m log n) complexity (which is an improvement assuming m << n)
         while header_idx < headers.len() && req_idx < request.daa_scores.len() {
-            let header = headers.get(header_idx).unwrap();
+            let header = headers.get(header_idx)
+                .ok_or_else(|| RpcError::General(format!(
+                    "Header index {} out of range (0..{})",
+                    header_idx, headers.len()
+                )))?;
             let curr_daa_score = requested_daa_scores[req_idx];
 
             // Found daa_score in range

--- a/rpc/wrpc/server/src/server.rs
+++ b/rpc/wrpc/server/src/server.rs
@@ -157,7 +157,11 @@ impl Server {
             let _ = connection.grpc_client().join().await;
         }
 
-        self.inner.sockets.lock().unwrap().remove(&connection.id());
+        if let Ok(mut guard) = self.inner.sockets.lock() {
+            guard.remove(&connection.id());
+        } else {
+            log::error!("Failed to remove connection {} from sockets - mutex poisoned", connection.id());
+        }
 
         // FIXME: determine if messenger should be closed explicitly
         // connection.close();


### PR DESCRIPTION
## Summary

This PR adds comprehensive safety improvements to the RPC domain by replacing unsafe `unwrap()` calls, assertions, and unchecked operations with proper error handling. The changes follow a risk-based approach, progressing from simple bounds checking to more complex mutex and optional service handling.

**All changes have been tested:**
- ✅ Full RPC test suite passes
- ✅ Tested with live kaspad node - runs successfully

## Changes by Commit

### 1. Bounds checking (Low Risk)
- Add safe vector/array access in RPC service
- Prevent panics from empty virtual chain batches
- Add index validation for header array access

### 2. Optional services (Medium-Low Risk)  
- Handle UTXO index service when disabled/unavailable
- Add proper error handling for missing consensus data
- Return descriptive errors instead of panicking

### 3. Entry API & Protocol (Medium Risk)
- Refactor GRPC routing map to use Entry API correctly
- Replace check-and-unwrap patterns with `map_or`
- Add graceful mutex poisoning handling in WRPC server

### 4. Mutex & Assertions (Higher Risk)
- Fix 13+ mutex unwraps in WRPC client
- Replace regex unwrap with simple string check in GRPC client
- Add serialization failure fallbacks

## Philosophy

- **Minimal changes only** - No cosmetic improvements or refactoring
- **Maintain compatibility** - All changes are backward compatible
- **Focus on runtime safety** - Prevent panics in production scenarios
- **Use fully qualified paths** - Avoid modifying import structures

## Files Changed

- `rpc/service/src/service.rs` - Service layer safety
- `rpc/service/src/converter/consensus.rs` - Consensus data handling
- `rpc/service/src/converter/protocol.rs` - Protocol conversion
- `rpc/grpc/client/src/lib.rs` - GRPC client improvements
- `rpc/grpc/server/src/connection.rs` - GRPC server safety
- `rpc/wrpc/client/src/client.rs` - WRPC client mutex handling
- `rpc/wrpc/server/src/connection.rs` - WRPC server safety
- `rpc/wrpc/server/src/server.rs` - WRPC server socket management

🤖 Generated with [Claude Code](https://claude.com/claude-code)