### PR TITLE
feat(rpc): add GetBlocksV2 with verbosity-aware UTXO enrichment (#615, #686)

### DIFF
--- a/rpc/core/src/api/ops.rs
+++ b/rpc/core/src/api/ops.rs
@@ -140,6 +140,8 @@ pub enum RpcApiOps {
     GetUtxoReturnAddress = 150,
     /// Get Virtual Chain from Block V2
     GetVirtualChainFromBlockV2 = 151,
+    /// Get Blocks V2 with verbosity-aware responses
+    GetBlocksV2 = 152,
 }
 
 impl RpcApiOps {

--- a/rpc/core/src/api/rpc.rs
+++ b/rpc/core/src/api/rpc.rs
@@ -500,6 +500,21 @@ pub trait RpcApi: Sync + Send + AnySync {
         request: GetVirtualChainFromBlockV2Request,
     ) -> RpcResult<GetVirtualChainFromBlockV2Response>;
 
+    /// Requests blocks between a certain block `low_hash` up to this node's current virtual (V2 with verbosity).
+    async fn get_blocks_v2(
+        &self,
+        low_hash: Option<RpcHash>,
+        include_blocks: bool,
+        data_verbosity_level: Option<RpcDataVerbosityLevel>,
+    ) -> RpcResult<GetBlocksV2Response> {
+        self.get_blocks_v2_call(None, GetBlocksV2Request::new(low_hash, include_blocks, data_verbosity_level)).await
+    }
+    async fn get_blocks_v2_call(
+        &self,
+        connection: Option<&DynRpcConnection>,
+        request: GetBlocksV2Request,
+    ) -> RpcResult<GetBlocksV2Response>;
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -2804,6 +2804,73 @@ impl Deserializer for GetVirtualChainFromBlockV2Response {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlocksV2Request {
+    pub low_hash: Option<RpcHash>,
+    pub include_blocks: bool,
+    pub data_verbosity_level: Option<RpcDataVerbosityLevel>,
+}
+
+impl GetBlocksV2Request {
+    pub fn new(low_hash: Option<RpcHash>, include_blocks: bool, data_verbosity_level: Option<RpcDataVerbosityLevel>) -> Self {
+        Self { low_hash, include_blocks, data_verbosity_level }
+    }
+}
+
+impl Serializer for GetBlocksV2Request {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(Option<RpcHash>, &self.low_hash, writer)?;
+        store!(bool, &self.include_blocks, writer)?;
+        serialize!(Option<RpcDataVerbosityLevel>, &self.data_verbosity_level, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetBlocksV2Request {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let low_hash = load!(Option<RpcHash>, reader)?;
+        let include_blocks = load!(bool, reader)?;
+        let data_verbosity_level = deserialize!(Option<RpcDataVerbosityLevel>, reader)?;
+        Ok(Self { low_hash, include_blocks, data_verbosity_level })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlocksV2Response {
+    pub block_hashes: Vec<RpcHash>,
+    pub blocks: Vec<RpcOptionalBlock>,
+}
+
+impl GetBlocksV2Response {
+    pub fn new(block_hashes: Vec<RpcHash>, blocks: Vec<RpcOptionalBlock>) -> Self {
+        Self { block_hashes, blocks }
+    }
+}
+
+impl Serializer for GetBlocksV2Response {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(Vec<RpcHash>, &self.block_hashes, writer)?;
+        serialize!(Vec<RpcOptionalBlock>, &self.blocks, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetBlocksV2Response {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let block_hashes = load!(Vec<RpcHash>, reader)?;
+        let blocks = deserialize!(Vec<RpcOptionalBlock>, reader)?;
+        Ok(Self { block_hashes, blocks })
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Subscriptions & notifications
 // ----------------------------------------------------------------------------

--- a/rpc/core/src/model/optional/block.rs
+++ b/rpc/core/src/model/optional/block.rs
@@ -25,7 +25,7 @@ impl Serializer for RpcOptionalBlock {
 impl Deserializer for RpcOptionalBlock {
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u16, reader)?;
-        let header = Some(deserialize!(RpcOptionalHeader, reader)?);
+        let header = deserialize!(Option<RpcOptionalHeader>, reader)?;
         let transactions = deserialize!(Vec<RpcOptionalTransaction>, reader)?;
         let verbose_data = deserialize!(Option<RpcBlockVerboseData>, reader)?;
         Ok(Self { header, transactions, verbose_data })

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -199,6 +199,12 @@ mod mockery {
         }
     }
 
+    impl Mock for RpcOptionalBlock {
+        fn mock() -> Self {
+            RpcOptionalBlock { header: mock(), transactions: mock(), verbose_data: mock() }
+        }
+    }
+
     impl Mock for RpcRawBlock {
         fn mock() -> Self {
             RpcRawBlock { header: mock(), transactions: mock() }
@@ -1294,6 +1300,22 @@ mod mockery {
     }
 
     test!(GetVirtualChainFromBlockV2Response);
+
+    impl Mock for GetBlocksV2Request {
+        fn mock() -> Self {
+            GetBlocksV2Request { low_hash: mock(), include_blocks: mock(), data_verbosity_level: None }
+        }
+    }
+
+    test!(GetBlocksV2Request);
+
+    impl Mock for GetBlocksV2Response {
+        fn mock() -> Self {
+            GetBlocksV2Response { block_hashes: mock(), blocks: mock() }
+        }
+    }
+
+    test!(GetBlocksV2Response);
 
     impl Mock for NotifyBlockAddedRequest {
         fn mock() -> Self {

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -833,6 +833,43 @@ try_from! ( args: GetBlocksResponse, IGetBlocksResponse, {
 // ---
 
 declare! {
+    IGetBlocksV2Request,
+    r#"
+    /**
+     * @category Node RPC
+     */
+    export interface IGetBlocksV2Request {
+        lowHash? : HexString;
+        includeBlocks : boolean;
+        dataVerbosityLevel? : DataVerbosityLevel;
+    }
+    "#,
+}
+
+try_from! ( args: IGetBlocksV2Request, GetBlocksV2Request, {
+    Ok(from_value(args.into())?)
+});
+
+declare! {
+    IGetBlocksV2Response,
+    r#"
+    /**
+     * @category Node RPC
+     */
+    export interface IGetBlocksV2Response {
+        blockHashes : HexString[];
+        blocks : IOptionalBlock[];
+    }
+    "#,
+}
+
+try_from! ( args: GetBlocksV2Response, IGetBlocksV2Response, {
+    Ok(to_value(&args)?.into())
+});
+
+// ---
+
+declare! {
     IGetBlockTemplateRequest,
     r#"
     /**

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -278,6 +278,7 @@ impl RpcApi for GrpcClient {
     route!(get_current_block_color_call, GetCurrentBlockColor);
     route!(get_utxo_return_address_call, GetUtxoReturnAddress);
     route!(get_virtual_chain_from_block_v2_call, GetVirtualChainFromBlockV2);
+    route!(get_blocks_v2_call, GetBlocksV2);
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API

--- a/rpc/grpc/core/proto/messages.proto
+++ b/rpc/grpc/core/proto/messages.proto
@@ -67,6 +67,7 @@ message KaspadRequest {
     GetCurrentBlockColorRequestMessage getCurrentBlockColorRequest = 1110;
     GetUtxoReturnAddressRequestMessage getUtxoReturnAddressRequest = 1112;
     GetVirtualChainFromBlockV2RequestMessage getVirtualChainFromBlockV2Request = 1114;
+    GetBlocksV2RequestMessage getBlocksV2Request = 1116;
   }
 }
 
@@ -134,6 +135,7 @@ message KaspadResponse {
     GetCurrentBlockColorResponseMessage getCurrentBlockColorResponse = 1111;
     GetUtxoReturnAddressResponseMessage getUtxoReturnAddressResponse = 1113;
     GetVirtualChainFromBlockV2ResponseMessage getVirtualChainFromBlockV2Response = 1115;
+    GetBlocksV2ResponseMessage getBlocksV2Response = 1117;
   }
 }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -1084,6 +1084,24 @@ message GetVirtualChainFromBlockV2ResponseMessage {
   RPCError error = 1000;
 }
 
+message RpcOptionalBlock {
+  optional RpcOptionalHeader header = 1;
+  repeated RpcOptionalTransaction transactions = 2;
+  optional RpcBlockVerboseData verboseData = 3;
+}
+
+message GetBlocksV2RequestMessage {
+  string lowHash = 1;
+  bool includeBlocks = 2;
+  optional RpcDataVerbosityLevel dataVerbosityLevel = 3;
+}
+
+message GetBlocksV2ResponseMessage {
+  repeated string blockHashes = 1;
+  repeated RpcOptionalBlock blocks = 2;
+  RPCError error = 1000;
+}
+
 message GetCurrentBlockColorRequestMessage {
   string hash = 1;
 }

--- a/rpc/grpc/core/src/convert/kaspad.rs
+++ b/rpc/grpc/core/src/convert/kaspad.rs
@@ -65,6 +65,7 @@ pub mod kaspad_request_convert {
     impl_into_kaspad_request!(GetCurrentBlockColor);
     impl_into_kaspad_request!(GetUtxoReturnAddress);
     impl_into_kaspad_request!(GetVirtualChainFromBlockV2);
+    impl_into_kaspad_request!(GetBlocksV2);
 
     impl_into_kaspad_request!(NotifyBlockAdded);
     impl_into_kaspad_request!(NotifyNewBlockTemplate);
@@ -204,6 +205,7 @@ pub mod kaspad_response_convert {
     impl_into_kaspad_response!(GetCurrentBlockColor);
     impl_into_kaspad_response!(GetUtxoReturnAddress);
     impl_into_kaspad_response!(GetVirtualChainFromBlockV2);
+    impl_into_kaspad_response!(GetBlocksV2);
 
     impl_into_kaspad_notify_response!(NotifyBlockAdded);
     impl_into_kaspad_notify_response!(NotifyNewBlockTemplate);

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -533,6 +533,21 @@ from!(item: RpcResult<&kaspa_rpc_core::GetVirtualChainFromBlockV2Response>, prot
     }
 });
 
+from!(item: &kaspa_rpc_core::GetBlocksV2Request, protowire::GetBlocksV2RequestMessage, {
+    Self {
+        low_hash: item.low_hash.map_or(Default::default(), |x| x.to_string()),
+        include_blocks: item.include_blocks,
+        data_verbosity_level: item.data_verbosity_level.map(|v| v as i32),
+    }
+});
+from!(item: RpcResult<&kaspa_rpc_core::GetBlocksV2Response>, protowire::GetBlocksV2ResponseMessage, {
+    Self {
+        block_hashes: item.block_hashes.iter().map(|x| x.to_string()).collect(),
+        blocks: item.blocks.iter().map(protowire::RpcOptionalBlock::from).collect(),
+        error: None,
+    }
+});
+
 from!(item: &kaspa_rpc_core::NotifyUtxosChangedRequest, protowire::NotifyUtxosChangedRequestMessage, {
     Self { addresses: item.addresses.iter().map(|x| x.into()).collect(), command: item.command.into() }
 });
@@ -798,6 +813,20 @@ try_from!(item: &protowire::GetVirtualChainFromBlockV2ResponseMessage, RpcResult
         removed_chain_block_hashes: Arc::new(item.removed_chain_block_hashes.iter().map(|x| RpcHash::from_str(x)).collect::<Result<Vec<_>, _>>()?),
         added_chain_block_hashes: Arc::new(item.added_chain_block_hashes.iter().map(|x| RpcHash::from_str(x)).collect::<Result<Vec<_>, _>>()?),
         chain_block_accepted_transactions: Arc::new(item.chain_block_accepted_transactions.iter().map(|x| x.try_into()).collect::<Result<Vec<_>, _>>()?),
+    }
+});
+
+try_from!(item: &protowire::GetBlocksV2RequestMessage, kaspa_rpc_core::GetBlocksV2Request, {
+    Self {
+        low_hash: if item.low_hash.is_empty() { None } else { Some(RpcHash::from_str(&item.low_hash)?) },
+        include_blocks: item.include_blocks,
+        data_verbosity_level: item.data_verbosity_level.map(RpcDataVerbosityLevel::try_from).transpose()?,
+    }
+});
+try_from!(item: &protowire::GetBlocksV2ResponseMessage, RpcResult<kaspa_rpc_core::GetBlocksV2Response>, {
+    Self {
+        block_hashes: item.block_hashes.iter().map(|x| RpcHash::from_str(x)).collect::<Result<Vec<_>, _>>()?,
+        blocks: item.blocks.iter().map(kaspa_rpc_core::RpcOptionalBlock::try_from).collect::<Result<Vec<_>, _>>()?,
     }
 });
 

--- a/rpc/grpc/core/src/convert/optional/block.rs
+++ b/rpc/grpc/core/src/convert/optional/block.rs
@@ -1,0 +1,30 @@
+use crate::protowire;
+use crate::{from, try_from};
+use kaspa_rpc_core::{RpcError, RpcResult};
+
+// ----------------------------------------------------------------------------
+// rpc_core to protowire
+// ----------------------------------------------------------------------------
+
+from!(item: &kaspa_rpc_core::RpcOptionalBlock, protowire::RpcOptionalBlock, {
+    Self {
+        header: item.header.as_ref().map(|h| h.into()),
+        transactions: item.transactions.iter().map(protowire::RpcOptionalTransaction::from).collect(),
+        verbose_data: item.verbose_data.as_ref().map(|x| x.into()),
+    }
+});
+
+// ----------------------------------------------------------------------------
+// protowire to rpc_core
+// ----------------------------------------------------------------------------
+
+try_from!(item: &protowire::RpcOptionalBlock, kaspa_rpc_core::RpcOptionalBlock, {
+    Self {
+        header: item.header.as_ref().map(|h| h.try_into()).transpose()?,
+        transactions: item.transactions.iter()
+            .map(kaspa_rpc_core::RpcOptionalTransaction::try_from)
+            .collect::<RpcResult<Vec<_>>>()?,
+        verbose_data: item.verbose_data.as_ref()
+            .map(kaspa_rpc_core::RpcBlockVerboseData::try_from).transpose()?,
+    }
+});

--- a/rpc/grpc/core/src/convert/optional/mod.rs
+++ b/rpc/grpc/core/src/convert/optional/mod.rs
@@ -1,2 +1,3 @@
+pub mod block;
 pub mod header;
 pub mod tx;

--- a/rpc/grpc/core/src/ops.rs
+++ b/rpc/grpc/core/src/ops.rs
@@ -89,6 +89,7 @@ pub enum KaspadPayloadOps {
     GetCurrentBlockColor,
     GetUtxoReturnAddress,
     GetVirtualChainFromBlockV2,
+    GetBlocksV2,
 
     // Subscription commands for starting/stopping notifications
     NotifyBlockAdded,

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -83,6 +83,7 @@ impl Factory {
                 GetCurrentBlockColor,
                 GetUtxoReturnAddress,
                 GetVirtualChainFromBlockV2,
+                GetBlocksV2,
                 NotifyBlockAdded,
                 NotifyNewBlockTemplate,
                 NotifyFinalityConflict,

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -378,6 +378,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_blocks_v2_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetBlocksV2Request,
+    ) -> RpcResult<GetBlocksV2Response> {
+        Err(RpcError::NotImplemented)
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -21,7 +21,7 @@ use kaspa_notify::converter::Converter;
 use kaspa_rpc_core::{
     BlockAddedNotification, Notification, RpcAcceptanceDataVerbosity, RpcAcceptedTransactionIds, RpcBlock, RpcBlockVerboseData,
     RpcChainBlockAcceptedTransactions, RpcError, RpcHash, RpcHeaderVerbosity, RpcMempoolEntry, RpcMempoolEntryByAddress,
-    RpcMergesetBlockAcceptanceDataVerbosity, RpcOptionalHeader, RpcOptionalTransaction, RpcOptionalTransactionInput,
+    RpcMergesetBlockAcceptanceDataVerbosity, RpcOptionalBlock, RpcOptionalHeader, RpcOptionalTransaction, RpcOptionalTransactionInput,
     RpcOptionalTransactionInputVerboseData, RpcOptionalTransactionOutput, RpcOptionalTransactionOutputVerboseData,
     RpcOptionalTransactionVerboseData, RpcOptionalUtxoEntry, RpcOptionalUtxoEntryVerboseData, RpcResult, RpcTransaction,
     RpcTransactionInput, RpcTransactionInputVerboseDataVerbosity, RpcTransactionInputVerbosity, RpcTransactionOutput,
@@ -491,6 +491,76 @@ impl ConsensusConverter {
                 Default::default()
             },
         })
+    }
+
+    /// Converts a consensus [`Block`] into an [`RpcOptionalBlock`] with verbosity control.
+    ///
+    /// When `signable_transactions` is provided (for chain blocks at High+ verbosity),
+    /// uses them to populate UTXO entries in input verbose data.
+    pub async fn get_block_with_verbosity(
+        &self,
+        consensus: &ConsensusProxy,
+        block: &Block,
+        header_verbosity: Option<&RpcHeaderVerbosity>,
+        tx_verbosity: Option<&RpcTransactionVerbosity>,
+        signable_transactions: Option<&[SignableTransaction]>,
+    ) -> RpcResult<RpcOptionalBlock> {
+        let hash = block.hash();
+        let ghostdag_data = consensus.async_get_ghostdag_data(hash).await.ok();
+        let block_status = consensus.async_get_block_status(hash).await;
+        let children = consensus.async_get_block_children(hash).await.unwrap_or_default();
+        let is_chain_block = consensus.async_is_chain_block(hash).await.unwrap_or(false);
+
+        let verbose_data = ghostdag_data.as_ref().map(|gd| RpcBlockVerboseData {
+            hash,
+            difficulty: self.get_difficulty_ratio(block.header.bits),
+            selected_parent_hash: gd.selected_parent,
+            transaction_ids: block.transactions.iter().map(|x| x.id()).collect(),
+            is_header_only: block_status.map_or(true, |s| s.is_header_only()),
+            blue_score: gd.blue_score,
+            children_hashes: children,
+            merge_set_blues_hashes: gd.mergeset_blues.clone(),
+            merge_set_reds_hashes: gd.mergeset_reds.clone(),
+            is_chain_block,
+        });
+
+        let header = if let Some(hv) = header_verbosity {
+            let h = self.adapt_header_to_header_with_verbosity(hv, &block.header)?;
+            if h.is_empty() { None } else { Some(h) }
+        } else {
+            None
+        };
+
+        let transactions = if let Some(tv) = tx_verbosity {
+            if let Some(signable_txs) = signable_transactions {
+                // Chain block with UTXO enrichment
+                let mut txs = Vec::with_capacity(signable_txs.len());
+                for stx in signable_txs {
+                    let rpc_tx = self
+                        .convert_signable_transaction_with_verbosity(consensus, stx, Some(hash), block.header.timestamp, tv)
+                        .await?;
+                    if !rpc_tx.is_empty() {
+                        txs.push(rpc_tx);
+                    }
+                }
+                txs
+            } else {
+                // No UTXO enrichment (anticone blocks or Low verbosity)
+                let mut txs = Vec::with_capacity(block.transactions.len());
+                for tx in block.transactions.iter() {
+                    let rpc_tx =
+                        self.convert_transaction_with_verbosity(consensus, tx, Some(hash), block.header.timestamp, tv).await?;
+                    if !rpc_tx.is_empty() {
+                        txs.push(rpc_tx);
+                    }
+                }
+                txs
+            }
+        } else {
+            vec![]
+        };
+
+        Ok(RpcOptionalBlock { header, transactions, verbose_data })
     }
 
     pub async fn get_accepted_transactions_with_verbosity(

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -1293,6 +1293,108 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         })
     }
 
+    async fn get_blocks_v2_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        request: GetBlocksV2Request,
+    ) -> RpcResult<GetBlocksV2Response> {
+        let session = self.consensus_manager.consensus().session().await;
+
+        // Default to Full verbosity if not specified
+        let data_verbosity_level = request.data_verbosity_level.or(Some(RpcDataVerbosityLevel::Full));
+        let header_verbosity = data_verbosity_level.map(RpcHeaderVerbosity::from);
+        let tx_verbosity = data_verbosity_level.map(RpcTransactionVerbosity::from);
+
+        // If low_hash is empty - use genesis instead.
+        let low_hash = match request.low_hash {
+            Some(low_hash) => {
+                // Make sure low_hash points to an existing and valid block
+                session.async_get_ghostdag_data(low_hash).await?;
+                low_hash
+            }
+            None => self.config.genesis.hash,
+        };
+
+        // Get hashes between low_hash and sink
+        let sink_hash = session.async_get_sink().await;
+
+        // We use +1 because low_hash is also returned
+        // max_blocks MUST be >= mergeset_size_limit + 1
+        let max_blocks = self.config.mergeset_size_limit() as usize + 1;
+        let (block_hashes, high_hash) = session.async_get_hashes_between(low_hash, sink_hash, max_blocks).await?;
+
+        // If the high hash is equal to sink it means get_hashes_between didn't skip any hashes, and
+        // there's space to add the sink anticone, otherwise we cannot add the anticone because
+        // there's no guarantee that all of the anticone root ancestors will be present.
+        let filtered_sink_anticone = if high_hash == sink_hash {
+            let sink_anticone = session.async_get_anticone(sink_hash).await?;
+            let mut seen_hashes: std::collections::HashSet<_> = once(low_hash).chain(block_hashes.iter().copied()).collect();
+            sink_anticone.into_iter().filter(|hash| seen_hashes.insert(*hash)).collect()
+        } else {
+            vec![]
+        };
+
+        // Prepend low hash to make it inclusive and append the filtered sink anticone
+        let block_hashes = once(low_hash).chain(block_hashes).chain(filtered_sink_anticone).collect::<Vec<_>>();
+        let blocks = if request.include_blocks {
+            let needs_utxo = tx_verbosity.as_ref().is_some_and(|v| v.requires_populated_transaction());
+            let mut blocks = Vec::with_capacity(block_hashes.len());
+            for hash in block_hashes.iter().copied() {
+                let block = session.async_get_block_even_if_header_only(hash).await?;
+                let is_chain_block = session.async_is_chain_block(hash).await.unwrap_or(false);
+
+                // For chain blocks at High+ verbosity, fetch signable transactions with UTXO entries
+                let signable_txs = if needs_utxo && is_chain_block {
+                    match session.async_get_blocks_acceptance_data(vec![hash], None).await {
+                        Ok(acceptance_data_vec) => {
+                            let mut all_txs = Vec::new();
+                            for acceptance_data in acceptance_data_vec.iter() {
+                                for merged_block_data in acceptance_data.iter() {
+                                    if merged_block_data.block_hash == hash {
+                                        match session
+                                            .async_get_transactions_by_block_acceptance_data(
+                                                hash,
+                                                merged_block_data.clone(),
+                                                None,
+                                                TransactionType::SignableTransaction,
+                                            )
+                                            .await
+                                        {
+                                            Ok(TransactionQueryResult::SignableTransaction(txs)) => {
+                                                all_txs.extend(txs.iter().cloned());
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                            if all_txs.is_empty() { None } else { Some(all_txs) }
+                        }
+                        Err(_) => None,
+                    }
+                } else {
+                    None
+                };
+
+                let rpc_block = self
+                    .consensus_converter
+                    .get_block_with_verbosity(
+                        &session,
+                        &block,
+                        header_verbosity.as_ref(),
+                        tx_verbosity.as_ref(),
+                        signable_txs.as_deref(),
+                    )
+                    .await?;
+                blocks.push(rpc_block);
+            }
+            blocks
+        } else {
+            Vec::new()
+        };
+        Ok(GetBlocksV2Response { block_hashes, blocks })
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -631,6 +631,7 @@ impl RpcApi for KaspaRpcClient {
             GetBlockCount,
             GetBlockDagInfo,
             GetBlocks,
+            GetBlocksV2,
             GetBlockTemplate,
             GetCurrentBlockColor,
             GetCoinSupply,

--- a/rpc/wrpc/server/src/router.rs
+++ b/rpc/wrpc/server/src/router.rs
@@ -43,6 +43,7 @@ impl Router {
                 GetBlockCount,
                 GetBlockDagInfo,
                 GetBlocks,
+                GetBlocksV2,
                 GetBlockTemplate,
                 GetCurrentBlockColor,
                 GetCoinSupply,

--- a/rpc/wrpc/wasm/src/client.rs
+++ b/rpc/wrpc/wasm/src/client.rs
@@ -1006,6 +1006,9 @@ build_wrpc_wasm_bindgen_interface!(
         /// Retrieves multiple blocks from the Kaspa BlockDAG.
         /// Returned information: List of block information.
         GetBlocks,
+        /// Retrieves multiple blocks from the Kaspa BlockDAG with verbosity control.
+        /// Returned information: List of block information with optional UTXO enrichment.
+        GetBlocksV2,
         /// Generates a new block template for mining.
         /// Returned information: Block template information.
         GetBlockTemplate,

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -689,6 +689,20 @@ async fn sanity_test() {
                 })
             }
 
+            KaspadPayloadOps::GetBlocksV2 => {
+                let rpc_client = client.clone();
+                tst!(op, {
+                    let response = rpc_client
+                        .get_blocks_v2_call(
+                            None,
+                            GetBlocksV2Request { low_hash: None, include_blocks: true, data_verbosity_level: None },
+                        )
+                        .await
+                        .unwrap();
+                    assert!(!response.block_hashes.is_empty());
+                })
+            }
+
             KaspadPayloadOps::GetVirtualChainFromBlockV2 => {
                 let rpc_client = client.clone();
                 tst!(op, {

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -395,6 +395,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_blocks_v2_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetBlocksV2Request,
+    ) -> RpcResult<GetBlocksV2Response> {
+        Err(RpcError::NotImplemented)
+    }
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Notification API
 


### PR DESCRIPTION
## Summary

Closes #615 (GetBlocks portion), closes #686

Add `GetBlocksV2` RPC method that returns blocks with verbosity-controlled transaction data including resolved input UTXO entries (amount, scriptPublicKey). This eliminates the need for indexers/explorers to maintain their own UTXO database to resolve input addresses and compute fees.

- At `High`+ verbosity, chain block transactions include populated `UtxoEntry` for each input via acceptance data
- Anticone blocks return transactions without UTXO enrichment (`None`) — they are transient and will be resolved in subsequent calls
- Pruned data gracefully degrades to `None` (no error)
- Uses `RpcOptional*` types for forward-compatible deserialization with Covenant++ HF fields
- Follows the exact registration pattern of `GetVirtualChainFromBlockV2` (PR #740)

## Changes (23 files)

**Core RPC** — `GetBlocksV2 = 152` op, trait methods, Request/Response with Borsh serialization
**Proto** — `RpcOptionalBlock`, `GetBlocksV2RequestMessage`/`ResponseMessage`, oneof 1116/1117
**gRPC** — conversions, client route, server handler, `RpcOptionalBlock` ↔ proto converter (new file)
**wRPC** — client/server/WASM registration, TypeScript interfaces
**Service** — `get_blocks_v2_call` implementation with UTXO enrichment via acceptance data, `get_block_with_verbosity` converter method
**Tests** — mock stubs, `RpcOptionalBlock` Mock, serialization roundtrip, integration test
**Bugfix** — `RpcOptionalBlock` Borsh deserializer: `header` field was read as bare `RpcOptionalHeader` instead of `Option<RpcOptionalHeader>`, causing serialization roundtrip failure

## API

```
GetBlocksV2Request {
    low_hash: Option<Hash>,       // start block (default: genesis)
    include_blocks: bool,         // include block data
    data_verbosity_level: Option<DataVerbosityLevel>,  // None|Low|High|Full
}

GetBlocksV2Response {
    block_hashes: Vec<Hash>,
    blocks: Vec<RpcOptionalBlock>,  // verbosity-controlled fields
}
```

## Note

This PR may be best reviewed after the Covenant++ HF lands, as the `RpcOptional*` types and verbosity infrastructure will see further changes in that context.