### PR TITLE
Feat: Kaspa-Math 32 bit malachite support

### DIFF
--- a/math/src/uint.rs
+++ b/math/src/uint.rs
@@ -349,10 +349,14 @@ macro_rules! construct_uint {
                 use $crate::uint::malachite_nz::platform::Limb;
                 use $crate::uint::malachite_base::num::arithmetic::traits::ModInverse;
 
+                // Malachite's Limb is u64 on 64-bit platforms but u32 on 32-bit
+                // (e.g. risc0 riscv32im). Convert our u64 words to limbs, splitting
+                // each word into two 32-bit halves when necessary.
                 let to_limbs = |words: &[u64]| -> Vec<Limb> {
                     if core::mem::size_of::<Limb>() == 8 {
                         words.iter().map(|&w| w as Limb).collect()
                     } else {
+                        // Split each u64 into [low_u32, high_u32] (little-endian limb order).
                         words.iter().flat_map(|&w| {
                             [(w & 0xFFFF_FFFF) as Limb, ((w >> 32) & 0xFFFF_FFFF) as Limb]
                         }).collect()
@@ -365,11 +369,13 @@ macro_rules! construct_uint {
                 x.mod_inverse(p).map(|n| {
                     let limbs = n.into_limbs_asc();
                     let mut res = [0u64; Self::LIMBS];
+                    // Reassemble limbs back into u64 words.
                     if core::mem::size_of::<Limb>() == 8 {
                         for (r, &l) in res.iter_mut().zip(limbs.iter()) {
                             *r = l as u64;
                         }
                     } else {
+                        // Combine pairs of u32 limbs into u64: low | (high << 32).
                         for (i, chunk) in limbs.chunks(2).enumerate() {
                             if i < Self::LIMBS {
                                 res[i] = chunk[0] as u64

--- a/math/src/uint.rs
+++ b/math/src/uint.rs
@@ -349,40 +349,42 @@ macro_rules! construct_uint {
                 use $crate::uint::malachite_nz::platform::Limb;
                 use $crate::uint::malachite_base::num::arithmetic::traits::ModInverse;
 
-                // Malachite's Limb is u64 on 64-bit platforms but u32 on 32-bit
-                // (e.g. risc0 riscv32im). Convert our u64 words to limbs, splitting
-                // each word into two 32-bit halves when necessary.
-                let to_limbs = |words: &[u64]| -> Vec<Limb> {
-                    if core::mem::size_of::<Limb>() == 8 {
-                        words.iter().map(|&w| w as Limb).collect()
-                    } else {
-                        // Split each u64 into [low_u32, high_u32] (little-endian limb order).
-                        words.iter().flat_map(|&w| {
-                            [(w & 0xFFFF_FFFF) as Limb, ((w >> 32) & 0xFFFF_FFFF) as Limb]
-                        }).collect()
+                // Malachite's Limb type changes from u64 to u32 when the `32_bit_limbs`
+                // feature is enabled (e.g. by risc0 via Cargo feature unification).
+                // On little-endian, [u64; N] and [Limb; N * 8/sizeof(Limb)] have
+                // identical byte layouts, so we reinterpret directly without copying.
+                #[cfg(not(target_endian = "little"))]
+                compile_error!("mod_inverse assumes little-endian byte order");
+
+                const LIMBS_PER_WORD: usize =
+                    core::mem::size_of::<u64>() / core::mem::size_of::<Limb>();
+
+                // SAFETY: On LE, a u64 in memory [b0..b7] is read identically as
+                // one u64 limb or two u32 limbs [b0..b3, b4..b7]. Alignment is
+                // satisfied since align_of::<u64>() >= align_of::<Limb>().
+                let as_limbs = |words: &[u64; $n_words]| -> &[Limb] {
+                    unsafe {
+                        core::slice::from_raw_parts(
+                            words.as_ptr() as *const Limb,
+                            $n_words * LIMBS_PER_WORD,
+                        )
                     }
                 };
 
-                let x = Natural::from_limbs_asc(&to_limbs(&self.0));
-                let p = Natural::from_limbs_asc(&to_limbs(&prime.0));
+                let x = Natural::from_limbs_asc(as_limbs(&self.0));
+                let p = Natural::from_limbs_asc(as_limbs(&prime.0));
 
                 x.mod_inverse(p).map(|n| {
                     let limbs = n.into_limbs_asc();
-                    let mut res = [0u64; Self::LIMBS];
-                    // Reassemble limbs back into u64 words.
-                    if core::mem::size_of::<Limb>() == 8 {
-                        for (r, &l) in res.iter_mut().zip(limbs.iter()) {
-                            *r = l as u64;
-                        }
-                    } else {
-                        // Combine pairs of u32 limbs into u64: low | (high << 32).
-                        for (i, chunk) in limbs.chunks(2).enumerate() {
-                            if i < Self::LIMBS {
-                                res[i] = chunk[0] as u64
-                                    | ((chunk.get(1).copied().unwrap_or(0 as Limb) as u64) << 32);
-                            }
-                        }
-                    }
+                    let mut res = [0u64; $n_words];
+                    // SAFETY: Same LE byte-layout argument, in reverse.
+                    let res_limbs: &mut [Limb] = unsafe {
+                        core::slice::from_raw_parts_mut(
+                            res.as_mut_ptr() as *mut Limb,
+                            $n_words * LIMBS_PER_WORD,
+                        )
+                    };
+                    res_limbs[..limbs.len()].copy_from_slice(&limbs);
                     Self(res)
                 })
             }

--- a/math/src/uint.rs
+++ b/math/src/uint.rs
@@ -346,16 +346,37 @@ macro_rules! construct_uint {
             #[inline]
             pub fn mod_inverse(self, prime: Self) -> Option<Self> {
                 use $crate::uint::malachite_nz::natural::Natural;
+                use $crate::uint::malachite_nz::platform::Limb;
                 use $crate::uint::malachite_base::num::arithmetic::traits::ModInverse;
 
-                let x = Natural::from_limbs_asc(&self.0);
-                let p = Natural::from_limbs_asc(&prime.0);
-                let mod_inv = x.mod_inverse(p);
+                let to_limbs = |words: &[u64]| -> Vec<Limb> {
+                    if core::mem::size_of::<Limb>() == 8 {
+                        words.iter().map(|&w| w as Limb).collect()
+                    } else {
+                        words.iter().flat_map(|&w| {
+                            [(w & 0xFFFF_FFFF) as Limb, ((w >> 32) & 0xFFFF_FFFF) as Limb]
+                        }).collect()
+                    }
+                };
 
-                mod_inv.map(|n| {
-                    let mut res = [0u64; Self::LIMBS];
+                let x = Natural::from_limbs_asc(&to_limbs(&self.0));
+                let p = Natural::from_limbs_asc(&to_limbs(&prime.0));
+
+                x.mod_inverse(p).map(|n| {
                     let limbs = n.into_limbs_asc();
-                    res[..limbs.len()].copy_from_slice(&limbs);
+                    let mut res = [0u64; Self::LIMBS];
+                    if core::mem::size_of::<Limb>() == 8 {
+                        for (r, &l) in res.iter_mut().zip(limbs.iter()) {
+                            *r = l as u64;
+                        }
+                    } else {
+                        for (i, chunk) in limbs.chunks(2).enumerate() {
+                            if i < Self::LIMBS {
+                                res[i] = chunk[0] as u64
+                                    | ((chunk.get(1).copied().unwrap_or(0 as Limb) as u64) << 32);
+                            }
+                        }
+                    }
                     Self(res)
                 })
             }


### PR DESCRIPTION
This PR fixes a compilation failure when kaspa-math is used in a workspace alongside risc0-based crates.

**Problem**

kaspa-math's mod_inverse passes its internal [u64; N] limb array directly to malachite's Natural::from_limbs_asc(&[Limb]), assuming Limb = u64. This breaks when malachite's 32_bit_limbs feature is enabled, causing a type
 mismatch (expected &[u32], found &[u64; N]).

**Root cause: Cargo feature unification**

malachite-nz has an optional 32_bit_limbs feature that switches Limb from u64 to u32. By default it is disabled, so Limb = u64 and kaspa-math compiles fine in the rusty-kaspa workspace.

However, Cargo unifies features across an entire workspace. In the vprogs workspace, risc0-circuit-rv32im (RISC Zero zkVM) depends on malachite with:

`features = ["naturals_and_integers", "32_bit_limbs"]`

This activates 32_bit_limbs globally - including for kaspa-math - making Limb = u32 and breaking mod_inverse.

**Fix**

Make mod_inverse generic over the Limb type by converting between the internal u64 words and malachite Limbs at the boundary:

  - u64 → Limb (input): When Limb is 32-bit, each u64 word is split into two u32 limbs (low, high) in little-endian order. When Limb is 64-bit, the words pass through directly.
  - Limb → u64 (output): The inverse operation - pairs of u32 limbs are reassembled into u64 words.

The size_of::<Limb>() check is a compile-time constant, so the compiler eliminates the unused branch entirely - zero runtime cost.