### PR TITLE
rpc: add optional start_daa_score catch-up for NotifyUtxosChanged

### DIFF
--- a/rpc/core/src/api/rpc.rs
+++ b/rpc/core/src/api/rpc.rs
@@ -525,6 +525,19 @@ pub trait RpcApi: Sync + Send + AnySync {
             Command::Stop => self.stop_notify(id, scope).await,
         }
     }
+
+    /// Execute a UTXOs-changed subscription command and optionally return historical catch-up entries.
+    ///
+    /// The default implementation performs a regular subscribe/unsubscribe flow and returns no catch-up entries.
+    async fn execute_utxos_changed_subscribe_command(
+        &self,
+        id: ListenerId,
+        request: NotifyUtxosChangedRequest,
+    ) -> RpcResult<Vec<RpcUtxosByAddressesEntry>> {
+        let command = request.command;
+        self.execute_subscribe_command(id, request.into(), command).await?;
+        Ok(vec![])
+    }
 }
 
 pub type DynRpcService = Arc<dyn RpcApi>;

--- a/rpc/core/src/convert/notification.rs
+++ b/rpc/core/src/convert/notification.rs
@@ -82,9 +82,11 @@ impl From<&consensus_notify::FinalityConflictResolvedNotification> for FinalityC
 }
 
 impl From<&consensus_notify::UtxosChangedNotification> for UtxosChangedNotification {
-    fn from(_: &consensus_notify::UtxosChangedNotification) -> Self {
-        // TODO: investigate if this conversion is possible
-        UtxosChangedNotification::default()
+    fn from(item: &consensus_notify::UtxosChangedNotification) -> Self {
+        Self {
+            added: item.added.iter().map(|entry| entry.into()).collect(),
+            removed: item.removed.iter().map(|entry| entry.into()).collect(),
+        }
     }
 }
 

--- a/rpc/core/src/convert/utxo.rs
+++ b/rpc/core/src/convert/utxo.rs
@@ -25,3 +25,57 @@ pub fn utxo_set_into_rpc(item: &UtxoSetByScriptPublicKey, prefix: Option<Prefix>
         })
         .collect::<Vec<_>>()
 }
