### PR TITLE
Raise the network minimum relay fee and refine mempool gas selection

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -121,6 +121,11 @@ impl<T: Copy> ForkedParam<T> {
         }
     }
 
+    /// Returns the configured post-fork value regardless of whether activation is scheduled.
+    pub fn raw_post(&self) -> T {
+        self.post
+    }
+
     /// Maps the ForkedParam<T> to a new ForkedParam<U> by applying a map function on both pre and post
     pub fn map<U: Copy, F: Fn(T) -> U>(&self, f: F) -> ForkedParam<U> {
         ForkedParam::new(f(self.pre), f(self.post), self.activation)

--- a/mining/errors/src/mempool.rs
+++ b/mining/errors/src/mempool.rs
@@ -146,9 +146,6 @@ pub enum NonStandardError {
         "transaction has {1} fees which is under the required amount of {2} for normalized transient mass {3} (proportional to transaction byte size)"
     )]
     RejectInsufficientTransientFee(TransactionId, u64, u64, u64),
-
-    #[error("transaction input #{1} has {2} signature operations which is more than the allowed max amount of {3}")]
-    RejectSignatureCount(TransactionId, usize, u64, u16),
 }
 
 impl NonStandardError {
@@ -165,7 +162,6 @@ impl NonStandardError {
             NonStandardError::RejectInputScriptClass(id, _) => id,
             NonStandardError::RejectInsufficientComputeFee(id, _, _, _) => id,
             NonStandardError::RejectInsufficientTransientFee(id, _, _, _) => id,
-            NonStandardError::RejectSignatureCount(id, _, _, _) => id,
         }
     }
 }

--- a/mining/src/feerate/mod.rs
+++ b/mining/src/feerate/mod.rs
@@ -117,6 +117,10 @@ impl FeerateEstimator {
     /// Returns the feerate value for which the integral area is `frac` of the total area between `lower` and `upper`.
     fn quantile(&self, lower: f64, upper: f64, frac: f64) -> f64 {
         assert!((0f64..=1f64).contains(&frac));
+        if lower == upper {
+            // A collapsed interval has only one quantile; avoid formula roundoff.
+            return lower;
+        }
         assert!(0.0 < lower && lower <= upper, "{lower}, {upper}");
         let (c1, c2) = (self.inclusion_interval, self.total_weight);
         if c1 == 0.0 || c2 == 0.0 {

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1042,7 +1042,7 @@ mod tests {
         consensus.add_transaction(child_tx_2.clone(), 3);
 
         // Add to mempool a transaction that spends child_tx_2 (as high priority)
-        let spending_tx = create_transaction(&child_tx_2, 1_000);
+        let spending_tx = create_transaction(&child_tx_2, DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE);
         let result = mining_manager.validate_and_insert_transaction(
             consensus.as_ref(),
             spending_tx.clone(),
@@ -1165,6 +1165,7 @@ mod tests {
             validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), tx).unwrap();
         }
         assert_eq!(mining_manager.get_all_transactions(TransactionQuery::TransactionsOnly).0.len(), TX_COUNT);
+        let high_fee = MAX_BLOCK_MASS * DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE / 1000;
 
         let heavy_tx_low_fee = {
             let mut heavy_tx = create_transaction_with_utxo_entry(TX_COUNT as u32, 0);
@@ -1182,7 +1183,7 @@ mod tests {
             let mut inner_tx = (*(heavy_tx.tx)).clone();
             inner_tx.payload = vec![0u8; TX_COUNT / 2 * tx_size - inner_tx.estimate_mem_bytes()];
             heavy_tx.tx = inner_tx.into();
-            heavy_tx.calculated_fee = Some(500_000);
+            heavy_tx.calculated_fee = Some(high_fee);
             heavy_tx
         };
         validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), heavy_tx_high_fee.clone()).unwrap();
@@ -1194,10 +1195,35 @@ mod tests {
             let mut inner_tx = (*(heavy_tx.tx)).clone();
             inner_tx.payload = vec![0u8; size_limit];
             heavy_tx.tx = inner_tx.into();
-            heavy_tx.calculated_fee = Some(500_000);
+            heavy_tx.calculated_fee = Some(high_fee);
             heavy_tx
         };
         assert!(validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), too_big_tx.clone()).is_err());
