### PR TITLE
Add rocknroll SMT prune scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3582,6 +3582,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaspa-rocknroll"
+version = "2.0.0"
+dependencies = [
+ "clap",
+ "kaspa-consensus",
+ "kaspa-consensus-core",
+ "kaspa-database",
+ "kaspa-hashes",
+ "kaspa-smt-store",
+ "kaspad",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kaspa-rpc-core"
 version = "2.0.0"
 dependencies = [
@@ -5984,20 +5998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "rocknroll"
-version = "1.1.1-toc.1"
-dependencies = [
- "clap",
- "kaspa-consensus",
- "kaspa-consensus-core",
- "kaspa-database",
- "kaspa-hashes",
- "kaspa-smt-store",
- "kaspad",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,6 +5987,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocknroll"
+version = "1.1.1-toc.1"
+dependencies = [
+ "clap",
+ "kaspa-consensus",
+ "kaspa-consensus-core",
+ "kaspa-database",
+ "kaspa-hashes",
+ "kaspa-smt-store",
+ "kaspad",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "components/consensusmanager",
     "bridge",
     "database",
+    "database/rocknroll",
     "crypto/txscript",
     "crypto/txscript/errors",
     "testing/integration",

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -219,8 +219,7 @@ impl MultiConsensusManagementStore {
         let mut metadata = self.metadata.read().unwrap();
         if metadata.is_archival_node != is_archival_node {
             metadata.is_archival_node = is_archival_node;
-            let mut batch = WriteBatch::default();
-            self.metadata.write(BatchDbWriter::new(&mut batch), &metadata).unwrap();
+            self.metadata.write(DirectDbWriter::new(&self.db), &metadata).unwrap();
         }
     }
 
@@ -447,5 +446,31 @@ impl ConsensusFactory for Factory {
             };
             write_guard.cancel_staging_consensus().unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MultiConsensusManagementStore;
+    use kaspa_database::{prelude::ConnBuilder, utils::get_kaspa_tempdir};
+
+    #[test]
+    fn archival_node_flag_persists_after_reopen() {
+        let db_tempdir = get_kaspa_tempdir();
+        let db_path = db_tempdir.path().to_owned();
+        let db = ConnBuilder::default().with_db_path(db_path.clone()).with_files_limit(10).build().unwrap();
+        let mut store = MultiConsensusManagementStore::new(db.clone());
+
+        store.set_is_archival_node(true);
+        assert!(store.is_archival_node().unwrap());
+        drop(store);
+        drop(db);
+
+        let db = ConnBuilder::default().with_db_path(db_path).with_create_if_missing(false).with_files_limit(10).build().unwrap();
+        let store = MultiConsensusManagementStore::new_readonly(db.clone());
+
+        assert!(store.is_archival_node().unwrap());
+        drop(store);
+        drop(db);
     }
 }

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -83,13 +83,17 @@ pub struct MultiConsensusManagementStore {
 
 impl MultiConsensusManagementStore {
     pub fn new(db: Arc<DB>) -> Self {
-        let mut store = Self {
+        let mut store = Self::new_readonly(db);
+        store.init();
+        store
+    }
+
+    pub fn new_readonly(db: Arc<DB>) -> Self {
+        Self {
             db: db.clone(),
             entries: CachedDbAccess::new(db.clone(), CachePolicy::Count(16), DatabaseStorePrefixes::ConsensusEntries.into()),
             metadata: CachedDbItem::new(db, DatabaseStorePrefixes::MultiConsensusMetadata.into()),
-        };
-        store.init();
-        store
+        }
     }
 
     fn init(&mut self) {
@@ -105,7 +109,7 @@ impl MultiConsensusManagementStore {
     pub fn active_consensus_dir_name(&self) -> StoreResult<Option<String>> {
         let metadata = self.metadata.read()?;
         match metadata.current_consensus_key {
-            Some(key) => Ok(Some(self.entries.read(key.into()).unwrap().directory_name)),
+            Some(key) => Ok(Some(self.entries.read(key.into())?.directory_name)),
             None => Ok(None),
         }
     }

--- a/database/rocknroll/Cargo.toml
+++ b/database/rocknroll/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rocknroll"
+description = "Kaspa RocksDB developer scanning tools"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+include.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+kaspa-consensus = { workspace = true, features = ["test-smt-pruning-diagnostics"] }
+kaspa-consensus-core.workspace = true
+kaspa-database.workspace = true
+kaspa-hashes.workspace = true
+kaspa-smt-store = { workspace = true, features = ["test-smt-pruning-diagnostics"] }
+kaspad.workspace = true
+
+clap = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/database/rocknroll/Cargo.toml
+++ b/database/rocknroll/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rocknroll"
+name = "kaspa-rocknroll"
 description = "Kaspa RocksDB developer scanning tools"
 version.workspace = true
 edition.workspace = true

--- a/database/rocknroll/src/args.rs
+++ b/database/rocknroll/src/args.rs
@@ -28,13 +28,14 @@ impl NetworkArgs {
             return Err(Error::InvalidArgs("select exactly one network flag: --testnet, --devnet, or --simnet".to_string()));
         }
 
-        let mut args = KaspadArgs::default();
-        args.appdir = appdir;
-        args.testnet = self.testnet;
-        args.testnet_suffix = self.netsuffix;
-        args.devnet = self.devnet;
-        args.simnet = self.simnet;
-        Ok(args)
+        Ok(KaspadArgs {
+            appdir,
+            testnet: self.testnet,
+            testnet_suffix: self.netsuffix,
+            devnet: self.devnet,
+            simnet: self.simnet,
+            ..Default::default()
+        })
     }
 
     pub fn network(&self) -> Result<NetworkId> {

--- a/database/rocknroll/src/args.rs
+++ b/database/rocknroll/src/args.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use kaspa_consensus_core::network::NetworkId;
+use kaspad_lib::args::Args as KaspadArgs;
+
+use crate::{Error, Result};
+
+#[derive(Args, Debug, Clone)]
+pub struct NetworkArgs {
+    #[arg(long, help = "Use the test network")]
+    pub testnet: bool,
+
+    #[arg(long, default_value_t = 10, help = "Testnet network suffix number")]
+    pub netsuffix: u32,
+
+    #[arg(long, help = "Use the development test network")]
+    pub devnet: bool,
+
+    #[arg(long, help = "Use the simulation test network")]
+    pub simnet: bool,
+}
+
+impl NetworkArgs {
+    pub fn to_kaspad_args(&self, appdir: Option<String>) -> Result<KaspadArgs> {
+        let selected = [self.testnet, self.devnet, self.simnet].into_iter().filter(|selected| *selected).count();
+        if selected != 1 {
+            return Err(Error::InvalidArgs("select exactly one network flag: --testnet, --devnet, or --simnet".to_string()));
+        }
+
+        let mut args = KaspadArgs::default();
+        args.appdir = appdir;
+        args.testnet = self.testnet;
+        args.testnet_suffix = self.netsuffix;
+        args.devnet = self.devnet;
+        args.simnet = self.simnet;
+        Ok(args)
+    }
+
+    pub fn network(&self) -> Result<NetworkId> {
+        Ok(self.to_kaspad_args(None)?.network())
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DbSourceArgs {
+    #[command(flatten)]
+    pub network: NetworkArgs,
+
+    #[arg(long, value_name = "APP_DIR", conflicts_with = "consensus_db", help = "Kaspad application directory")]
+    pub appdir: Option<PathBuf>,
+
+    #[arg(long, value_name = "CONSENSUS_DB", conflicts_with = "appdir", help = "Direct path to a consensus RocksDB directory")]
+    pub consensus_db: Option<PathBuf>,
+
+    #[arg(long, default_value_t = 128, help = "RocksDB max open files budget for the consensus DB")]
+    pub files_limit: i32,
+}

--- a/database/rocknroll/src/args.rs
+++ b/database/rocknroll/src/args.rs
@@ -24,8 +24,8 @@ pub struct NetworkArgs {
 impl NetworkArgs {
     pub fn to_kaspad_args(&self, appdir: Option<String>) -> Result<KaspadArgs> {
         let selected = [self.testnet, self.devnet, self.simnet].into_iter().filter(|selected| *selected).count();
-        if selected != 1 {
-            return Err(Error::InvalidArgs("select exactly one network flag: --testnet, --devnet, or --simnet".to_string()));
+        if selected > 1 {
+            return Err(Error::InvalidArgs("select at most one network flag: --testnet, --devnet, or --simnet".to_string()));
         }
 
         Ok(KaspadArgs {

--- a/database/rocknroll/src/bin/smt_prune_scan.rs
+++ b/database/rocknroll/src/bin/smt_prune_scan.rs
@@ -10,12 +10,12 @@ use kaspa_consensus::model::stores::{
 };
 use kaspa_consensus::{config::ConfigBuilder, params::Params};
 use kaspa_database::prelude::CachePolicy;
-use kaspa_smt_store::processor::{SmtStores, StaleSmtEntriesCount};
-use rocknroll::{
+use kaspa_rocknroll::{
     Result,
     args::DbSourceArgs,
     db::{ResolvedConsensusDb, resolve_consensus_db},
 };
+use kaspa_smt_store::processor::{SmtStores, StaleSmtEntriesCount};
 
 #[derive(Parser, Debug)]
 #[command(about = "Scan a consensus DB for stale SMT pruning entries")]

--- a/database/rocknroll/src/bin/smt_prune_scan.rs
+++ b/database/rocknroll/src/bin/smt_prune_scan.rs
@@ -1,0 +1,119 @@
+use std::{
+    io::{self, Write},
+    process::ExitCode,
+};
+
+use clap::Parser;
+use kaspa_consensus::model::stores::{
+    headers::{DbHeadersStore, HeaderStoreReader},
+    pruning::{DbPruningStore, PruningStoreReader},
+};
+use kaspa_consensus::{config::ConfigBuilder, params::Params};
+use kaspa_database::prelude::CachePolicy;
+use kaspa_smt_store::processor::{SmtStores, StaleSmtEntriesCount};
+use rocknroll::{
+    Result,
+    args::DbSourceArgs,
+    db::{ResolvedConsensusDb, resolve_consensus_db},
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Scan a consensus DB for stale SMT pruning entries")]
+struct Args {
+    #[command(flatten)]
+    db: DbSourceArgs,
+
+    #[arg(long, value_name = "BLUE_SCORE", help = "Override the pruning cutoff blue score")]
+    cutoff_blue_score: Option<u64>,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("error: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run() -> Result<ExitCode> {
+    let args = Args::parse();
+    let resolved = resolve_consensus_db(&args.db)?;
+    print_db_header(&resolved);
+    println!("archival: {}", resolved.archival.map_or("unknown".to_string(), |value| value.to_string()));
+
+    if resolved.archival == Some(true) {
+        print_archival_skip();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let db = resolved.open_consensus_readonly(args.db.files_limit)?;
+    let pruning_store = DbPruningStore::new(db.clone());
+    let pruning_point = pruning_store.pruning_point()?;
+    let retention_period_root = pruning_store.retention_period_root()?;
+    let retention_checkpoint = pruning_store.retention_checkpoint()?;
+    println!("pruning_point: {pruning_point}");
+    println!("retention_period_root: {retention_period_root}");
+    println!("retention_checkpoint: {retention_checkpoint}");
+
+    if retention_checkpoint != retention_period_root {
+        print_unstable_pruning();
+        return Ok(ExitCode::from(2));
+    }
+    println!("stable: true");
+
+    let headers_store = DbHeadersStore::new(db.clone(), CachePolicy::Empty, CachePolicy::Empty);
+    let pruning_point_blue_score = headers_store.get_blue_score(pruning_point)?;
+    let params: Params = resolved.network.into();
+    let config = ConfigBuilder::new(params).adjust_perf_params_to_consensus_params().build();
+    let finality_depth = config.params.finality_depth();
+    let cutoff_blue_score = args.cutoff_blue_score.unwrap_or_else(|| inclusive_prune_cutoff(pruning_point_blue_score, finality_depth));
+    println!("pruning_point_blue_score: {pruning_point_blue_score}");
+    println!("finality_depth: {finality_depth}");
+    println!("cutoff_blue_score: {cutoff_blue_score}");
+    println!("scanning...");
+    let _ = io::stdout().flush();
+
+    let smt_stores = SmtStores::new(db, 1, 1);
+    let stale = smt_stores.count_entries_at_or_below(cutoff_blue_score)?;
+    print_counts(stale);
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn inclusive_prune_cutoff(blue_score: u64, finality_depth: u64) -> u64 {
+    blue_score.saturating_sub(finality_depth).saturating_sub(1)
+}
+
+fn print_archival_skip() {
+    println!("scan: skipped");
+    println!("reason: archival nodes do not prune SMT history");
+}
+
+fn print_unstable_pruning() {
+    println!("stable: false");
+    println!("scan: skipped");
+    println!("reason: retention checkpoint differs from retention period root, so pruning has not completed cleanly");
+}
+
+fn print_counts(stale: StaleSmtEntriesCount) {
+    println!("branch_versions: {}", stale.branch_versions);
+    println!("lane_versions: {}", stale.lane_versions);
+    println!("score_index: {}", stale.score_index);
+    println!("total: {}", stale.total());
+}
+
+fn print_db_header(resolved: &ResolvedConsensusDb) {
+    println!("network: {}", resolved.network);
+    if let Some(app_dir) = resolved.app_dir.as_ref() {
+        println!("app_dir: {}", app_dir.display());
+    }
+    if let Some(meta_db_path) = resolved.meta_db_path.as_ref() {
+        println!("meta_db: {}", meta_db_path.display());
+    }
+    if let Some(active_consensus_dir) = resolved.active_consensus_dir.as_ref() {
+        println!("active_consensus_dir: {active_consensus_dir}");
+    }
+    println!("consensus_db: {}", resolved.consensus_db_path.display());
+}

--- a/database/rocknroll/src/db.rs
+++ b/database/rocknroll/src/db.rs
@@ -1,10 +1,9 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use kaspa_consensus::consensus::factory::MultiConsensusManagementStore;
 use kaspa_consensus_core::network::NetworkId;
 use kaspa_database::prelude::{ConnBuilder, DB};
 use kaspad_lib::daemon::get_app_dir_from_args;
-use std::sync::Arc;
 
 use crate::{Error, Result, args::DbSourceArgs};
 
@@ -69,6 +68,14 @@ pub fn resolve_consensus_db(args: &DbSourceArgs) -> Result<ResolvedConsensusDb> 
     })
 }
 
+/// Opens a RocksDB instance in read-only mode for diagnostics.
+///
+/// RocksDB documents read-only opens against a concurrently open read-write DB
+/// as undefined. This diagnostic still uses read-only mode because secondary
+/// opens can stall on large kaspad DBs; live-node scans are therefore best-effort.
+///
+/// Custom WAL directories are not wired here, so scan such nodes only after a
+/// clean shutdown if authoritative results are required.
 pub fn open_readonly_db(db_path: PathBuf, files_limit: i32) -> Result<Arc<DB>> {
     Ok(ConnBuilder::default().with_db_path(db_path).with_files_limit(files_limit).build_readonly()?)
 }

--- a/database/rocknroll/src/db.rs
+++ b/database/rocknroll/src/db.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use kaspa_consensus::consensus::factory::MultiConsensusManagementStore;
+use kaspa_consensus_core::network::NetworkId;
+use kaspa_database::prelude::{ConnBuilder, DB};
+use kaspad_lib::daemon::get_app_dir_from_args;
+use std::sync::Arc;
+
+use crate::{Error, Result, args::DbSourceArgs};
+
+const DEFAULT_DATA_DIR: &str = "datadir";
+const CONSENSUS_DB: &str = "consensus";
+const META_DB: &str = "meta";
+const META_DB_FILE_LIMIT: i32 = 5;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedConsensusDb {
+    pub network: NetworkId,
+    pub app_dir: Option<PathBuf>,
+    pub meta_db_path: Option<PathBuf>,
+    pub consensus_db_path: PathBuf,
+    pub active_consensus_dir: Option<String>,
+    pub archival: Option<bool>,
+}
+
+impl ResolvedConsensusDb {
+    pub fn open_consensus_readonly(&self, files_limit: i32) -> Result<Arc<DB>> {
+        open_readonly_db(self.consensus_db_path.clone(), files_limit)
+    }
+}
+
+pub fn resolve_consensus_db(args: &DbSourceArgs) -> Result<ResolvedConsensusDb> {
+    let network = args.network.network()?;
+
+    if let Some(consensus_db_path) = args.consensus_db.clone() {
+        return Ok(ResolvedConsensusDb {
+            network,
+            app_dir: None,
+            meta_db_path: None,
+            consensus_db_path,
+            active_consensus_dir: None,
+            archival: None,
+        });
+    }
+
+    let kaspad_args = args.network.to_kaspad_args(args.appdir.as_ref().map(|path| path.display().to_string()))?;
+    let app_dir = get_app_dir_from_args(&kaspad_args);
+    let db_dir = app_dir.join(network.to_prefixed()).join(DEFAULT_DATA_DIR);
+    let meta_db_path = db_dir.join(META_DB);
+    let consensus_db_root = db_dir.join(CONSENSUS_DB);
+
+    let meta_db = open_readonly_db(meta_db_path.clone(), META_DB_FILE_LIMIT)?;
+    let management_store = MultiConsensusManagementStore::new_readonly(meta_db);
+    let archival = management_store.is_archival_node()?;
+    let active_consensus_dir = management_store.active_consensus_dir_name()?;
+    let consensus_db_path = match active_consensus_dir.as_ref() {
+        Some(active_consensus_dir) => consensus_db_root.join(active_consensus_dir),
+        None if archival => consensus_db_root,
+        None => return Err(Error::MissingActiveConsensus),
+    };
+
+    Ok(ResolvedConsensusDb {
+        network,
+        app_dir: Some(app_dir),
+        meta_db_path: Some(meta_db_path),
+        consensus_db_path,
+        active_consensus_dir,
+        archival: Some(archival),
+    })
+}
+
+pub fn open_readonly_db(db_path: PathBuf, files_limit: i32) -> Result<Arc<DB>> {
+    Ok(ConnBuilder::default().with_db_path(db_path).with_files_limit(files_limit).build_readonly()?)
+}

--- a/database/rocknroll/src/lib.rs
+++ b/database/rocknroll/src/lib.rs
@@ -1,0 +1,19 @@
+pub mod args;
+pub mod db;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    InvalidArgs(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] kaspa_database::prelude::StoreError),
+
+    #[error("failed opening RocksDB: {0}")]
+    RocksDb(#[from] Box<dyn std::error::Error>),
+
+    #[error("missing active consensus DB in meta database")]
+    MissingActiveConsensus,
+}

--- a/database/src/db/conn_builder.rs
+++ b/database/src/db/conn_builder.rs
@@ -169,8 +169,16 @@ impl ConnBuilder<PathBuf, false, Unspecified, i32> {
     }
 
     pub fn build_readonly(self) -> Result<Arc<DB>, Box<dyn std::error::Error>> {
-        let (opts, guard) =
+        if !self.db_path.exists() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("database path does not exist: {}", self.db_path.display()),
+            )));
+        }
+
+        let (mut opts, guard) =
             default_opts!(self).map_err(|err: kaspa_utils::fd_budget::Error| -> Box<dyn std::error::Error> { Box::new(err) })?;
+        opts.create_if_missing(false);
         let db = Arc::new(DB::new(<DBWithThreadMode<MultiThreaded>>::open_for_read_only(&opts, &self.db_path, false)?, guard));
         Ok(db)
     }

--- a/database/src/db/conn_builder.rs
+++ b/database/src/db/conn_builder.rs
@@ -167,6 +167,13 @@ impl ConnBuilder<PathBuf, false, Unspecified, i32> {
         let db = Arc::new(DB::new(<DBWithThreadMode<MultiThreaded>>::open(&opts, self.db_path.to_str().unwrap()).unwrap(), guard));
         Ok(db)
     }
+
+    pub fn build_readonly(self) -> Result<Arc<DB>, Box<dyn std::error::Error>> {
+        let (opts, guard) =
+            default_opts!(self).map_err(|err: kaspa_utils::fd_budget::Error| -> Box<dyn std::error::Error> { Box::new(err) })?;
+        let db = Arc::new(DB::new(<DBWithThreadMode<MultiThreaded>>::open_for_read_only(&opts, &self.db_path, false)?, guard));
+        Ok(db)
+    }
 }
 
 impl ConnBuilder<PathBuf, true, Unspecified, i32> {


### PR DESCRIPTION
Introduce the rocknroll dev DB scanner crate and add an smt_prune_scan binary for readonly consensus DB inspection.

The scanner resolves appdir-based consensus DBs through meta, skips archive nodes, verifies pruning stability, mirrors the inclusive SMT prune cutoff, and reports stale branch, lane, and score-index entries.

Also add readonly RocksDB opening support and a readonly MultiConsensusManagementStore constructor for scanner use.