+
+pub fn utxo_set_into_rpc_after_daa_score(
+    item: &UtxoSetByScriptPublicKey,
+    prefix: Option<Prefix>,
+    start_daa_score: u64,
+) -> Vec<RpcUtxosByAddressesEntry> {
+    item.iter()
+        .flat_map(|(script_public_key, utxo_collection)| {
+            let address = prefix.and_then(|x| extract_script_pub_key_address(script_public_key, x).ok());
+            utxo_collection
+                .iter()
+                .filter(|(_, entry)| entry.block_daa_score > start_daa_score)
+                .map(|(outpoint, entry)| RpcUtxosByAddressesEntry {
+                    address: address.clone(),
+                    outpoint: (*outpoint).into(),
+                    utxo_entry: RpcUtxoEntry::new(entry.amount, script_public_key.clone(), entry.block_daa_score, entry.is_coinbase),
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_consensus_core::tx::{ScriptPublicKey, TransactionOutpoint};
+    use kaspa_hashes::Hash;
+    use kaspa_index_core::indexed_utxos::{CompactUtxoCollection, CompactUtxoEntry};
+    use std::collections::HashMap;
+
+    #[test]
+    fn utxo_set_into_rpc_after_daa_score_filters_strictly_greater() {
+        let script_public_key = ScriptPublicKey::new(0, vec![1, 2, 3].into());
+        let mut utxos = CompactUtxoCollection::new();
+
+        utxos.insert(
+            TransactionOutpoint { transaction_id: Hash::from_bytes([1u8; 32]), index: 0 },
+            CompactUtxoEntry::new(100, 10, false),
+        );
+        utxos.insert(
+            TransactionOutpoint { transaction_id: Hash::from_bytes([2u8; 32]), index: 1 },
+            CompactUtxoEntry::new(200, 11, false),
+        );
+
+        let mut set: UtxoSetByScriptPublicKey = HashMap::new();
+        set.insert(script_public_key.clone(), utxos);
+
+        let filtered = utxo_set_into_rpc_after_daa_score(&set, None, 10);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].utxo_entry.amount, 200);
+        assert_eq!(filtered[0].utxo_entry.block_daa_score, 11);
+        assert_eq!(filtered[0].utxo_entry.script_public_key, script_public_key);
+    }
+}

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -3135,12 +3135,26 @@ impl Deserializer for FinalityConflictResolvedNotification {
 #[serde(rename_all = "camelCase")]
 pub struct NotifyUtxosChangedRequest {
     pub addresses: Vec<RpcAddress>,
-    pub command: Command,
+    /// Optional: If provided, the node will first emit all currently known 
+    /// UTXOs for these addresses with a DAA score > this value.
+    pub start_daa_score: Option<u64>, 
 }
 
 impl NotifyUtxosChangedRequest {
-    pub fn new(addresses: Vec<RpcAddress>, command: Command) -> Self {
-        Self { addresses, command }
+    // Keep the old way working for existing code
+    pub fn new(addresses: Vec<RpcAddress>) -> Self {
+        Self { 
+            addresses, 
+            start_daa_score: None 
+        }
+    }
+
+    // returning UTXOs past a certain daa
+    pub fn with_start_score(addresses: Vec<RpcAddress>, score: u64) -> Self {
+        Self { 
+            addresses, 
+            start_daa_score: Some(score) 
+        }
     }
 }
 

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -3135,33 +3135,21 @@ impl Deserializer for FinalityConflictResolvedNotification {
 #[serde(rename_all = "camelCase")]
 pub struct NotifyUtxosChangedRequest {
     pub addresses: Vec<RpcAddress>,
-    /// Optional: If provided, the node will first emit all currently known 
-    /// UTXOs for these addresses with a DAA score > this value.
-    pub start_daa_score: Option<u64>, 
+    pub start_daa_score: Option<u64>,
+    pub command: Command,
 }
 
 impl NotifyUtxosChangedRequest {
-    // Keep the old way working for existing code
-    pub fn new(addresses: Vec<RpcAddress>) -> Self {
-        Self { 
-            addresses, 
-            start_daa_score: None 
-        }
-    }
-
-    // returning UTXOs past a certain daa
-    pub fn with_start_score(addresses: Vec<RpcAddress>, score: u64) -> Self {
-        Self { 
-            addresses, 
-            start_daa_score: Some(score) 
-        }
+    pub fn new(addresses: Vec<RpcAddress>, start_daa_score: Option<u64>, command: Command) -> Self {
+        Self { addresses, start_daa_score, command }
     }
 }
 
 impl Serializer for NotifyUtxosChangedRequest {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        store!(u16, &1, writer)?;
+        store!(u16, &2, writer)?;
         store!(Vec<RpcAddress>, &self.addresses, writer)?;
+        store!(Option<u64>, &self.start_daa_score, writer)?;
         store!(Command, &self.command, writer)?;
         Ok(())
     }
@@ -3169,10 +3157,11 @@ impl Serializer for NotifyUtxosChangedRequest {
 
 impl Deserializer for NotifyUtxosChangedRequest {
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let _version = load!(u16, reader)?;
+        let version = load!(u16, reader)?;
         let addresses = load!(Vec<RpcAddress>, reader)?;
+        let start_daa_score = if version > 1 { load!(Option<u64>, reader)? } else { None };
         let command = load!(Command, reader)?;
-        Ok(Self { addresses, command })
+        Ok(Self { addresses, start_daa_score, command })
     }
 }
 

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -1397,7 +1397,7 @@ mod mockery {
 
     impl Mock for NotifyUtxosChangedRequest {
         fn mock() -> Self {
-            NotifyUtxosChangedRequest { addresses: mock(), command: Command::Start }
+            NotifyUtxosChangedRequest { addresses: mock(), start_daa_score: mock(), command: Command::Start }
         }
     }
 

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -28,7 +28,7 @@ use kaspa_notify::{
     },
 };
 use kaspa_rpc_core::{
-    Notification,
+    Notification, RpcAddress,
     api::rpc::RpcApi,
     error::RpcError,
     error::RpcResult,
@@ -226,6 +226,31 @@ impl GrpcClient {
 
     pub fn notification_mode(&self) -> NotificationMode {
         self.notification_mode
+    }
+
+    /// Starts UTXOsChanged notifications with an optional historical catch-up lower bound.
+    ///
+    /// Currently this helper is available in direct notification mode only.
+    pub async fn start_notify_utxos_changed_with_catchup(
+        &self,
+        addresses: Vec<RpcAddress>,
+        start_daa_score: u64,
+    ) -> RpcResult<()> {
+        match self.notification_mode {
+            NotificationMode::MultiListeners => Err(RpcError::UnsupportedFeature),
+            NotificationMode::Direct => {
+                if self.inner.will_reconnect() {
+                    let scope = Scope::UtxosChanged(kaspa_notify::scope::UtxosChangedScope::new(addresses.clone()));
+                    let event = scope.event_type();
+                    self.subscriptions.as_ref().unwrap().lock().await[event].mutate(
+                        Mutation::new(Command::Start, scope),
+                        self.policies,
+                        &self.subscription_context,
+                    )?;
+                }
+                self.inner.start_notify_utxos_changed_to_client(addresses, start_daa_score).await
+            }
+        }
     }
 }
 
@@ -914,6 +939,12 @@ impl Inner {
     async fn start_notify_to_client(&self, scope: Scope) -> RpcResult<()> {
         let request = kaspad_request::Payload::from_notification_type(&scope, Command::Start);
         self.call((&request).into(), request).await?;
+        Ok(())
+    }
+
+    async fn start_notify_utxos_changed_to_client(&self, addresses: Vec<RpcAddress>, start_daa_score: u64) -> RpcResult<()> {
+        let request = NotifyUtxosChangedRequest::new(addresses, Some(start_daa_score), Command::Start);
+        self.call(KaspadPayloadOps::NotifyUtxosChanged, request).await?;
         Ok(())
     }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -512,6 +512,12 @@ message NotifyUtxosChangedRequestMessage {
   // UTXOs addresses to start/stop getting notified about
   // Leave empty to start/stop all updates
   repeated string addresses = 1;
+  // Optional historical catch-up lower bound (exclusive) for added UTXOs.
+  // When provided with command = NOTIFY_START, the server may emit an initial
+  // UTXOsChanged notification containing only entries with block_daa_score > start_daa_score.
+  //
+  // Notes:
+  // 1. Clients should de-duplicate by outpoint when merging catch-up and live notifications.
   optional uint64 start_daa_score = 2;
   RpcNotifyCommand command = 101;
 }

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -512,6 +512,7 @@ message NotifyUtxosChangedRequestMessage {
   // UTXOs addresses to start/stop getting notified about
   // Leave empty to start/stop all updates
   repeated string addresses = 1;
+  optional uint64 start_daa_score = 2;
   RpcNotifyCommand command = 101;
 }
 

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -534,7 +534,11 @@ from!(item: RpcResult<&kaspa_rpc_core::GetVirtualChainFromBlockV2Response>, prot
 });
 
 from!(item: &kaspa_rpc_core::NotifyUtxosChangedRequest, protowire::NotifyUtxosChangedRequestMessage, {
-    Self { addresses: item.addresses.iter().map(|x| x.into()).collect(), command: item.command.into() }
+    Self {
+        addresses: item.addresses.iter().map(|x| x.into()).collect(),
+        start_daa_score: item.start_daa_score,
+        command: item.command.into(),
+    }
 });
 from!(item: &kaspa_rpc_core::NotifyUtxosChangedRequest, protowire::StopNotifyingUtxosChangedRequestMessage, {
     Self { addresses: item.addresses.iter().map(|x| x.into()).collect() }
@@ -1040,12 +1044,14 @@ try_from!(item: &protowire::GetSyncStatusResponseMessage, RpcResult<kaspa_rpc_co
 try_from!(item: &protowire::NotifyUtxosChangedRequestMessage, kaspa_rpc_core::NotifyUtxosChangedRequest, {
     Self {
         addresses: item.addresses.iter().map(|x| x.as_str().try_into()).collect::<Result<Vec<_>, _>>()?,
+        start_daa_score: item.start_daa_score,
         command: item.command.into(),
     }
 });
 try_from!(item: &protowire::StopNotifyingUtxosChangedRequestMessage, kaspa_rpc_core::NotifyUtxosChangedRequest, {
     Self {
         addresses: item.addresses.iter().map(|x| x.as_str().try_into()).collect::<Result<Vec<_>, _>>()?,
+        start_daa_score: None,
         command: Command::Stop,
     }
 });
@@ -1099,9 +1105,14 @@ try_from!(&protowire::NotifySinkBlueScoreChangedResponseMessage, RpcResult<kaspa
 
 #[cfg(test)]
 mod tests {
-    use kaspa_rpc_core::{RpcError, RpcResult, SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse};
+    use kaspa_notify::subscription::Command;
+    use kaspa_rpc_core::{NotifyUtxosChangedRequest, RpcError, RpcResult, SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse};
 
-    use crate::protowire::{self, SubmitBlockResponseMessage, submit_block_response_message::RejectReason};
+    use crate::protowire::{self, NotifyUtxosChangedRequestMessage, SubmitBlockResponseMessage, submit_block_response_message::RejectReason};
+
+    fn sample_address() -> kaspa_rpc_core::RpcAddress {
+        "kaspa:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjellj43pf".try_into().unwrap()
+    }
 
     #[test]
     fn test_submit_block_response() {
@@ -1170,5 +1181,32 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_notify_utxos_changed_request_start_daa_score_to_protowire() {
+        let request = NotifyUtxosChangedRequest {
+            addresses: vec![sample_address()],
+            start_daa_score: Some(123),
+            command: Command::Start,
+        };
+
+        let message: NotifyUtxosChangedRequestMessage = (&request).into();
+        assert_eq!(message.addresses.len(), 1);
+        assert_eq!(message.start_daa_score, Some(123));
+    }
+
+    #[test]
+    fn test_notify_utxos_changed_request_start_daa_score_from_protowire() {
+        let message = NotifyUtxosChangedRequestMessage {
+            addresses: vec![sample_address().to_string()],
+            start_daa_score: Some(456),
+            command: protowire::RpcNotifyCommand::NotifyStart as i32,
+        };
+
+        let request = NotifyUtxosChangedRequest::try_from(&message).unwrap();
+        assert_eq!(request.addresses.len(), 1);
+        assert_eq!(request.start_daa_score, Some(456));
+        assert_eq!(request.command, Command::Start);
     }
 }

--- a/rpc/grpc/core/src/convert/notification.rs
+++ b/rpc/grpc/core/src/convert/notification.rs
@@ -82,7 +82,7 @@ from!(item: Command, RpcNotifyCommand, {
 });
 
 from!(item: &StopNotifyingUtxosChangedRequestMessage, NotifyUtxosChangedRequestMessage, {
-    Self { addresses: item.addresses.clone(), command: Command::Stop.into() }
+    Self { addresses: item.addresses.clone(), start_daa_score: None, command: Command::Stop.into() }
 });
 
 from!(_item: &StopNotifyingPruningPointUtxoSetOverrideRequestMessage, NotifyPruningPointUtxoSetOverrideRequestMessage, {

--- a/rpc/grpc/core/src/ext/kaspad.rs
+++ b/rpc/grpc/core/src/ext/kaspad.rs
@@ -47,6 +47,7 @@ impl kaspad_request::Payload {
             }
             Scope::UtxosChanged(scope) => kaspad_request::Payload::NotifyUtxosChangedRequest(NotifyUtxosChangedRequestMessage {
                 addresses: scope.addresses.iter().map(|x| x.into()).collect::<Vec<String>>(),
+                start_daa_score: None,
                 command: command.into(),
             }),
             Scope::SinkBlueScoreChanged(_) => {

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -14,7 +14,7 @@ use crate::{
 use kaspa_grpc_core::protowire::{kaspad_request::Payload, *};
 use kaspa_grpc_core::{ops::KaspadPayloadOps, protowire::NotifyFinalityConflictResponseMessage};
 use kaspa_notify::{scope::FinalityConflictResolvedScope, subscriber::SubscriptionManager};
-use kaspa_rpc_core::{SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse};
+use kaspa_rpc_core::{Notification, SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse, UtxosChangedNotification};
 use kaspa_rpc_macros::build_grpc_server_interface;
 
 pub struct Factory {}
@@ -136,6 +136,47 @@ impl Factory {
             })
         });
         interface.replace_method(KaspadPayloadOps::NotifyFinalityConflict, method);
+
+        // Manually reimplementing NotifyUtxosChangedRequest to support optional historical catch-up
+        // while preserving a single subscribe command entry point in the service layer.
+        let method: KaspadMethod = Method::new(|server_ctx: ServerContext, connection: Connection, request: KaspadRequest| {
+            Box::pin(async move {
+                let mut response: KaspadResponse = match request.payload {
+                    Some(Payload::NotifyUtxosChangedRequest(ref request)) => {
+                        match kaspa_rpc_core::NotifyUtxosChangedRequest::try_from(request) {
+                            Ok(request) => {
+                                let listener_id = connection.get_or_register_listener_id()?;
+                                let mut catchup_added = vec![];
+                                let result = server_ctx
+                                    .core_service
+                                    .execute_utxos_changed_subscribe_command(listener_id, request)
+                                    .await
+                                    .map(|entries| {
+                                        catchup_added = entries;
+                                    });
+
+                                if result.is_ok() && !catchup_added.is_empty() {
+                                    let notification = Notification::UtxosChanged(UtxosChangedNotification {
+                                        added: Arc::new(catchup_added),
+                                        removed: Arc::new(vec![]),
+                                    });
+                                    connection.enqueue((&notification).into()).await?;
+                                }
+
+                                NotifyUtxosChangedResponseMessage::from(result).into()
+                            }
+                            Err(err) => NotifyUtxosChangedResponseMessage::from(err).into(),
+                        }
+                    }
+                    _ => {
+                        return Err(GrpcServerError::InvalidRequestPayload);
+                    }
+                };
+                response.id = request.id;
+                Ok(response)
+            })
+        });
+        interface.replace_method(KaspadPayloadOps::NotifyUtxosChanged, method);
 
         // Methods with special properties
         let network_bps = network_bps as usize;

--- a/rpc/grpc/server/src/tests/client_server.rs
+++ b/rpc/grpc/server/src/tests/client_server.rs
@@ -4,6 +4,7 @@ use kaspa_core::info;
 use kaspa_grpc_client::GrpcClient;
 use kaspa_notify::scope::{NewBlockTemplateScope, Scope};
 use kaspa_rpc_core::api::rpc::RpcApi;
+use kaspa_rpc_core::Notification;
 use kaspa_utils::networking::{ContextualNetAddress, NetAddress};
 use std::sync::Arc;
 
@@ -184,6 +185,44 @@ async fn test_client_server_notifications() {
 
     // Stop the server
     assert!(server.stop().await.is_ok(), "error stopping the server");
+    drop(server);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+#[tokio::test]
+async fn test_notify_utxos_changed_start_daa_score_catchup() {
+    kaspa_core::log::try_init_logger("info, kaspa_grpc_core=trace, kaspa_grpc_server=trace, kaspa_grpc_client=trace");
+
+    // Create and start a fake core service
+    let rpc_core_service = Arc::new(RpcCoreMock::new());
+    rpc_core_service.start();
+
+    // Create and start the server
+    let server = create_server(rpc_core_service.clone());
+
+    // Connect a direct-mode client
+    let client = create_client(server.serve_address()).await;
+
+    let address = "kaspa:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjellj43pf".try_into().unwrap();
+    assert!(client.start_notify_utxos_changed_with_catchup(vec![address], 50).await.is_ok());
+
+    // The custom server handler should emit an initial catch-up UtxosChanged notification.
+    let notification = client.notification_channel_receiver().recv().await.unwrap();
+    match notification {
+        Notification::UtxosChanged(notification) => {
+            assert_eq!(notification.added.len(), 1);
+            assert_eq!(notification.removed.len(), 0);
+            assert_eq!(notification.added[0].utxo_entry.block_daa_score, 51);
+        }
+        other => panic!("unexpected notification: {other:?}"),
+    }
+
+    // Stop the fake service
+    rpc_core_service.join().await;
+
+    // Stop the server
+    assert!(server.stop().await.is_ok(), "error stopping the server");
+    assert!(client.disconnect().await.is_ok(), "client failed to disconnect");
     drop(server);
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 }

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -5,7 +5,7 @@ use kaspa_notify::listener::{ListenerId, ListenerLifespan};
 use kaspa_notify::notifier::{Notifier, Notify};
 use kaspa_notify::scope::Scope;
 use kaspa_notify::subscription::context::SubscriptionContext;
-use kaspa_notify::subscription::{MutationPolicies, UtxosChangedMutationPolicy};
+use kaspa_notify::subscription::{Command, MutationPolicies, UtxosChangedMutationPolicy};
 use kaspa_rpc_core::{RpcResult, notify::connection::ChannelConnection};
 use kaspa_rpc_core::{api::connection::DynRpcConnection, api::rpc::RpcApi, *};
 use std::sync::Arc;
@@ -398,5 +398,28 @@ impl RpcApi for RpcCoreMock {
     async fn stop_notify(&self, id: ListenerId, scope: Scope) -> RpcResult<()> {
         self.core_notifier.try_stop_notify(id, scope)?;
         Ok(())
+    }
+
+    async fn execute_utxos_changed_subscribe_command(
+        &self,
+        id: ListenerId,
+        request: NotifyUtxosChangedRequest,
+    ) -> RpcResult<Vec<RpcUtxosByAddressesEntry>> {
+        let command = request.command;
+        self.execute_subscribe_command(id, request.clone().into(), command).await?;
+
+        if command != Command::Start {
+            return Ok(vec![]);
+        }
+
+        let Some(start_daa_score) = request.start_daa_score else {
+            return Ok(vec![]);
+        };
+
+        Ok(vec![RpcUtxosByAddressesEntry {
+            address: request.addresses.first().cloned(),
+            outpoint: RpcTransactionOutpoint { transaction_id: RpcHash::from_bytes([3u8; 32]), index: 0 },
+            utxo_entry: RpcUtxoEntry::new(123, Default::default(), start_daa_score + 1, false),
+        }])
     }
 }

--- a/rpc/service/src/converter/index.rs
+++ b/rpc/service/src/converter/index.rs
@@ -3,7 +3,7 @@ use kaspa_consensus_core::config::Config;
 use kaspa_index_core::indexed_utxos::UtxoSetByScriptPublicKey;
 use kaspa_index_core::notification::{self as index_notify, Notification as IndexNotification};
 use kaspa_notify::converter::Converter;
-use kaspa_rpc_core::{Notification, RpcUtxosByAddressesEntry, UtxosChangedNotification, utxo_set_into_rpc};
+use kaspa_rpc_core::{Notification, RpcUtxosByAddressesEntry, UtxosChangedNotification, utxo_set_into_rpc, utxo_set_into_rpc_after_daa_score};
 use std::sync::Arc;
 
 /// Conversion of consensus_core to rpc_core structures
@@ -26,6 +26,14 @@ impl IndexConverter {
 
     pub fn get_utxos_by_addresses_entries(&self, item: &UtxoSetByScriptPublicKey) -> Vec<RpcUtxosByAddressesEntry> {
         utxo_set_into_rpc(item, Some(self.config.prefix()))
+    }
+
+    pub fn get_utxos_by_addresses_entries_after_daa_score(
+        &self,
+        item: &UtxoSetByScriptPublicKey,
+        start_daa_score: u64,
+    ) -> Vec<RpcUtxosByAddressesEntry> {
+        utxo_set_into_rpc_after_daa_score(item, Some(self.config.prefix()), start_daa_score)
     }
 }
 

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -43,7 +43,7 @@ use kaspa_mining::model::tx_query::TransactionQuery;
 use kaspa_mining::{manager::MiningManagerProxy, mempool::tx::Orphan};
 use kaspa_notify::listener::ListenerLifespan;
 use kaspa_notify::subscription::context::SubscriptionContext;
-use kaspa_notify::subscription::{MutationPolicies, UtxosChangedMutationPolicy};
+use kaspa_notify::subscription::{Command, MutationPolicies, UtxosChangedMutationPolicy};
 use kaspa_notify::{
     collector::DynCollector,
     connection::ChannelType,
@@ -75,7 +75,7 @@ use kaspa_utils_tower::counters::TowerConnectionCounters;
 use kaspa_utxoindex::api::UtxoIndexProxy;
 use std::time::Duration;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     iter::once,
     sync::{Arc, atomic::Ordering},
     vec,
@@ -317,6 +317,17 @@ impl RpcCoreService {
             (false, true) => Ok(TransactionQuery::All),
             (false, false) => Ok(TransactionQuery::TransactionsOnly),
         }
+    }
+
+    #[inline(always)]
+    fn should_collect_utxos_catchup(command: Command, start_daa_score: Option<u64>) -> Option<u64> {
+        if command == Command::Start { start_daa_score } else { None }
+    }
+
+    fn dedup_utxo_entries_by_outpoint(mut entries: Vec<RpcUtxosByAddressesEntry>) -> Vec<RpcUtxosByAddressesEntry> {
+        let mut seen = HashSet::with_capacity(entries.len());
+        entries.retain(|entry| seen.insert(entry.outpoint));
+        entries
     }
 }
 
@@ -1342,6 +1353,34 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         Ok(())
     }
 
+    async fn execute_utxos_changed_subscribe_command(
+        &self,
+        id: ListenerId,
+        request: NotifyUtxosChangedRequest,
+    ) -> RpcResult<Vec<RpcUtxosByAddressesEntry>> {
+        let command = request.command;
+        self.execute_subscribe_command(id, request.clone().into(), command).await?;
+
+        let Some(start_daa_score) = Self::should_collect_utxos_catchup(command, request.start_daa_score) else {
+            return Ok(vec![]);
+        };
+
+        // Catch-up requires a local UTXO index, but subscription can still proceed without it.
+        if !self.config.utxoindex || self.utxoindex.is_none() {
+            return Ok(vec![]);
+        }
+
+        let session = self.consensus_manager.consensus().unguarded_session();
+        // Historical catch-up requires a stable consensus/index view.
+        if session.async_is_consensus_in_transitional_ibd_state().await {
+            return Err(RpcError::ConsensusInTransitionalIbdState);
+        }
+
+        let entry_map = self.get_utxo_set_by_script_public_key(request.addresses.iter()).await;
+        let entries = self.index_converter.get_utxos_by_addresses_entries_after_daa_score(&entry_map, start_daa_score);
+        Ok(Self::dedup_utxo_entries_by_outpoint(entries))
+    }
+
     /// Start sending notifications of some type to a listener.
     async fn start_notify(&self, id: ListenerId, scope: Scope) -> RpcResult<()> {
         match scope {
@@ -1366,6 +1405,53 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
     async fn stop_notify(&self, id: ListenerId, scope: Scope) -> RpcResult<()> {
         self.notifier.clone().stop_notify(id, scope).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_consensus_core::tx::TransactionId;
+
+    fn sample_outpoint(byte: u8, index: u32) -> RpcTransactionOutpoint {
+        RpcTransactionOutpoint { transaction_id: TransactionId::from_slice(&[byte; 32]), index }
+    }
+
+    #[test]
+    fn should_collect_utxos_catchup_only_on_start_with_threshold() {
+        assert_eq!(RpcCoreService::should_collect_utxos_catchup(Command::Stop, Some(1)), None);
+        assert_eq!(RpcCoreService::should_collect_utxos_catchup(Command::Start, None), None);
+        assert_eq!(RpcCoreService::should_collect_utxos_catchup(Command::Start, Some(42)), Some(42));
+    }
+
+    #[test]
+    fn dedup_utxo_entries_by_outpoint_keeps_first_entry() {
+        let outpoint_a = sample_outpoint(1, 0);
+        let outpoint_b = sample_outpoint(2, 0);
+
+        let entries = vec![
+            RpcUtxosByAddressesEntry {
+                address: None,
+                outpoint: outpoint_a,
+                utxo_entry: RpcUtxoEntry::new(10, Default::default(), 100, false),
+            },
+            RpcUtxosByAddressesEntry {
+                address: None,
+                outpoint: outpoint_a,
+                utxo_entry: RpcUtxoEntry::new(11, Default::default(), 101, false),
+            },
+            RpcUtxosByAddressesEntry {
+                address: None,
+                outpoint: outpoint_b,
+                utxo_entry: RpcUtxoEntry::new(20, Default::default(), 200, false),
+            },
+        ];
+
+        let deduped = RpcCoreService::dedup_utxo_entries_by_outpoint(entries);
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].outpoint, outpoint_a);
+        assert_eq!(deduped[0].utxo_entry.amount, 10);
+        assert_eq!(deduped[1].outpoint, outpoint_b);
     }
 }
 

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -231,6 +231,38 @@ impl RpcCoreService {
         }
     }
 
+    pub async fn notify_utxos_changed(
+        &self, 
+        request: NotifyUtxosChangedRequest
+    ) -> RpcResult<NotifyUtxosChangedResponse> {
+        
+        // Ensure utxoindex exists (it's an Option in your constructor)
+        if let Some(ref utxoindex) = self.utxoindex {
+            if let Some(start_score) = request.start_daa_score {
+                for address in &request.addresses {
+                    // 1. Fetch from the index
+                    // Use .get_utxos_by_addresses (plural) or verify the trait method name
+                    let utxos = utxoindex.get_utxos_by_addresses(vec![address.clone()])?;
+                    
+                    // 2. Filter, Map, and Collect
+                    let added: Vec<RpcUtxoEntry> = utxos
+                        .into_iter()
+                        .filter(|(_addr, entry)| entry.block_daa_score > start_score)
+                        .map(|(_addr, entry)| entry.into()) 
+                        .collect();
+
+                    // 3. Push the "Initial Burst" 
+                    if !added.is_empty() {
+                        self.notifier.notify(Notification::UtxosChanged(UtxosChangedNotification {
+                            added,
+                            removed: vec![],
+                        })).await?;
+                    }
+                }
+            }
+        }
+
+    
     pub fn start_impl(&self) {
         self.notifier().start();
     }

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -9,6 +9,7 @@ use kaspa_consensus_core::daa_score_timestamp::DaaScoreTimestamp;
 use kaspa_consensus_core::errors::block::RuleError;
 use kaspa_consensus_core::tx::{TransactionQueryResult, TransactionType};
 use kaspa_consensus_core::utxo::utxo_inquirer::UtxoInquirerError;
+use kaspa_consensus_core::utxo::utxo_diff::UtxoDiff;
 use kaspa_consensus_core::{
     block::Block,
     coinbase::MinerData,
@@ -57,7 +58,7 @@ use kaspa_p2p_lib::common::ProtocolError;
 use kaspa_p2p_mining::rule_engine::MiningRuleEngine;
 use kaspa_perf_monitor::{Monitor as PerfMonitor, counters::CountersSnapshot};
 use kaspa_rpc_core::{
-    Notification, RpcError, RpcResult,
+    Notification, RpcError, RpcResult, UtxosChangedNotification;
     api::{
         connection::DynRpcConnection,
         ops::{RPC_API_REVISION, RPC_API_VERSION},


### PR DESCRIPTION
Fixes #939

Adds optional start_daa_score to NotifyUtxosChanged subscription to support historical catch-up while preserving normal subscription behavior when omitted. Improves local indexing of specific address UTXOs, supporting large vProg pool or protocol addresses in the future. Removes the need for querying the entire per-address UTXO set every time a device loses node connection.