### PR TITLE
feat(wasm/txscript): allows passing script builder flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -338,13 +338,15 @@ jobs:
 
       - name: Run wasm tests for crypto/addresses
         run: wasm-pack test --node crypto/addresses
+        
+      - name: Run wasm tests for crypto/txscript
+        run: wasm-pack test --node crypto/txscript --features wasm32-sdk
 
       - name: Run wasm tests for wallet/pskt
         run: wasm-pack test --node wallet/pskt
 
       - name: Run wasm tests for consensus/client
         run: wasm-pack test --node consensus/client --features wasm32-sdk
-
 
   build-wasm32:
     name: Build WASM32 SDK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3851,6 +3851,7 @@ dependencies = [
  "hexplay",
  "indexmap 2.14.0",
  "itertools 0.13.0",
+ "js-sys",
  "kaspa-addresses",
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3874,6 +3875,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "workflow-wasm",
 ]
 

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 name = "kip-10"
 
 [features]
-wasm32-core = ["dep:kaspa-wasm-core"]
+wasm32-core = ["dep:js-sys", "dep:kaspa-wasm-core"]
 wasm32-sdk = ["wasm32-core", "kaspa-consensus-core/wasm32-sdk"]
 
 [dependencies]
@@ -32,6 +32,7 @@ faster-hex.workspace = true
 hexplay.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
+js-sys = { workspace = true, optional = true }
 kaspa-addresses.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-hashes.workspace = true
@@ -65,6 +66,7 @@ rayon.workspace = true
 kaspa-core.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
+wasm-bindgen-test.workspace = true
 
 [[bench]]
 name = "zk_precompiles"

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -129,6 +129,7 @@ pub struct EngineFlags {
 
 impl Default for EngineFlags {
     fn default() -> Self {
+        // TODO(post-toccata): change default values (wasm client is based on this one, no other changes needed)
         Self { covenants_enabled: false, sigop_script_units: Gram(1000).into() }
     }
 }

--- a/crypto/txscript/src/script_builder.rs
+++ b/crypto/txscript/src/script_builder.rs
@@ -79,6 +79,10 @@ impl ScriptBuilder {
         Self { script: Vec::with_capacity(DEFAULT_SCRIPT_ALLOC), flags }
     }
 
+    pub fn flags(&self) -> EngineFlags {
+        self.flags
+    }
+
     pub fn script(&self) -> &[u8] {
         &self.script
     }

--- a/crypto/txscript/src/wasm/builder.rs
+++ b/crypto/txscript/src/wasm/builder.rs
@@ -1,6 +1,5 @@
-use crate::result::Result;
-use crate::{script_builder as native, standard};
-use kaspa_consensus_core::tx::ScriptPublicKey;
+use crate::{EngineFlags, error::Error, result::Result, script_builder as native, standard};
+use kaspa_consensus_core::{mass::ScriptUnits, tx::ScriptPublicKey};
 use kaspa_utils::hex::ToHex;
 use kaspa_wasm_core::hex::{HexViewConfig, HexViewConfigT};
 use kaspa_wasm_core::types::{BinaryT, HexString};
@@ -8,6 +7,37 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use workflow_wasm::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_SCRIPT_BUILDER_OPTIONS: &'static str = r#"
+/**
+ * Script builder engine flags.
+ *
+ * @category TxScript
+ */
+export interface ScriptBuilderFlags {
+    /** Whether or not covenant opcodes and post-Toccata script limits are enabled. */
+    covenantsEnabled?: boolean;
+    /** Script units charged for each signature operation. Defaults to the native engine default. */
+    sigopScriptUnits?: bigint | number;
+}
+
+/**
+ * Script builder options.
+ *
+ * @category TxScript
+ */
+export interface ScriptBuilderOptions {
+    /** Engine flags used by the underlying native ScriptBuilder. */
+    flags?: ScriptBuilderFlags;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "ScriptBuilderOptions")]
+    pub type ScriptBuilderOptions;
+}
 
 /// ScriptBuilder provides a facility for building custom scripts. It allows
 /// you to push opcodes, ints, and data while respecting canonical encoding. In
