### PR TITLE
fix(wallet): accumulate UTXOs on storage mass exceed instead of failing (#701)

### DIFF
--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -801,7 +801,13 @@ impl Generator {
 
         // calculate storage mass
         let MassDisposition { transaction_mass, storage_mass, transaction_fees, absorb_change_to_fees } =
-            self.calculate_mass(stage, data, final_transaction.value_with_priority_fee)?;
+            match self.calculate_mass(stage, data, final_transaction.value_with_priority_fee) {
+                Ok(disp) => disp,
+                // Storage mass exceeds the limit — continue accumulating more inputs
+                // to reduce storage mass via KIP-9 input arithmetic (issue #701)
+                Err(Error::StorageMassExceedsMaximumTransactionMass { .. }) => return Ok(None),
+                Err(e) => return Err(e),
+            };
 
         let total_stage_value_needed = if self.inner.final_transaction_priority_fee.sender_pays() {
             final_transaction.value_with_priority_fee + stage.aggregate_fees + transaction_fees

--- a/wallet/core/src/tx/generator/test.rs
+++ b/wallet/core/src/tx/generator/test.rs
@@ -823,3 +823,28 @@ fn test_generator_fan_out_1() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_generator_storage_mass_exceed_accumulates() -> Result<()> {
+    // Issue #701: Generator should accumulate more UTXOs when storage mass
+    // exceeds the limit, not fail immediately.
+    //
+    // With only the first UTXO (0.296 KAS), sending 0.2 KAS produces
+    // storage_mass ≈ 120,383 > 100,000 limit. Adding the second UTXO
+    // (4.0 KAS) reduces storage_mass to ≈ 43,130 via KIP-9 input arithmetic.
+    let generator = generator(
+        test_network_id(),
+        &[0.296],
+        &[4.0],
+        None,
+        Fees::sender(Kaspa(0.0)),
+        [(output_address, Kaspa(0.2))].as_slice(),
+    )?;
+    let pt = generator.generate_transaction()?.expect("transaction should succeed with accumulated UTXOs");
+    let tx = pt.transaction();
+    assert_eq!(tx.inputs.len(), 2, "should accumulate both UTXOs to reduce storage mass");
+    assert_eq!(tx.outputs.len(), 2, "destination + change");
+    assert!(pt.is_final(), "should be a final transaction");
+    assert!(generator.generate_transaction()?.is_none(), "no more transactions expected");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #701

When `calculate_mass()` returns `StorageMassExceedsMaximumTransactionMass`, the Generator now returns `Ok(None)` to continue the accumulation loop instead of propagating the error via `?`. Adding more inputs strictly reduces storage mass per KIP-9, so the loop converges.

Previously, a user with a small UTXO (e.g. 0.296 KAS) and a larger one (e.g. 4.0 KAS) would get a hard failure when sending 0.2 KAS — the first UTXO alone exceeded the storage mass limit, and the Generator never tried accumulating the second.

## Changes (2 files)

- `wallet/core/src/tx/generator/generator.rs` — catch `StorageMassExceedsMaximumTransactionMass` in `try_finish_standard_stage_processing`, return `Ok(None)` to continue accumulation
- `wallet/core/src/tx/generator/test.rs` — add `test_generator_storage_mass_exceed_accumulates`