### PR TITLE
Android asm support for Keccak

### DIFF
--- a/crypto/hashes/build.rs
+++ b/crypto/hashes/build.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         builder.flag("-c");
         match target_os.as_str() {
             "macos" => builder.file("src/asm/keccakf1600_x86-64-osx.s"),
-            "linux" => builder.file("src/asm/keccakf1600_x86-64-elf.s"),
+            "linux" | "android" => builder.file("src/asm/keccakf1600_x86-64-elf.s"),
             "windows" if target_env == "gnu" => builder.file("src/asm/keccakf1600_x86-64-mingw64.s"),
             "windows" if target_env == "msvc" => builder.file("src/asm/keccakf1600_x86-64-msvc.asm"),
             _ => unimplemented!("Unsupported OS"),


### PR DESCRIPTION
In pull request https://github.com/kaspanet/rusty-kaspa/pull/694 android support was removed from the build script. This adds it back in. From what I understand linux and android should be similar in the assembly file. I am not sure the correct way to test this. I can build the `x86_64-linux-android` target after this change.