### PR TITLE
ci: add profile overrides for hot-path crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,6 +378,12 @@ opt-level = 2
 [profile.dev.package.malachite-nz]
 opt-level = 2
 
+[profile.dev.package.secp256k1]
+opt-level = 2
+
+[profile.dev.package.sha2]
+opt-level = 2
+
 [workspace.lints.clippy]
 empty_docs = "allow"
 uninlined_format_args = "allow"


### PR DESCRIPTION
Follow-up to #854 and #862 which switched CI from --release to debug builds and replace verbose actions/cache@v4 configurations with Swatinem/rust-cache@v2 across all CI jobs.  What is done:

Add [profile.dev.package.*] overrides with opt-level=2 for hot-path crates so tests run at reasonable speed.

Optimized crates:
- kaspa-consensus, kaspa-consensus-core 
- kaspa-hashes, kaspa-math, kaspa-muhash 
- kaspa-pow, kaspa-txscript (validation)