+    }
+
+    #[test]
+    fn test_realtime_feerate_estimations_respect_minimum_standard_feerate() {
+        let minimum_feerate = DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE as f64 / 1000.0;
+
+        for tx_count in [0, 1, 10, 100, 500] {
+            let consensus = Arc::new(ConsensusMock::new());
+            let mining_manager = default_mining_manager();
+
+            for i in 0..tx_count {
+                let tx = create_transaction_with_utxo_entry(i, 0);
+                validate_and_insert_mutable_transaction(&mining_manager, consensus.as_ref(), tx).unwrap();
+            }
+
+            let estimations = mining_manager.get_realtime_feerate_estimations();
+            for bucket in estimations.ordered_buckets() {
+                assert!(
+                    bucket.feerate >= minimum_feerate,
+                    "mempool with {tx_count} txs returned bucket feerate {} below minimum standard feerate {}",
+                    bucket.feerate,
+                    minimum_feerate
+                );
+            }
+        }
     }
 
     fn validate_and_insert_mutable_transaction(
@@ -1470,7 +1496,7 @@ mod tests {
 
     fn create_child_and_parent_txs_and_add_parent_to_consensus(consensus: &Arc<ConsensusMock>) -> Transaction {
         let parent_tx = create_transaction_without_input(vec![500 * SOMPI_PER_KASPA]);
-        let child_tx = create_transaction(&parent_tx, 1000);
+        let child_tx = create_transaction(&parent_tx, DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE);
         consensus.add_transaction(parent_tx, 1);
         child_tx
     }

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -53,10 +53,10 @@ impl Mempool {
         // minimum cost, whether dominated by compute or by transient byte footprint.
         // Storage mass does not require an additional relay-fee floor here since storage growth is
         // sufficiently protected even under worst-case block-limit usage.
-        // Use the post-activation cofactors for fee pricing even before activation: activation policy
-        // should only change which transient limit is allowed, not reprice the same transaction.
+        // Use raw_post so all networks, including non-scheduled ones, use the same standardness
+        // pricing value and do not fluctuate with activation status.
         let masses = transaction.calculated_non_contextual_masses.unwrap();
-        let cofactors = self.config.mempool_mass_cofactors.after();
+        let cofactors = self.config.mempool_mass_cofactors.raw_post();
         let normalized_transient_mass = masses.normalized_transient(&cofactors);
         let fee_mass = masses.compute_mass.max(normalized_transient_mass);
         let minimum_fee = self.minimum_required_transaction_relay_fee(fee_mass);

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -2,22 +2,11 @@ use crate::mempool::{
     Mempool,
     errors::{NonStandardError, NonStandardResult},
 };
-use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::{
     constants::{MAX_SCRIPT_PUBLIC_KEY_VERSION, MAX_SOMPI},
-    tx::{MutableTransaction, PopulatedTransaction},
+    tx::MutableTransaction,
 };
-use kaspa_txscript::{get_sig_op_count_upper_bound, script_class::ScriptClass};
-
-/// MAX_STANDARD_P2SH_SIG_OPS is the maximum number of signature operations
-/// that are considered standard in a pay-to-script-hash script.
-///
-/// The upper-bound execution limit comes from compute mass: some zk opcodes already cost the equivalent
-/// of roughly 140-250 signature operations. However, for classic Schnorr/ECDSA signature operations, this
-/// standardness limit encourages parallelism across inputs rather than concentrating work in one input.
-/// It is also at least as permissive as the previous standard compute-mass limit of 100k,
-/// which allowed at most 100 sigops since each sigop costs 1000 grams.
-const MAX_STANDARD_P2SH_SIG_OPS: u16 = 100;
+use kaspa_txscript::script_class::ScriptClass;
 
 impl Mempool {
     pub(crate) fn check_transaction_standard_in_isolation(&self, transaction: &MutableTransaction) -> NonStandardResult<()> {
@@ -40,13 +29,12 @@ impl Mempool {
     /// check_transaction_standard_in_context performs a series of checks on a transaction's
     /// inputs to ensure they are "standard". A standard transaction input within the
     /// context of this function is one whose referenced public key script is of a
-    /// standard form and, for pay-to-script-hash, does not have more than
-    /// maxStandardP2SHSigOps signature operations.
+    /// standard form.
     /// In addition, makes sure that the transaction's fee is above the minimum for acceptance
     /// into the mempool and relay.
     pub(crate) fn check_transaction_standard_in_context(&self, transaction: &MutableTransaction) -> NonStandardResult<()> {
         let transaction_id = transaction.id();
-        for (i, input) in transaction.tx.inputs.iter().enumerate() {
+        for i in 0..transaction.tx.inputs.len() {
             // It is safe to elide existence and index checks here since
             // they have already been checked prior to calling this
             // function.
@@ -57,20 +45,7 @@ impl Mempool {
                 }
                 ScriptClass::PubKey => {}
                 ScriptClass::PubKeyECDSA => {}
-                ScriptClass::ScriptHash => {
-                    // TODO: relax due to on the fly sigop calculation
-                    // Possible options:
-                    //      1. remove all together and rely on compute mass limits
-                    //      2. extract an upper bound on the committed value from input.mass and min
-                    //         with the static count (relying on validation to fail if the commitment is wrong)
-                    let num_sig_ops = get_sig_op_count_upper_bound::<PopulatedTransaction, SigHashReusedValuesUnsync>(
-                        &input.signature_script,
-                        &entry.script_public_key,
-                    );
-                    if num_sig_ops > MAX_STANDARD_P2SH_SIG_OPS as u64 {
-                        return Err(NonStandardError::RejectSignatureCount(transaction_id, i, num_sig_ops, MAX_STANDARD_P2SH_SIG_OPS));
-                    }
-                }
+                ScriptClass::ScriptHash => {}
             }
         }
 

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -127,8 +127,8 @@ mod tests {
     };
     use kaspa_addresses::{Address, Prefix, Version};
     use kaspa_consensus_core::{
-        config::params::Params,
-        constants::{MAX_TX_IN_SEQUENCE_NUM, SOMPI_PER_KASPA, TX_VERSION},
+        config::params::{ForkActivation, Params},
+        constants::{MAX_TX_IN_SEQUENCE_NUM, SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION},
         mass::NonContextualMasses,
         network::NetworkType,
         subnets::SUBNETWORK_ID_NATIVE,
@@ -141,6 +141,9 @@ mod tests {
     use std::sync::Arc;
 
     const RELAY_FEE_TEST_MASS: u64 = 500_000;
+    const fn default_minimum_relay_fee_for_mass(mass: u64) -> u64 {
+        mass * DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE / 1000
+    }
 
     #[test]
     fn test_calc_min_required_tx_relay_fee() {
@@ -164,13 +167,13 @@ mod tests {
                 name: "100 bytes with default minimum relay fee",
                 size: 100,
                 minimum_relay_transaction_fee: DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE,
-                want: 100,
+                want: default_minimum_relay_fee_for_mass(100),
             },
             Test {
                 name: "large relay fee test mass with default minimum relay fee",
                 size: RELAY_FEE_TEST_MASS,
                 minimum_relay_transaction_fee: DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE,
-                want: RELAY_FEE_TEST_MASS,
+                want: default_minimum_relay_fee_for_mass(RELAY_FEE_TEST_MASS),
             },
             Test { name: "1500 bytes with 5000 relay fee", size: 1500, minimum_relay_transaction_fee: 5000, want: 7500 },
             Test { name: "1500 bytes with 3000 relay fee", size: 1500, minimum_relay_transaction_fee: 3000, want: 4500 },
@@ -379,36 +382,58 @@ mod tests {
             mtx
         }
 
+        // Use simnet params so prior and post-activation transient limits differ while the fork is active;
+        // this verifies that relay-fee pricing uses stable post-activation cofactors.
+        let params: Params = NetworkType::Simnet.into();
+        assert_ne!(params.toccata_activation, ForkActivation::never(), "this test requires post-activation cofactors");
+        let cofactors = params.mempool_block_mass_cofactors().after();
+        let transient = |bytes| bytes * TRANSIENT_BYTE_TO_MASS_FACTOR;
+        let normalized_transient = |bytes| NonContextualMasses::new(0, transient(bytes)).normalized_transient(&cofactors);
+
+        let bytes = 5_000;
+        let compute = normalized_transient(bytes);
+        let boundary_fee = default_minimum_relay_fee_for_mass(compute);
+        let insufficient_fee = boundary_fee - 1;
+
         let tests = vec![
             Test {
-                name: "standard input with sufficient fee",
-                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(1_000, 500), 1_000),
+                name: "standard input with exactly sufficient relay fee",
+                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(compute, transient(bytes)), boundary_fee),
                 expected: Expected::Standard,
             },
             Test {
                 name: "non-standard input script class",
-                mtx: new_mtx(non_standard_script_public_key, NonContextualMasses::new(1_000, 1_000), 1_000),
+                mtx: new_mtx(
+                    non_standard_script_public_key,
+                    NonContextualMasses::new(1_000, 1_000),
+                    DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE,
+                ),
                 expected: Expected::RejectInputScriptClass,
             },
             Test {
                 name: "compute mass triggers insufficient relay fee",
-                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(10_000, 1), 9_999),
-                expected: Expected::RejectInsufficientComputeFee { fee: 9_999, minimum_fee: 10_000, compute_mass: 10_000 },
+                mtx: new_mtx(
+                    standard_script_public_key.clone(),
+                    NonContextualMasses::new(compute, transient(bytes - 1)),
+                    insufficient_fee,
+                ),
+                expected: Expected::RejectInsufficientComputeFee {
+                    fee: insufficient_fee,
+                    minimum_fee: boundary_fee,
+                    compute_mass: compute,
+                },
             },
             Test {
                 name: "transient mass triggers insufficient relay fee",
-                mtx: new_mtx(standard_script_public_key, NonContextualMasses::new(1, 20_000), 9_999),
+                mtx: new_mtx(standard_script_public_key, NonContextualMasses::new(compute - 1, transient(bytes)), insufficient_fee),
                 expected: Expected::RejectInsufficientTransientFee {
-                    fee: 9_999,
-                    minimum_fee: 10_000,
-                    normalized_transient_mass: 10_000,
+                    fee: insufficient_fee,
+                    minimum_fee: boundary_fee,
+                    normalized_transient_mass: compute,
                 },
             },
         ];
 
-        // Use simnet params so prior and post-activation transient limits differ while the fork is active;
-        // this verifies that relay-fee pricing uses stable post-activation cofactors.
-        let params: Params = NetworkType::Simnet.into();
         let config =
             Config::build_default(params.target_time_per_block(), false, params.mempool_block_mass_limits(), params.block_lane_limits);
         let counters = Arc::new(MiningCounters::default());

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -19,7 +19,8 @@ pub(crate) const DEFAULT_MAXIMUM_ORPHAN_TRANSACTION_COUNT: u64 = 500;
 
 /// DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE specifies the minimum transaction fee for a transaction to be accepted to
 /// the mempool and relayed. It is specified in sompi per 1kg (or 1000 grams) of transaction mass.
-pub(crate) const DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE: u64 = 1000;
+/// The default is 100 sompi per gram.
+pub(crate) const DEFAULT_MINIMUM_RELAY_TRANSACTION_FEE: u64 = 100_000;
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -435,9 +435,11 @@ impl Frontier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mempool::config::Config;
     use feerate_key::tests::build_feerate_key;
     use itertools::Itertools;
     use kaspa_consensus_core::{
+        mass::BlockMassLimits,
         subnets::SubnetworkId,
         tx::{Transaction, TransactionInput, TransactionOutpoint},
     };
@@ -579,10 +581,31 @@ mod tests {
 
     /// Epsilon used for various test comparisons
     const EPS: f64 = 0.000001;
+    /// Test estimation floors: legacy behavior, current policy, and a higher stress floor.
+    const TEST_MIN_FEERATES: [f64; 3] = [1.0, 100.0, 1000.0];
+
+    fn minimum_standard_feerate() -> f64 {
+        Config::build_default(1_000, false, BlockMassLimits::with_shared_limit(500_000), DEFAULT_BLOCK_LANE_LIMITS).minimum_feerate()
+    }
+
+    fn assert_valid_feerate_buckets(estimations: &crate::feerate::FeerateEstimations, min_feerate: f64) {
+        for bucket in estimations.ordered_buckets() {
+            // Test for the absence of NaN, infinite or zero values in buckets.
+            assert!(
+                bucket.feerate.is_normal() && bucket.feerate >= min_feerate - EPS,
+                "bucket feerate {} must be finite and at least {}",
+                bucket.feerate,
+                min_feerate
+            );
+            assert!(
+                bucket.estimated_seconds.is_normal() && bucket.estimated_seconds > 0.0,
+                "bucket estimated seconds must be a finite number greater than zero"
+            );
+        }
+    }
 
     #[test]
     fn test_feerate_estimator() {
-        const MIN_FEERATE: f64 = 1.0;
         let mut rng = thread_rng();
         let cap = 2000;
         let mut map = HashMap::with_capacity(cap);
@@ -607,63 +630,44 @@ mod tests {
             let args = FeerateEstimatorArgs { network_blocks_per_second: 1, maximum_mass_per_block: 500_000 };
             // We are testing that the build function actually returns and is not looping indefinitely
             let estimator = frontier.build_feerate_estimator(args);
-            let estimations = estimator.calc_estimations(MIN_FEERATE);
 
-            let buckets = estimations.ordered_buckets();
-            // Test for the absence of NaN, infinite or zero values in buckets
-            for b in buckets.iter() {
-                assert!(
-                    b.feerate.is_normal() && b.feerate >= MIN_FEERATE - EPS,
-                    "bucket feerate must be a finite number greater or equal to the minimum standard feerate"
-                );
-                assert!(
-                    b.estimated_seconds.is_normal() && b.estimated_seconds > 0.0,
-                    "bucket estimated seconds must be a finite number greater than zero"
-                );
+            for min_feerate in TEST_MIN_FEERATES {
+                let estimations = estimator.calc_estimations(min_feerate);
+                assert_valid_feerate_buckets(&estimations, min_feerate);
+                dbg!(len, min_feerate, &estimator);
+                dbg!(estimations);
             }
-            dbg!(len, estimator);
-            dbg!(estimations);
         }
     }
 
     #[test]
     fn test_constant_feerate_estimator() {
-        const MIN_FEERATE: f64 = 1.0;
         let cap = 20_000;
-        let mut map = HashMap::with_capacity(cap);
-        for i in 0..cap as u64 {
-            let mass: u64 = 1650;
-            let fee = (mass as f64 * MIN_FEERATE) as u64;
-            let key = build_feerate_key(fee, mass, i);
-            map.insert(key.tx.id(), key);
-        }
-
-        for len in [0, 1, 10, 100, 200, 300, 500, 750, cap / 2, (cap * 2) / 3, (cap * 4) / 5, (cap * 5) / 6, cap] {
-            println!();
-            println!("Testing a frontier with {} txs...", len.min(cap));
-            let mut frontier = Frontier::new(1.0);
-            for item in map.values().take(len).cloned() {
-                frontier.insert(item).then_some(()).unwrap();
+        for min_feerate in TEST_MIN_FEERATES {
+            let mut map = HashMap::with_capacity(cap);
+            for i in 0..cap as u64 {
+                let mass: u64 = 1650;
+                let fee = (mass as f64 * min_feerate) as u64;
+                let key = build_feerate_key(fee, mass, i);
+                map.insert(key.tx.id(), key);
             }
 
-            let args = FeerateEstimatorArgs { network_blocks_per_second: 1, maximum_mass_per_block: 500_000 };
-            // We are testing that the build function actually returns and is not looping indefinitely
-            let estimator = frontier.build_feerate_estimator(args);
-            let estimations = estimator.calc_estimations(MIN_FEERATE);
-            let buckets = estimations.ordered_buckets();
-            // Test for the absence of NaN, infinite or zero values in buckets
-            for b in buckets.iter() {
-                assert!(
-                    b.feerate.is_normal() && b.feerate >= MIN_FEERATE - EPS,
-                    "bucket feerate must be a finite number greater or equal to the minimum standard feerate"
-                );
-                assert!(
-                    b.estimated_seconds.is_normal() && b.estimated_seconds > 0.0,
-                    "bucket estimated seconds must be a finite number greater than zero"
-                );
+            for len in [0, 1, 10, 100, 200, 300, 500, 750, cap / 2, (cap * 2) / 3, (cap * 4) / 5, (cap * 5) / 6, cap] {
+                println!();
+                println!("Testing a frontier with {} txs and min feerate {}...", len.min(cap), min_feerate);
+                let mut frontier = Frontier::new(1.0);
+                for item in map.values().take(len).cloned() {
+                    frontier.insert(item).then_some(()).unwrap();
+                }
+
+                let args = FeerateEstimatorArgs { network_blocks_per_second: 1, maximum_mass_per_block: 500_000 };
+                // We are testing that the build function actually returns and is not looping indefinitely
+                let estimator = frontier.build_feerate_estimator(args);
+                let estimations = estimator.calc_estimations(min_feerate);
+                assert_valid_feerate_buckets(&estimations, min_feerate);
+                dbg!(len, min_feerate, estimator);
+                dbg!(estimations);
             }
-            dbg!(len, estimator);
-            dbg!(estimations);
         }
     }
 
@@ -719,7 +723,6 @@ mod tests {
 
     #[test]
     fn test_feerate_estimator_with_less_than_block_capacity() {
-        const MIN_FEERATE: f64 = 1.0;
         let mut map = HashMap::new();
         for i in 0..304 {
             let mass: u64 = 1650;
@@ -738,23 +741,71 @@ mod tests {
             let args = FeerateEstimatorArgs { network_blocks_per_second: 1, maximum_mass_per_block: 500_000 };
             // We are testing that the build function actually returns and is not looping indefinitely
             let estimator = frontier.build_feerate_estimator(args);
-            let estimations = estimator.calc_estimations(MIN_FEERATE);
 
-            let buckets = estimations.ordered_buckets();
-            // Test for the absence of NaN, infinite or zero values in buckets
-            for b in buckets.iter() {
-                // Expect min feerate bcs blocks are not full
+            for min_feerate in TEST_MIN_FEERATES {
+                let estimations = estimator.calc_estimations(min_feerate);
+                let buckets = estimations.ordered_buckets();
+                // Test for the absence of NaN, infinite or zero values in buckets
+                for b in buckets.iter() {
+                    // Expect min feerate bcs blocks are not full
+                    assert!(
+                        (b.feerate - min_feerate).abs() <= EPS,
+                        "bucket feerate is expected to be equal to the minimum standard feerate"
+                    );
+                    assert!(
+                        b.estimated_seconds.is_normal() && b.estimated_seconds > 0.0 && b.estimated_seconds <= 1.0,
+                        "bucket estimated seconds must be a finite number greater than zero & less than 1.0"
+                    );
+                }
+                dbg!(len, min_feerate, &estimator);
+                dbg!(estimations);
+            }
+        }
+    }
+
+    #[test]
+    fn test_feerate_estimator_buckets_never_drop_below_minimum_standard_feerate() {
+        let minimum_feerate = minimum_standard_feerate();
+        let scenarios = [
+            ("empty", vec![]),
+            ("single below-floor transaction", vec![(1, 1000)]),
+            ("single minimum-feerate transaction", vec![((minimum_feerate * 1000.0) as u64, 1000)]),
+            ("less than one block", (0..100).map(|i| (50_000 + i, 1650)).collect_vec()),
+            ("around one block", (0..304).map(|i| (50_000 + i, 1650)).collect_vec()),
+            ("many low-feerate transactions", (0..2000).map(|i| (1 + i, 1650)).collect_vec()),
+            (
+                "high outliers over low-feerate backlog",
+                (0..2000).map(|i| if i < 10 { (50_000_000_000 + i, 1650) } else { (1 + i, 1650) }).collect_vec(),
+            ),
+            (
+                "mixed masses over several blocks",
+                (0..2000)
+                    .map(|i| {
+                        let mass = if i % 5 == 0 { 90_000 } else { 1650 };
+                        let fee = if i % 11 == 0 { 100_000_000 + i } else { 1 + i };
+                        (fee, mass)
+                    })
+                    .collect_vec(),
+            ),
+        ];
+
+        for (name, txs) in scenarios {
+            let mut frontier = Frontier::new(1.0);
+            for (i, (fee, mass)) in txs.into_iter().enumerate() {
+                frontier.insert(build_feerate_key(fee, mass, i as u64)).then_some(()).unwrap();
+            }
+
+            let args = FeerateEstimatorArgs { network_blocks_per_second: 1, maximum_mass_per_block: 500_000 };
+            let estimator = frontier.build_feerate_estimator(args);
+            let estimations = estimator.calc_estimations(minimum_feerate);
+            assert_valid_feerate_buckets(&estimations, minimum_feerate);
+
+            for (higher, lower) in estimations.ordered_buckets().into_iter().tuple_windows() {
                 assert!(
-                    (b.feerate - MIN_FEERATE).abs() <= EPS,
-                    "bucket feerate is expected to be equal to the minimum standard feerate"
-                );
-                assert!(
-                    b.estimated_seconds.is_normal() && b.estimated_seconds > 0.0 && b.estimated_seconds <= 1.0,
-                    "bucket estimated seconds must be a finite number greater than zero & less than 1.0"
+                    higher.feerate + EPS >= lower.feerate,
+                    "{name}: buckets must remain ordered by decreasing feerate: {higher:?}, {lower:?}"
                 );
             }
-            dbg!(len, estimator);
-            dbg!(estimations);
         }
     }
 }

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -67,6 +67,8 @@ pub struct Frontier {
     average_transaction_mass: f64,
 
     target_time_per_block_seconds: f64,
+
+    gas_cofactor: f64,
 }
 
 #[derive(Default)]
@@ -134,12 +136,17 @@ impl SampleMassTracker {
 
 impl Frontier {
     pub fn new(target_time_per_block_seconds: f64) -> Self {
+        Self::new_with_gas_cofactor(target_time_per_block_seconds, 500_000f64 / DEFAULT_BLOCK_LANE_LIMITS.gas_per_lane as f64)
+    }
+
+    pub fn new_with_gas_cofactor(target_time_per_block_seconds: f64, gas_cofactor: f64) -> Self {
         Self {
             search_tree: Default::default(),
             by_lane: Default::default(),
             total_mass: Default::default(),
             average_transaction_mass: INITIAL_AVG_MASS,
             target_time_per_block_seconds,
+            gas_cofactor,
         }
     }
 }
@@ -165,7 +172,8 @@ impl Frontier {
         let mass = key.mass;
         let lane = key.lane();
         if self.search_tree.insert(key.clone()) {
-            self.by_lane.entry(lane).or_default().insert(key);
+            // Per-lane ordering should account for gas as another lane-limited resource.
+            self.by_lane.entry(lane).or_default().insert(FeerateTransactionKey::with_normalized_gas(key, self.gas_cofactor));
             self.total_mass += mass;
             // A decaying average formula. Denote ɛ = 1 - AVG_MASS_DECAY_FACTOR. A transaction inserted N slots ago has
             // ɛ * (1 - ɛ)^N weight within the updated average. This gives some weight to the full mempool history while
@@ -184,7 +192,7 @@ impl Frontier {
             let lane = key.lane();
             let mut remove_lane = false;
             if let Some(entries) = self.by_lane.get_mut(&lane) {
-                entries.remove(key);
+                entries.remove(&FeerateTransactionKey::with_normalized_gas(key.clone(), self.gas_cofactor));
                 remove_lane = entries.is_empty();
             }
             if remove_lane {
@@ -439,7 +447,7 @@ mod tests {
     use feerate_key::tests::build_feerate_key;
     use itertools::Itertools;
     use kaspa_consensus_core::{
-        mass::BlockMassLimits,
+        mass::{BlockLaneLimits, BlockMassLimits},
         subnets::SubnetworkId,
         tx::{Transaction, TransactionInput, TransactionOutpoint},
     };
@@ -448,11 +456,11 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    fn build_feerate_key_with_lane(fee: u64, mass: u64, id: u64, lane: SubnetworkId) -> FeerateTransactionKey {
+    fn build_feerate_key_with_lane(fee: u64, mass: u64, id: u64, lane: SubnetworkId, gas: u64) -> FeerateTransactionKey {
         let mut hasher = TransactionID::new();
         let prev = hasher.update(id.to_le_bytes()).clone().finalize();
         let input = TransactionInput::new(TransactionOutpoint::new(prev, 0), vec![], 0, 0);
-        let tx = Arc::new(Transaction::new(0, vec![input], vec![], 0, lane, 0, vec![]));
+        let tx = Arc::new(Transaction::new(0, vec![input], vec![], 0, lane, gas, vec![]));
         FeerateTransactionKey::new(fee, mass, tx)
     }
 
@@ -568,7 +576,7 @@ mod tests {
         for i in 0..90u64 {
             let lane = lanes[(i as usize) % lanes.len()];
             let fee = 1_000_000 - i;
-            frontier.insert(build_feerate_key_with_lane(fee, 100, i, lane)).then_some(()).unwrap();
+            frontier.insert(build_feerate_key_with_lane(fee, 100, i, lane, 0)).then_some(()).unwrap();
         }
 
         let mut policy = Policy::new(1_000, DEFAULT_BLOCK_LANE_LIMITS);
@@ -577,6 +585,32 @@ mod tests {
         let selected_lanes = sample.iter().map(|tx| tx.tx.subnetwork_id).collect::<HashSet<_>>();
 
         assert_eq!(selected_lanes.len(), policy.lanes_per_block_limit);
+    }
+
+    #[test]
+    fn test_by_lane_feerate_key_accounts_for_normalized_gas() {
+        let lane = SubnetworkId::from_namespace([1, 1, 0, 0]);
+        let block_lane_limits = BlockLaneLimits { lanes_per_block: 1, gas_per_lane: 100 };
+        let policy = Policy::new(10_000, block_lane_limits);
+        let mut frontier = Frontier::new_with_gas_cofactor(1.0, 1_000f64 / block_lane_limits.gas_per_lane as f64);
+
+        let keys = (11..=22).map(|gas| build_feerate_key_with_lane(1_000, 100, gas, lane, gas)).collect_vec();
+        for key in keys.iter().cloned() {
+            frontier.insert(key).then_some(()).unwrap();
+        }
+
+        let mut sequence = SequenceSelectorInput::default();
+        let lanes = Lanes { occupied: HashSet::from([lane]), frozen: true };
+        let mut mass = SampleMassTracker::new(&policy);
+        frontier.finish_intra_lane_selection(&mut sequence, &HashSet::new(), &lanes, &mut mass);
+
+        assert_eq!(sequence.iter().map(|item| item.tx.gas).collect_vec(), (11..=22).collect_vec());
+
+        for key in &keys {
+            frontier.remove(key).then_some(()).unwrap();
+        }
+        assert!(frontier.is_empty());
+        assert!(frontier.by_lane.is_empty());
     }
 
     /// Epsilon used for various test comparisons

--- a/mining/src/mempool/model/frontier/feerate_key.rs
+++ b/mining/src/mempool/model/frontier/feerate_key.rs
@@ -31,6 +31,16 @@ impl FeerateTransactionKey {
         Self { fee, mass, weight: (fee as f64 / mass as f64).powi(ALPHA), tx }
     }
 
+    /// Builds a lane-local feerate key which accounts for gas as another lane-limited resource.
+    ///
+    /// The global key intentionally ignores gas, but once lane selection is frozen we compare
+    /// candidates within each occupied lane using max(normalized mass, normalized gas).
+    pub fn with_normalized_gas(inner: FeerateTransactionKey, gas_cofactor: f64) -> Self {
+        let normalized_gas_mass = (inner.tx.gas as f64 * gas_cofactor).ceil() as u64;
+        let lane_normalized_mass = inner.mass.max(normalized_gas_mass);
+        Self::new(inner.fee, lane_normalized_mass, inner.tx)
+    }
+
     pub fn feerate(&self) -> f64 {
         self.fee as f64 / self.mass as f64
     }

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -83,12 +83,16 @@ pub(crate) struct TransactionsPool {
 impl TransactionsPool {
     pub(crate) fn new(config: Arc<Config>) -> Self {
         let target_time_per_block = 1.0 / (config.network_blocks_per_second as f64);
+        // Params::mempool_block_mass_cofactors asserts that the reference mass is stable across activation.
+        assert!(config.block_lane_limits.gas_per_lane > 0);
+        let gas_cofactor = config.mempool_mass_cofactors.after().reference as f64 / config.block_lane_limits.gas_per_lane as f64;
+        let ready_transactions = Frontier::new_with_gas_cofactor(target_time_per_block, gas_cofactor);
         Self {
             config,
             all_transactions: MempoolTransactionCollection::default(),
             parent_transactions: TransactionsEdges::default(),
             chained_transactions: TransactionsEdges::default(),
-            ready_transactions: Frontier::new(target_time_per_block),
+            ready_transactions,
             last_expire_scan_daa_score: 0,
             last_expire_scan_time: unix_now(),
             utxo_set: MempoolUtxoSet::new(),

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
     config::params::{DEVNET_PARAMS, Params, TESTNET_PARAMS, TESTNET12_PARAMS},
-    constants::{SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION, TX_VERSION_TOCCATA},
+    constants::{SOMPI_PER_KASPA, TX_VERSION, TX_VERSION_TOCCATA},
     hashing::covenant_id::covenant_id,
     network::NetworkType,
     sign::sign,
@@ -30,9 +30,14 @@ use secp256k1::{
 use tokio::time::{Instant, MissedTickBehavior, interval};
 
 const DEFAULT_SEND_AMOUNT: u64 = 10 * SOMPI_PER_KASPA;
-const FEE_RATE: u64 = 101;
 const MILLIS_PER_TICK: u64 = 10;
 const ADDRESS_VERSION: Version = Version::PubKey;
+
+// Minimum standard relay fee is 100 sompi/gram; use 110 for a safety margin.
+const FEE_RATE: u64 = 110;
+
+// Mempool minimum relay fee uses post-Toccata cofactors immediately, so we normalize accordingly (factor / ratio between limits).
+const NORMALIZED_TRANSIENT_BYTE_FACTOR: u64 = 2;
 
 struct Stats {
     num_txs: usize,
@@ -197,7 +202,6 @@ struct TxConfig {
     payload_size: usize,
     with_covenant_id: bool,
     randomize_tx_version: bool,
-    normalized_transient_mass_per_byte: f64,
 }
 
 #[tokio::main]
@@ -287,8 +291,6 @@ async fn main() {
         _ => unreachable!("CLI only accepts testnet and devnet"),
     };
     let coinbase_maturity = consensus_params.coinbase_maturity();
-    let normalized_transient_mass_per_byte =
-        TRANSIENT_BYTE_TO_MASS_FACTOR as f64 * consensus_params.mempool_block_mass_cofactors().after().transient;
 
     let tx_config = TxConfig {
         priority_fee: args.priority_fee,
@@ -296,7 +298,6 @@ async fn main() {
         payload_size: args.payload_size,
         with_covenant_id: args.enable_covenant_id,
         randomize_tx_version: args.randomize_tx_version,
-        normalized_transient_mass_per_byte,
     };
     info!(
         "Node block-DAG info: \n\tNetwork: {}, \n\tBlock count: {}, \n\tHeader count: {}, \n\tDifficulty: {},
@@ -586,27 +587,28 @@ fn clean_old_pending_outpoints(pending: &mut HashMap<TransactionOutpoint, Instan
     pending.retain(|_, &mut time| now.duration_since(time) <= Duration::from_secs(3600));
 }
 
-fn required_fee(num_utxos: usize, num_outs: u64, payload_size: usize, normalized_transient_mass_per_byte: f64) -> u64 {
-    FEE_RATE
-        * estimated_compute_mass(num_utxos, num_outs).max(estimated_normalized_transient_mass(
-            num_utxos,
-            num_outs,
-            payload_size,
-            normalized_transient_mass_per_byte,
-        ))
+fn required_fee(num_utxos: usize, num_outs: u64, payload_size: usize, with_covenant_binding: bool) -> u64 {
+    let (compute_mass, serialized_bytes) =
+        estimated_compute_mass_and_serialized_bytes(num_utxos, num_outs, payload_size, with_covenant_binding);
+    let normalized_transient_mass = serialized_bytes * NORMALIZED_TRANSIENT_BYTE_FACTOR;
+    FEE_RATE * compute_mass.max(normalized_transient_mass)
 }
 
-fn estimated_compute_mass(num_utxos: usize, num_outs: u64) -> u64 {
-    200 + 34 * num_outs + 1000 * (num_utxos as u64)
-}
-
-fn estimated_normalized_transient_mass(
+const fn estimated_compute_mass_and_serialized_bytes(
     num_utxos: usize,
     num_outs: u64,
     payload_size: usize,
-    normalized_transient_mass_per_byte: f64,
-) -> u64 {
-    ((200 + 34 * num_outs + 1000 * (num_utxos as u64) + payload_size as u64) as f64 * normalized_transient_mass_per_byte).ceil() as u64
+    with_covenant_binding: bool,
+) -> (u64, u64) {
+    let covenant_bytes_per_output = if with_covenant_binding { 34 } else { 0 }; // covenant binding: authorizing input [2] + covenant id [32]
+    let serialized_bytes = 94 // plain tx: version [2] + input/output counts [16] + locktime [8] + subnetwork id [20] + gas [8] + payload hash [32] + payload length [8]
+        + 118 * (num_utxos as u64) // std input: outpoint [36] + signature script length [8] + single-signature script [66] + sequence [8]
+        + (53 + covenant_bytes_per_output) * num_outs // std output: value [8] + script public key version [2] + script public key length [8] + max std script public key [35] + covenant binding [0/34]
+        + payload_size as u64;
+    let compute_mass = serialized_bytes
+        + 1000 * (num_utxos as u64) // std input script mass (1 sigop)
+        + 370 * num_outs; // std output spk mass: (script public key version [2] + max std script public key [35]) * 10
+    (compute_mass, serialized_bytes)
 }
 
 fn apply_random_covenant_binding_from_inputs(tx: &mut MutableTransaction<Transaction>, with_covenant_id: bool) {
@@ -703,7 +705,10 @@ fn select_utxos(
         selected_amount += entry.amount;
         selected.push((outpoint, entry));
 
-        let fee = required_fee(selected.len(), num_outs, tx_config.payload_size, tx_config.normalized_transient_mass_per_byte);
+        // Pass with_covenant_id as a signal that the tx might have covenant bindings. This can
+        // slightly overestimate the fee when tx versions are randomized, since bindings are only
+        // added later if the final tx version is Toccata.
+        let fee = required_fee(selected.len(), num_outs, tx_config.payload_size, tx_config.with_covenant_id);
         let priority_fee = if tx_config.randomize_fee && tx_config.priority_fee > 0 {
             rng.gen_range(0..tx_config.priority_fee)
         } else {

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -4,8 +4,8 @@ use clap::{Arg, ArgAction, Command};
 use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
-    config::params::{TESTNET_PARAMS, TESTNET12_PARAMS},
-    constants::{SOMPI_PER_KASPA, TX_VERSION, TX_VERSION_TOCCATA},
+    config::params::{DEVNET_PARAMS, Params, TESTNET_PARAMS, TESTNET12_PARAMS},
+    constants::{SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION, TX_VERSION_TOCCATA},
     hashing::covenant_id::covenant_id,
     network::NetworkType,
     sign::sign,
@@ -30,7 +30,7 @@ use secp256k1::{
 use tokio::time::{Instant, MissedTickBehavior, interval};
 
 const DEFAULT_SEND_AMOUNT: u64 = 10 * SOMPI_PER_KASPA;
-const FEE_RATE: u64 = 10;
+const FEE_RATE: u64 = 101;
 const MILLIS_PER_TICK: u64 = 10;
 const ADDRESS_VERSION: Version = Version::PubKey;
 
@@ -197,6 +197,7 @@ struct TxConfig {
     payload_size: usize,
     with_covenant_id: bool,
     randomize_tx_version: bool,
+    normalized_transient_mass_per_byte: f64,
 }
 
 #[tokio::main]
@@ -248,14 +249,6 @@ async fn main() {
 
     (args.payload_size <= 20000).then_some(()).expect("payload-size can be max 20000");
 
-    let tx_config = TxConfig {
-        priority_fee: args.priority_fee,
-        randomize_fee: args.randomize_fee,
-        payload_size: args.payload_size,
-        with_covenant_id: args.enable_covenant_id,
-        randomize_tx_version: args.randomize_tx_version,
-    };
-
     rayon::ThreadPoolBuilder::new().num_threads(args.threads as usize).build_global().unwrap();
 
     let mut log_message = format!(
@@ -273,21 +266,37 @@ async fn main() {
     if args.priority_fee != 0 {
         log_message.push_str(&format!(
             "\n\tpriority fee: {} SOMPS {}",
-            tx_config.priority_fee,
-            if tx_config.randomize_fee { "[randomize]" } else { "" }
+            args.priority_fee,
+            if args.randomize_fee { "[randomize]" } else { "" }
         ));
     }
     if args.payload_size != 0 {
-        log_message.push_str(&format!("\n\tpayload size: {} random bytes", tx_config.payload_size,));
+        log_message.push_str(&format!("\n\tpayload size: {} random bytes", args.payload_size,));
     }
     info!("{}", log_message);
 
     let info = rpc_client.get_block_dag_info().await.expect("Failed to get block dag info.");
 
-    let coinbase_maturity = match info.network.suffix {
-        Some(11) => panic!("TN11 is not supported on this version"),
-        Some(12) => TESTNET12_PARAMS.coinbase_maturity(),
-        None | Some(_) => TESTNET_PARAMS.coinbase_maturity(),
+    let consensus_params: Params = match args.network {
+        NetworkType::Testnet => match info.network.suffix {
+            Some(11) => panic!("TN11 is not supported on this version"),
+            Some(12) => TESTNET12_PARAMS,
+            None | Some(_) => TESTNET_PARAMS,
+        },
+        NetworkType::Devnet => DEVNET_PARAMS,
+        _ => unreachable!("CLI only accepts testnet and devnet"),
+    };
+    let coinbase_maturity = consensus_params.coinbase_maturity();
+    let normalized_transient_mass_per_byte =
+        TRANSIENT_BYTE_TO_MASS_FACTOR as f64 * consensus_params.mempool_block_mass_cofactors().after().transient;
+
+    let tx_config = TxConfig {
+        priority_fee: args.priority_fee,
+        randomize_fee: args.randomize_fee,
+        payload_size: args.payload_size,
+        with_covenant_id: args.enable_covenant_id,
+        randomize_tx_version: args.randomize_tx_version,
+        normalized_transient_mass_per_byte,
     };
     info!(
         "Node block-DAG info: \n\tNetwork: {}, \n\tBlock count: {}, \n\tHeader count: {}, \n\tDifficulty: {},
@@ -577,12 +586,27 @@ fn clean_old_pending_outpoints(pending: &mut HashMap<TransactionOutpoint, Instan
     pending.retain(|_, &mut time| now.duration_since(time) <= Duration::from_secs(3600));
 }
 
-fn required_fee(num_utxos: usize, num_outs: u64) -> u64 {
-    FEE_RATE * estimated_mass(num_utxos, num_outs)
+fn required_fee(num_utxos: usize, num_outs: u64, payload_size: usize, normalized_transient_mass_per_byte: f64) -> u64 {
+    FEE_RATE
+        * estimated_compute_mass(num_utxos, num_outs).max(estimated_normalized_transient_mass(
+            num_utxos,
+            num_outs,
+            payload_size,
+            normalized_transient_mass_per_byte,
+        ))
 }
 
-fn estimated_mass(num_utxos: usize, num_outs: u64) -> u64 {
+fn estimated_compute_mass(num_utxos: usize, num_outs: u64) -> u64 {
     200 + 34 * num_outs + 1000 * (num_utxos as u64)
+}
+
+fn estimated_normalized_transient_mass(
+    num_utxos: usize,
+    num_outs: u64,
+    payload_size: usize,
+    normalized_transient_mass_per_byte: f64,
+) -> u64 {
+    ((200 + 34 * num_outs + 1000 * (num_utxos as u64) + payload_size as u64) as f64 * normalized_transient_mass_per_byte).ceil() as u64
 }
 
 fn apply_random_covenant_binding_from_inputs(tx: &mut MutableTransaction<Transaction>, with_covenant_id: bool) {
@@ -679,7 +703,7 @@ fn select_utxos(
         selected_amount += entry.amount;
         selected.push((outpoint, entry));
 
-        let fee = required_fee(selected.len(), num_outs);
+        let fee = required_fee(selected.len(), num_outs, tx_config.payload_size, tx_config.normalized_transient_mass_per_byte);
         let priority_fee = if tx_config.randomize_fee && tx_config.priority_fee > 0 {
             rng.gen_range(0..tx_config.priority_fee)
         } else {

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Arg, ArgAction, Command};
 use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
-    config::params::{DEVNET_PARAMS, Params, TESTNET_PARAMS, TESTNET12_PARAMS},
+    config::params::{TESTNET_PARAMS, TESTNET12_PARAMS},
     constants::{SOMPI_PER_KASPA, TX_VERSION, TX_VERSION_TOCCATA},
     hashing::covenant_id::covenant_id,
     network::NetworkType,
@@ -253,6 +253,14 @@ async fn main() {
 
     (args.payload_size <= 20000).then_some(()).expect("payload-size can be max 20000");
 
+    let tx_config = TxConfig {
+        priority_fee: args.priority_fee,
+        randomize_fee: args.randomize_fee,
+        payload_size: args.payload_size,
+        with_covenant_id: args.enable_covenant_id,
+        randomize_tx_version: args.randomize_tx_version,
+    };
+
     rayon::ThreadPoolBuilder::new().num_threads(args.threads as usize).build_global().unwrap();
 
     let mut log_message = format!(
@@ -270,34 +278,21 @@ async fn main() {
     if args.priority_fee != 0 {
         log_message.push_str(&format!(
             "\n\tpriority fee: {} SOMPS {}",
-            args.priority_fee,
-            if args.randomize_fee { "[randomize]" } else { "" }
+            tx_config.priority_fee,
+            if tx_config.randomize_fee { "[randomize]" } else { "" }
         ));
     }
     if args.payload_size != 0 {
-        log_message.push_str(&format!("\n\tpayload size: {} random bytes", args.payload_size,));
+        log_message.push_str(&format!("\n\tpayload size: {} random bytes", tx_config.payload_size,));
     }
     info!("{}", log_message);
 
     let info = rpc_client.get_block_dag_info().await.expect("Failed to get block dag info.");
 
-    let consensus_params: Params = match args.network {
-        NetworkType::Testnet => match info.network.suffix {
-            Some(11) => panic!("TN11 is not supported on this version"),
-            Some(12) => TESTNET12_PARAMS,
-            None | Some(_) => TESTNET_PARAMS,
-        },
-        NetworkType::Devnet => DEVNET_PARAMS,
-        _ => unreachable!("CLI only accepts testnet and devnet"),
-    };
-    let coinbase_maturity = consensus_params.coinbase_maturity();
-
-    let tx_config = TxConfig {
-        priority_fee: args.priority_fee,
-        randomize_fee: args.randomize_fee,
-        payload_size: args.payload_size,
-        with_covenant_id: args.enable_covenant_id,
-        randomize_tx_version: args.randomize_tx_version,
+    let coinbase_maturity = match info.network.suffix {
+        Some(11) => panic!("TN11 is not supported on this version"),
+        Some(12) => TESTNET12_PARAMS.coinbase_maturity(),
+        None | Some(_) => TESTNET_PARAMS.coinbase_maturity(),
     };
     info!(
         "Node block-DAG info: \n\tNetwork: {}, \n\tBlock count: {}, \n\tHeader count: {}, \n\tDifficulty: {},

--- a/testing/integration/src/common/fee.rs
+++ b/testing/integration/src/common/fee.rs
@@ -1,0 +1,62 @@
+use kaspa_consensus_core::{
+    constants::{STORAGE_MASS_PARAMETER, TRANSIENT_BYTE_TO_MASS_FACTOR},
+    mass::MassCalculator,
+    tx::Transaction,
+};
+
+// Minimum standard relay fee is 100 sompi/gram; use 101 for fixture slack.
+pub(crate) const FEE_RATE: u64 = 101;
+
+// Mempool minimum relay fee uses post-Toccata cofactors immediately, so we normalize accordingly (factor / ratio between limits).
+const NORMALIZED_TRANSIENT_BYTE_FACTOR: u64 = 2;
+
+/// Calculates the relay fee used by integration fixtures for plain vanilla std txs.
+pub const fn calc_for_plain_standard_tx(num_inputs: usize, num_outputs: u64) -> u64 {
+    calc_for_plain_standard_tx_with_extra_serialized_bytes(num_inputs, num_outputs, 0)
+}
+
+/// Calculates the relay fee used by integration fixtures for plain vanilla std txs,
+/// with known extra serialized bytes such as a larger signature script.
+pub const fn calc_for_plain_standard_tx_with_extra_serialized_bytes(
+    num_inputs: usize,
+    num_outputs: u64,
+    extra_serialized_bytes: u64,
+) -> u64 {
+    let (compute_mass, serialized_bytes) =
+        estimated_plain_standard_tx_compute_mass_and_serialized_bytes(num_inputs, num_outputs, extra_serialized_bytes);
+    let normalized_transient_mass = serialized_bytes * NORMALIZED_TRANSIENT_BYTE_FACTOR;
+    let fee_mass = if compute_mass > normalized_transient_mass { compute_mass } else { normalized_transient_mass };
+    FEE_RATE * fee_mass
+}
+
+/// Calculates relay fee from a transaction probe using the real non-contextual mass calculator.
+pub fn calc_for_transaction(tx: &Transaction) -> u64 {
+    let masses = MassCalculator::new(1, 10, STORAGE_MASS_PARAMETER).calc_non_contextual_masses(tx);
+    let serialized_bytes = masses.transient_mass / TRANSIENT_BYTE_TO_MASS_FACTOR;
+    let normalized_transient_mass = serialized_bytes * NORMALIZED_TRANSIENT_BYTE_FACTOR;
+    FEE_RATE * masses.compute_mass.max(normalized_transient_mass)
+}
+
+/// Builds a transaction probe and calculates its relay fee using the real non-contextual mass calculator.
+pub fn calc_from_probe(build_probe: impl FnOnce() -> Transaction) -> u64 {
+    calc_for_transaction(&build_probe())
+}
+
+// Estimates mass for plain vanilla std txs used by integration fixtures:
+// native subnet, no payload, no covenants, standard single-signature inputs,
+// and standard pay-to-address outputs. Callers with custom input mass, payload,
+// covenants, or other non-plain shapes should use a transaction probe.
+const fn estimated_plain_standard_tx_compute_mass_and_serialized_bytes(
+    num_inputs: usize,
+    num_outputs: u64,
+    extra_serialized_bytes: u64,
+) -> (u64, u64) {
+    let serialized_bytes = 94 // plain tx: version [2] + input/output counts [16] + locktime [8] + subnetwork id [20] + gas [8] + payload hash [32] + payload length [8]
+        + 118 * (num_inputs as u64) // std input: outpoint [36] + signature script length [8] + single-signature script [66] + sequence [8]
+        + 53 * num_outputs // std output: value [8] + script public key version [2] + script public key length [8] + max std script public key [35]
+        + extra_serialized_bytes;
+    let compute_mass = serialized_bytes
+        + 1000 * (num_inputs as u64) // std input script mass (1 sigop)
+        + 370 * num_outputs; // std output spk mass: (script public key version [2] + max std script public key [35]) * 10
+    (compute_mass, serialized_bytes)
+}

--- a/testing/integration/src/common/mod.rs
+++ b/testing/integration/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod args;
 pub mod client;
 pub mod client_notify;
 pub mod daemon;
+pub mod fee;
 pub mod json;
 pub mod listener;
 pub mod utils;

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -2,7 +2,7 @@ use super::client::ListeningClient;
 use itertools::Itertools;
 use kaspa_addresses::Address;
 use kaspa_consensus_core::{
-    constants::{TX_VERSION, TX_VERSION_TOCCATA},
+    constants::{TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION, TX_VERSION_TOCCATA},
     header::Header,
     mass::SigopCount,
     sign::sign,
@@ -34,13 +34,23 @@ use tokio::time::timeout;
 pub(crate) const EXPAND_FACTOR: u64 = 2;
 pub(crate) const CONTRACT_FACTOR: u64 = 2;
 
-const fn estimated_mass(num_inputs: usize, num_outputs: u64) -> u64 {
+const fn estimated_compute_mass(num_inputs: usize, num_outputs: u64) -> u64 {
     200 + 34 * num_outputs + 1000 * (num_inputs as u64)
 }
 
+const fn estimated_transient_mass(num_inputs: usize, num_outputs: u64, extra_serialized_bytes: u64) -> u64 {
+    (200 + 34 * num_outputs + 1000 * (num_inputs as u64) + extra_serialized_bytes) * TRANSIENT_BYTE_TO_MASS_FACTOR
+}
+
 pub const fn required_fee(num_inputs: usize, num_outputs: u64) -> u64 {
-    const FEE_RATE: u64 = 10;
-    FEE_RATE * estimated_mass(num_inputs, num_outputs)
+    required_fee_with_extra_serialized_bytes(num_inputs, num_outputs, 0)
+}
+
+pub const fn required_fee_with_extra_serialized_bytes(num_inputs: usize, num_outputs: u64, extra_serialized_bytes: u64) -> u64 {
+    const FEE_RATE: u64 = 101;
+    let compute_mass = estimated_compute_mass(num_inputs, num_outputs);
+    let transient_mass = estimated_transient_mass(num_inputs, num_outputs, extra_serialized_bytes);
+    FEE_RATE * if compute_mass > transient_mass { compute_mass } else { transient_mass }
 }
 
 /// Builds a TX DAG based on the initial UTXO set and on constant params

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -1,8 +1,8 @@
-use super::client::ListeningClient;
+use super::{client::ListeningClient, fee};
 use itertools::Itertools;
 use kaspa_addresses::Address;
 use kaspa_consensus_core::{
-    constants::{TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION, TX_VERSION_TOCCATA},
+    constants::{TX_VERSION, TX_VERSION_TOCCATA},
     header::Header,
     mass::SigopCount,
     sign::sign,
@@ -33,25 +33,6 @@ use tokio::time::timeout;
 
 pub(crate) const EXPAND_FACTOR: u64 = 2;
 pub(crate) const CONTRACT_FACTOR: u64 = 2;
-
-const fn estimated_compute_mass(num_inputs: usize, num_outputs: u64) -> u64 {
-    200 + 34 * num_outputs + 1000 * (num_inputs as u64)
-}
-
-const fn estimated_transient_mass(num_inputs: usize, num_outputs: u64, extra_serialized_bytes: u64) -> u64 {
-    (200 + 34 * num_outputs + 1000 * (num_inputs as u64) + extra_serialized_bytes) * TRANSIENT_BYTE_TO_MASS_FACTOR
-}
-
-pub const fn required_fee(num_inputs: usize, num_outputs: u64) -> u64 {
-    required_fee_with_extra_serialized_bytes(num_inputs, num_outputs, 0)
-}
-
-pub const fn required_fee_with_extra_serialized_bytes(num_inputs: usize, num_outputs: u64, extra_serialized_bytes: u64) -> u64 {
-    const FEE_RATE: u64 = 101;
-    let compute_mass = estimated_compute_mass(num_inputs, num_outputs);
-    let transient_mass = estimated_transient_mass(num_inputs, num_outputs, extra_serialized_bytes);
-    FEE_RATE * if compute_mass > transient_mass { compute_mass } else { transient_mass }
-}
 
 /// Builds a TX DAG based on the initial UTXO set and on constant params
 pub fn generate_tx_dag(
@@ -89,7 +70,7 @@ pub fn generate_tx_dag(
             .into_par_iter()
             .map(|(inputs, entries)| {
                 let total_in = entries.iter().map(|e| e.amount).sum::<u64>();
-                let total_out = total_in - required_fee(num_inputs, num_outputs);
+                let total_out = total_in - fee::calc_for_plain_standard_tx(num_inputs, num_outputs);
                 let outputs = (0..num_outputs)
                     .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone(), covenant: None })
                     .collect_vec();
@@ -172,7 +153,7 @@ pub fn generate_tx_dag_with_lanes(
             .map(|(j, (inputs, entries))| {
                 let subnetwork = level_lane_assignments[j];
                 let total_in = entries.iter().map(|e| e.amount).sum::<u64>();
-                let total_out = total_in - required_fee(num_inputs, num_outputs);
+                let total_out = total_in - fee::calc_for_plain_standard_tx(num_inputs, num_outputs);
                 let outputs = (0..num_outputs)
                     .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone(), covenant: None })
                     .collect_vec();
@@ -242,7 +223,7 @@ pub fn generate_tx(
     address: &Address,
 ) -> Transaction {
     let total_in = utxos.iter().map(|x| x.1.amount).sum::<u64>();
-    assert!(amount <= total_in - required_fee(utxos.len(), num_outputs));
+    assert!(amount <= total_in - fee::calc_for_plain_standard_tx(utxos.len(), num_outputs));
     let script_public_key = pay_to_address_script(address);
     let inputs = utxos
         .iter()

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -2,7 +2,8 @@ use crate::common::{
     client::ListeningClient,
     client_notify::ChannelNotify,
     daemon::Daemon,
-    utils::{fetch_spendable_utxos, mine_block, required_fee, required_fee_with_extra_serialized_bytes, wait_for},
+    fee,
+    utils::{fetch_spendable_utxos, mine_block, wait_for},
 };
 use kaspa_addresses::Address;
 use kaspa_alloc::init_allocator_with_default_settings;
@@ -643,33 +644,48 @@ async fn daemon_compute_budget_relay_test() {
     let utxos = fetch_spendable_utxos(&rpc_client1, miner_address.clone(), coinbase_maturity).await;
     const NUMBER_INPUTS: u64 = 2;
     const NUMBER_OUTPUTS: u64 = 2;
+    const PER_INPUT_COMPUTE_BUDGET: u16 = 30;
     const EXTRA_FEE: u64 = 10_000;
     let oldest_utxos_start = utxos.len() - NUMBER_INPUTS as usize;
     let selected_utxos = &utxos[oldest_utxos_start..];
     let total_in = selected_utxos.iter().map(|x| x.1.amount).sum::<u64>();
-    let tx_fee = required_fee(selected_utxos.len(), NUMBER_OUTPUTS).saturating_add(EXTRA_FEE);
-    let tx_amount = total_in.checked_sub(tx_fee).expect("expected enough input value for test transaction fee");
     let script_public_key = pay_to_address_script(&user_address);
-    let inputs = selected_utxos
-        .iter()
-        .map(|(op, _)| TransactionInput {
-            previous_outpoint: *op,
-            signature_script: vec![],
-            sequence: 0,
-            mass: ComputeBudget(0).into(),
-        })
-        .collect();
-    let outputs = (0..NUMBER_OUTPUTS)
-        .map(|_| TransactionOutput { value: tx_amount / NUMBER_OUTPUTS, script_public_key: script_public_key.clone(), covenant: None })
-        .collect();
-    let unsigned_tx = Transaction::new(TX_VERSION_TOCCATA, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
-    let signed_tx = sign_with_multiple_v2(
-        MutableTransaction::with_entries(unsigned_tx, selected_utxos.iter().map(|(_, entry)| entry.clone()).collect()),
-        &[miner_sk.secret_bytes()],
-    )
-    .unwrap();
-    let mut transaction = signed_tx.tx;
-    transaction.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(30).into());
+    let build_transaction = |tx_output_amount: u64| {
+        let inputs = selected_utxos
+            .iter()
+            .map(|(op, _)| TransactionInput {
+                previous_outpoint: *op,
+                signature_script: vec![],
+                sequence: 0,
+                mass: ComputeBudget(0).into(),
+            })
+            .collect();
+        let outputs = (0..NUMBER_OUTPUTS)
+            .map(|_| TransactionOutput {
+                value: tx_output_amount / NUMBER_OUTPUTS,
+                script_public_key: script_public_key.clone(),
+                covenant: None,
+            })
+            .collect();
+        let unsigned_tx = Transaction::new(TX_VERSION_TOCCATA, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+        sign_with_multiple_v2(
+            MutableTransaction::with_entries(unsigned_tx, selected_utxos.iter().map(|(_, entry)| entry.clone()).collect()),
+            &[miner_sk.secret_bytes()],
+        )
+        .unwrap()
+        .tx
+    };
+
+    let tx_fee = fee::calc_from_probe(|| {
+        let mut tx = build_transaction(total_in);
+        tx.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
+        tx
+    })
+    .saturating_add(EXTRA_FEE);
+    let tx_amount = total_in.checked_sub(tx_fee).expect("expected enough input value for test transaction fee");
+
+    let mut transaction = build_transaction(tx_amount);
+    transaction.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
     assert!(
         transaction.inputs.iter().any(|input| input.mass.compute_budget().unwrap() > 0),
         "expected non-zero compute_budget commitment for v1 transaction"
@@ -771,7 +787,7 @@ async fn daemon_rejects_transactions_with_inconsistent_input_mass_and_version() 
     assert!(utxos.len() >= 2, "expected enough spendable UTXOs for malformed transaction tests");
 
     let build_single_input_tx = |version: u16, selected_utxo: &(TransactionOutpoint, UtxoEntry)| {
-        let fee = required_fee(1, 1);
+        let fee = fee::calc_for_plain_standard_tx(1, 1);
         let output_value = selected_utxo.1.amount.checked_sub(fee).expect("expected enough input value for test fee");
         let mass = ComputeBudget(0).into(); // set correctly by sign below
         let tx = Transaction::new(
@@ -879,7 +895,7 @@ async fn daemon_pruning_seqcommit_sync_test() {
     let utxos = fetch_spendable_utxos(&rpc_client1, miner_address.clone(), 10).await;
     let input_utxos = &utxos[0..1];
     let total_in = input_utxos.iter().map(|x| x.1.amount).sum::<u64>();
-    let fee = required_fee(input_utxos.len(), 1);
+    let fee = fee::calc_for_plain_standard_tx(input_utxos.len(), 1);
     let outputs = vec![TransactionOutput { value: total_in - fee, script_public_key: seqcommit_spk.clone(), covenant: None }];
     let inputs = input_utxos.iter().map(|(op, _)| TransactionInput::new(*op, vec![], 0, 1)).collect();
     let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
@@ -909,7 +925,7 @@ async fn daemon_pruning_seqcommit_sync_test() {
     let outpoint = TransactionOutpoint::new(seqcommit_tx.id(), 0);
     let pay_spk = pay_to_address_script(&miner_address);
     let signature_script = pay_to_script_hash_signature_script(redeem_script, vec![]).expect("canonical signature script");
-    let spend_fee = required_fee_with_extra_serialized_bytes(1, 1, signature_script.len() as u64);
+    let spend_fee = fee::calc_for_plain_standard_tx_with_extra_serialized_bytes(1, 1, signature_script.len() as u64);
     let spend_value = total_in - fee - spend_fee;
     let spend_tx = Transaction::new(
         TX_VERSION,
@@ -1087,7 +1103,7 @@ async fn daemon_ibd_smt_state_sync_test() {
         subnet_bytes[3] = (i as u8) + 1;
         let lane_subnet = SubnetworkId::from_bytes(subnet_bytes);
 
-        let fee = required_fee(1, 1);
+        let fee = fee::calc_for_plain_standard_tx(1, 1);
         assert!(entry.amount > fee, "coinbase utxo is too small to cover a tx fee");
         let out_value = entry.amount - fee;
         let unsigned_tx = Transaction::new(

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -2,7 +2,7 @@ use crate::common::{
     client::ListeningClient,
     client_notify::ChannelNotify,
     daemon::Daemon,
-    utils::{fetch_spendable_utxos, mine_block, required_fee, wait_for},
+    utils::{fetch_spendable_utxos, mine_block, required_fee, required_fee_with_extra_serialized_bytes, wait_for},
 };
 use kaspa_addresses::Address;
 use kaspa_alloc::init_allocator_with_default_settings;
@@ -908,9 +908,9 @@ async fn daemon_pruning_seqcommit_sync_test() {
     // still within the finality depth of the spending block.
     let outpoint = TransactionOutpoint::new(seqcommit_tx.id(), 0);
     let pay_spk = pay_to_address_script(&miner_address);
-    let spend_fee = required_fee(1, 1);
-    let spend_value = total_in - fee - spend_fee;
     let signature_script = pay_to_script_hash_signature_script(redeem_script, vec![]).expect("canonical signature script");
+    let spend_fee = required_fee_with_extra_serialized_bytes(1, 1, signature_script.len() as u64);
+    let spend_value = total_in - fee - spend_fee;
     let spend_tx = Transaction::new(
         TX_VERSION,
         vec![TransactionInput::new(outpoint, signature_script, 0, 1)],

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -633,8 +633,12 @@ impl Generator {
     }
 
     /// Calculates the required transaction fee from the mass dimensions.
-    /// - Mempool minimum relay policy only prices compute mass.
+    /// - Mempool minimum relay policy prices compute mass.
     /// - User-provided fee rate follows mempool prioritization by pricing full transaction mass including storage mass.
+    ///
+    /// Note: `compute_mass` is the wallet's minimum-relay mass proxy. It is mostly
+    /// compute mass, but its payload component is hardened to account for normalized
+    /// transient byte mass.
     fn calc_transaction_fees(&self, compute_mass: u64, transaction_mass: u64) -> u64 {
         self.inner.mass_calculator.calc_minimum_transaction_fee_from_mass(compute_mass).max(self.calc_fee_rate(transaction_mass))
     }

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -880,7 +880,6 @@ impl Generator {
 
                 data.aggregate_mass = calc.combine_mass(compute_mass, storage_mass);
 
-                transaction_fees += change_output_value;
                 data.transaction_fees = transaction_fees;
                 stage.aggregate_fees += transaction_fees;
                 context.aggregate_fees += transaction_fees;

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -616,19 +616,27 @@ impl Generator {
 
     /// Calculate relay transaction mass for the current transaction `data`
     #[inline(always)]
-    fn calc_relay_transaction_mass(&self, data: &Data) -> u64 {
+    fn calc_relay_transaction_compute_mass(&self, data: &Data) -> u64 {
         data.aggregate_mass + self.inner.standard_change_output_compute_mass
     }
 
     /// Calculate relay transaction fees for the current transaction `data`
     #[inline(always)]
     fn calc_relay_transaction_compute_fees(&self, data: &Data) -> u64 {
-        let mass = self.calc_relay_transaction_mass(data);
-        self.inner.mass_calculator.calc_minimum_transaction_fee_from_mass(mass).max(self.calc_fee_rate(mass))
+        let compute_mass = self.calc_relay_transaction_compute_mass(data);
+        self.calc_compute_fees(compute_mass)
     }
 
-    fn calc_fees_from_mass(&self, mass: u64) -> u64 {
-        self.inner.mass_calculator.calc_minimum_transaction_fee_from_mass(mass).max(self.calc_fee_rate(mass))
+    /// Calculates fees for compute-only contexts where transaction mass equals compute mass.
+    fn calc_compute_fees(&self, compute_mass: u64) -> u64 {
+        self.calc_transaction_fees(compute_mass, compute_mass)
+    }
+
+    /// Calculates the required transaction fee from the mass dimensions.
+    /// - Mempool minimum relay policy only prices compute mass.
+    /// - User-provided fee rate follows mempool prioritization by pricing full transaction mass including storage mass.
+    fn calc_transaction_fees(&self, compute_mass: u64, transaction_mass: u64) -> u64 {
+        self.inner.mass_calculator.calc_minimum_transaction_fee_from_mass(compute_mass).max(self.calc_fee_rate(transaction_mass))
     }
 
     /// Main UTXO entry processing loop. This function sources UTXOs from [`Generator::get_utxo_entry()`] and
@@ -891,16 +899,15 @@ impl Generator {
 
         let mut absorb_change_to_fees = false;
 
-        let compute_mass_with_change = data.aggregate_mass
-            + self.inner.standard_change_output_compute_mass
-            + self.inner.final_transaction_outputs_compute_mass
-            + self.inner.final_transaction_payload_mass;
+        let compute_mass_no_change =
+            data.aggregate_mass + self.inner.final_transaction_outputs_compute_mass + self.inner.final_transaction_payload_mass;
+        let compute_mass_with_change = compute_mass_no_change + self.inner.standard_change_output_compute_mass;
 
         let storage_mass = if stage.number_of_transactions > 0 {
             // calculate for edge transaction boundaries
             // we know that stage.number_of_transactions > 0 will trigger stage generation
             let edge_compute_mass = data.aggregate_mass + self.inner.standard_change_output_compute_mass; //self.inner.final_transaction_outputs_compute_mass + self.inner.final_transaction_payload_mass;
-            let edge_fees = self.calc_fees_from_mass(edge_compute_mass);
+            let edge_fees = self.calc_compute_fees(edge_compute_mass);
             let edge_output_value = data.aggregate_input_value.saturating_sub(edge_fees);
             if edge_output_value != 0 {
                 let edge_output_harmonic = calc.calc_storage_mass_output_harmonic_single(edge_output_value);
@@ -933,8 +940,14 @@ impl Generator {
                     if storage_mass_with_change < storage_mass_no_change {
                         storage_mass_with_change
                     } else {
-                        let fees_with_change = calc.calc_fee_for_mass(storage_mass_with_change);
-                        let fees_no_change = calc.calc_fee_for_mass(storage_mass_no_change);
+                        let fees_with_change = self.calc_transaction_fees(
+                            compute_mass_with_change,
+                            calc.combine_mass(compute_mass_with_change, storage_mass_with_change),
+                        );
+                        let fees_no_change = self.calc_transaction_fees(
+                            compute_mass_no_change,
+                            calc.combine_mass(compute_mass_no_change, storage_mass_no_change),
+                        );
                         let difference = fees_with_change.saturating_sub(fees_no_change);
 
                         if difference > change_value {
@@ -951,8 +964,9 @@ impl Generator {
         if storage_mass > MAXIMUM_STANDARD_TRANSACTION_MASS {
             Err(Error::StorageMassExceedsMaximumTransactionMass { storage_mass })
         } else {
-            let transaction_mass = calc.combine_mass(compute_mass_with_change, storage_mass);
-            let transaction_fees = self.calc_fees_from_mass(transaction_mass); //calc.calc_minimum_transaction_fee_from_mass(transaction_mass) + self.calc_fee_rate(transaction_mass);
+            let compute_mass = if absorb_change_to_fees { compute_mass_no_change } else { compute_mass_with_change };
+            let transaction_mass = calc.combine_mass(compute_mass, storage_mass);
+            let transaction_fees = self.calc_transaction_fees(compute_mass, transaction_mass);
 
             Ok(MassDisposition { transaction_mass, transaction_fees, storage_mass, absorb_change_to_fees })
         }
@@ -967,7 +981,7 @@ impl Generator {
             + self.inner.standard_change_output_compute_mass
             + self.inner.network_params.additional_compound_transaction_mass();
         // let compute_fees = calc.calc_minimum_transaction_fee_from_mass(compute_mass) + self.calc_fee_rate(compute_mass);
-        let compute_fees = self.calc_fees_from_mass(compute_mass);
+        let compute_fees = self.calc_compute_fees(compute_mass);
 
         // TODO - consider removing this as calculated storage mass should produce `0` value
         let edge_output_harmonic =
@@ -986,7 +1000,7 @@ impl Generator {
             }
         } else {
             data.aggregate_mass = transaction_mass;
-            data.transaction_fees = self.calc_fees_from_mass(transaction_mass);
+            data.transaction_fees = self.calc_transaction_fees(compute_mass, transaction_mass);
             stage.aggregate_fees += data.transaction_fees;
             context.aggregate_fees += data.transaction_fees;
             Ok(Some(DataKind::Edge))

--- a/wallet/core/src/tx/generator/test.rs
+++ b/wallet/core/src/tx/generator/test.rs
@@ -211,7 +211,8 @@ where
     }
 
     let calculated_mass = calc.combine_mass(compute_mass, storage_mass) + additional_mass;
-    let calculated_fees = calc.calc_minimum_transaction_fee_from_mass(calculated_mass);
+    // Minimum standard relay fee requires only compute mass.
+    let calculated_fees = calc.calc_minimum_transaction_fee_from_mass(compute_mass + additional_mass);
 
     if storage_mass != 0 {
         println!("PT outputs: {}", tx.outputs.len());
@@ -560,7 +561,9 @@ fn test_generator_compound_100k_random_transactions() -> Result<()> {
     let mut rng = StdRng::seed_from_u64(0);
     let inputs: Vec<f64> = (0..100_000).map(|_| rng.gen_range(0.001..10.0)).collect();
     let total = inputs.iter().sum::<f64>();
-    let outputs = [(output_address, Kaspa(total - 10.0))];
+    // The generated tree uses roughly 225 block-equivalents, so 150 KAS leaves
+    // enough room at the 0.5 KAS/block relay floor.
+    let outputs = [(output_address, Kaspa(total - 150.0))];
     generator(test_network_id(), &inputs, &[], None, Fees::sender(Kaspa(5.0)), outputs.as_slice())
         .unwrap()
         .harness()
@@ -657,7 +660,7 @@ fn test_generator_inputs_100_outputs_1_fees_exclude_success() -> Result<()> {
         .fetch(&Expected {
             is_final: true,
             input_count: 2,
-            aggregate_input_value: Sompi(999_99886576),
+            aggregate_input_value: Sompi(999_88657600),
             output_count: 2,
             // priority_fees: FeesExpected::sender(Kaspa(5.0)),
             priority_fees: FeesExpected::sender(Kaspa(0.0)),
@@ -697,7 +700,7 @@ fn test_generator_inputs_100_outputs_1_fees_include_success() -> Result<()> {
     .fetch(&Expected {
         is_final: true,
         input_count: 2,
-        aggregate_input_value: Sompi(99_99886576),
+        aggregate_input_value: Sompi(99_88657600),
         output_count: 1,
         priority_fees: FeesExpected::receiver(Kaspa(5.0)),
     })
@@ -748,7 +751,7 @@ fn test_generator_inputs_1k_outputs_2_fees_exclude() -> Result<()> {
         .fetch(&Expected {
             is_final: true,
             input_count: 11,
-            aggregate_input_value: Sompi(9009_98981896),
+            aggregate_input_value: Sompi(9008_98189600),
             output_count: 2,
             priority_fees: FeesExpected::receiver(Kaspa(5.0)),
         })
@@ -766,7 +769,7 @@ fn test_generator_inputs_32k_outputs_2_fees_exclude() -> Result<()> {
         &[],
         None,
         Fees::sender(Kaspa(10_000.0)),
-        [(output_address, Kaspa(f * 32_747.0 - 10_001.0))].as_slice(),
+        [(output_address, Kaspa(f * 32_747.0 - 10_050.0))].as_slice(),
     )
     .unwrap()
     .harness()

--- a/wallet/core/src/tx/generator/test.rs
+++ b/wallet/core/src/tx/generator/test.rs
@@ -7,7 +7,7 @@ use crate::utxo::UtxoEntryReference;
 use crate::{tx::PaymentOutputs, utils::kaspa_to_sompi};
 use kaspa_addresses::Address;
 use kaspa_consensus_core::config::params::Params;
-use kaspa_consensus_core::mass::UtxoCell;
+use kaspa_consensus_core::mass::{UtxoCell, transaction_estimated_serialized_size};
 use kaspa_consensus_core::network::{NetworkId, NetworkType};
 use kaspa_consensus_core::tx::Transaction;
 use rand::prelude::*;
@@ -419,6 +419,22 @@ pub(crate) fn make_generator<F>(
 where
     F: FnOnce(NetworkType) -> Address,
 {
+    make_generator_with_payload(network_id, head, tail, fee_rate, fees, change_address, final_transaction_destination, None)
+}
+
+pub(crate) fn make_generator_with_payload<F>(
+    network_id: NetworkId,
+    head: &[f64],
+    tail: &[f64],
+    fee_rate: Option<f64>,
+    fees: Fees,
+    change_address: F,
+    final_transaction_destination: PaymentDestination,
+    final_transaction_payload: Option<Vec<u8>>,
+) -> Result<Generator>
+where
+    F: FnOnce(NetworkType) -> Address,
+{
     let mut values = head.to_vec();
     values.extend(tail);
 
@@ -431,7 +447,6 @@ where
     let source_utxo_context = None;
     let destination_utxo_context = None;
     let final_priority_fee = fees;
-    let final_transaction_payload = None;
     let change_address = change_address(network_id.into());
 
     let settings = GeneratorSettings {
@@ -517,6 +532,43 @@ fn test_generator_sweep_two_utxos_with_priority_fees_rejection() -> Result<()> {
         Err(Error::GeneratorFeesInSweepTransaction) => {}
         _ => panic!("merge 2 UTXOs with fees must fail generator creation"),
     }
+    Ok(())
+}
+
+#[test]
+fn test_generator_large_payload_min_relay_fee() -> Result<()> {
+    let network_id = test_network_id();
+    let harness = make_generator_with_payload(
+        network_id,
+        &[1.0; 19],
+        &[],
+        None,
+        Fees::sender(Kaspa(0.0)),
+        change_address,
+        PaymentOutputs::from([(output_address(network_id.into()), kaspa_to_sompi(18.0))].as_slice()).into(),
+        Some(vec![0; 20_000]),
+    )
+    .unwrap()
+    .harness()
+    .fetch(&Expected {
+        is_final: true,
+        input_count: 19,
+        aggregate_input_value: Kaspa(19.0),
+        output_count: 2,
+        priority_fees: FeesExpected::sender(Kaspa(0.0)),
+    });
+
+    const NORMALIZED_TRANSIENT_BYTE_FACTOR: u64 = 2;
+
+    let pt = harness.accumulator.borrow().list[0].clone();
+    let tx = pt.transaction();
+    let calc = MassCalculator::new(&network_id.into());
+    let mempool_minimum_fee =
+        calc.calc_minimum_transaction_fee_from_mass(transaction_estimated_serialized_size(&tx) * NORMALIZED_TRANSIENT_BYTE_FACTOR);
+    assert!(pt.fees() >= mempool_minimum_fee, "large payloads must cover the mempool transient fee floor");
+
+    harness.finalize();
+
     Ok(())
 }
 

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -242,7 +242,16 @@ impl MassCalculator {
     }
 
     pub(crate) fn calc_compute_mass_for_payload(&self, payload_byte_size: usize) -> u64 {
-        payload_byte_size as u64 * self.mass_per_tx_byte
+        // Inputs and outputs also increase transaction bytes, but their wallet
+        // compute mass includes script/sigop costs which dominate the normalized
+        // transient byte cost for standard transactions. Payload adds raw bytes
+        // without such a matching compute cost, so we harden only the payload term.
+        //
+        // TODO: model the full tx-wide max(compute, normalized transient) instead.
+        // This local compromise can slightly overprice payload bytes because it
+        // does not credit them with compute slack contributed by inputs/outputs.
+        const NORMALIZED_TRANSIENT_BYTE_FACTOR: u64 = 2;
+        payload_byte_size as u64 * self.mass_per_tx_byte.max(NORMALIZED_TRANSIENT_BYTE_FACTOR)
     }
 
     pub(crate) fn calc_compute_mass_for_client_transaction_outputs(&self, outputs: &[TransactionOutput]) -> u64 {

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -17,7 +17,8 @@ pub const SIGNATURE_SIZE: u64 = 1 + 64 + 1; //1 byte for OP_DATA_65 + 64 (length
 
 /// MINIMUM_RELAY_TRANSACTION_FEE specifies the minimum transaction fee for a transaction to be accepted to
 /// the mempool and relayed. It is specified in sompi per 1kg (or 1000 grams) of transaction mass.
-pub(crate) const MINIMUM_RELAY_TRANSACTION_FEE: u64 = 1000;
+/// The default is 100 sompi per gram.
+pub(crate) const MINIMUM_RELAY_TRANSACTION_FEE: u64 = 100_000;
 
 /// MAXIMUM_STANDARD_TRANSACTION_MASS is the maximum mass allowed for transactions that
 /// are considered standard and will therefore be relayed and considered for mining.
@@ -47,15 +48,9 @@ pub fn calc_minimum_required_transaction_relay_fee(mass: u64) -> u64 {
 /// amount is considered dust or not based on the configured minimum transaction
 /// relay fee.
 ///
-/// Dust is defined in terms of the minimum transaction relay fee. In particular,
-/// if the cost to the network to spend coins is more than 1/3 of the minimum
-/// transaction relay fee, it is considered dust.
-///
-/// It is exposed by `MiningManager` for use by transaction generators and wallets.
+/// Mempool does not reject dust outputs by threshold, but the wallet still uses this
+/// heuristic to avoid creating change outputs that cost more to preserve than they are worth.
 pub fn is_transaction_output_dust(transaction_output: &TransactionOutput) -> bool {
-    // TODO(post-toccata): review this wallet-side dust helper against the updated mempool
-    // standardness policy. Mempool no longer rejects dust by threshold, but wallet generation
-    // may still want a local small-output/change-disposal heuristic.
     // TODO: call script engine when available
     // if txscript.is_unspendable(transaction_output.script_public_key.script()) {
     //     return true
@@ -86,8 +81,6 @@ pub fn is_transaction_output_dust(transaction_output: &TransactionOutput) -> boo
 
     // The output is considered dust if the cost to the network to spend the
     // coins is more than 1/3 of the minimum free transaction relay fee.
-    // mp.config.MinimumRelayTransactionFee is in sompi/KB, so multiply
-    // by 1000 to convert to bytes.
     //
     // Using the typical values for a pay-to-pubkey transaction from
     // the breakdown above and the default minimum free transaction relay
@@ -291,7 +284,7 @@ impl MassCalculator {
     // provisional
     #[inline(always)]
     pub fn calc_fee_for_mass(&self, mass: u64) -> u64 {
-        mass
+        self.calc_minimum_transaction_fee_from_mass(mass)
     }
 
     pub fn combine_mass(&self, compute_mass: u64, storage_mass: u64) -> u64 {


### PR DESCRIPTION
Raises the minimum relay fee to 100 sompi/gram and updates fee estimation, wallet transaction generation, integration fixtures, and Rothschild transaction generation to follow the new relay floor.

Context: https://gist.github.com/michaelsutton/a5c9bff6c9e9713edd0de9a3059bab9a

Wallet generation follows the mempool fee rules:

- the new standard minimum fee is required only for compute/transient mass
- storage mass still matters for feerate/priority
- payload-heavy transactions account for the normalized transient byte floor, with a conservative approximation that may slightly overprice payload bytes

Also removes the standardness sigops limit so block mass limits remain the standardness bound, and refines mempool intra-lane selection by accounting for normalized gas.