### PR TITLE
update mimalloc to 0.1.48 and remove git workaround

### DIFF
--- a/utils/alloc/Cargo.toml
+++ b/utils/alloc/Cargo.toml
@@ -9,16 +9,14 @@ edition.workspace = true
 include.workspace = true
 repository.workspace = true
 
-# TODO: advance to version > 0.1.46 once released. The following commit includes a fix required for rust 1.87 windows linker error 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-mimalloc = { git = "https://github.com/purpleprotocol/mimalloc_rust", rev = "eff21096d5ee5337ec89e2b7174f1bbb11026c70", default-features = false, features = [
+mimalloc = { version = "0.1.48", default-features = false, features = [
     'override',
 ] }
 
-# TODO: advance to version > 0.1.46 once released. The following commit includes a fix required for rust 1.87 windows linker error
 [target.'cfg(target_os = "macos")'.dependencies]
 # override is unstable in MacOS and is thus excluded
-mimalloc = { git = "https://github.com/purpleprotocol/mimalloc_rust", rev = "eff21096d5ee5337ec89e2b7174f1bbb11026c70", default-features = false }
+mimalloc = { version = "0.1.48", default-features = false }
 
 [features]
 heap = []


### PR DESCRIPTION
Reverts the mimalloc workaround from https://github.com/kaspanet/rusty-kaspa/pull/687 because the fix for the Rust 1.87 Windows linker issue is included since the official 0.1.47 release see: https://github.com/purpleprotocol/mimalloc_rust/commit/c0ad27d87363b90dd97198cd4355030246cd9c72.

The previous workaround was necessary because mimalloc ≤ 0.1.46 didn't explicitly link `advapi32` which became required after Rust 1.87 stopped linking it by default.