### PR TITLE
Allow non-minimal i32 encoding

### DIFF
--- a/crypto/txscript/src/data_stack.rs
+++ b/crypto/txscript/src/data_stack.rs
@@ -199,7 +199,12 @@ impl OpcodeData<i64> for StackEntry {
 impl OpcodeData<i32> for StackEntry {
     #[inline]
     fn deserialize(&self, enforce_minimal: bool) -> Result<i32, TxScriptError> {
-        OpcodeData::<SizedEncodeInt<4>>::deserialize(self, enforce_minimal).map(|v| v.try_into().expect("number is within i32 range"))
+        if enforce_minimal {
+            OpcodeData::<SizedEncodeInt<4>>::deserialize(self, true).map(|v| v.try_into().expect("number is within i32 range"))
+        } else {
+            OpcodeData::<SizedEncodeInt<8>>::deserialize(self, false)
+                .and_then(|v| v.try_into().map_err(|e: TryFromIntError| TxScriptError::NumberTooBig(e.to_string())))
+        }
     }
 
     #[inline]

--- a/crypto/txscript/test-data/script_tests.json
+++ b/crypto/txscript/test-data/script_tests.json
@@ -3296,6 +3296,20 @@
     "EQUALVERIFY"
   ],
   [
+    "1",
+    "0x05 0x0000000000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "Without covenants, PICK rejects a 5-byte integer encoding for its i32 argument"
+  ],
+  [
+    "1",
+    "0x05 0x0000008000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "Without covenants, PICK rejects a 5-byte integer encoding whose value exceeds i32::MAX"
+  ],
+  [
     "",
     "0 ROLL",
     "",
@@ -4260,7 +4274,7 @@
     "",
     "OK",
     "10,001-byte scriptPubKey TODO(pre-covpp): add script size check"
-  ],  
+  ],
   [
     "1",
     "VER",

--- a/crypto/txscript/test-data/script_tests_covenants.json
+++ b/crypto/txscript/test-data/script_tests_covenants.json
@@ -3310,6 +3310,62 @@
     "EQUALVERIFY"
   ],
   [
+    "1",
+    "0x05 0x0000000000 PICK EQUAL",
+    "",
+    "OK",
+    "With covenants enabled, PICK accepts a 5-byte integer encoding for its i32 argument"
+  ],
+  [
+    "1",
+    "0x06 0x000000000000 PICK EQUAL",
+    "",
+    "OK",
+    "With covenants enabled, PICK accepts a 6-byte integer encoding for its i32 argument"
+  ],
+  [
+    "1",
+    "0x07 0x00000000000000 PICK EQUAL",
+    "",
+    "OK",
+    "With covenants enabled, PICK accepts a 7-byte integer encoding for its i32 argument"
+  ],
+  [
+    "1",
+    "0x08 0x0000000000000000 PICK EQUAL",
+    "",
+    "OK",
+    "With covenants enabled, PICK accepts an 8-byte integer encoding for its i32 argument"
+  ],
+  [
+    "1",
+    "0x05 0x0000008000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "With covenants enabled, PICK rejects a 5-byte integer encoding whose value exceeds i32::MAX"
+  ],
+  [
+    "1",
+    "0x06 0x000000800000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "With covenants enabled, PICK rejects a 6-byte integer encoding whose value exceeds i32::MAX"
+  ],
+  [
+    "1",
+    "0x07 0x00000080000000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "With covenants enabled, PICK rejects a 7-byte integer encoding whose value exceeds i32::MAX"
+  ],
+  [
+    "1",
+    "0x08 0x0000008000000000 PICK EQUAL",
+    "",
+    "UNKNOWN_ERROR",
+    "With covenants enabled, PICK rejects an 8-byte integer encoding whose value exceeds i32::MAX"
+  ],
+  [
     "",
     "0 ROLL",
     "",


### PR DESCRIPTION
After removing the requirement of minimally encoded numbers, there's no sense anymore in requiring i32 to be encoded with at most 4 bytes.