### PR TITLE
fix(notification): reject utxo change sub when no utxo index

### DIFF
--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -1312,6 +1312,7 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
     /// Start sending notifications of some type to a listener.
     async fn start_notify(&self, id: ListenerId, scope: Scope) -> RpcResult<()> {
         match scope {
+            Scope::UtxosChanged(_) if !self.config.utxoindex => Err(RpcError::NoUtxoIndex),
             Scope::UtxosChanged(ref utxos_changed_scope) if !self.config.unsafe_rpc && utxos_changed_scope.addresses.is_empty() => {
                 // The subscription to blanket UtxosChanged notifications is restricted to unsafe mode only
                 // since the notifications yielded are highly resource intensive.


### PR DESCRIPTION
Fixes #960

When subscribing to `UtxosChanged` notification, it now rejects early if `utxoindex` is not enabled on the node