### PR TITLE
Change consensus-client CovenantBinding's inner type

### DIFF
--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -26,38 +26,72 @@ export interface ICovenantBinding {
 }
 "#;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, BorshSerialize, BorshDeserialize, CastFromJs)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CovenantBindingInner {
+    pub authorizing_input: u16,
+    pub covenant_id: Hash,
+}
+
+impl CovenantBindingInner {
+    pub fn new(authorizing_input: u16, covenant_id: Hash) -> Self {
+        Self { authorizing_input, covenant_id }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, CastFromJs)]
 #[serde(rename_all = "camelCase")]
 #[wasm_bindgen(inspectable)]
 pub struct CovenantBinding {
-    inner: CoreCovenantBinding,
+    inner: Arc<Mutex<CovenantBindingInner>>,
+}
+
+impl BorshSerialize for CovenantBinding {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let inner = self.inner.lock().unwrap();
+        BorshSerialize::serialize(&*inner, writer)
+    }
+}
+
+impl BorshDeserialize for CovenantBinding {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let inner = CovenantBindingInner::deserialize_reader(reader)?;
+        Ok(Self { inner: Arc::new(Mutex::new(inner)) })
+    }
+}
+
+impl CovenantBinding {
+    pub fn inner(&self) -> MutexGuard<'_, CovenantBindingInner> {
+        self.inner.lock().unwrap()
+    }
 }
 
 #[wasm_bindgen]
 impl CovenantBinding {
     #[wasm_bindgen(constructor)]
     pub fn new(authorizing_input: u16, covenant_id: Hash) -> Self {
-        Self { inner: CoreCovenantBinding::new(authorizing_input, covenant_id) }
+        let inner = Arc::new(Mutex::new(CovenantBindingInner::new(authorizing_input, covenant_id)));
+        Self { inner }
     }
 
     #[wasm_bindgen(setter, js_name = authorizingInput)]
     pub fn set_authorizing_input(&mut self, v: u16) {
-        self.inner.authorizing_input = v;
+        self.inner().authorizing_input = v;
     }
 
     #[wasm_bindgen(getter, js_name = authorizingInput)]
     pub fn get_authorizing_input(&self) -> u16 {
-        self.inner.authorizing_input
+        self.inner().authorizing_input
     }
 
     #[wasm_bindgen(setter, js_name = covenantId)]
     pub fn set_covenant_id(&mut self, v: Hash) {
-        self.inner.covenant_id = v;
+        self.inner().covenant_id = v;
     }
 
     #[wasm_bindgen(getter, js_name = covenantId)]
     pub fn get_covenant_id(&self) -> Hash {
-        self.inner.covenant_id
+        self.inner().covenant_id
     }
 
     #[wasm_bindgen(js_name = toJSON)]
@@ -70,14 +104,14 @@ impl CovenantBinding {
 }
 
 impl From<CoreCovenantBinding> for CovenantBinding {
-    fn from(value: CoreCovenantBinding) -> Self {
-        Self { inner: value }
+    fn from(covenant: CoreCovenantBinding) -> Self {
+        CovenantBinding::new(covenant.authorizing_input, covenant.covenant_id)
     }
 }
 
 impl From<CovenantBinding> for CoreCovenantBinding {
-    fn from(value: CovenantBinding) -> Self {
-        value.inner
+    fn from(covenant: CovenantBinding) -> Self {
+        CoreCovenantBinding::new(covenant.get_authorizing_input(), covenant.get_covenant_id())
     }
 }
 
@@ -92,7 +126,7 @@ impl TryCastFromJs for CovenantBinding {
             let Some(object) = Object::try_from(value.as_ref()) else { return Err(Self::Error::NotAnObject) };
             let authorizing_input = object.get_u16("authorizingInput")?;
             let covenant_id = object.get_value("covenantId")?.try_into_owned()?;
-            Ok(Self { inner: CoreCovenantBinding::new(authorizing_input, covenant_id) })
+            Ok(CovenantBinding::new(authorizing_input, covenant_id))
         })
     }
 }

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -224,7 +224,7 @@ impl GenesisCovenantGroup {
         self.inner.authorizing_input = value;
     }
 
