### PR TITLE
fix(wallet): replace unsafe UTF-8 conversion in decrypt_mnemonic

### DIFF
--- a/wallet/core/src/compat/gen1.rs
+++ b/wallet/core/src/compat/gen1.rs
@@ -8,14 +8,16 @@ pub fn decrypt_mnemonic<T: AsRef<[u8]>>(
 ) -> Result<String> {
     let params = argon2::ParamsBuilder::new().t_cost(1).m_cost(64 * 1024).p_cost(num_threads).output_len(32).build().unwrap();
     let mut key = [0u8; 32];
-    argon2::Argon2::new(argon2::Algorithm::Argon2id, Default::default(), params)
-        .hash_password_into(pass, salt.as_ref(), &mut key[..])
-        .unwrap();
+    argon2::Argon2::new(argon2::Algorithm::Argon2id, Default::default(), params).hash_password_into(
+        pass,
+        salt.as_ref(),
+        &mut key[..],
+    )?;
     let mut aead = chacha20poly1305::XChaCha20Poly1305::new(Key::from_slice(&key));
     let (nonce, ciphertext) = cipher.as_ref().split_at(24);
 
     let decrypted = aead.decrypt(nonce.into(), ciphertext)?;
-    Ok(unsafe { String::from_utf8_unchecked(decrypted) })
+    Ok(String::from_utf8(decrypted)?)
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Description:
  ## Summary
  - Replace `String::from_utf8_unchecked` with `String::from_utf8` in `decrypt_mnemonic`
    to eliminate undefined behavior on invalid UTF-8 input
  - Invalid UTF-8 in decrypted bytes (e.g. corrupted wallet file, wrong password)
    now returns an error instead of triggering UB

  ## Motivation
  `from_utf8_unchecked` violates Rust's safety invariants if the decrypted payload
  is not valid UTF-8. This can happen with a corrupted wallet file or a wrong
  decryption key, turning a recoverable error into undefined behavior.