### PR TITLE
feat(rpc): add SubmitLocalTransaction (#514)

### DIFF
--- a/mining/src/block_template/selector.rs
+++ b/mining/src/block_template/selector.rs
@@ -1,6 +1,6 @@
 use kaspa_core::{time::Stopwatch, trace};
 use rand::Rng;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::model::candidate_tx::CandidateTransaction;
 
@@ -253,6 +253,53 @@ impl TemplateTransactionSelector for RebalancingWeightedTransactionSelector {
         self.overall_rejections == 0
             || (self.total_mass as f64) > self.policy.max_block_mass as f64 * SUFFICIENT_MASS_THRESHOLD
             || (self.overall_rejections as f64) < self.transactions.len() as f64 * LOW_REJECTION_FRACTION
+    }
+}
+
+/// A wrapper selector that yields local (operator-submitted) transactions first,
+/// then delegates to the inner frontier selector for remaining block capacity.
+/// Used by `MiningManager` when local transactions have been submitted via
+/// `SubmitLocalTransaction` RPC.
+pub struct LocalFirstSelector {
+    /// Local transactions to include, consumed on first `select_transactions()` call
+    local_txs: Vec<Transaction>,
+    /// IDs of local transactions that have been yielded and not yet rejected
+    local_tx_ids: HashSet<TransactionId>,
+    /// The normal frontier-based selector
+    inner: Box<dyn TemplateTransactionSelector>,
+    /// Whether local transactions have already been yielded
+    local_yielded: bool,
+}
+
+impl LocalFirstSelector {
+    pub fn new(local_txs: Vec<Transaction>, inner: Box<dyn TemplateTransactionSelector>) -> Self {
+        let local_tx_ids: HashSet<TransactionId> = local_txs.iter().map(|tx| tx.id()).collect();
+        Self { local_txs, local_tx_ids, inner, local_yielded: false }
+    }
+}
+
+impl TemplateTransactionSelector for LocalFirstSelector {
+    fn select_transactions(&mut self) -> Vec<Transaction> {
+        if !self.local_yielded {
+            self.local_yielded = true;
+            if !self.local_txs.is_empty() {
+                return std::mem::take(&mut self.local_txs);
+            }
+        }
+        self.inner.select_transactions()
+    }
+
+    fn reject_selection(&mut self, tx_id: TransactionId) {
+        if self.local_tx_ids.remove(&tx_id) {
+            // Local tx was rejected by consensus — just drop it silently.
+            // Do NOT propagate to inner selector since this tx was never in it.
+        } else {
+            self.inner.reject_selection(tx_id);
+        }
+    }
+
+    fn is_successful(&self) -> bool {
+        self.inner.is_successful() || !self.local_tx_ids.is_empty()
     }
 }
 

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -1,6 +1,6 @@
 use crate::{
     MempoolCountersSnapshot, MiningCounters, P2pTxCountSample,
-    block_template::{builder::BlockTemplateBuilder, errors::BuilderError},
+    block_template::{builder::BlockTemplateBuilder, errors::BuilderError, selector::LocalFirstSelector},
     cache::BlockTemplateCache,
     errors::MiningManagerResult,
     feerate::{FeeEstimateVerbose, FeerateEstimations, FeerateEstimatorArgs},
@@ -35,7 +35,7 @@ use kaspa_consensusmanager::{ConsensusProxy, spawn_blocking};
 use kaspa_core::{debug, error, info, time::Stopwatch, warn};
 use kaspa_mining_errors::{manager::MiningManagerError, mempool::RuleError};
 use parking_lot::RwLock;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 
 pub struct MiningManager {
@@ -43,6 +43,10 @@ pub struct MiningManager {
     block_template_cache: BlockTemplateCache,
     mempool: RwLock<Mempool>,
     counters: Arc<MiningCounters>,
+    /// Local transactions submitted by the node operator for prioritized inclusion
+    /// in block templates. These bypass the mempool relay fee check and are NOT
+    /// broadcast to peers.
+    local_transactions: RwLock<HashMap<TransactionId, Arc<Transaction>>>,
 }
 
 impl MiningManager {
@@ -74,7 +78,7 @@ impl MiningManager {
         let config = Arc::new(config);
         let mempool = RwLock::new(Mempool::new(config.clone(), counters.clone()));
         let block_template_cache = BlockTemplateCache::new(cache_lifetime);
-        Self { config, block_template_cache, mempool, counters }
+        Self { config, block_template_cache, mempool, counters, local_transactions: RwLock::new(HashMap::new()) }
     }
 
     pub fn get_block_template(&self, consensus: &dyn ConsensusApi, miner_data: &MinerData) -> MiningManagerResult<BlockTemplate> {
@@ -197,9 +201,13 @@ impl MiningManager {
         }
     }
 
-    /// Dynamically builds a transaction selector based on the specific state of the ready transactions frontier
+    /// Dynamically builds a transaction selector based on the specific state of the ready transactions frontier.
+    /// If local transactions have been submitted, wraps the frontier selector with a `LocalFirstSelector`
+    /// that yields local transactions before frontier transactions.
     pub(crate) fn build_selector(&self) -> Box<dyn TemplateTransactionSelector> {
-        self.mempool.read().build_selector()
+        let frontier_selector = self.mempool.read().build_selector();
+        let local_txs: Vec<Transaction> = self.local_transactions.read().values().map(|tx| tx.as_ref().clone()).collect();
+        if local_txs.is_empty() { frontier_selector } else { Box::new(LocalFirstSelector::new(local_txs, frontier_selector)) }
     }
 
     /// Returns realtime feerate estimations based on internal mempool state
@@ -286,6 +294,60 @@ impl MiningManager {
         rbf_policy: RbfPolicy,
     ) -> MiningManagerResult<TransactionInsertion> {
         self.validate_and_insert_mutable_transaction(consensus, MutableTransaction::from_tx(transaction), priority, orphan, rbf_policy)
+    }
+
+    /// Validates and inserts a transaction into the local transaction store for
+    /// prioritized inclusion in block templates. Local transactions bypass the
+    /// mempool relay fee check and are NOT broadcast to peers.
+    ///
+    /// The transaction undergoes full standard checks (dust, mass, script class)
+    /// via the mempool's existing validation, plus full consensus validation
+    /// (signatures, UTXO existence, locktime). Only the relay fee check is skipped.
+    ///
+    /// The transaction is stored separately from the mempool and injected first
+    /// into block templates via `LocalFirstSelector`.
+    // TODO: Consider adding a CLI flag (e.g. --enable-submit-local-transaction) to
+    // gate access to this feature. Currently, any RPC client can call this endpoint.
+    pub fn validate_and_insert_local_transaction(
+        &self,
+        consensus: &dyn ConsensusApi,
+        transaction: Transaction,
+    ) -> MiningManagerResult<TransactionInsertion> {
+        let transaction_id = transaction.id();
+
+        // Check if already in local store
+        if self.local_transactions.read().contains_key(&transaction_id) {
+            return Err(MiningManagerError::MempoolError(RuleError::RejectDuplicate(transaction_id)));
+        }
+
+        let mut mtx = MutableTransaction::from_tx(transaction);
+
+        // Calculate non-contextual masses (needed for standard and consensus validation)
+        mtx.calculated_non_contextual_masses = Some(consensus.calculate_transaction_non_contextual_masses(&mtx.tx));
+
+        // Standard checks in isolation (no UTXO needed):
+        // TX version, compute/transient mass limits, sig script size,
+        // output script class, and dust output check.
+        // These protect the network from UTXO set pollution even for fee-exempt local TXs.
+        self.mempool.read().check_transaction_standard_in_isolation(&mtx).map_err(RuleError::from)?;
+
+        // Full consensus validation: signatures, UTXO lookups, locktime.
+        // feerate_threshold = None skips the consensus-level fee check.
+        let args = TransactionValidationArgs::new(None);
+        validate_mempool_transaction(consensus, &mut mtx, &args)?;
+
+        // Standard checks in context (needs populated UTXO entries):
+        // storage mass limit, input script class, P2SH sig op count.
+        // Relay fee check is skipped (check_fee = false) — this is the purpose of local TX.
+        self.mempool.read().check_transaction_standard_in_context(&mtx, false).map_err(RuleError::from)?;
+
+        // Store in local transaction map
+        let tx = mtx.tx.clone();
+        self.local_transactions.write().insert(transaction_id, tx.clone());
+
+        info!("Local transaction {} accepted into local store", transaction_id);
+
+        Ok(TransactionInsertion::new(None, vec![tx]))
     }
 
     /// Exposed for tests only
@@ -591,6 +653,16 @@ impl MiningManager {
         // write lock on mempool
         let unorphaned_transactions = self.mempool.write().handle_new_block_transactions(block_daa_score, block_transactions)?;
 
+        // Clean up local transactions that were included in the block
+        {
+            let mut local = self.local_transactions.write();
+            if !local.is_empty() {
+                for transaction in block_transactions[1..].iter() {
+                    local.remove(&transaction.id());
+                }
+            }
+        }
+
         // alternate no & write lock on mempool
         let accepted_transactions = self.validate_and_insert_unorphaned_transactions(consensus, unorphaned_transactions);
 
@@ -886,6 +958,16 @@ impl MiningManagerProxy {
             .clone()
             .spawn_blocking(move |c| self.inner.validate_and_insert_transaction(c, transaction, priority, orphan, rbf_policy))
             .await
+    }
+
+    /// Validates and inserts a transaction into the local transaction store.
+    /// See `MiningManager::validate_and_insert_local_transaction` for details.
+    pub async fn validate_and_insert_local_transaction(
+        self,
+        consensus: &ConsensusProxy,
+        transaction: Transaction,
+    ) -> MiningManagerResult<TransactionInsertion> {
+        consensus.clone().spawn_blocking(move |c| self.inner.validate_and_insert_local_transaction(c, transaction)).await
     }
 
     /// Validates a batch of transactions, handling iteratively only the independent ones, and

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1529,4 +1529,303 @@ mod tests {
         let count = mining_manager.transaction_count(TransactionQuery::TransactionsOnly);
         assert_eq!(expected_count, count, "{message} mempool transaction count: expected {}, got {}", expected_count, count);
     }
+
+    // =========================================================================
+    // SubmitLocalTransaction tests (A1–A13)
+    // =========================================================================
+
+    /// Helper: create a funded local transaction (op_true script, with UTXO in consensus).
+    /// Returns the raw Transaction (not MutableTransaction) since that's what
+    /// validate_and_insert_local_transaction expects.
+    fn create_local_transaction(consensus: &Arc<ConsensusMock>, i: u64, fee: u64) -> Transaction {
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA + i]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+        create_transaction(&funding_tx, fee)
+    }
+
+    /// A1: Zero-fee local transaction is accepted
+    #[test]
+    fn test_local_tx_zero_fee_accepted() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let tx = create_local_transaction(&consensus, 0, 0);
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx);
+        assert!(result.is_ok(), "zero-fee local transaction should be accepted");
+    }
+
+    /// A2: Local transaction appears in block template
+    #[test]
+    fn test_local_tx_appears_in_template() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let tx = create_local_transaction(&consensus, 0, 0);
+        let tx_id = tx.id();
+        mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx).unwrap();
+
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        // Template transactions: [coinbase, ...user txs]
+        let has_local_tx = template.block.transactions[1..].iter().any(|t| t.id() == tx_id);
+        assert!(has_local_tx, "local transaction should appear in block template");
+    }
+
+    /// A3: Multiple local transactions all appear in block template
+    #[test]
+    fn test_local_tx_priority_over_mempool() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        // Insert two local transactions (zero fee)
+        let local_tx1 = create_local_transaction(&consensus, 100, 0);
+        let local_tx1_id = local_tx1.id();
+        mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), local_tx1).unwrap();
+
+        let local_tx2 = create_local_transaction(&consensus, 200, 0);
+        let local_tx2_id = local_tx2.id();
+        mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), local_tx2).unwrap();
+
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        let user_txs = &template.block.transactions[1..];
+
+        // Both local transactions should be in the template
+        assert!(user_txs.iter().any(|t| t.id() == local_tx1_id), "local tx1 should be in template");
+        assert!(user_txs.iter().any(|t| t.id() == local_tx2_id), "local tx2 should be in template");
+    }
+
+    /// A4: Local transaction is cleaned up after block is mined
+    #[test]
+    fn test_local_tx_cleanup_after_block() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let tx = create_local_transaction(&consensus, 0, 0);
+        let tx_id = tx.id();
+        let insertion = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx).unwrap();
+        let accepted_tx = insertion.accepted.first().unwrap().clone();
+
+        // Simulate block containing this transaction
+        let block_txs = build_block_transactions(once(accepted_tx.as_ref()));
+        mining_manager.handle_new_block_transactions(consensus.as_ref(), 1, &block_txs).unwrap();
+
+        // Local tx should no longer appear in block template
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        let has_tx = template.block.transactions[1..].iter().any(|t| t.id() == tx_id);
+        assert!(!has_tx, "local transaction should be removed after block acceptance");
+    }
+
+    /// A5: Dust output is rejected for local transactions
+    #[test]
+    fn test_local_tx_reject_dust() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        // Create a transaction with a dust output (1 sompi)
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+
+        let (script_public_key, _) = op_true_script();
+        let input = TransactionInput::new(
+            TransactionOutpoint::new(funding_tx.id(), 0),
+            pay_to_script_hash_signature_script(op_true_script().1, vec![]).unwrap(),
+            MAX_TX_IN_SEQUENCE_NUM,
+            1,
+        );
+        // Output value of 1 sompi is dust
+        let output = TransactionOutput::new(1, script_public_key);
+        let dust_tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), dust_tx);
+        assert!(result.is_err(), "dust output should be rejected for local transactions");
+    }
+
+    /// A6: Duplicate local transaction is rejected
+    #[test]
+    fn test_local_tx_reject_duplicate() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let tx = create_local_transaction(&consensus, 0, 0);
+        let tx_clone = tx.clone();
+
+        mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx).unwrap();
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx_clone);
+        assert!(result.is_err(), "duplicate local transaction should be rejected");
+    }
+
+    /// A7: Transaction rejected by consensus validation is rejected
+    #[test]
+    fn test_local_tx_reject_invalid_signature() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+
+        // Set a predefined error for this transaction to simulate consensus rejection
+        let (script_public_key, _) = op_true_script();
+        let input = TransactionInput::new(
+            TransactionOutpoint::new(funding_tx.id(), 0),
+            vec![], // empty sig script
+            MAX_TX_IN_SEQUENCE_NUM,
+            1,
+        );
+        let output = TransactionOutput::new(SOMPI_PER_KASPA - DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE, script_public_key);
+        let bad_tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+        consensus.set_status(bad_tx.id(), Err(TxRuleError::MissingTxOutpoints));
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), bad_tx);
+        assert!(result.is_err(), "transaction rejected by consensus should be rejected");
+    }
+
+    /// A8: Transaction spending non-existent UTXO is rejected
+    #[test]
+    fn test_local_tx_reject_missing_utxo() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        // Create a transaction referencing a non-existent UTXO (no funding tx added to consensus)
+        let (script_public_key, _) = op_true_script();
+        let input = TransactionInput::new(
+            TransactionOutpoint::new(Hash::from_u64_word(9999), 0),
+            pay_to_script_hash_signature_script(op_true_script().1, vec![]).unwrap(),
+            MAX_TX_IN_SEQUENCE_NUM,
+            1,
+        );
+        let output = TransactionOutput::new(SOMPI_PER_KASPA - 1000, script_public_key);
+        let tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx);
+        assert!(result.is_err(), "transaction with missing UTXO should be rejected");
+    }
+
+    /// A9: Transaction exceeding mass limit is rejected
+    #[test]
+    fn test_local_tx_reject_mass_exceeded() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+
+        let (script_public_key, _) = op_true_script();
+        let input = TransactionInput::new(
+            TransactionOutpoint::new(funding_tx.id(), 0),
+            // Oversized signature script to push mass over the limit
+            vec![0u8; 200_000],
+            MAX_TX_IN_SEQUENCE_NUM,
+            1,
+        );
+        let output = TransactionOutput::new(SOMPI_PER_KASPA - 1000, script_public_key);
+        let tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx);
+        assert!(result.is_err(), "transaction exceeding mass limit should be rejected");
+    }
+
+    /// A10: Non-standard output script is rejected
+    #[test]
+    fn test_local_tx_reject_non_standard_script() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+
+        let input = TransactionInput::new(
+            TransactionOutpoint::new(funding_tx.id(), 0),
+            pay_to_script_hash_signature_script(op_true_script().1, vec![]).unwrap(),
+            MAX_TX_IN_SEQUENCE_NUM,
+            1,
+        );
+        // Non-standard output script (OpReturn makes it unspendable → dust)
+        let non_standard_spk = ScriptPublicKey::new(0, kaspa_consensus_core::tx::scriptvec![0x6a]); // OP_RETURN
+        let output = TransactionOutput::new(SOMPI_PER_KASPA - 1000, non_standard_spk);
+        let tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx);
+        assert!(result.is_err(), "non-standard output script should be rejected");
+    }
+
+    /// A11: Multiple local transactions all appear in template
+    #[test]
+    fn test_local_tx_multiple_accepted() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let mut tx_ids = vec![];
+        for i in 0..5u64 {
+            let tx = create_local_transaction(&consensus, i, 0);
+            tx_ids.push(tx.id());
+            mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx).unwrap();
+        }
+
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        let user_txs = &template.block.transactions[1..];
+
+        for tx_id in &tx_ids {
+            assert!(user_txs.iter().any(|t| t.id() == *tx_id), "local transaction {} should be in template", tx_id);
+        }
+    }
+
+    /// A12: When no local transactions exist, build_selector returns normal frontier selector
+    #[test]
+    fn test_local_tx_no_effect_when_empty() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        // Insert only a mempool transaction
+        let tx = create_local_transaction(&consensus, 0, DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE);
+        let tx_id = tx.id();
+        mining_manager
+            .validate_and_insert_transaction(consensus.as_ref(), tx, Priority::High, Orphan::Forbidden, RbfPolicy::Forbidden)
+            .unwrap();
+
+        // Block template should still contain the mempool transaction
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        let has_tx = template.block.transactions[1..].iter().any(|t| t.id() == tx_id);
+        assert!(has_tx, "mempool transaction should be in template when no local TXs exist");
+    }
+
+    /// A13: Failed consensus validation does not leave TX in local store
+    #[test]
+    fn test_local_tx_rejected_by_consensus_not_stored() {
+        let consensus = Arc::new(ConsensusMock::new());
+        let counters = Arc::new(MiningCounters::default());
+        let mining_manager = MiningManager::new(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS, None, counters);
+
+        let funding_tx = create_transaction_without_input(vec![SOMPI_PER_KASPA]);
+        consensus.add_transaction(funding_tx.clone(), 1);
+
+        let tx = create_transaction(&funding_tx, 0);
+        let tx_id = tx.id();
+        // Set consensus to reject this transaction
+        consensus.set_status(tx_id, Err(TxRuleError::NotFinalized(0)));
+
+        let result = mining_manager.validate_and_insert_local_transaction(consensus.as_ref(), tx);
+        assert!(result.is_err(), "consensus rejection should propagate");
+
+        // Verify the transaction is NOT in the block template
+        let miner_data = get_miner_data(Prefix::Simnet);
+        let template = mining_manager.get_block_template(consensus.as_ref(), &miner_data).unwrap();
+        let has_tx = template.block.transactions[1..].iter().any(|t| t.id() == tx_id);
+        assert!(!has_tx, "rejected transaction should not appear in block template");
+    }
 }

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -167,9 +167,15 @@ impl Mempool {
     /// context of this function is one whose referenced public key script is of a
     /// standard form and, for pay-to-script-hash, does not have more than
     /// maxStandardP2SHSigOps signature operations.
-    /// In addition, makes sure that the transaction's fee is above the minimum for acceptance
-    /// into the mempool and relay.
-    pub(crate) fn check_transaction_standard_in_context(&self, transaction: &MutableTransaction) -> NonStandardResult<()> {
+    /// In addition, when `check_fee` is true, makes sure that the transaction's fee is above
+    /// the minimum for acceptance into the mempool and relay. When `check_fee` is false
+    /// (used by `SubmitLocalTransaction`), the relay fee check is skipped while all other
+    /// standard checks (storage mass, input script class, P2SH sig ops) are still enforced.
+    pub(crate) fn check_transaction_standard_in_context(
+        &self,
+        transaction: &MutableTransaction,
+        check_fee: bool,
+    ) -> NonStandardResult<()> {
         let transaction_id = transaction.id();
         let contextual_mass = transaction.tx.mass();
         if contextual_mass > MAXIMUM_STANDARD_TRANSACTION_MASS {
@@ -198,12 +204,18 @@ impl Mempool {
                 }
             }
 
-            // TODO: For now, until wallets adapt, we only require minimum fee as function of compute mass (but the fee/mass ratio will
-            // use the max over all masses and will affect tx selection to block template)
-            let minimum_fee =
-                self.minimum_required_transaction_relay_fee(transaction.calculated_non_contextual_masses.unwrap().compute_mass);
-            if transaction.calculated_fee.unwrap() < minimum_fee {
-                return Err(NonStandardError::RejectInsufficientFee(transaction_id, transaction.calculated_fee.unwrap(), minimum_fee));
+            if check_fee {
+                // TODO: For now, until wallets adapt, we only require minimum fee as function of compute mass (but the fee/mass ratio will
+                // use the max over all masses and will affect tx selection to block template)
+                let minimum_fee =
+                    self.minimum_required_transaction_relay_fee(transaction.calculated_non_contextual_masses.unwrap().compute_mass);
+                if transaction.calculated_fee.unwrap() < minimum_fee {
+                    return Err(NonStandardError::RejectInsufficientFee(
+                        transaction_id,
+                        transaction.calculated_fee.unwrap(),
+                        minimum_fee,
+                    ));
+                }
             }
         }
 

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -153,7 +153,7 @@ impl Mempool {
 
     fn validate_transaction_in_context(&self, transaction: &MutableTransaction) -> RuleResult<()> {
         if !self.config.accept_non_standard {
-            self.check_transaction_standard_in_context(transaction)?;
+            self.check_transaction_standard_in_context(transaction, true)?;
         }
         Ok(())
     }

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -667,6 +667,17 @@ impl FlowContext {
         ))
     }
 
+    /// Validates and adds a local (operator) transaction to the local transaction store
+    /// for inclusion in block templates. The transaction is NOT broadcast to peers.
+    ///
+    /// This is intended for node operators who want to include their own transactions
+    /// in blocks they mine, potentially at zero fee.
+    pub async fn submit_local_transaction(&self, consensus: &ConsensusProxy, transaction: Transaction) -> Result<(), ProtocolError> {
+        self.mining_manager().clone().validate_and_insert_local_transaction(consensus, transaction).await?;
+        // Deliberately NO broadcast to peers -- local only
+        Ok(())
+    }
+
     /// Returns true if the time has come for running the task cleaning mempool transactions.
     async fn should_run_mempool_scanning_task(&self) -> bool {
         self.transactions_spread.write().await.should_run_mempool_scanning_task()

--- a/rpc/core/src/api/ops.rs
+++ b/rpc/core/src/api/ops.rs
@@ -140,6 +140,8 @@ pub enum RpcApiOps {
     GetUtxoReturnAddress = 150,
     /// Get Virtual Chain from Block V2
     GetVirtualChainFromBlockV2 = 151,
+    /// Submits a transaction to the local transaction store for prioritized inclusion in block templates without relay fee requirements
+    SubmitLocalTransaction = 152,
 }
 
 impl RpcApiOps {

--- a/rpc/core/src/api/rpc.rs
+++ b/rpc/core/src/api/rpc.rs
@@ -226,6 +226,18 @@ pub trait RpcApi: Sync + Send + AnySync {
         request: SubmitTransactionReplacementRequest,
     ) -> RpcResult<SubmitTransactionReplacementResponse>;
 
+    /// Submits a transaction to the local transaction store for prioritized inclusion
+    /// in block templates mined by this node. The transaction bypasses the relay fee
+    /// check and is NOT broadcast to peers.
+    async fn submit_local_transaction(&self, transaction: RpcTransaction) -> RpcResult<RpcTransactionId> {
+        Ok(self.submit_local_transaction_call(None, SubmitLocalTransactionRequest { transaction }).await?.transaction_id)
+    }
+    async fn submit_local_transaction_call(
+        &self,
+        connection: Option<&DynRpcConnection>,
+        request: SubmitLocalTransactionRequest,
+    ) -> RpcResult<SubmitLocalTransactionResponse>;
+
     /// Requests information about a specific block.
     async fn get_block(&self, hash: RpcHash, include_transactions: bool) -> RpcResult<RpcBlock> {
         Ok(self.get_block_call(None, GetBlockRequest::new(hash, include_transactions)).await?.block)

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -794,6 +794,62 @@ impl Deserializer for SubmitTransactionReplacementResponse {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitLocalTransactionRequest {
+    pub transaction: RpcTransaction,
+}
+
+impl SubmitLocalTransactionRequest {
+    pub fn new(transaction: RpcTransaction) -> Self {
+        Self { transaction }
+    }
+}
+
+impl Serializer for SubmitLocalTransactionRequest {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        serialize!(RpcTransaction, &self.transaction, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for SubmitLocalTransactionRequest {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let transaction = deserialize!(RpcTransaction, reader)?;
+        Ok(Self { transaction })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitLocalTransactionResponse {
+    pub transaction_id: RpcTransactionId,
+}
+
+impl SubmitLocalTransactionResponse {
+    pub fn new(transaction_id: RpcTransactionId) -> Self {
+        Self { transaction_id }
+    }
+}
+
+impl Serializer for SubmitLocalTransactionResponse {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(RpcTransactionId, &self.transaction_id, writer)?;
+        Ok(())
+    }
+}
+
+impl Deserializer for SubmitLocalTransactionResponse {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let transaction_id = load!(RpcTransactionId, reader)?;
+        Ok(Self { transaction_id })
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSubnetworkRequest {

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1458,6 +1458,60 @@ try_from! ( args: SubmitBlockResponse, ISubmitBlockResponse, {
 // ---
 
 declare! {
+    ISubmitLocalTransactionRequest,
+    r#"
+    /**
+     * Submit a transaction to the local store for prioritized inclusion
+     * in block templates without relay fee requirements. Not broadcast to peers.
+     *
+     * @category Node RPC
+     */
+    export interface ISubmitLocalTransactionRequest {
+        transaction : Transaction,
+    }
+    "#,
+}
+
+try_from! ( args: ISubmitLocalTransactionRequest, SubmitLocalTransactionRequest, {
+    let transaction = if let Some(transaction) = args.try_get_value("transaction")? {
+        transaction
+    } else {
+        args.into()
+    };
+
+    let request = if let Ok(transaction) = Transaction::try_owned_from(&transaction) {
+        SubmitLocalTransactionRequest {
+            transaction : transaction.into(),
+        }
+    } else {
+        from_value(transaction)?
+    };
+    Ok(request)
+});
+
+declare! {
+    ISubmitLocalTransactionResponse,
+    r#"
+    /**
+     *
+     *
+     * @category Node RPC
+     */
+    export interface ISubmitLocalTransactionResponse {
+        transactionId : HexString;
+    }
+    "#,
+}
+
+try_from! ( args: SubmitLocalTransactionResponse, ISubmitLocalTransactionResponse, {
+    let response = ISubmitLocalTransactionResponse::default();
+    response.set("transactionId", &args.transaction_id.into())?;
+    Ok(response)
+});
+
+// ---
+
+declare! {
     ISubmitTransactionReplacementRequest,
     // "ISubmitTransactionRequest | Transaction",
     r#"

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -255,6 +255,7 @@ impl RpcApi for GrpcClient {
     route!(add_peer_call, AddPeer);
     route!(submit_transaction_call, SubmitTransaction);
     route!(submit_transaction_replacement_call, SubmitTransactionReplacement);
+    route!(submit_local_transaction_call, SubmitLocalTransaction);
     route!(get_subnetwork_call, GetSubnetwork);
     route!(get_virtual_chain_from_block_call, GetVirtualChainFromBlock);
     route!(get_blocks_call, GetBlocks);

--- a/rpc/grpc/core/proto/messages.proto
+++ b/rpc/grpc/core/proto/messages.proto
@@ -67,6 +67,7 @@ message KaspadRequest {
     GetCurrentBlockColorRequestMessage getCurrentBlockColorRequest = 1110;
     GetUtxoReturnAddressRequestMessage getUtxoReturnAddressRequest = 1112;
     GetVirtualChainFromBlockV2RequestMessage getVirtualChainFromBlockV2Request = 1114;
+    SubmitLocalTransactionRequestMessage submitLocalTransactionRequest = 1116;
   }
 }
 
@@ -134,6 +135,7 @@ message KaspadResponse {
     GetCurrentBlockColorResponseMessage getCurrentBlockColorResponse = 1111;
     GetUtxoReturnAddressResponseMessage getUtxoReturnAddressResponse = 1113;
     GetVirtualChainFromBlockV2ResponseMessage getVirtualChainFromBlockV2Response = 1115;
+    SubmitLocalTransactionResponseMessage submitLocalTransactionResponse = 1117;
   }
 }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -331,6 +331,18 @@ message SubmitTransactionReplacementResponseMessage {
   RPCError error = 1000;
 }
 
+// SubmitLocalTransactionRequestMessage submits a transaction to the local store
+// for prioritized inclusion in block templates without relay fee requirements
+message SubmitLocalTransactionRequestMessage {
+  RpcTransaction transaction = 1;
+}
+
+message SubmitLocalTransactionResponseMessage {
+  string transactionId = 1;
+
+  RPCError error = 1000;
+}
+
 // NotifyVirtualChainChangedRequestMessage registers this connection for virtualChainChanged notifications.
 //
 // See: VirtualChainChangedNotificationMessage

--- a/rpc/grpc/core/src/convert/kaspad.rs
+++ b/rpc/grpc/core/src/convert/kaspad.rs
@@ -37,6 +37,7 @@ pub mod kaspad_request_convert {
     impl_into_kaspad_request!(AddPeer);
     impl_into_kaspad_request!(SubmitTransaction);
     impl_into_kaspad_request!(SubmitTransactionReplacement);
+    impl_into_kaspad_request!(SubmitLocalTransaction);
     impl_into_kaspad_request!(GetSubnetwork);
     impl_into_kaspad_request!(GetVirtualChainFromBlock);
     impl_into_kaspad_request!(GetBlocks);
@@ -176,6 +177,7 @@ pub mod kaspad_response_convert {
     impl_into_kaspad_response!(AddPeer);
     impl_into_kaspad_response!(SubmitTransaction);
     impl_into_kaspad_response!(SubmitTransactionReplacement);
+    impl_into_kaspad_response!(SubmitLocalTransaction);
     impl_into_kaspad_response!(GetSubnetwork);
     impl_into_kaspad_response!(GetVirtualChainFromBlock);
     impl_into_kaspad_response!(GetBlocks);

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -257,6 +257,13 @@ from!(item: RpcResult<&kaspa_rpc_core::SubmitTransactionReplacementResponse>, pr
     Self { transaction_id: item.transaction_id.to_string(), replaced_transaction: Some((&item.replaced_transaction).into()), error: None }
 });
 
+from!(item: &kaspa_rpc_core::SubmitLocalTransactionRequest, protowire::SubmitLocalTransactionRequestMessage, {
+    Self { transaction: Some((&item.transaction).into()) }
+});
+from!(item: RpcResult<&kaspa_rpc_core::SubmitLocalTransactionResponse>, protowire::SubmitLocalTransactionResponseMessage, {
+    Self { transaction_id: item.transaction_id.to_string(), error: None }
+});
+
 from!(item: &kaspa_rpc_core::GetSubnetworkRequest, protowire::GetSubnetworkRequestMessage, {
     Self { subnetwork_id: item.subnetwork_id.to_string() }
 });
@@ -762,6 +769,19 @@ try_from!(item: &protowire::SubmitTransactionReplacementResponseMessage, RpcResu
             .ok_or_else(|| RpcError::MissingRpcFieldError("SubmitTransactionReplacementRequestMessage".to_string(), "replaced_transaction".to_string()))?
             .try_into()?,
     }
+});
+
+try_from!(item: &protowire::SubmitLocalTransactionRequestMessage, kaspa_rpc_core::SubmitLocalTransactionRequest, {
+    Self {
+        transaction: item
+            .transaction
+            .as_ref()
+            .ok_or_else(|| RpcError::MissingRpcFieldError("SubmitLocalTransactionRequestMessage".to_string(), "transaction".to_string()))?
+            .try_into()?,
+    }
+});
+try_from!(item: &protowire::SubmitLocalTransactionResponseMessage, RpcResult<kaspa_rpc_core::SubmitLocalTransactionResponse>, {
+    Self { transaction_id: RpcHash::from_str(&item.transaction_id)? }
 });
 
 try_from!(item: &protowire::GetSubnetworkRequestMessage, kaspa_rpc_core::GetSubnetworkRequest, {

--- a/rpc/grpc/core/src/ops.rs
+++ b/rpc/grpc/core/src/ops.rs
@@ -62,6 +62,7 @@ pub enum KaspadPayloadOps {
     AddPeer,
     SubmitTransaction,
     SubmitTransactionReplacement,
+    SubmitLocalTransaction,
     GetSubnetwork,
     GetVirtualChainFromBlock,
     GetBlockCount,

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -56,6 +56,7 @@ impl Factory {
                 AddPeer,
                 SubmitTransaction,
                 SubmitTransactionReplacement,
+                SubmitLocalTransaction,
                 GetSubnetwork,
                 GetVirtualChainFromBlock,
                 GetBlockCount,

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -190,6 +190,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn submit_local_transaction_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: SubmitLocalTransactionRequest,
+    ) -> RpcResult<SubmitLocalTransactionResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     async fn add_peer_call(&self, _connection: Option<&DynRpcConnection>, _request: AddPeerRequest) -> RpcResult<AddPeerResponse> {
         Err(RpcError::NotImplemented)
     }

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -598,6 +598,22 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         Ok(SubmitTransactionReplacementResponse::new(transaction_id, (&*replaced_transaction).into()))
     }
 
+    async fn submit_local_transaction_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        request: SubmitLocalTransactionRequest,
+    ) -> RpcResult<SubmitLocalTransactionResponse> {
+        let transaction: Transaction = request.transaction.try_into()?;
+        let transaction_id = transaction.id();
+        let session = self.consensus_manager.consensus().unguarded_session();
+        self.flow_context.submit_local_transaction(&session, transaction).await.map_err(|err| {
+            let err = RpcError::RejectedTransaction(transaction_id, err.to_string());
+            debug!("{err}");
+            err
+        })?;
+        Ok(SubmitLocalTransactionResponse::new(transaction_id))
+    }
+
     async fn get_current_network_call(
         &self,
         _connection: Option<&DynRpcConnection>,

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -662,6 +662,7 @@ impl RpcApi for KaspaRpcClient {
             SubmitBlock,
             SubmitTransaction,
             SubmitTransactionReplacement,
+            SubmitLocalTransaction,
             Unban,
         ]
     );

--- a/rpc/wrpc/server/src/router.rs
+++ b/rpc/wrpc/server/src/router.rs
@@ -75,6 +75,7 @@ impl Router {
                 SubmitBlock,
                 SubmitTransaction,
                 SubmitTransactionReplacement,
+                SubmitLocalTransaction,
                 Unban,
             ]
         );

--- a/rpc/wrpc/wasm/src/client.rs
+++ b/rpc/wrpc/wasm/src/client.rs
@@ -1052,6 +1052,10 @@ build_wrpc_wasm_bindgen_interface!(
         /// Submits an RBF transaction to the Kaspa network.
         /// Returned information: Submitted Transaction Id, Transaction that was replaced.
         SubmitTransactionReplacement,
+        /// Submits a transaction to the local store for prioritized inclusion
+        /// in block templates without relay fee requirements. Not broadcast to peers.
+        /// Returned information: Submitted Transaction Id.
+        SubmitLocalTransaction,
         /// Unbans a previously banned peer, allowing it to connect
         /// to the Kaspa node again.
         /// Returned information: None.

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -363,6 +363,17 @@ async fn sanity_test() {
                 })
             }
 
+            KaspadPayloadOps::SubmitLocalTransaction => {
+                let rpc_client = client.clone();
+                tst!(op, {
+                    // Build an erroneous transaction...
+                    let transaction = Transaction::new(0, vec![], vec![], 0, SubnetworkId::default(), 0, vec![]);
+                    let result = rpc_client.submit_local_transaction((&transaction).into()).await;
+                    // ...that gets rejected by the consensus
+                    assert!(result.is_err());
+                })
+            }
+
             KaspadPayloadOps::GetSubnetwork => {
                 let rpc_client = client.clone();
                 tst!(op, {
@@ -799,6 +810,210 @@ async fn sanity_test() {
     //
     // Fold-up
     //
+    client.disconnect().await.unwrap();
+    drop(client);
+    daemon.shutdown();
+}
+
+// =============================================================================
+// SubmitLocalTransaction E2E tests (B1–B5)
+// =============================================================================
+
+/// `cargo test --release --package kaspa-testing-integration --lib -- rpc_tests::submit_local_transaction_e2e`
+#[tokio::test]
+async fn submit_local_transaction_e2e() {
+    use crate::common::{client_notify::ChannelNotify, utils::fetch_spendable_utxos};
+    use kaspa_consensus_core::{constants::TX_VERSION, sign::sign, subnets::SUBNETWORK_ID_NATIVE, tx::SignableTransaction};
+    use kaspa_notify::scope::VirtualDaaScoreChangedScope;
+    use kaspa_txscript::pay_to_address_script;
+    use rand::thread_rng;
+    use std::time::Duration;
+
+    kaspa_core::log::try_init_logger("info");
+    kaspa_core::panic::configure_panic();
+
+    let args = Args {
+        simnet: true,
+        disable_upnp: true,
+        enable_unsynced_mining: true,
+        block_template_cache_lifetime: Some(0),
+        utxoindex: true,
+        unsafe_rpc: true,
+        ..Default::default()
+    };
+
+    let fd_total_budget = fd_budget::limit();
+    let mut daemon = Daemon::new_random_with_args(args, fd_total_budget);
+    let client = daemon.start().await;
+
+    // Mining key and address
+    let (miner_sk, miner_pk) = secp256k1::generate_keypair(&mut thread_rng());
+    let miner_address =
+        Address::new(daemon.network.into(), kaspa_addresses::Version::PubKey, &miner_pk.x_only_public_key().0.serialize());
+    let miner_schnorr_key = secp256k1::Keypair::from_secret_key(secp256k1::SECP256K1, &miner_sk);
+
+    // User key and address
+    let (_, user_pk) = secp256k1::generate_keypair(&mut thread_rng());
+    let user_address =
+        Address::new(daemon.network.into(), kaspa_addresses::Version::PubKey, &user_pk.x_only_public_key().0.serialize());
+
+    // Set up notifications
+    let (sender, event_receiver) = async_channel::unbounded();
+    client.start(Some(Arc::new(ChannelNotify::new(sender)))).await;
+    client.start_notify(Default::default(), VirtualDaaScoreChangedScope {}.into()).await.unwrap();
+
+    // Mine initial blocks to reach coinbase maturity
+    let coinbase_maturity = kaspa_consensus::params::SIMNET_PARAMS.coinbase_maturity();
+    let extra_blocks = 10u64;
+    for _ in 0..coinbase_maturity + extra_blocks {
+        let template = client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        client.submit_block(template.block, false).await.unwrap();
+    }
+    // Wait for virtual DAA score to catch up
+    loop {
+        match tokio::time::timeout(Duration::from_millis(500), event_receiver.recv()).await {
+            Ok(Ok(Notification::VirtualDaaScoreChanged(msg))) if msg.virtual_daa_score >= coinbase_maturity + extra_blocks => break,
+            Ok(Ok(_)) => continue,
+            _ => break,
+        }
+    }
+
+    // Fetch spendable UTXOs
+    let utxos = fetch_spendable_utxos(&client, miner_address.clone(), coinbase_maturity).await;
+    assert!(!utxos.is_empty(), "should have spendable UTXOs after mining");
+
+    // =========================================================================
+    // B1: Happy path — submit valid local TX, verify template inclusion
+    // =========================================================================
+    info!("B1: submit_local_tx_rpc_happy_path");
+    {
+        let spk = pay_to_address_script(&user_address);
+        let utxo = &utxos[0];
+        let amount = utxo.1.amount - 1000; // small fee for mass, though local TX allows zero
+        let inputs = vec![kaspa_consensus_core::tx::TransactionInput {
+            previous_outpoint: utxo.0,
+            signature_script: vec![],
+            sequence: 0,
+            sig_op_count: 1,
+        }];
+        let outputs = vec![kaspa_consensus_core::tx::TransactionOutput { value: amount, script_public_key: spk }];
+        let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+        let signed_tx = sign(SignableTransaction::with_entries(unsigned_tx, vec![utxo.1.clone()]), miner_schnorr_key);
+        let tx_id = signed_tx.id();
+
+        // Submit as local transaction
+        let result = client.submit_local_transaction((&signed_tx.tx).into()).await;
+        assert!(result.is_ok(), "B1: valid local transaction should be accepted: {:?}", result.err());
+        assert_eq!(result.unwrap(), tx_id, "B1: returned transaction ID should match");
+
+        // Verify it appears in the block template
+        let template = client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        let template_tx_ids: Vec<_> =
+            template.block.transactions.iter().filter_map(|t| Transaction::try_from(t.clone()).ok()).map(|t| t.id()).collect();
+        assert!(
+            template_tx_ids.contains(&tx_id),
+            "B1: local TX {} should be in block template. Template TXs: {:?}",
+            tx_id,
+            template_tx_ids
+        );
+
+        // Mine the block and verify acceptance
+        client.submit_block(template.block, false).await.unwrap();
+    }
+
+    // =========================================================================
+    // B2: Reject invalid transaction via RPC
+    // =========================================================================
+    info!("B2: submit_local_tx_rpc_reject_invalid");
+    {
+        // Empty transaction — should be rejected
+        let bad_tx = Transaction::new(0, vec![], vec![], 0, SubnetworkId::default(), 0, vec![]);
+        let result = client.submit_local_transaction((&bad_tx).into()).await;
+        assert!(result.is_err(), "B2: invalid transaction should be rejected");
+    }
+
+    // =========================================================================
+    // B3: Zero-fee TX gets included in a block
+    // =========================================================================
+    info!("B3: submit_local_tx_zero_fee_in_block");
+    {
+        // Refresh UTXOs after B1 mined a block
+        let utxos = fetch_spendable_utxos(&client, miner_address.clone(), coinbase_maturity).await;
+        assert!(!utxos.is_empty(), "B3: should have spendable UTXOs");
+
+        let spk = pay_to_address_script(&user_address);
+        let utxo = &utxos[0];
+        let amount = utxo.1.amount; // zero fee — use full amount
+        let inputs = vec![kaspa_consensus_core::tx::TransactionInput {
+            previous_outpoint: utxo.0,
+            signature_script: vec![],
+            sequence: 0,
+            sig_op_count: 1,
+        }];
+        let outputs = vec![kaspa_consensus_core::tx::TransactionOutput { value: amount, script_public_key: spk }];
+        let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+        let signed_tx = sign(SignableTransaction::with_entries(unsigned_tx, vec![utxo.1.clone()]), miner_schnorr_key);
+        let tx_id = signed_tx.id();
+
+        let result = client.submit_local_transaction((&signed_tx.tx).into()).await;
+        assert!(result.is_ok(), "B3: zero-fee local transaction should be accepted: {:?}", result.err());
+
+        // Get template and mine
+        let template = client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        let template_tx_ids: Vec<_> =
+            template.block.transactions.iter().filter_map(|t| Transaction::try_from(t.clone()).ok()).map(|t| t.id()).collect();
+        assert!(template_tx_ids.contains(&tx_id), "B3: zero-fee local TX should be in template");
+
+        client.submit_block(template.block, false).await.unwrap();
+    }
+
+    // =========================================================================
+    // B4: Local TX does not appear in mempool entries
+    // =========================================================================
+    info!("B4: submit_local_tx_not_in_mempool");
+    {
+        let utxos = fetch_spendable_utxos(&client, miner_address.clone(), coinbase_maturity).await;
+        assert!(!utxos.is_empty(), "B4: should have spendable UTXOs");
+
+        let spk = pay_to_address_script(&user_address);
+        let utxo = &utxos[0];
+        let amount = utxo.1.amount;
+        let inputs = vec![kaspa_consensus_core::tx::TransactionInput {
+            previous_outpoint: utxo.0,
+            signature_script: vec![],
+            sequence: 0,
+            sig_op_count: 1,
+        }];
+        let outputs = vec![kaspa_consensus_core::tx::TransactionOutput { value: amount, script_public_key: spk }];
+        let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+        let signed_tx = sign(SignableTransaction::with_entries(unsigned_tx, vec![utxo.1.clone()]), miner_schnorr_key);
+        let tx_id = signed_tx.id();
+
+        client.submit_local_transaction((&signed_tx.tx).into()).await.unwrap();
+
+        // Check that TX is NOT in mempool
+        let mempool_result = client.get_mempool_entry(tx_id, false, false).await;
+        assert!(mempool_result.is_err(), "B4: local TX should NOT appear in mempool entries");
+
+        // But it should be in the block template
+        let template = client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        let template_tx_ids: Vec<_> =
+            template.block.transactions.iter().filter_map(|t| Transaction::try_from(t.clone()).ok()).map(|t| t.id()).collect();
+        assert!(template_tx_ids.contains(&tx_id), "B4: local TX should be in template despite not being in mempool");
+
+        // Mine to clean up
+        client.submit_block(template.block, false).await.unwrap();
+    }
+
+    // NOTE: B5 (2-node broadcast test) removed — CI environment fd_budget limit
+    // prevents running 2 daemons concurrently. The no-broadcast behavior is verified
+    // by code inspection: submit_local_transaction in flow_context.rs does not call
+    // broadcast_transactions. Can be tested manually with 2 nodes.
+
+    // =========================================================================
+    // Cleanup
+    // =========================================================================
+    let _ = client.shutdown_call(None, ShutdownRequest {}).await;
     client.disconnect().await.unwrap();
     drop(client);
     daemon.shutdown();

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -207,6 +207,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn submit_local_transaction_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: SubmitLocalTransactionRequest,
+    ) -> RpcResult<SubmitLocalTransactionResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     async fn add_peer_call(&self, _connection: Option<&DynRpcConnection>, _request: AddPeerRequest) -> RpcResult<AddPeerResponse> {
         Err(RpcError::NotImplemented)
     }


### PR DESCRIPTION
## Summary

Implements [#514](https://github.com/kaspanet/rusty-kaspa/issues/514) — a new RPC method `SubmitLocalTransaction` that lets node operators include their own transactions in blocks they mine, bypassing the relay fee while preserving all other standard checks.

- **Local TX store** in `MiningManager` — separate `HashMap`, not in mempool
- **`LocalFirstSelector`** wraps frontier selector, yields local TXs first in block templates
- **Full validation** — consensus (sigs, UTXO, locktime) + standard checks (dust, mass, script class). Only relay fee is skipped via `check_fee: bool` parameter on existing `check_transaction_standard_in_context`
- **Not broadcast** — local TXs are never sent to peers
- **Auto-cleanup** — removed from store when included in a mined block

## Changes (24 files, +883 -16)

| Area | Files | What |
|------|-------|------|
| Mining | `selector.rs`, `manager.rs`, `check_transaction_standard.rs`, `validate_and_insert_transaction.rs` | `LocalFirstSelector`, local store, `check_fee` param |
| RPC Core | `ops.rs`, `rpc.rs`, `message.rs`, `wasm/message.rs` | Op enum, trait, request/response types, TS bindings |
| RPC Service | `service.rs` | Handler implementation |
| Protocol | `flow_context.rs` | `submit_local_transaction()` (no broadcast) |
| gRPC | `proto/*.proto`, `convert/`, `ops.rs`, `factory.rs`, `client/lib.rs` | Full gRPC plumbing |
| wRPC | `client.rs`, `router.rs`, `wasm/client.rs` | wRPC + WASM bindings |
| Tests | `manager_tests.rs` (12 unit), `rpc_tests.rs` (4 E2E) | Acceptance, rejection, template, zero-fee, mempool isolation |
| Mocks | `rpc_core_mock.rs` ×2 | Mock implementations |

## Security

- **Relay fee is the only check skipped.** Dust threshold, mass limits, script standardness, and all consensus validation rules are enforced.
- **Access control**: Same model as existing RPC — infrastructure-level protection (firewall/VPN). A `TODO` comment notes potential future CLI flag gating.
- **No new attack surface beyond free TX inclusion**: An unauthorized caller can include transactions without paying fees, but all other protections (dust, mass, signatures) remain.