### PR TITLE
fix(wallet): handle storage mass exceeds in Generator by trying more inputs

### DIFF
--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -801,7 +801,18 @@ impl Generator {
 
         // calculate storage mass
         let MassDisposition { transaction_mass, storage_mass, transaction_fees, absorb_change_to_fees } =
-            self.calculate_mass(stage, data, final_transaction.value_with_priority_fee)?;
+            match self.calculate_mass(stage, data, final_transaction.value_with_priority_fee) {
+                Ok(disposition) => disposition,
+                Err(Error::StorageMassExceedsMaximumTransactionMass { storage_mass }) => {
+                    // storage mass exceeds maximum; try to accumulate more inputs to lower it (KIP-9)
+                    if self.has_utxo_entries(context, stage) {
+                        return Ok(None);
+                    } else {
+                        return Err(Error::StorageMassExceedsMaximumTransactionMass { storage_mass });
+                    }
+                }
+                Err(err) => return Err(err),
+            };
 
         let total_stage_value_needed = if self.inner.final_transaction_priority_fee.sender_pays() {
             final_transaction.value_with_priority_fee + stage.aggregate_fees + transaction_fees


### PR DESCRIPTION
## Summary

- When the Generator builds a transaction and `calculate_mass()` returns `StorageMassExceedsMaximumTransactionMass`, it now tries to accumulate more UTXOs instead of immediately failing
- Under KIP-9, more inputs lower storage mass, so adding UTXOs can resolve the exceeded limit
- If no more UTXOs are available, the error is returned as before
- Follows the existing pattern in `generate_edge_transaction()` which already handles mass overflow this way

Resolves #701