### PR TITLE
feat(rpc): implement Drop for KaspaRpcClient (RAII cleanup)

### DIFF
--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -200,6 +200,29 @@ impl Inner {
     }
 }
 
+impl Drop for Inner {
+    fn drop(&mut self) {
+        if self.background_services_running.load(Ordering::SeqCst) {
+            log_warn!("KaspaRpcClient: dropped without calling disconnect() — cleaning up resources");
+
+            // Close channels synchronously to signal background tasks to stop
+            self.notification_relay_channel.sender.close();
+            if let Ok(intake) = self.notification_intake_channel.lock() {
+                intake.sender.close();
+            }
+            self.service_ctl.request.sender.close();
+
+            // Fire-and-forget async WebSocket shutdown (only works if a runtime is still alive)
+            let rpc_client = self.rpc_client.clone();
+            workflow_core::task::spawn(async move {
+                let _ = rpc_client.shutdown().await;
+            });
+
+            self.background_services_running.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
 impl Debug for Inner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KaspaRpcClient")


### PR DESCRIPTION
## Summary
Closes #683.

Adds `impl Drop for Inner` so that `KaspaRpcClient` cleans up resources when dropped without an explicit `disconnect().await` call.

### What it does
- Checks `background_services_running` — if still `true`, the client was dropped without disconnect
- Logs a warning so developers know they forgot `disconnect().await`
- Closes channels synchronously (`notification_relay_channel`, `notification_intake_channel`, `service_ctl`) to signal background tasks to stop
- Spawns a fire-and-forget async task for WebSocket shutdown via `rpc_client.shutdown()`
- Sets `background_services_running` to `false`

### Design decisions
- **Drop on `Inner`, not `KaspaRpcClient`**: `KaspaRpcClient` is `Clone` (wraps `Arc<Inner>`), so Drop on it would fire per-clone. `Inner::drop` fires only when the last `Arc` reference is gone — correct semantics.
- **Sync channel close + async spawn**: `disconnect()` is async and cannot be called from sync `Drop`. Channel `close()` is sync (async-channel `Sender::close(&self)`), which is sufficient to signal background `select!` loops. WebSocket shutdown is spawned as fire-and-forget.
- **Poisoned mutex guard**: `notification_intake_channel` is behind `std::sync::Mutex`; uses `if let Ok(...)` to safely skip if poisoned during a panic unwind.
- **Dead runtime**: If the async runtime is already shut down when Drop fires, `workflow_core::task::spawn` silently fails. Acceptable — Drop is a safety net, not the primary cleanup path.

### Files changed
- `rpc/wrpc/client/src/client.rs` — 23 lines added (one `impl Drop for Inner` block)

## Test plan
- [ ] CI passes (`cargo check --tests --workspace` + `cargo nextest run --workspace`)
- [ ] Existing wrpc client tests (parse, resolver) still pass
- [ ] Manual: create `KaspaRpcClient`, connect, drop without disconnect — verify warning log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)