### PR TITLE
feat(wasm): add utxoEntry getter alias on UtxoEntryReference

### DIFF
--- a/consensus/client/src/utxo.rs
+++ b/consensus/client/src/utxo.rs
@@ -161,6 +161,11 @@ impl UtxoEntryReference {
         self.as_ref().clone()
     }
 
+    #[wasm_bindgen(getter, js_name = "utxoEntry")]
+    pub fn utxo_entry(&self) -> UtxoEntry {
+        self.as_ref().clone()
+    }
+
     #[wasm_bindgen(getter)]
     pub fn outpoint(&self) -> TransactionOutpoint {
         self.utxo.outpoint.clone()


### PR DESCRIPTION
Addresses #332

The RPC `getUtxosByAddresses` response serializes the field as `utxoEntry` (camelCase), but the WASM `UtxoEntryReference` class only exposes `.entry`. This adds a `.utxoEntry` getter alias so the WASM SDK property name matches the RPC JSON field name.

## Change

- Add `utxoEntry` getter on `UtxoEntryReference` (returns same `UtxoEntry` as `.entry`)
- **Non-breaking**: existing `.entry` getter is preserved

## File

`consensus/client/src/utxo.rs` — 5 lines added