### PR TITLE
fix(wallet): use actual P2PK script size instead of SCRIPT_VECTOR_SIZE (#733)

### DIFF
--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -7,7 +7,7 @@ use crate::result::Result;
 use kaspa_consensus_client as kcc;
 use kaspa_consensus_client::UtxoEntryReference;
 use kaspa_consensus_core::mass::calc_storage_mass as consensus_calc_storage_mass;
-use kaspa_consensus_core::tx::{SCRIPT_VECTOR_SIZE, Transaction, TransactionInput, TransactionOutput};
+use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput};
 use kaspa_consensus_core::{config::params::Params, constants::*, subnets::SUBNETWORK_ID_SIZE};
 use kaspa_hashes::HASH_SIZE;
 
@@ -207,8 +207,8 @@ pub const fn transaction_standard_output_serialized_byte_size() -> u64 {
     size += 8; // value (u64)
     size += 2; // output.ScriptPublicKey.Version (u16)
     size += 8; // length of script public key (u64)
-    //max script size as per SCRIPT_VECTOR_SIZE
-    size += SCRIPT_VECTOR_SIZE as u64;
+    // standard P2PK script: 1 (OP_DATA_32) + 32 (pubkey) + 1 (OP_CHECKSIG) = 34 bytes
+    size += 34;
     size
 }
 


### PR DESCRIPTION
## Summary
- `transaction_standard_output_serialized_byte_size()` was using `SCRIPT_VECTOR_SIZE` (35) instead of the actual standard P2PK script size (34 bytes: 1 OP_DATA_32 + 32 pubkey + 1 OP_CHECKSIG)
- `SCRIPT_VECTOR_SIZE` is the SmallVec stack allocation size, not the serialized script size
- This caused the function to return 53 instead of the correct 52

Closes #733