@@ -23,6 +53,15 @@ pub struct ScriptBuilder {
 }
 
 impl ScriptBuilder {
+    fn with_flags(flags: EngineFlags) -> Self {
+        Self { script_builder: Rc::new(RefCell::new(native::ScriptBuilder::with_flags(flags))) }
+    }
+
+    fn try_new(options: Option<ScriptBuilderOptions>) -> Result<Self> {
+        let flags = options.map(EngineFlags::try_from).transpose()?.unwrap_or_default();
+        Ok(Self::with_flags(flags))
+    }
+
     #[inline]
     pub fn inner(&self) -> Ref<'_, native::ScriptBuilder> {
         self.script_builder.borrow()
@@ -36,23 +75,49 @@ impl ScriptBuilder {
 
 impl Default for ScriptBuilder {
     fn default() -> Self {
-        Self { script_builder: Rc::new(RefCell::new(native::ScriptBuilder::new())) }
+        Self::with_flags(Default::default())
     }
 }
 
-// TODO: Add `ScriptBuilder::with_flags` method that allows setting script engine flags for the builder.
+impl TryFrom<ScriptBuilderOptions> for EngineFlags {
+    type Error = Error;
+
+    fn try_from(value: ScriptBuilderOptions) -> Result<Self> {
+        let object = js_sys::Object::try_from(&value).ok_or_else(|| Error::Custom("options must be an object".into()))?;
+        let flags = object.try_get_value("flags")?;
+        let Some(flags) = flags else {
+            return Ok(Self::default());
+        };
+
+        let flags = js_sys::Object::try_from(&flags).ok_or_else(|| Error::Custom("options.flags must be an object".into()))?;
+        let mut engine_flags = Self::default();
+
+        if let Some(value) = flags.try_get_value("covenantsEnabled")? {
+            engine_flags.covenants_enabled =
+                value.as_bool().ok_or_else(|| Error::convert("flags.covenantsEnabled", "expected boolean"))?;
+        }
+
+        if flags.try_get_value("sigopScriptUnits")?.is_some() {
+            engine_flags.sigop_script_units =
+                ScriptUnits(flags.get_u64("sigopScriptUnits").map_err(|err| Error::convert("flags.sigopScriptUnits", err))?);
+        }
+
+        Ok(engine_flags)
+    }
+}
+
 #[wasm_bindgen]
 impl ScriptBuilder {
     #[wasm_bindgen(constructor)]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(options: Option<ScriptBuilderOptions>) -> Result<ScriptBuilder> {
+        Self::try_new(options)
     }
 
     /// Creates a new ScriptBuilder over an existing script.
     /// Supplied script can be represented as an `Uint8Array` or a `HexString`.
     #[wasm_bindgen(js_name = "fromScript")]
-    pub fn from_script(script: BinaryT) -> Result<ScriptBuilder> {
-        let builder = ScriptBuilder::default();
+    pub fn from_script(script: BinaryT, options: Option<ScriptBuilderOptions>) -> Result<ScriptBuilder> {
+        let builder = ScriptBuilder::try_new(options)?;
         let script = script.try_as_vec_u8()?;
         builder.inner_mut().script_mut().extend(&script);
 
@@ -163,8 +228,9 @@ impl ScriptBuilder {
     pub fn pay_to_script_hash_signature_script(&self, signature: BinaryT) -> Result<HexString> {
         let inner = self.inner();
         let script = inner.script();
+        let flags = inner.flags();
         let signature = signature.try_as_vec_u8()?;
-        let generated_script = standard::pay_to_script_hash_signature_script(script.into(), signature)?;
+        let generated_script = standard::pay_to_script_hash_signature_script_with_flags(script.into(), signature, flags)?;
 
         Ok(generated_script.to_hex().into())
     }
@@ -176,5 +242,49 @@ impl ScriptBuilder {
 
         let config = args.map(HexViewConfig::try_from).transpose()?.unwrap_or_default();
         Ok(config.build(script).to_string())
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::{ScriptBuilder, ScriptBuilderOptions};
+    use crate::{max_script_element_size, wasm::Opcodes};
+    use js_sys::{Object, Reflect, Uint8Array};
+    use kaspa_wasm_core::types::BinaryT;
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    fn binary(bytes: &[u8]) -> BinaryT {
+        Uint8Array::from(bytes).unchecked_into()
+    }
+
+    fn script_builder_options(covenants_enabled: bool) -> ScriptBuilderOptions {
+        let flags = Object::new();
+        Reflect::set(&flags, &JsValue::from_str("covenantsEnabled"), &JsValue::from_bool(covenants_enabled)).unwrap();
+
+        let options = Object::new();
+        Reflect::set(&options, &JsValue::from_str("flags"), &flags).unwrap();
+        options.unchecked_into()
+    }
+
+    #[wasm_bindgen_test]
+    fn script_builder_js_test() {
+        let builder = ScriptBuilder::new(None).expect("builder should be created");
+        builder.add_op(Opcodes::OpTrue as u8).expect("opcode should be added");
+        builder.add_data(binary(&[0xab, 0xcd])).expect("data should be added");
+
+        assert_eq!(builder.to_string_js().as_string().unwrap(), "5102abcd");
+    }
+
+    #[wasm_bindgen_test]
+    fn script_builder_uses_flags_js_test() {
+        let data_with_length_greater_than_max = vec![0x01; max_script_element_size(false) + 1];
+
+        let builder_without_covenants = ScriptBuilder::new(None).expect("builder should be created");
+        assert!(builder_without_covenants.add_data(binary(&data_with_length_greater_than_max)).is_err());
+
+        let builder_with_covenants =
+            ScriptBuilder::new(Some(script_builder_options(true))).expect("builder should be created with covenant flags");
+        builder_with_covenants.add_data(binary(&data_with_length_greater_than_max)).expect("covenant flag allow pushes > 520");
     }
 }

--- a/wasm/examples/nodejs/javascript/zkproof/groth16.js
+++ b/wasm/examples/nodejs/javascript/zkproof/groth16.js
@@ -1,215 +1,238 @@
-const { PrivateKey, RpcClient, ScriptBuilder, Opcodes,
-    payToScriptHashScript, addressFromScriptPublicKey,
-    createTransaction, signTransaction } = require('./kaspa');
+const {
+  PrivateKey,
+  RpcClient,
+  ScriptBuilder,
+  Opcodes,
+  payToScriptHashScript,
+  addressFromScriptPublicKey,
+  createTransaction,
+  signTransaction,
+  Encoding,
+} = require("../../../../nodejs/kaspa");
 
-// Configuration  
-const NETWORK_ID = 'devnet';
-const RPC_URL = 'ws://127.0.0.1:17610';
-const PRIVATE_KEY = 'b99d75736a0fd0ae2da658959813d680474f5a740a9c970a7da867141596178f';
+// Configuration
+const NETWORK_ID = "devnet";
+const RPC_URL = "ws://127.0.0.1:17610";
+const PRIVATE_KEY =
+  "b99d75736a0fd0ae2da658959813d680474f5a740a9c970a7da867141596178f";
 
 // ZK Proof configuration - Hardcoded values
 const ZK_VERIFIER_TAG = 0x20; // Groth16
 
-const UNPREPARED_VK_HEX = 'e2f26dbea299f5223b646cb1fb33eadb059d9407559d7441dfd902e3a79a4d2dabb73dc17fbc13021e2471e0c08bd67d8401f52b73d6d07483794cad4778180e0c06f33bbc4c79a9cadef253a68084d382f17788f885c9afd176f7cb2f036789edf692d95cbdde46ddda5ef7d422436779445c5e66006a42761e1f12efde0018c212f3aeb785e49712e7a9353349aaf1255dfb31b7bf60723a480d9293938e1933033e7fea1f40604eaacf699d4be9aacc577054a0db22d9129a1728ff85a01a1c3af829b62bf4914c0bcf2c81a4bd577190eff5f194ee9bac95faefd53cb0030600000000000000e43bdc655d0f9d730535554d9caa611ddd152c081a06a932a8e1d5dc259aac123f42a188f683d869873ccc4c119442e57b056e03e2fa92f2028c97bc20b9078747c30f85444697fdf436e348711c011115963f855197243e4b39e6cbe236ca8ba7f2042e11f9255afbb6c6e2c3accb88e401f2aac21c097c92b3fbdb99f98a9b0dcd6c075ada6ed0ddfece1d4a2d005f61a7d5df0b75c18a5b2374d64e495fab93d4c4b1200394d5253cce2f25a59b862ee8e4cd43686603faa09d5d0d3c1c8f';
+const UNPREPARED_VK_HEX =
+  "e2f26dbea299f5223b646cb1fb33eadb059d9407559d7441dfd902e3a79a4d2dabb73dc17fbc13021e2471e0c08bd67d8401f52b73d6d07483794cad4778180e0c06f33bbc4c79a9cadef253a68084d382f17788f885c9afd176f7cb2f036789edf692d95cbdde46ddda5ef7d422436779445c5e66006a42761e1f12efde0018c212f3aeb785e49712e7a9353349aaf1255dfb31b7bf60723a480d9293938e1933033e7fea1f40604eaacf699d4be9aacc577054a0db22d9129a1728ff85a01a1c3af829b62bf4914c0bcf2c81a4bd577190eff5f194ee9bac95faefd53cb0030600000000000000e43bdc655d0f9d730535554d9caa611ddd152c081a06a932a8e1d5dc259aac123f42a188f683d869873ccc4c119442e57b056e03e2fa92f2028c97bc20b9078747c30f85444697fdf436e348711c011115963f855197243e4b39e6cbe236ca8ba7f2042e11f9255afbb6c6e2c3accb88e401f2aac21c097c92b3fbdb99f98a9b0dcd6c075ada6ed0ddfece1d4a2d005f61a7d5df0b75c18a5b2374d64e495fab93d4c4b1200394d5253cce2f25a59b862ee8e4cd43686603faa09d5d0d3c1c8f";
 
-const PROOF_HEX = '570253c0c483a1b16460118e63c155f3684e784ae7d97e8fc3f544128b37fe15075eab5ac31150c8a44253d8525971241bbd7227fcefbae2db4ae71675c56a2e0eb9235136b15ab72f16e707832f3d6ae5b0ba7cca53ae17cb52b3201919eb9d908c16297abd90aa7e00267bc21a9a78116e717d4d76edd44e21cca17e3d592d';
+const PROOF_HEX =
+  "570253c0c483a1b16460118e63c155f3684e784ae7d97e8fc3f544128b37fe15075eab5ac31150c8a44253d8525971241bbd7227fcefbae2db4ae71675c56a2e0eb9235136b15ab72f16e707832f3d6ae5b0ba7cca53ae17cb52b3201919eb9d908c16297abd90aa7e00267bc21a9a78116e717d4d76edd44e21cca17e3d592d";
 
 // Public inputs (5 field elements, 32 bytes each, little-endian)
 const PUBLIC_INPUTS = [
-    'a54dc85ac99f851c92d7c96d7318af4100000000000000000000000000000000',
-    'dbe7c0194edfcc37eb4d422a998c1f5600000000000000000000000000000000',
-    'a95ac0b37bfedcd8136e6c1143086bf500000000000000000000000000000000',
-    'd223ffcb21c6ffcb7c8f60392ca49dde00000000000000000000000000000000',
-    'c07a65145c3cb48b6101962ea607a4dd93c753bb26975cb47feb00d3666e4404'
+  "a54dc85ac99f851c92d7c96d7318af4100000000000000000000000000000000",
+  "dbe7c0194edfcc37eb4d422a998c1f5600000000000000000000000000000000",
+  "a95ac0b37bfedcd8136e6c1143086bf500000000000000000000000000000000",
+  "d223ffcb21c6ffcb7c8f60392ca49dde00000000000000000000000000000000",
+  "c07a65145c3cb48b6101962ea607a4dd93c753bb26975cb47feb00d3666e4404",
 ];
 
 async function groth16Verify() {
-    const privateKey = new PrivateKey(PRIVATE_KEY);
-    const keypair = privateKey.toKeypair();
-    const sourceAddress = keypair.toAddress(NETWORK_ID);
-    
-    // Parse proof data
-    const unpreparedVk = Buffer.from(UNPREPARED_VK_HEX, 'hex');
-    const proof = Buffer.from(PROOF_HEX, 'hex');
-    const publicInputs = PUBLIC_INPUTS.map(hex => Buffer.from(hex, 'hex'));
-    const numInputs = PUBLIC_INPUTS.length;
+  const privateKey = new PrivateKey(PRIVATE_KEY);
+  const keypair = privateKey.toKeypair();
+  const sourceAddress = keypair.toAddress(NETWORK_ID);
 
-    console.log(`Verifying Groth16 proof with:`);
-    console.log(`  - Verifying key: ${unpreparedVk.length} bytes`);
-    console.log(`  - Proof: ${proof.length} bytes`);
-    console.log(`  - Public inputs: ${numInputs} field elements`);
+  // Parse proof data
+  const unpreparedVk = Buffer.from(UNPREPARED_VK_HEX, "hex");
+  const proof = Buffer.from(PROOF_HEX, "hex");
+  const publicInputs = PUBLIC_INPUTS.map((hex) => Buffer.from(hex, "hex"));
+  const numInputs = PUBLIC_INPUTS.length;
 
-    const rpc = new RpcClient({
-        url: RPC_URL,
-        encoding: 'borsh',
-        networkId: NETWORK_ID
+  console.log(`Verifying Groth16 proof with:`);
+  console.log(`  - Verifying key: ${unpreparedVk.length} bytes`);
+  console.log(`  - Proof: ${proof.length} bytes`);
+  console.log(`  - Public inputs: ${numInputs} field elements`);
+
+  const rpc = new RpcClient({
+    url: RPC_URL,
+    encoding: Encoding.Borsh,
+    networkId: NETWORK_ID,
+  });
+
+  await rpc.connect();
+
+  try {
+    // Get UTXOs and wait for maturity
+    console.log("Fetching UTXOs...");
+    const response = await rpc.getUtxosByAddresses([sourceAddress]);
+
+    const info = await rpc.getBlockDagInfo();
+    const currentDaaScore = info.virtualDaaScore;
+
+    const matureUtxos = response.entries.filter((entry) => {
+      if (!entry.entry.isCoinbase) return true;
+      return currentDaaScore - entry.entry.blockDaaScore >= 100n;
     });
 
-    await rpc.connect();
-    
-    try {
-        // Get UTXOs and wait for maturity
-        console.log('Fetching UTXOs...');
-        let response = await rpc.getUtxosByAddresses([sourceAddress]);
-        
-        const info = await rpc.getBlockDagInfo();
-        const currentDaaScore = info.virtualDaaScore;
-        
-        const matureUtxos = response.entries.filter(entry => {
-            if (!entry.entry.isCoinbase) return true;
-            return (currentDaaScore - entry.entry.blockDaaScore) >= 100n;
-        });
-
-        if (matureUtxos.length === 0) {
-            console.log('No mature UTXOs available. Mining or waiting required.');
-            return;
-        }
-
-        console.log(`Found ${matureUtxos.length} mature UTXOs`);
-
-        // Create P2SH redeem script
-        // Stack layout when executed:
-        // 1. Signature script pushes: input4, input3, input2, input1, input0, num_inputs(5), proof, vk
-        // 2. Redeem script pushes: tag (0x20)
-        // 3. OpZkPrecompile pops in order: tag, vk, proof, num_inputs, input0...input4
-        const redeemScriptBuilder = new ScriptBuilder();
-        
-        // The signature script will push all the proof data
-        // The redeem script only needs to push the tag and call the opcode
-        redeemScriptBuilder.addData(Buffer.from([ZK_VERIFIER_TAG])); // Push tag (0x20)
-        redeemScriptBuilder.addOp(Opcodes.OpZkPrecompile);            // Execute ZK verification
-        
-        const redeemScript = redeemScriptBuilder.drain();
-        const lockingScript = payToScriptHashScript(redeemScript);
-        
-        console.log(`Redeem script (hex): ${redeemScript}`);
-
-        // Convert the P2SH script to an address
-        const p2shAddress = addressFromScriptPublicKey(lockingScript, NETWORK_ID);
-        console.log(`P2SH address: ${p2shAddress}`);
-
-        // Create COMMIT transaction
-        const utxoToSpend = matureUtxos[0];
-        const commitAmount = utxoToSpend.amount - 10000n;
-
-        const utxoEntries = [{
-            address: sourceAddress,
-            outpoint: {
-                transactionId: utxoToSpend.outpoint.transactionId,
-                index: utxoToSpend.outpoint.index
-            },
-            scriptPublicKey: utxoToSpend.entry.scriptPublicKey,
-            amount: utxoToSpend.amount,
-            isCoinbase: utxoToSpend.entry.isCoinbase,
-            blockDaaScore: utxoToSpend.entry.blockDaaScore
-        }];
-
-        const commitTx = createTransaction(
-            utxoEntries,
-            [{
-                address: p2shAddress,
-                amount: commitAmount
-            }],
-            0n,
-            '',
-            1
-        );
-
-        console.log('Commit transaction created');
-
-        const signedCommitTx = signTransaction(commitTx, [privateKey], false);
-        console.log('Commit transaction signed');
-
-        const submitResult = await rpc.submitTransaction({ transaction: signedCommitTx });
-        const commitTxId = submitResult.transactionId || submitResult;
-        console.log(`Commit transaction submitted: ${commitTxId}`);
-
-        // Wait for commit transaction confirmation
-        console.log('Waiting for commit transaction to be accepted...');
-        await new Promise(resolve => setTimeout(resolve, 5000));
-
-        // Create REDEEM transaction
-        console.log('Creating redeem transaction...');
-
-        // Build signature script with proof data
-        // Stack order (bottom to top): vk, proof, num_inputs, input0, input1, input2, input3, input4
-        const signatureScriptBuilder = new ScriptBuilder();
-        
-        
-        
-        
-        // Push public inputs in order (input0 first, pushed last so it's on top)
-        for (let i = publicInputs.length - 1; i >= 0; i--) {
-            signatureScriptBuilder.addData(publicInputs[i]);
-        }
-        signatureScriptBuilder.addI64(BigInt(numInputs));
-
-        // Push verifying key
-        // Push proof
-        signatureScriptBuilder.addData(proof);
-        // Push number of inputs (little-endian u16)
-        
-                signatureScriptBuilder.addData(unpreparedVk);
-
-        // Push redeem script (P2SH requirement)
-        signatureScriptBuilder.addData(Buffer.from(redeemScript, 'hex'));
-        
-        const signatureScript = signatureScriptBuilder.drain();
-
-        console.log(`Signature script length: ${Buffer.from(signatureScript, 'hex').length} bytes`);
-        console.log('Stack contents (signature script):');
-        console.log(`  - Verifying key: ${unpreparedVk.length} bytes`);
-        console.log(`  - Proof: ${proof.length} bytes`);
-        console.log(`  - Number of inputs: ${numInputs}`);
-        publicInputs.forEach((input, idx) => {
-            console.log(`  - Input ${idx}: ${input.toString('hex').substring(0, 32)}...`);
-        });
-
-        // Construct the P2SH UTXO entry
-        const p2shUtxoEntry = {
-            address: p2shAddress,
-            outpoint: {
-                transactionId: commitTxId,
-                index: 0
-            },
-            scriptPublicKey: lockingScript,
-            amount: commitAmount,
-            isCoinbase: false,
-            blockDaaScore: currentDaaScore
-        };
-
-        // Create redeem transaction
-        const redeemTx = createTransaction(
-            [p2shUtxoEntry],
-            [{
-                address: sourceAddress,
-                amount: commitAmount - 142000n
-            }],
-            0n,
-            '',
-            104
-        );
-
-        // Set the signature script
-        redeemTx.inputs[0].signatureScript = signatureScript;
-
-        console.log('Redeem transaction created');
-        console.log('Submitting redeem transaction with Groth16 proof verification...');
-
-        // Submit redeem transaction
-        const redeemResult = await rpc.submitTransaction({ transaction: redeemTx });
-        const redeemTxId = redeemResult.transactionId || redeemResult;
-        console.log(`✓ Redeem transaction submitted: ${redeemTxId}`);
-        console.log('✓ Groth16 proof verification successful!');
-
-    } catch (error) {
-        console.error('Error:', error);
-        if (error.stack) {
-            console.error('Stack:', error.stack);
-        }
-    } finally {
-        await rpc.disconnect();
+    if (matureUtxos.length === 0) {
+      console.log("No mature UTXOs available. Mining or waiting required.");
+      return;
     }
+
+    console.log(`Found ${matureUtxos.length} mature UTXOs`);
+
+    // Create P2SH redeem script
+    // Stack layout when executed:
+    // 1. Signature script pushes: input4, input3, input2, input1, input0, num_inputs(5), proof, vk
+    // 2. Redeem script pushes: tag (0x20)
+    // 3. OpZkPrecompile pops in order: tag, vk, proof, num_inputs, input0...input4
+    const redeemScriptBuilder = new ScriptBuilder();
+
+    // The signature script will push all the proof data
+    // The redeem script only needs to push the tag and call the opcode
+    redeemScriptBuilder.addData(Buffer.from([ZK_VERIFIER_TAG])); // Push tag (0x20)
+    redeemScriptBuilder.addOp(Opcodes.OpZkPrecompile); // Execute ZK verification
+
+    const redeemScript = redeemScriptBuilder.drain();
+    const lockingScript = payToScriptHashScript(redeemScript);
+
+    console.log(`Redeem script (hex): ${redeemScript}`);
+
+    // Convert the P2SH script to an address
+    const p2shAddress = addressFromScriptPublicKey(lockingScript, NETWORK_ID);
+    console.log(`P2SH address: ${p2shAddress}`);
+
+    // Create COMMIT transaction
+    const utxoToSpend = matureUtxos[0];
+    const commitAmount = utxoToSpend.amount - 10000n;
+
+    const utxoEntries = [
+      {
+        address: sourceAddress,
+        outpoint: {
+          transactionId: utxoToSpend.outpoint.transactionId,
+          index: utxoToSpend.outpoint.index,
+        },
+        scriptPublicKey: utxoToSpend.entry.scriptPublicKey,
+        amount: utxoToSpend.amount,
+        isCoinbase: utxoToSpend.entry.isCoinbase,
+        blockDaaScore: utxoToSpend.entry.blockDaaScore,
+      },
+    ];
+
+    const commitTx = createTransaction(
+      utxoEntries,
+      [
+        {
+          address: p2shAddress,
+          amount: commitAmount,
+        },
+      ],
+      0n,
+      "",
+      1,
+    );
+
+    console.log("Commit transaction created");
+
+    const signedCommitTx = signTransaction(commitTx, [privateKey], false);
+    console.log("Commit transaction signed");
+
+    const submitResult = await rpc.submitTransaction({
+      transaction: signedCommitTx,
+    });
+    const commitTxId = submitResult.transactionId;
+    console.log(`Commit transaction submitted: ${commitTxId}`);
+
+    // Wait for commit transaction confirmation
+    console.log("Waiting for commit transaction to be accepted...");
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Create REDEEM transaction
+    console.log("Creating redeem transaction...");
+
+    // Build signature script with proof data
+    // Stack order (bottom to top): vk, proof, num_inputs, input0, input1, input2, input3, input4
+    const signatureScriptBuilder = new ScriptBuilder({
+      flags: { covenantsEnabled: true },
+    });
+
+    // Push public inputs in order (input0 first, pushed last so it's on top)
+    for (let i = publicInputs.length - 1; i >= 0; i--) {
+      signatureScriptBuilder.addData(publicInputs[i]);
+    }
+    signatureScriptBuilder.addI64(BigInt(numInputs));
+
+    // Push verifying key
+    // Push proof
+    signatureScriptBuilder.addData(proof);
+    // Push number of inputs (little-endian u16)
+
+    signatureScriptBuilder.addData(unpreparedVk);
+
+    // Push redeem script (P2SH requirement)
+    signatureScriptBuilder.addData(Buffer.from(redeemScript, "hex"));
+
+    const signatureScript = signatureScriptBuilder.drain();
+
+    console.log(
+      `Signature script length: ${Buffer.from(signatureScript, "hex").length} bytes`,
+    );
+    console.log("Stack contents (signature script):");
+    console.log(`  - Verifying key: ${unpreparedVk.length} bytes`);
+    console.log(`  - Proof: ${proof.length} bytes`);
+    console.log(`  - Number of inputs: ${numInputs}`);
+    publicInputs.forEach((input, idx) => {
+      console.log(
+        `  - Input ${idx}: ${input.toString("hex").substring(0, 32)}...`,
+      );
+    });
+
+    // Construct the P2SH UTXO entry
+    const p2shUtxoEntry = {
+      address: p2shAddress,
+      outpoint: {
+        transactionId: commitTxId,
+        index: 0,
+      },
+      scriptPublicKey: lockingScript,
+      amount: commitAmount,
+      isCoinbase: false,
+      blockDaaScore: currentDaaScore,
+    };
+
+    // Create redeem transaction
+    const redeemTx = createTransaction(
+      [p2shUtxoEntry],
+      [
+        {
+          address: sourceAddress,
+          amount: commitAmount - 142000n,
+        },
+      ],
+      0n,
+      "",
+      104,
+    );
+
+    // Set the signature script
+    redeemTx.inputs[0].signatureScript = signatureScript;
+
+    console.log("Redeem transaction created");
+    console.log(
+      "Submitting redeem transaction with Groth16 proof verification...",
+    );
+
+    // Submit redeem transaction
+    const redeemResult = await rpc.submitTransaction({ transaction: redeemTx });
+    const redeemTxId = redeemResult.transactionId || redeemResult;
+    console.log(`✓ Redeem transaction submitted: ${redeemTxId}`);
+    console.log("✓ Groth16 proof verification successful!");
+  } catch (error) {
+    console.error("Error:", error);
+    if (error.stack) {
+      console.error("Stack:", error.stack);
+    }
+  } finally {
+    await rpc.disconnect();
+  }
 }
 
 groth16Verify().catch(console.error);

--- a/wasm/examples/nodejs/javascript/zkproof/risc0-succinct.js
+++ b/wasm/examples/nodejs/javascript/zkproof/risc0-succinct.js
@@ -1,220 +1,243 @@
-const { PrivateKey, RpcClient, ScriptBuilder, Opcodes,
-    payToScriptHashScript, addressFromScriptPublicKey,
-    createTransaction, signTransaction } = require('../../../../nodejs/kaspa');
-const fs = require('fs');
-const path = require('path');
+const {
+  PrivateKey,
+  RpcClient,
+  ScriptBuilder,
+  Opcodes,
+  payToScriptHashScript,
+  addressFromScriptPublicKey,
+  createTransaction,
+  signTransaction,
+  Encoding,
+} = require("../../../../nodejs/kaspa");
+const fs = require("fs");
 
 // Configuration
-const NETWORK_ID = 'testnet-12';
-const RPC_URL = 'ws://127.0.0.1:16310';
-const PRIVATE_KEY = 'b99d75736a0fd0ae2da658959813d680474f5a740a9c970a7da867141596178f';
+const NETWORK_ID = "testnet-12";
+const RPC_URL = "ws://127.0.0.1:16310";
+const PRIVATE_KEY =
+  "b99d75736a0fd0ae2da658959813d680474f5a740a9c970a7da867141596178f";
 
 // ZK Proof configuration
 const ZK_VERIFIER_TAG = 0x21; // R0Succinct
 
 // Data files - matches the stack layout expected by R0SuccinctPrecompile::verify_zk
 // Stack (bottom to top): seal, claim, hashfn, control_index, control_digests, journal, image_id, tag
-const SEAL_FILE = './succinct.seal.hex';
-const CLAIM_FILE = './succinct.claim.hex';
-const HASHFN_FILE = './succinct.hashfn.hex';
-const CONTROL_INDEX_FILE = './succinct.control_index.hex';
-const CONTROL_DIGESTS_FILE = './succinct.control_digests.hex';
-const JOURNAL_FILE = './succinct.journal.hex';
-const IMAGE_ID_FILE = './succinct.image.hex';
+const SEAL_FILE = "./succinct.seal.hex";
+const CLAIM_FILE = "./succinct.claim.hex";
+const HASHFN_FILE = "./succinct.hashfn.hex";
+const CONTROL_INDEX_FILE = "./succinct.control_index.hex";
+const CONTROL_DIGESTS_FILE = "./succinct.control_digests.hex";
+const JOURNAL_FILE = "./succinct.journal.hex";
+const IMAGE_ID_FILE = "./succinct.image.hex";
 
 function loadHexFile(filePath, label) {
-    const hex = fs.readFileSync(filePath, 'utf8').trim();
-    const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex;
-    const buf = Buffer.from(cleanHex, 'hex');
-    console.log(`Loaded ${label}: ${buf.length} bytes`);
-    return buf;
+  const hex = fs.readFileSync(filePath, "utf8").trim();
+  const cleanHex = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const buf = Buffer.from(cleanHex, "hex");
+  console.log(`Loaded ${label}: ${buf.length} bytes`);
+  return buf;
 }
 
 async function zktest() {
-    const privateKey = new PrivateKey(PRIVATE_KEY);
-    const keypair = privateKey.toKeypair();
-    const sourceAddress = keypair.toAddress(NETWORK_ID);
-    console.log(`Using source address: ${sourceAddress}`);
+  const privateKey = new PrivateKey(PRIVATE_KEY);
+  const keypair = privateKey.toKeypair();
+  const sourceAddress = keypair.toAddress(NETWORK_ID);
+  console.log(`Using source address: ${sourceAddress}`);
 
-    // Load all proof components
-    let seal, claim, hashfn, controlIndex, controlDigests, journal, imageId;
-    try {
-        seal = loadHexFile(SEAL_FILE, 'seal');
-        claim = loadHexFile(CLAIM_FILE, 'claim');
-        hashfn = loadHexFile(HASHFN_FILE, 'hashfn');
-        controlIndex = loadHexFile(CONTROL_INDEX_FILE, 'control_index');
-        controlDigests = loadHexFile(CONTROL_DIGESTS_FILE, 'control_digests');
-        journal = loadHexFile(JOURNAL_FILE, 'journal');
-        imageId = loadHexFile(IMAGE_ID_FILE, 'image_id');
-    } catch (error) {
-        console.error('Failed to load proof data:', error.message);
-        return;
-    }
+  // Load all proof components
+  let seal, claim, hashfn, controlIndex, controlDigests, journal, imageId;
+  try {
+    seal = loadHexFile(SEAL_FILE, "seal");
+    claim = loadHexFile(CLAIM_FILE, "claim");
+    hashfn = loadHexFile(HASHFN_FILE, "hashfn");
+    controlIndex = loadHexFile(CONTROL_INDEX_FILE, "control_index");
+    controlDigests = loadHexFile(CONTROL_DIGESTS_FILE, "control_digests");
+    journal = loadHexFile(JOURNAL_FILE, "journal");
+    imageId = loadHexFile(IMAGE_ID_FILE, "image_id");
+  } catch (error) {
+    console.error("Failed to load proof data:", error.message);
+    return;
+  }
 
-    const rpc = new RpcClient({
-        url: RPC_URL,
-        encoding: 'borsh',
-        networkId: NETWORK_ID
+  const rpc = new RpcClient({
+    url: RPC_URL,
+    encoding: Encoding.Borsh,
+    networkId: NETWORK_ID,
+  });
+
+  await rpc.connect();
+
+  try {
+    // Get UTXOs and wait for maturity
+    console.log("Fetching UTXOs...");
+    const response = await rpc.getUtxosByAddresses([sourceAddress]);
+
+    const info = await rpc.getBlockDagInfo();
+    const currentDaaScore = info.virtualDaaScore;
+
+    const matureUtxos = response.entries.filter((entry) => {
+      if (!entry.entry.isCoinbase) return true;
+      return currentDaaScore - entry.entry.blockDaaScore >= 100n;
     });
 
-    await rpc.connect();
-
-    try {
-        // Get UTXOs and wait for maturity
-        console.log('Fetching UTXOs...');
-        let response = await rpc.getUtxosByAddresses([sourceAddress]);
-
-        const info = await rpc.getBlockDagInfo();
-        const currentDaaScore = info.virtualDaaScore;
-
-        const matureUtxos = response.entries.filter(entry => {
-            if (!entry.entry.isCoinbase) return true;
-            return (currentDaaScore - entry.entry.blockDaaScore) >= 100n;
-        });
-
-        if (matureUtxos.length === 0) {
-            console.log('No mature UTXOs available. Mining or waiting required.');
-            return;
-        }
-
-        console.log(`Found ${matureUtxos.length} mature UTXOs`);
-
-        // Create P2SH redeem script
-        // The redeem script pushes journal, image_id, and tag, then calls OpZkPrecompile.
-        // The signature script provides: seal, claim, hashfn, control_index, control_digests.
-        //
-        // Combined stack (bottom to top) before OpZkPrecompile:
-        //   seal, claim, hashfn, control_index, control_digests, journal, image_id, tag
-        const redeemScript = new ScriptBuilder()
-            .addData(journal)                              // Push journal onto stack
-            .addData(imageId)                              // Push image ID onto stack
-            .addData(Buffer.from([ZK_VERIFIER_TAG]))       // Push tag (0x21) onto stack
-            .addOp(Opcodes.OpZkPrecompile)                 // Execute ZK verification
-            .drain();
-
-        const lockingScript = payToScriptHashScript(redeemScript);
-        console.log(`Locking script created:`, lockingScript);
-        console.log(`Redeem script (hex): ${redeemScript}`);
-
-        // Convert the P2SH script to an address
-        const p2shAddress = addressFromScriptPublicKey(lockingScript, NETWORK_ID);
-        console.log(`P2SH address: ${p2shAddress}`);
-
-        // Create COMMIT transaction
-        const utxoToSpend = matureUtxos[0];
-        const commitAmount = utxoToSpend.amount - 10000n;
-
-        // Convert UTXO to IUtxoEntry format
-        const utxoEntries = [{
-            address: sourceAddress,
-            outpoint: {
-                transactionId: utxoToSpend.outpoint.transactionId,
-                index: utxoToSpend.outpoint.index
-            },
-            scriptPublicKey: utxoToSpend.entry.scriptPublicKey,
-            amount: utxoToSpend.amount,
-            isCoinbase: utxoToSpend.entry.isCoinbase,
-            blockDaaScore: utxoToSpend.entry.blockDaaScore
-        }];
-
-        // Create commit transaction sending to P2SH address
-        const commitTx = createTransaction(
-            utxoEntries,
-            [{
-                address: p2shAddress,
-                amount: commitAmount
-            }],
-            0n,
-            '',
-            1
-        );
-
-        console.log('Commit transaction created');
-
-        // Sign the commit transaction
-        const signedCommitTx = signTransaction(commitTx, [privateKey], false);
-        console.log('Commit transaction signed');
-
-        // Submit commit transaction
-        const submitResult = await rpc.submitTransaction({ transaction: signedCommitTx });
-
-        // Extract the transaction ID from the result
-        const commitTxId = submitResult.transactionId || submitResult;
-        console.log(`Commit transaction submitted: ${commitTxId}`);
-
-        // Wait for commit transaction confirmation
-        console.log('Waiting for commit transaction to be accepted...');
-        await new Promise(resolve => setTimeout(resolve, 5000));
-
-        // Create REDEEM transaction
-        console.log('Creating redeem transaction...');
-
-        // Build signature script for P2SH spending.
-        // Push proof components that are NOT in the redeem script, then the redeem script itself.
-        // These go onto the stack before the redeem script executes.
-        const signatureScript = new ScriptBuilder()
-            .addData(seal)                                   // Push seal (bottom of proof stack)
-            .addData(claim)                                  // Push claim
-            .addData(hashfn)                                 // Push hash function id
-            .addData(controlIndex)                           // Push control inclusion proof index
-            .addData(controlDigests)                         // Push control inclusion proof digests
-            .addData(Buffer.from(redeemScript, 'hex'))       // Push redeem script (P2SH requirement)
-            .drain();
-
-        console.log(`Signature script length: ${Buffer.from(signatureScript, 'hex').length} bytes`);
-
-        // Construct the P2SH UTXO entry
-        const p2shUtxoEntry = {
-            address: p2shAddress,
-            outpoint: {
-                transactionId: commitTxId,
-                index: 0
-            },
-            scriptPublicKey: lockingScript,
-            amount: commitAmount,
-            isCoinbase: false,
-            blockDaaScore: currentDaaScore
-        };
-
-        // Create redeem transaction
-        const redeemTx = createTransaction(
-            [p2shUtxoEntry],
-            [{
-                address: sourceAddress,
-                amount: commitAmount - 1000000n
-            }],
-            0n,
-            '',
-            250
-        );
-
-        console.log(redeemTx)
-
-        // Set the signature script
-        redeemTx.inputs[0].signatureScript = signatureScript;
-
-        console.log('Redeem transaction created');
-        console.log('Redeem script contains:');
-        console.log('  - Journal:', journal.toString('hex'));
-        console.log('  - Image ID:', imageId.toString('hex'));
-        console.log('  - Tag: 0x21 (R0Succinct)');
-        console.log('  - OpZkPrecompile');
-        console.log('Signature script provides: seal, claim, hashfn, control_index, control_digests');
-
-        // Submit redeem transaction
-        const redeemResult = await rpc.submitTransaction({ transaction: redeemTx });
-        const redeemTxId = redeemResult.transactionId || redeemResult;
-        console.log(`Redeem transaction submitted: ${redeemTxId}`);
-        console.log('ZK proof verification successful!');
-
-    } catch (error) {
-        console.error('Error:', error);
-        if (error.stack) {
-            console.error('Stack:', error.stack);
-        }
-    } finally {
-        await rpc.disconnect();
+    if (matureUtxos.length === 0) {
+      console.log("No mature UTXOs available. Mining or waiting required.");
+      return;
     }
+
+    console.log(`Found ${matureUtxos.length} mature UTXOs`);
+
+    // Create P2SH redeem script
+    // The redeem script pushes journal, image_id, and tag, then calls OpZkPrecompile.
+    // The signature script provides: seal, claim, hashfn, control_index, control_digests.
+    //
+    // Combined stack (bottom to top) before OpZkPrecompile:
+    //   seal, claim, hashfn, control_index, control_digests, journal, image_id, tag
+    const redeemScript = new ScriptBuilder({
+      flags: { covenantsEnabled: true },
+    })
+      .addData(journal) // Push journal onto stack
+      .addData(imageId) // Push image ID onto stack
+      .addData(Buffer.from([ZK_VERIFIER_TAG])) // Push tag (0x21) onto stack
+      .addOp(Opcodes.OpZkPrecompile) // Execute ZK verification
+      .drain();
+
+    const lockingScript = payToScriptHashScript(redeemScript);
+    console.log(`Locking script created:`, lockingScript);
+    console.log(`Redeem script (hex): ${redeemScript}`);
+
+    // Convert the P2SH script to an address
+    const p2shAddress = addressFromScriptPublicKey(lockingScript, NETWORK_ID);
+    console.log(`P2SH address: ${p2shAddress}`);
+
+    // Create COMMIT transaction
+    const utxoToSpend = matureUtxos[0];
+    const commitAmount = utxoToSpend.amount - 10000n;
+
+    // Convert UTXO to IUtxoEntry format
+    const utxoEntries = [
+      {
+        address: sourceAddress,
+        outpoint: {
+          transactionId: utxoToSpend.outpoint.transactionId,
+          index: utxoToSpend.outpoint.index,
+        },
+        scriptPublicKey: utxoToSpend.entry.scriptPublicKey,
+        amount: utxoToSpend.amount,
+        isCoinbase: utxoToSpend.entry.isCoinbase,
+        blockDaaScore: utxoToSpend.entry.blockDaaScore,
+      },
+    ];
+
+    // Create commit transaction sending to P2SH address
+    const commitTx = createTransaction(
+      utxoEntries,
+      [
+        {
+          address: p2shAddress,
+          amount: commitAmount,
+        },
+      ],
+      0n,
+      "",
+      1,
+    );
+
+    console.log("Commit transaction created");
+
+    // Sign the commit transaction
+    const signedCommitTx = signTransaction(commitTx, [privateKey], false);
+    console.log("Commit transaction signed");
+
+    // Submit commit transaction
+    const submitResult = await rpc.submitTransaction({
+      transaction: signedCommitTx,
+    });
+
+    // Extract the transaction ID from the result
+    const commitTxId = submitResult.transactionId;
+    console.log(`Commit transaction submitted: ${commitTxId}`);
+
+    // Wait for commit transaction confirmation
+    console.log("Waiting for commit transaction to be accepted...");
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Create REDEEM transaction
+    console.log("Creating redeem transaction...");
+
+    // Build signature script for P2SH spending.
+    // Push proof components that are NOT in the redeem script, then the redeem script itself.
+    // These go onto the stack before the redeem script executes.
+    const signatureScript = new ScriptBuilder({
+      flags: { covenantsEnabled: true },
+    })
+      .addData(seal) // Push seal (bottom of proof stack)
+      .addData(claim) // Push claim
+      .addData(hashfn) // Push hash function id
+      .addData(controlIndex) // Push control inclusion proof index
+      .addData(controlDigests) // Push control inclusion proof digests
+      .addData(Buffer.from(redeemScript, "hex")) // Push redeem script (P2SH requirement)
+      .drain();
+
+    console.log(
+      `Signature script length: ${Buffer.from(signatureScript, "hex").length} bytes`,
+    );
+
+    // Construct the P2SH UTXO entry
+    const p2shUtxoEntry = {
+      address: p2shAddress,
+      outpoint: {
+        transactionId: commitTxId,
+        index: 0,
+      },
+      scriptPublicKey: lockingScript,
+      amount: commitAmount,
+      isCoinbase: false,
+      blockDaaScore: currentDaaScore,
+    };
+
+    // Create redeem transaction
+    const redeemTx = createTransaction(
+      [p2shUtxoEntry],
+      [
+        {
+          address: sourceAddress,
+          amount: commitAmount - 1000000n,
+        },
+      ],
+      0n,
+      "",
+      250,
+    );
+
+    console.log(redeemTx);
+
+    // Set the signature script
+    redeemTx.inputs[0].signatureScript = signatureScript;
+
+    console.log("Redeem transaction created");
+    console.log("Redeem script contains:");
+    console.log("  - Journal:", journal.toString("hex"));
+    console.log("  - Image ID:", imageId.toString("hex"));
+    console.log("  - Tag: 0x21 (R0Succinct)");
+    console.log("  - OpZkPrecompile");
+    console.log(
+      "Signature script provides: seal, claim, hashfn, control_index, control_digests",
+    );
+
+    // Submit redeem transaction
+    const redeemResult = await rpc.submitTransaction({ transaction: redeemTx });
+    const redeemTxId = redeemResult.transactionId || redeemResult;
+    console.log(`Redeem transaction submitted: ${redeemTxId}`);
+    console.log("ZK proof verification successful!");
+  } catch (error) {
+    console.error("Error:", error);
+    if (error.stack) {
+      console.error("Stack:", error.stack);
+    }
+  } finally {
+    await rpc.disconnect();
+  }
 }
 
 zktest().catch(console.error);


### PR DESCRIPTION
Target is `toccata`

- add script builder wasm tests
- add `ScriptBuilderOptions` which contains `flags` as a property (allows future expansion without API breaking changes)
- allows controlling script builder options at the time of ScriptBuilder creation