-    #[wasm_bindgen(setter = outputs, js_name = otuputs)]
+    #[wasm_bindgen(setter = outputs, js_name = outputs)]
     pub fn js_set_outputs(&mut self, outputs: NumberArray) -> ClientResult<()> {
         let outputs: Vec<u32> = serde_wasm_bindgen::from_value(outputs.into())?;
         self.inner.outputs = outputs;
@@ -232,7 +232,7 @@ impl GenesisCovenantGroup {
     }
 
     #[wasm_bindgen(getter, js_name = outputs)]
-    pub fn js_outputs(&self) -> NumberArray {
+    pub fn js_get_outputs(&self) -> NumberArray {
         serde_wasm_bindgen::to_value(&self.inner.outputs)
             .expect("serializing genesis covenant outputs should not fail")
             .unchecked_into()
@@ -329,7 +329,7 @@ mod tests {
     fn test_genesis_covenant_group_outputs_setter() {
         let mut group = construct_genesis_covenant_group(0, &[0, 1]);
 
-        group.set_outputs(to_js_array(&[3, 4, 5]).unchecked_into()).expect("set_outputs should succeed");
+        group.js_set_outputs(to_js_array(&[3, 4, 5]).unchecked_into()).expect("set_outputs should succeed");
 
         assert_eq!(get_genesis_covenant_group_outputs(&group), vec![3, 4, 5]);
     }

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -143,8 +143,20 @@ pub struct GenesisCovenantGroup {
 }
 
 impl GenesisCovenantGroup {
+    pub fn new(authorizing_input: u16, outputs: Vec<u32>) -> Self {
+        Self { inner: CoreGenesisCovenantGroup::new(authorizing_input, outputs) }
+    }
+
     pub fn inner(&self) -> &CoreGenesisCovenantGroup {
         &self.inner
+    }
+
+    pub fn outputs(&self) -> Vec<u32> {
+        self.inner.outputs.clone()
+    }
+
+    pub fn set_outputs(&mut self, outputs: Vec<u32>) {
+        self.inner.outputs = outputs
     }
 }
 
@@ -178,15 +190,15 @@ impl GenesisCovenantGroup {
         self.inner.authorizing_input = value;
     }
 
-    #[wasm_bindgen(setter = outputs)]
-    pub fn set_outputs(&mut self, outputs: NumberArray) -> ClientResult<()> {
+    #[wasm_bindgen(setter = outputs, js_name = otuputs)]
+    pub fn js_set_outputs(&mut self, outputs: NumberArray) -> ClientResult<()> {
         let outputs: Vec<u32> = serde_wasm_bindgen::from_value(outputs.into())?;
         self.inner.outputs = outputs;
         Ok(())
     }
 
-    #[wasm_bindgen(getter)]
-    pub fn outputs(&self) -> NumberArray {
+    #[wasm_bindgen(getter, js_name = outputs)]
+    pub fn js_outputs(&self) -> NumberArray {
         serde_wasm_bindgen::to_value(&self.inner.outputs)
             .expect("serializing genesis covenant outputs should not fail")
             .unchecked_into()

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -115,7 +115,7 @@ impl TransactionOutput {
 
     #[wasm_bindgen(getter, js_name = covenant)]
     pub fn get_covenant(&self) -> Option<CovenantBinding> {
-        self.inner().covenant
+        self.inner().covenant.clone()
     }
 
     #[wasm_bindgen(setter, js_name = covenant)]
@@ -148,7 +148,7 @@ impl From<&TransactionOutput> for cctx::TransactionOutput {
         cctx::TransactionOutput::with_covenant(
             inner.value,
             inner.script_public_key.clone(),
-            inner.covenant.map(cctx::CovenantBinding::from),
+            inner.covenant.clone().map(cctx::CovenantBinding::from),
         )
     }
 }

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -257,7 +257,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        let covenant = inner.covenant.map(SerializableCovenantBinding::from);
+        let covenant = inner.covenant.clone().map(SerializableCovenantBinding::from);
         Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), covenant })
     }
 }

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -276,7 +276,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        let covenant = inner.covenant.map(SerializableCovenantBinding::from);
+        let covenant = inner.covenant.clone().map(SerializableCovenantBinding::from);
         Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), covenant })
     }
 }

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -250,7 +250,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        let covenant = inner.covenant.map(SerializableCovenantBinding::from);
+        let covenant = inner.covenant.clone().map(SerializableCovenantBinding::from);
         Ok(Self { value: inner.value.to_string(), script_public_key: inner.script_public_key.clone(), covenant })
     }
 }

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -270,7 +270,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        let covenant = inner.covenant.map(SerializableCovenantBinding::from);
+        let covenant = inner.covenant.clone().map(SerializableCovenantBinding::from);
         Ok(Self { value: inner.value.to_string(), script_public_key: inner.script_public_key.clone(), covenant })
     }
 }

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -85,7 +85,7 @@ cfg_if::cfg_if! {
         impl From<TransactionOutput> for RpcTransactionOutput {
             fn from(output: TransactionOutput) -> Self {
                 let inner = output.inner();
-                RpcTransactionOutput { value: inner.value, script_public_key: inner.script_public_key.clone(), verbose_data: None, covenant: inner.covenant.map(Into::into) }
+                RpcTransactionOutput { value: inner.value, script_public_key: inner.script_public_key.clone(), verbose_data: None, covenant: inner.covenant.clone().map(Into::into) }
             }
         }
 
@@ -133,7 +133,7 @@ cfg_if::cfg_if! {
         impl From<TransactionOutput> for RpcOptionalTransactionOutput {
             fn from(output: TransactionOutput) -> Self {
                 let inner = output.inner();
-                RpcOptionalTransactionOutput { value: Some(inner.value), script_public_key: Some(inner.script_public_key.clone()), verbose_data: None, covenant: Some(inner.covenant.map(Into::into).into())}
+                RpcOptionalTransactionOutput { value: Some(inner.value), script_public_key: Some(inner.script_public_key.clone()), verbose_data: None, covenant: Some(inner.covenant.clone().map(Into::into).into())}
             }
         }
 

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -86,7 +86,7 @@ cfg_if::cfg_if! {
         impl From<TransactionOutput> for RpcTransactionOutput {
             fn from(output: TransactionOutput) -> Self {
                 let inner = output.inner();
-                RpcTransactionOutput { value: inner.value, script_public_key: inner.script_public_key.clone(), verbose_data: None, covenant: inner.covenant.map(Into::into) }
+                RpcTransactionOutput { value: inner.value, script_public_key: inner.script_public_key.clone(), verbose_data: None, covenant: inner.covenant.clone().map(Into::into) }
             }
         }
 
@@ -135,7 +135,7 @@ cfg_if::cfg_if! {
         impl From<TransactionOutput> for RpcOptionalTransactionOutput {
             fn from(output: TransactionOutput) -> Self {
                 let inner = output.inner();
-                RpcOptionalTransactionOutput { value: Some(inner.value), script_public_key: Some(inner.script_public_key.clone()), verbose_data: None, covenant: Some(inner.covenant.map(Into::into).into())}
+                RpcOptionalTransactionOutput { value: Some(inner.value), script_public_key: Some(inner.script_public_key.clone()), verbose_data: None, covenant: Some(inner.covenant.clone().map(Into::into).into())}
             }
         }
 

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -401,7 +401,7 @@ impl Generator {
                             TransactionOutput::with_covenant(
                                 output.amount,
                                 pay_to_address_script(&output.address),
-                                output.covenant.map(Into::into),
+                                output.covenant.clone().map(Into::into),
                             )
                         })
                         .collect(),

--- a/wallet/core/src/tx/payment.rs
+++ b/wallet/core/src/tx/payment.rs
@@ -68,6 +68,7 @@ pub struct PaymentOutput {
     #[wasm_bindgen(getter_with_clone)]
     pub address: Address,
     pub amount: u64,
+    #[wasm_bindgen(getter_with_clone)]
     pub covenant: Option<ClientCovenantBinding>,
 }
 

--- a/wallet/pskt/src/convert.rs
+++ b/wallet/pskt/src/convert.rs
@@ -50,7 +50,7 @@ impl TryFrom<TransactionOutput> for Output {
         let output = OutputBuilder::default()
             .amount(*value)
             .script_public_key(script_public_key.clone())
-            .covenant(covenant.map(cctx::CovenantBinding::from))
+            .covenant(covenant.clone().map(cctx::CovenantBinding::from))
         // .redeem_script
         // .bip32_derivations
         // .proprietaries

--- a/wallet/pskt/src/convert.rs
+++ b/wallet/pskt/src/convert.rs
@@ -51,7 +51,7 @@ impl TryFrom<TransactionOutput> for Output {
         let output = OutputBuilder::default()
             .amount(*value)
             .script_public_key(script_public_key.clone())
-            .covenant(covenant.map(cctx::CovenantBinding::from))
+            .covenant(covenant.clone().map(cctx::CovenantBinding::from))
         // .redeem_script
         // .bip32_derivations
         // .proprietaries


### PR DESCRIPTION
### Summary

This PR changes `kaspa_consensus_client::CovenantBinding`'s `inner` field type from  `kaspa_consensus_core::CovenantBinding`, to a new struct - `CovenantBindingInner`.

Additionally, two methods were added to `GenesisCovenantGroup` that use Rust-native arg/return types. These are needed for native Rust and Python SDK use, as the WASM exposed versions use JS type of `NumberArray` for arg/return.

- `outputs()` - get outputs. Js fn renamed to `js_get_outputs()` and exposed to js as `outputs()`
- `set_outputs()` - set outputs. Js fn renamed to `js_set_outputs()` and exposed to js as `outputs()`

---

### Why

All other consensus-client transaction related structs define and wrap their own inner types (e.g. [`TransactionOutpointInner`](https://github.com/kaspanet/rusty-kaspa/blob/33702259d72d848bce246add2f1890716b7bc7c8/consensus/client/src/outpoint.rs#L88), [`TransactionInputInner`](https://github.com/kaspanet/rusty-kaspa/blob/33702259d72d848bce246add2f1890716b7bc7c8/consensus/client/src/input.rs#L84), [`TransactionOutputInner`](https://github.com/kaspanet/rusty-kaspa/blob/33702259d72d848bce246add2f1890716b7bc7c8/consensus/client/src/output.rs#L65), [`TransactionInner`](https://github.com/kaspanet/rusty-kaspa/blob/33702259d72d848bce246add2f1890716b7bc7c8/consensus/client/src/transaction.rs#L92)) instead of wrapping consensus core. These inner types are structured similar to their corresponding consensus core structs. 

These inner types are then wrapped in `Arc<T>` or `Arc<Mutex<T>>`.

After reviewing old conversations with Anton, this approach fixes the issue where:
- A WASM getter returns a clone
- A setter is then called on a property of the returned value (the clone)
- The original object is not updated as the JS/TS developer would expect

This issue is present on the current implementation of consensus-client `CovenantBinding`. Here is an example to illustrate the issue:
```js
const output = tx.outputs[0];

// output before attempted update:
console.log(output);
// {
//   authorizingInput: 0,
//   covenantId: '536dfeb03835bc0586be4986db584592e17c16f3542b1eed7ab5df986226544b'
// }

// This (silently) updates the clone, not the original output object
output.covenant.authorizingInput = 16;

// Here authorizingInput is still 0
console.log(output);
// {
//   authorizingInput: 0,
//   covenantId: '536dfeb03835bc0586be4986db584592e17c16f3542b1eed7ab5df986226544b'
// }
```

This is not obvious to JS/TS developers - the clone is silently the actual object changed. I also believe this is not conventional in the JS/TS world, something not thought about often.

This issue is resolved by changing consensus-client `CovenantBinding` to this approach. It also brings consensus-client `CovenantBinding` inline from a design perspective with other consensus-client transaction related structs.

---

### Notes

`BorshSerialize` and `BorshDeserialize` are required due to `client::CovenantBinding`'s presence as field type of `PaymentOutput`, which itself derives `BorshSerialize` and `BorshDeserialize`.  These are manually implemented for `client::CovenantBinding` due to field `inner`'s use of `Arc<Mutex<T>>`.

Intentionally did not change  `GenesisCovenantGroups`'s inner to `<Arc<Mutex<GenesisCovenantGroupsInner>>`, this continues to wrap core. Primarily because `GenesisCovenantGroups` is not stored in any other Rust struct.

