### PR TITLE
Switch to `taiki-e/install-action`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
       
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: Cache
         uses: actions/cache@v4
@@ -324,7 +326,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
Switch to `taiki-e/install-action` for installing `cargo-nextest` and… `wasm-pack` in CI

Fixes https://github.com/nextest-rs/nextest/issues/2990#issuecomment-3793377341