### PR TITLE
Bump the header version for Toccata

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -5,7 +5,7 @@ pub use super::{
 };
 use crate::{
     BlockLevel, KType,
-    constants::STORAGE_MASS_PARAMETER,
+    constants::{BLOCK_VERSION, STORAGE_MASS_PARAMETER, TOCCATA_BLOCK_VERSION},
     mass::{BlockLaneLimits, BlockMassLimits, MassCofactors},
     network::{NetworkId, NetworkType},
 };
@@ -515,6 +515,15 @@ impl Params {
         // the two to avoid a situation where a block can be pruned and
         // not finalized.
         min(self.blockrate.pruning_depth, anticone_finalization_depth)
+    }
+
+    pub fn block_version(&self) -> ForkedParam<u16> {
+        if self.net == TESTNET12_PARAMS.net {
+            // The testnet12 hardfork was activated without a block version bump, so we return a constant value of 1 for compatibility with the existing testnet12 chain.
+            ForkedParam::new_const(BLOCK_VERSION)
+        } else {
+            ForkedParam::new(BLOCK_VERSION, TOCCATA_BLOCK_VERSION, self.covenants_activation)
+        }
     }
 
     pub fn network_name(&self) -> String {

--- a/consensus/core/src/constants.rs
+++ b/consensus/core/src/constants.rs
@@ -1,8 +1,10 @@
 /// BLOCK_VERSION represents the current block version
+// TODO(post-toccata): Change this to 2 and remove TOCCATA_BLOCK_VERSION.
 pub const BLOCK_VERSION: u16 = 1;
 
 /// The block version activated by the Toccata hardfork. This change denotes the use of
 /// the new sequencing commit described in KIP-21.
+// TOOD(post-toccata): Remove this and change BLOCK_VERSION to 2.
 pub const TOCCATA_BLOCK_VERSION: u16 = 2;
 
 /// TX_VERSION is the current latest supported transaction version.

--- a/consensus/core/src/constants.rs
+++ b/consensus/core/src/constants.rs
@@ -1,6 +1,10 @@
 /// BLOCK_VERSION represents the current block version
 pub const BLOCK_VERSION: u16 = 1;
 
+/// The block version activated by the Toccata hardfork. This change denotes the use of
+/// the new sequencing commit described in KIP-21.
+pub const TOCCATA_BLOCK_VERSION: u16 = 2;
+
 /// TX_VERSION is the current latest supported transaction version.
 pub const TX_VERSION: u16 = 0;
 

--- a/consensus/core/src/errors/block.rs
+++ b/consensus/core/src/errors/block.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Display};
 
 use crate::{
-    BlueWorkType, constants,
+    BlueWorkType,
     errors::{coinbase::CoinbaseError, tx::TxRuleError},
     subnets::SubnetworkId,
     tx::{TransactionId, TransactionOutpoint},
@@ -28,8 +28,8 @@ impl<T: Display + Clone> Display for TwoDimVecDisplay<T> {
 
 #[derive(Error, Debug, Clone)]
 pub enum RuleError {
-    #[error("wrong block version: got {0} but expected {block_version}", block_version = constants::BLOCK_VERSION)]
-    WrongBlockVersion(u16),
+    #[error("wrong block version: got {0} but expected {1}")]
+    WrongBlockVersion(u16, u16),
 
     #[error("the block timestamp is too far into the future: block timestamp is {0} but maximum timestamp allowed is {1}")]
     TimeTooFarIntoTheFuture(u64, u64),

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -2,8 +2,6 @@ use super::{HeaderProcessingContext, HeaderProcessor};
 use crate::errors::{BlockProcessResult, RuleError, TwoDimVecDisplay};
 use crate::model::services::reachability::ReachabilityService;
 use crate::processes::window::WindowManager;
-use kaspa_consensus_core::config::params::TESTNET12_GENESIS;
-use kaspa_consensus_core::constants;
 use kaspa_consensus_core::header::Header;
 use kaspa_hashes::Hash;
 use std::collections::HashSet;
@@ -105,14 +103,9 @@ impl HeaderProcessor {
 
     // TODO(post-toccata): Remove this and restore the context-free check_header_version.
     fn check_header_version_in_context(&self, header: &Header) -> BlockProcessResult<()> {
-        if self.genesis.hash == TESTNET12_GENESIS.hash {
-            if header.version != constants::BLOCK_VERSION {
-                return Err(RuleError::WrongBlockVersion(header.version));
-            }
-        } else {
-            if header.version != self.block_version.get(header.daa_score) {
-                return Err(RuleError::WrongBlockVersion(header.version));
-            }
+        let expected_version = self.block_version.get(header.daa_score);
+        if header.version != expected_version {
+            return Err(RuleError::WrongBlockVersion(header.version, expected_version));
         }
         Ok(())
     }

--- a/consensus/src/pipeline/header_processor/post_pow_validation.rs
+++ b/consensus/src/pipeline/header_processor/post_pow_validation.rs
@@ -2,12 +2,15 @@ use super::{HeaderProcessingContext, HeaderProcessor};
 use crate::errors::{BlockProcessResult, RuleError, TwoDimVecDisplay};
 use crate::model::services::reachability::ReachabilityService;
 use crate::processes::window::WindowManager;
+use kaspa_consensus_core::config::params::TESTNET12_GENESIS;
+use kaspa_consensus_core::constants;
 use kaspa_consensus_core::header::Header;
 use kaspa_hashes::Hash;
 use std::collections::HashSet;
 
 impl HeaderProcessor {
     pub fn post_pow_validation(&self, ctx: &mut HeaderProcessingContext, header: &Header) -> BlockProcessResult<()> {
+        self.check_header_version_in_context(header)?;
         self.check_blue_score(ctx, header)?;
         self.check_blue_work(ctx, header)?;
         self.check_median_timestamp(ctx, header)?;
@@ -97,6 +100,20 @@ impl HeaderProcessor {
 
         ctx.merge_depth_root = Some(merge_depth_root);
         ctx.finality_point = Some(finality_point);
+        Ok(())
+    }
+
+    // TODO(post-toccata): Remove this and restore the context-free check_header_version.
+    fn check_header_version_in_context(&self, header: &Header) -> BlockProcessResult<()> {
+        if self.genesis.hash == TESTNET12_GENESIS.hash {
+            if header.version != constants::BLOCK_VERSION {
+                return Err(RuleError::WrongBlockVersion(header.version));
+            }
+        } else {
+            if header.version != self.block_version.get(header.daa_score) {
+                return Err(RuleError::WrongBlockVersion(header.version));
+            }
+        }
         Ok(())
     }
 }

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::constants;
 use crate::errors::{BlockProcessResult, RuleError};
 use crate::model::services::reachability::ReachabilityService;
 use crate::model::stores::statuses::StatusesStoreReader;
@@ -28,10 +27,11 @@ impl HeaderProcessor {
         Ok(())
     }
 
-    fn check_header_version(&self, header: &Header) -> BlockProcessResult<()> {
-        if header.version != constants::BLOCK_VERSION {
-            return Err(RuleError::WrongBlockVersion(header.version));
-        }
+    fn check_header_version(&self, _header: &Header) -> BlockProcessResult<()> {
+        // TODO(post-toccata): Uncomment this and remove check_header_version_in_context.
+        // if header.version != constants::TOCCATA_BLOCK_VERSION {
+        //     return Err(RuleError::WrongBlockVersion(header.version));
+        // }
         Ok(())
     }
 

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -33,7 +33,7 @@ use kaspa_consensus_core::{
     BlockHashSet, BlockLevel,
     blockhash::{BlockHashes, ORIGIN},
     blockstatus::BlockStatus::{self, StatusHeaderOnly, StatusInvalid},
-    config::genesis::GenesisBlock,
+    config::{genesis::GenesisBlock, params::ForkedParam},
     header::Header,
 };
 use kaspa_consensusmanager::SessionLock;
@@ -108,6 +108,7 @@ pub struct HeaderProcessor {
     pub(super) mergeset_size_limit: u64,
     pub(super) skip_proof_of_work: bool,
     pub(super) max_block_level: BlockLevel,
+    pub(super) block_version: ForkedParam<u16>,
 
     // DB
     db: Arc<DB>,
@@ -194,6 +195,7 @@ impl HeaderProcessor {
             mergeset_size_limit: params.mergeset_size_limit(),
             skip_proof_of_work: params.skip_proof_of_work,
             max_block_level: params.max_block_level,
+            block_version: params.block_version(),
         }
     }
 

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -6,7 +6,6 @@ use crate::{
         },
         storage::ConsensusStorage,
     },
-    constants::BLOCK_VERSION,
     errors::RuleError,
     model::{
         services::{
@@ -86,6 +85,7 @@ use super::bounds::SeqCommitBounds;
 use super::errors::{PruningImportError, PruningImportResult};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use itertools::Itertools;
+use kaspa_consensus_core::config::params::ForkedParam;
 use kaspa_consensus_core::tx::ValidatedTransaction;
 use kaspa_utils::binary_heap::BinaryHeapExtensions;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -120,6 +120,7 @@ pub struct VirtualStateProcessor {
     pub(super) mergeset_size_limit: u64,
     pub(super) finality_depth: u64,
     pub(super) mempool_mass_cofactors: kaspa_consensus_core::config::params::ForkedParam<kaspa_consensus_core::mass::MassCofactors>,
+    pub(super) block_version: ForkedParam<u16>,
 
     // Stores
     pub(super) statuses_store: Arc<RwLock<DbStatusesStore>>,
@@ -207,6 +208,7 @@ impl VirtualStateProcessor {
             max_block_parents: params.max_block_parents(),
             mergeset_size_limit: params.mergeset_size_limit(),
             mempool_mass_cofactors: params.mempool_block_mass_cofactors(),
+            block_version: params.block_version(),
 
             db,
             statuses_store: storage.statuses_store.clone(),
@@ -1310,7 +1312,7 @@ impl VirtualStateProcessor {
             )
             .unwrap();
         txs.insert(0, coinbase.tx);
-        let version = BLOCK_VERSION;
+        let version = self.block_version.get(virtual_state.daa_score);
         assert_eq!(virtual_state.ghostdag_data.selected_parent, virtual_state.parents[0]);
         let parents_by_level = self.parents_manager.calc_block_parents(pruning_point, &virtual_state.parents);
         assert_eq!(virtual_state.ghostdag_data.selected_parent, parents_by_level.get(0).unwrap()[0]);

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -6,7 +6,11 @@ use kaspa_consensus_core::{
     blockhash,
     blockstatus::BlockStatus,
     coinbase::MinerData,
-    config::{ConfigBuilder, params::MAINNET_PARAMS},
+    config::{
+        ConfigBuilder,
+        params::{ForkActivation, MAINNET_PARAMS},
+    },
+    constants::{BLOCK_VERSION, TOCCATA_BLOCK_VERSION},
     tx::{ScriptPublicKey, ScriptVec, Transaction},
 };
 use kaspa_hashes::Hash;
@@ -167,6 +171,41 @@ async fn template_mining_sanity_test() {
             .assert_virtual_parents_subset()
             .assert_valid_utxo_tip();
     }
+}
+
+#[tokio::test]
+async fn block_template_version_changes_to_v2_upon_activation() {
+    let activation = MAINNET_PARAMS.genesis.daa_score + 10;
+    let config = ConfigBuilder::new(MAINNET_PARAMS)
+        .skip_proof_of_work()
+        .edit_consensus_params(|p| p.covenants_activation = ForkActivation::new(activation))
+        .build();
+    let consensus = TestConsensus::new(&config);
+    let join_handles = consensus.init();
+    let miner_data = new_miner_data();
+
+    let mut saw_pre_activation_template = false;
+    loop {
+        let template = consensus
+            .build_block_template(
+                miner_data.clone(),
+                Box::new(OnetimeTxSelector::new(Default::default())),
+                TemplateBuildMode::Standard,
+            )
+            .unwrap();
+        if template.block.header.daa_score >= activation {
+            assert!(saw_pre_activation_template);
+            assert_eq!(template.block.header.version, TOCCATA_BLOCK_VERSION);
+            break;
+        }
+
+        saw_pre_activation_template = true;
+        assert_eq!(template.block.header.version, BLOCK_VERSION);
+        let status = consensus.validate_and_insert_block(template.block.to_immutable()).virtual_state_task.await.unwrap();
+        assert!(status.has_block_body());
+    }
+
+    consensus.shutdown(join_handles);
 }
 
 #[tokio::test]

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -22,11 +22,11 @@ use kaspa_consensus::processes::reachability::tests::{DagBlock, DagBuilder, Stor
 use kaspa_consensus::processes::window::{WindowManager, WindowType};
 use kaspa_consensus_core::api::args::TransactionValidationArgs;
 use kaspa_consensus_core::api::{BlockValidationFutures, ConsensusApi};
-use kaspa_consensus_core::block::Block;
+use kaspa_consensus_core::block::{Block, MutableBlock};
 use kaspa_consensus_core::blockhash::{self, new_unique};
 use kaspa_consensus_core::blockstatus::BlockStatus;
 use kaspa_consensus_core::coinbase::MinerData;
-use kaspa_consensus_core::constants::{BLOCK_VERSION, SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR};
+use kaspa_consensus_core::constants::{BLOCK_VERSION, SOMPI_PER_KASPA, TOCCATA_BLOCK_VERSION, TRANSIENT_BYTE_TO_MASS_FACTOR};
 use kaspa_consensus_core::errors::block::{BlockProcessResult, RuleError};
 use kaspa_consensus_core::errors::tx::TxRuleError;
 use kaspa_consensus_core::hashing;
@@ -493,6 +493,58 @@ async fn header_in_isolation_validation_test() {
             }
         }
     }
+
+    consensus.shutdown(wait_handles);
+}
+
+#[tokio::test]
+async fn header_version_is_enforced_by_activation() {
+    fn set_block_version(mut block: MutableBlock, version: u16) -> MutableBlock {
+        block.header.version = version;
+        block.header.finalize();
+        block
+    }
+
+    init_allocator_with_default_settings();
+    let activation = MAINNET_PARAMS.genesis.daa_score + 10;
+    let config = ConfigBuilder::new(MAINNET_PARAMS)
+        .skip_proof_of_work()
+        .edit_consensus_params(|p| p.covenants_activation = ForkActivation::new(activation))
+        .build();
+    let consensus = TestConsensus::new(&config);
+    let wait_handles = consensus.init();
+
+    let mut parent = config.genesis.hash;
+    let mut next_hash = 2u64;
+    let active_block = loop {
+        let block = consensus.build_header_only_block_with_parents(next_hash.into(), vec![parent]);
+        next_hash += 1;
+        if block.header.daa_score >= activation {
+            break block;
+        }
+
+        assert_eq!(block.header.version, BLOCK_VERSION);
+        let wrong_version_block = set_block_version(block.clone(), TOCCATA_BLOCK_VERSION);
+        assert_match!(
+            consensus.validate_and_insert_block(wrong_version_block.to_immutable()).block_task.await,
+            Err(RuleError::WrongBlockVersion(TOCCATA_BLOCK_VERSION))
+        );
+
+        parent = block.header.hash;
+        assert_match!(consensus.validate_and_insert_block(block.to_immutable()).block_task.await, Ok(BlockStatus::StatusHeaderOnly));
+    };
+
+    let wrong_post_activation_block = set_block_version(active_block.clone(), BLOCK_VERSION);
+    assert_match!(
+        consensus.validate_and_insert_block(wrong_post_activation_block.to_immutable()).block_task.await,
+        Err(RuleError::WrongBlockVersion(BLOCK_VERSION))
+    );
+
+    let active_block = set_block_version(active_block, TOCCATA_BLOCK_VERSION);
+    assert_match!(
+        consensus.validate_and_insert_block(active_block.to_immutable()).block_task.await,
+        Ok(BlockStatus::StatusHeaderOnly)
+    );
 
     consensus.shutdown(wait_handles);
 }

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -438,8 +438,9 @@ async fn header_in_isolation_validation_test() {
         let block_version = BLOCK_VERSION - 1;
         block.header.version = block_version;
         match consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await {
-            Err(RuleError::WrongBlockVersion(wrong_version)) => {
-                assert_eq!(wrong_version, block_version)
+            Err(RuleError::WrongBlockVersion(wrong_version, expected_version)) => {
+                assert_eq!(wrong_version, block_version);
+                assert_eq!(expected_version, BLOCK_VERSION);
             }
             res => {
                 panic!("Unexpected result: {res:?}")
@@ -527,7 +528,7 @@ async fn header_version_is_enforced_by_activation() {
         let wrong_version_block = set_block_version(block.clone(), TOCCATA_BLOCK_VERSION);
         assert_match!(
             consensus.validate_and_insert_block(wrong_version_block.to_immutable()).block_task.await,
-            Err(RuleError::WrongBlockVersion(TOCCATA_BLOCK_VERSION))
+            Err(RuleError::WrongBlockVersion(TOCCATA_BLOCK_VERSION, BLOCK_VERSION))
         );
 
         parent = block.header.hash;
@@ -537,7 +538,7 @@ async fn header_version_is_enforced_by_activation() {
     let wrong_post_activation_block = set_block_version(active_block.clone(), BLOCK_VERSION);
     assert_match!(
         consensus.validate_and_insert_block(wrong_post_activation_block.to_immutable()).block_task.await,
-        Err(RuleError::WrongBlockVersion(BLOCK_VERSION))
+        Err(RuleError::WrongBlockVersion(BLOCK_VERSION, TOCCATA_BLOCK_VERSION))
     );
 
     let active_block = set_block_version(active_block, TOCCATA_BLOCK_VERSION);


### PR DESCRIPTION
We bump the header version to denote for the sequencing commitment changes that were introduced in  [KIP-21](https://github.com/kaspanet/kips/pull/36)