### PR TITLE
docs: add README for rothschild tx generator (#672)

### DIFF
--- a/rothschild/README.md
+++ b/rothschild/README.md
@@ -1,0 +1,19 @@
+# Rothschild - Transaction Generator
+
+Rothschild is a **transaction load generator** for the Kaspa network. It is used for stress-testing and benchmarking by generating high volumes of transactions against a running node.
+
+## Purpose
+
+- Stress-test node performance under heavy transaction load
+- Benchmark transaction throughput and block template generation
+- Simulate realistic network activity on testnets
+
+## Usage
+
+```bash
+cargo run --release --bin rothschild -- --help
+```
+
+Rothschild connects to a Kaspa node via gRPC and continuously generates transactions using a funded private key.
+
+> **Note:** This tool is intended for testing and development purposes only. It is not required for normal node operation.


### PR DESCRIPTION
## Summary
- Adds a README to the `rothschild/` crate explaining its purpose as a transaction load generator for testing
- Clarifies it is not required for normal node operation

Users encountering the `rothschild` binary in release bundles have been confused about its purpose (see #672). This README provides context.

Partially addresses #672.

## Test plan
- Documentation only, no code changes