### PR TITLE
Fix optional tx input mass validation rejecting protobuf defaults

### DIFF
--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -63,12 +63,12 @@ impl TryFrom<RpcOptionalInputWithVersion> for TransactionInput {
             value.input.sequence.ok_or(RpcError::MissingRpcFieldError("RpcTransactionInput".to_owned(), "sequence".to_owned()))?;
 
         let mass = if TxInputMass::version_expects_compute_budget_field(value.version) {
-            if value.input.sig_op_count.is_some() {
+            if value.input.sig_op_count.is_some_and(|v| v != 0) {
                 return Err(invalid_input_mass_variant("sig_op_count", value.version));
             }
             ComputeBudget(value.input.compute_budget.unwrap_or_default()).into()
         } else {
-            if value.input.compute_budget.is_some() {
+            if value.input.compute_budget.is_some_and(|v| v != 0) {
                 return Err(invalid_input_mass_variant("compute_budget", value.version));
             }
             SigopCount(value.input.sig_op_count.unwrap_or_default()).into()


### PR DESCRIPTION
The GRPC deserialization layer wraps protobuf default values as `Some(0)` in `RpcOptionalTransactionInput`, but the `TryFrom<RpcOptionalInputWithVersion>` conversion treats `Some(0)` as "field explicitly present" and rejects v0 transactions that carry `compute_budget` (and v1+ transactions that carry `sig_op_count`).

Since protobuf cannot distinguish "field absent" from "default value 0", `Some(0)` and `None` are semantically identical here. Change the checks from `.is_some()` to `.is_some_and(|v| v != 0)` so that zero-valued defaults pass through correctly.