### PR TITLE
Allow Wallet Core to generate transactions with 1 UTXO and a payload

### DIFF
--- a/wallet/core/src/account/pskb.rs
+++ b/wallet/core/src/account/pskb.rs
@@ -453,6 +453,7 @@ pub async fn commit_reveal_batch_bundle(
         CommitRevealBatchKind::Manual { hop_payment, destination_payment } => {
             let addr_commit = match hop_payment.clone() {
                 PaymentDestination::Change => Err(Error::CommitRevealInvalidPaymentDestination),
+                PaymentDestination::PayloadOnly => Err(Error::CommitRevealInvalidPaymentDestination),
                 PaymentDestination::PaymentOutputs(payment_outputs) => {
                     payment_outputs.outputs.first().map(|out| out.address.clone()).ok_or(Error::CommitRevealEmptyPaymentOutputs)
                 }
@@ -460,6 +461,7 @@ pub async fn commit_reveal_batch_bundle(
 
             let (addresses, payment_outputs) = match destination_payment {
                 PaymentDestination::Change => Err(Error::CommitRevealInvalidPaymentDestination),
+                PaymentDestination::PayloadOnly => Err(Error::CommitRevealInvalidPaymentDestination),
                 PaymentDestination::PaymentOutputs(payment_outputs) => {
                     Ok((payment_outputs.outputs.iter().map(|out| out.address.clone()).collect(), payment_outputs))
                 }

--- a/wallet/core/src/tx/generator/test.rs
+++ b/wallet/core/src/tx/generator/test.rs
@@ -833,7 +833,7 @@ fn test_generator_payload_only() -> Result<()> {
         change_address(test_network_id().into()),
         1,
         1,
-        PaymentDestination::Change,
+        PaymentDestination::PayloadOnly,
         None,
         Fees::None,
         Some("Test Payload".into()),

--- a/wallet/core/src/tx/payment.rs
+++ b/wallet/core/src/tx/payment.rs
@@ -46,6 +46,7 @@ extern "C" {
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum PaymentDestination {
     Change,
+    PayloadOnly, // No funds moved, just a payload and fees
     PaymentOutputs(PaymentOutputs),
 }
 
@@ -53,6 +54,7 @@ impl PaymentDestination {
     pub fn amount(&self) -> Option<u64> {
         match self {
             Self::Change => None,
+            Self::PayloadOnly => None,
             Self::PaymentOutputs(payment_outputs) => Some(payment_outputs.amount()),
         }
     }


### PR DESCRIPTION
The kasia broadcast use this form where you send yourself a transaction with a payload. The only kaspa is spent on the transaction fees so it should only need 1 utxo to cover the cost.