### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2337,14 +2337,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "bs58",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "cfg-if 1.0.0",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "duration-string",
  "futures",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -2870,14 +2870,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "futures-util",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 1.0.64",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "secp256k1",
  "thiserror 1.0.64",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "aes",
  "ahash",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "ctrlc",
  "futures",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "clap 4.5.51",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "async-std",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "clap 4.5.51",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.88.0"
-version = "1.1.0-rc.3"
+version = "1.1.0"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -83,62 +83,62 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.1.0-rc.3", path = "testing/integration" }
-kaspa-addresses = { version = "1.1.0-rc.3", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.1.0-rc.3", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.1.0-rc.3", path = "wallet/bip32" }
-kaspa-cli = { version = "1.1.0-rc.3", path = "cli" }
-kaspa-connectionmanager = { version = "1.1.0-rc.3", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.1.0-rc.3", path = "consensus" }
-kaspa-consensus-core = { version = "1.1.0-rc.3", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.1.0-rc.3", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.1.0-rc.3", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.1.0-rc.3", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.1.0-rc.3", path = "components/consensusmanager" }
-kaspa-core = { version = "1.1.0-rc.3", path = "core" }
-kaspa-daemon = { version = "1.1.0-rc.3", path = "daemon" }
-kaspa-database = { version = "1.1.0-rc.3", path = "database" }
-kaspa-grpc-client = { version = "1.1.0-rc.3", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.1.0-rc.3", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.1.0-rc.3", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.1.0-rc.3", path = "crypto/hashes" }
-kaspa-index-core = { version = "1.1.0-rc.3", path = "indexes/core" }
-kaspa-index-processor = { version = "1.1.0-rc.3", path = "indexes/processor" }
-kaspa-math = { version = "1.1.0-rc.3", path = "math" }
-kaspa-merkle = { version = "1.1.0-rc.3", path = "crypto/merkle" }
-kaspa-metrics-core = { version = "1.1.0-rc.3", path = "metrics/core" }
-kaspa-mining = { version = "1.1.0-rc.3", path = "mining" }
-kaspa-mining-errors = { version = "1.1.0-rc.3", path = "mining/errors" }
-kaspa-muhash = { version = "1.1.0-rc.3", path = "crypto/muhash" }
-kaspa-notify = { version = "1.1.0-rc.3", path = "notify" }
-kaspa-p2p-flows = { version = "1.1.0-rc.3", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.1.0-rc.3", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.1.0-rc.3", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.1.0-rc.3", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.1.0-rc.3", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.1.0-rc.3", path = "rpc/core" }
-kaspa-rpc-macros = { version = "1.1.0-rc.3", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.1.0-rc.3", path = "rpc/service" }
-kaspa-txscript = { version = "1.1.0-rc.3", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.1.0-rc.3", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.1.0-rc.3", path = "utils" }
-kaspa-utils-tower = { version = "1.1.0-rc.3", path = "utils/tower" }
-kaspa-utxoindex = { version = "1.1.0-rc.3", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.1.0-rc.3", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.1.0-rc.3", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.1.0-rc.3", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.1.0-rc.3", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.1.0-rc.3", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.1.0-rc.3", path = "wallet/macros" }
-kaspa-wasm = { version = "1.1.0-rc.3", path = "wasm" }
-kaspa-wasm-core = { version = "1.1.0-rc.3", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.1.0-rc.3", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.1.0-rc.3", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.1.0-rc.3", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.1.0-rc.3", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.1.0-rc.3", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.1.0-rc.3", path = "kaspad" }
-kaspa-alloc = { version = "1.1.0-rc.3", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.1.0", path = "testing/integration" }
+kaspa-addresses = { version = "1.1.0", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.1.0", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.1.0", path = "wallet/bip32" }
+kaspa-cli = { version = "1.1.0", path = "cli" }
+kaspa-connectionmanager = { version = "1.1.0", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.1.0", path = "consensus" }
+kaspa-consensus-core = { version = "1.1.0", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.1.0", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.1.0", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.1.0", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.1.0", path = "components/consensusmanager" }
+kaspa-core = { version = "1.1.0", path = "core" }
+kaspa-daemon = { version = "1.1.0", path = "daemon" }
+kaspa-database = { version = "1.1.0", path = "database" }
+kaspa-grpc-client = { version = "1.1.0", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.1.0", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.1.0", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.1.0", path = "crypto/hashes" }
+kaspa-index-core = { version = "1.1.0", path = "indexes/core" }
+kaspa-index-processor = { version = "1.1.0", path = "indexes/processor" }
+kaspa-math = { version = "1.1.0", path = "math" }
+kaspa-merkle = { version = "1.1.0", path = "crypto/merkle" }
+kaspa-metrics-core = { version = "1.1.0", path = "metrics/core" }
+kaspa-mining = { version = "1.1.0", path = "mining" }
+kaspa-mining-errors = { version = "1.1.0", path = "mining/errors" }
+kaspa-muhash = { version = "1.1.0", path = "crypto/muhash" }
+kaspa-notify = { version = "1.1.0", path = "notify" }
+kaspa-p2p-flows = { version = "1.1.0", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.1.0", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.1.0", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.1.0", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.1.0", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.1.0", path = "rpc/core" }
+kaspa-rpc-macros = { version = "1.1.0", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.1.0", path = "rpc/service" }
+kaspa-txscript = { version = "1.1.0", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.1.0", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.1.0", path = "utils" }
+kaspa-utils-tower = { version = "1.1.0", path = "utils/tower" }
+kaspa-utxoindex = { version = "1.1.0", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.1.0", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.1.0", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.1.0", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.1.0", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.1.0", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.1.0", path = "wallet/macros" }
+kaspa-wasm = { version = "1.1.0", path = "wasm" }
+kaspa-wasm-core = { version = "1.1.0", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.1.0", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.1.0", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.1.0", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.1.0", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.1.0", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.1.0", path = "kaspad" }
+kaspa-alloc = { version = "1.1.0", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -4,7 +4,7 @@
 ## Prerequisites
 
 Latest versions of tools:
-* rust 1.85.0+
+* rust 1.88.0+
 * wasm-pack 0.12.1+ https://rustwasm.github.io/wasm-pack/installer/
 * basic-http-server `cargo install basic-http-server`
 (alternatively you can use your favorite flavor of http server, just make sure to match the ports in this example)


### PR DESCRIPTION
prep for release v1.1.0

we can release from this point since RC3 is stable and the diff since only touched CI and docs: https://github.com/kaspanet/rusty-kaspa/compare/v1.1.0-rc.3...master 