### PR TITLE
fix(wasm): mempool entries request args are required

### DIFF
--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1043,13 +1043,13 @@ declare! {
     IGetMempoolEntriesRequest,
     r#"
     /**
-     *
-     *
      * @category Node RPC
      */
     export interface IGetMempoolEntriesRequest {
-        includeOrphanPool? : boolean;
-        filterTransactionPool? : boolean;
+        /// Whether or not to include the orphan pool (transactions which inputs are not known at this time)
+        includeOrphanPool: boolean;
+        /// Whether or not to filter out the transaction pool
+        filterTransactionPool: boolean;
     }
     "#,
 }

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1081,13 +1081,13 @@ declare! {
     IGetMempoolEntriesRequest,
     r#"
     /**
-     *
-     *
      * @category Node RPC
      */
     export interface IGetMempoolEntriesRequest {
-        includeOrphanPool? : boolean;
-        filterTransactionPool? : boolean;
+        /// Whether or not to include the orphan pool (transactions which inputs are not known at this time)
+        includeOrphanPool: boolean;
+        /// Whether or not to filter out the transaction pool
+        filterTransactionPool: boolean;
     }
     "#,
 }

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1084,9 +1084,9 @@ declare! {
      * @category Node RPC
      */
     export interface IGetMempoolEntriesRequest {
-        /// Whether or not to include the orphan pool (transactions which inputs are not known at this time)
+        /** Whether or not to include the orphan pool (transactions which inputs are not known at this time) */
         includeOrphanPool: boolean;
-        /// Whether or not to filter out the transaction pool
+        /** Whether or not to filter out the transaction pool */
         filterTransactionPool: boolean;
     }
     "#,
@@ -1126,8 +1126,10 @@ declare! {
      */
     export interface IGetMempoolEntriesByAddressesRequest {
         addresses : Address[] | string[];
-        includeOrphanPool? : boolean;
-        filterTransactionPool? : boolean;
+        /** Whether or not to include the orphan pool (transactions which inputs are not known at this time) */
+        includeOrphanPool: boolean;
+        /** Whether or not to filter out the transaction pool */
+        filterTransactionPool: boolean;
     }
     "#,
 }

--- a/wasm/examples/nodejs/javascript/general/mempool-entries.js
+++ b/wasm/examples/nodejs/javascript/general/mempool-entries.js
@@ -8,7 +8,7 @@ kaspa.initConsolePanicHook();
 
 (async () => {
   const rpc = new RpcClient({
-    url: "wss://devnet2-wrpc.kasia.fyi",
+    url: "127.0.0.1",
     encoding: Encoding.Borsh,
     // resolver: new Resolver(),
     networkId: "mainnet",

--- a/wasm/examples/nodejs/javascript/general/mempool-entries.js
+++ b/wasm/examples/nodejs/javascript/general/mempool-entries.js
@@ -1,0 +1,25 @@
+// @ts-ignore
+globalThis.WebSocket = require("websocket").w3cwebsocket; // W3C WebSocket module shim
+
+const kaspa = require("../../../../nodejs/kaspa");
+const { RpcClient, Encoding } = kaspa;
+
+kaspa.initConsolePanicHook();
+
+(async () => {
+  const rpc = new RpcClient({
+    url: "127.0.0.1",
+    encoding: Encoding.Borsh,
+    // resolver: new Resolver(),
+    networkId: "mainnet",
+  });
+  console.log(`Resolving RPC endpoint...`);
+  await rpc.connect();
+  console.log(`Connecting to ${rpc.url}`);
+
+  const response = await rpc.getMempoolEntries({
+    includeOrphanPool: true,
+    filterTransactionPool: false,
+  });
+  console.log(`${response.mempoolEntries.length} transations in the mempool`);
+})();

--- a/wasm/examples/nodejs/javascript/general/mempool-entries.js
+++ b/wasm/examples/nodejs/javascript/general/mempool-entries.js
@@ -1,0 +1,25 @@
+// @ts-ignore
+globalThis.WebSocket = require("websocket").w3cwebsocket; // W3C WebSocket module shim
+
+const kaspa = require("../../../../nodejs/kaspa");
+const { RpcClient, Encoding } = kaspa;
+
+kaspa.initConsolePanicHook();
+
+(async () => {
+  const rpc = new RpcClient({
+    url: "wss://devnet2-wrpc.kasia.fyi",
+    encoding: Encoding.Borsh,
+    // resolver: new Resolver(),
+    networkId: "mainnet",
+  });
+  console.log(`Resolving RPC endpoint...`);
+  await rpc.connect();
+  console.log(`Connecting to ${rpc.url}`);
+
+  const response = await rpc.getMempoolEntries({
+    includeOrphanPool: true,
+    filterTransactionPool: false,
+  });
+  console.log(`${response.mempoolEntries.length} transations in the mempool`);
+})();

--- a/wasm/examples/nodejs/javascript/general/mempool-entries.js
+++ b/wasm/examples/nodejs/javascript/general/mempool-entries.js
@@ -21,5 +21,5 @@ kaspa.initConsolePanicHook();
     includeOrphanPool: true,
     filterTransactionPool: false,
   });
-  console.log(`${response.mempoolEntries.length} transations in the mempool`);
+  console.log(`${response.mempoolEntries.length} transactions in the mempool`);
 })();


### PR DESCRIPTION
- adjusted wasm sdk types; IGetMempoolEntriesRequest require the two bool properties to be present
- added mempool entries wasm example