### PR TITLE
chore(tn10/toccata): hard fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "ahash",
  "borsh",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "duration-string",
  "futures",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "criterion",
@@ -3355,14 +3355,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "aes",
  "ahash",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "clap",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.1.1-toc.1"
+version = "1.2.0-toc"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -86,65 +86,65 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.1.1-toc.1", path = "testing/integration" }
-kaspa-addresses = { version = "1.1.1-toc.1", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.1.1-toc.1", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.1.1-toc.1", path = "wallet/bip32" }
-kaspa-cli = { version = "1.1.1-toc.1", path = "cli" }
-kaspa-connectionmanager = { version = "1.1.1-toc.1", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.1.1-toc.1", path = "consensus" }
-kaspa-consensus-core = { version = "1.1.1-toc.1", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.1.1-toc.1", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.1.1-toc.1", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.1.1-toc.1", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.1.1-toc.1", path = "components/consensusmanager" }
-kaspa-core = { version = "1.1.1-toc.1", path = "core" }
-kaspa-daemon = { version = "1.1.1-toc.1", path = "daemon" }
-kaspa-database = { version = "1.1.1-toc.1", path = "database" }
-kaspa-grpc-client = { version = "1.1.1-toc.1", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.1.1-toc.1", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.1.1-toc.1", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.1.1-toc.1", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.1.1-toc.1", path = "indexes/core" }
-kaspa-index-processor = { version = "1.1.1-toc.1", path = "indexes/processor" }
-kaspa-math = { version = "1.1.1-toc.1", path = "math" }
-kaspa-merkle = { version = "1.1.1-toc.1", path = "crypto/merkle" }
-kaspa-smt = { version = "1.1.1-toc.1", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.1.1-toc.1", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.1.1-toc.1", path = "metrics/core" }
-kaspa-mining = { version = "1.1.1-toc.1", path = "mining" }
-kaspa-mining-errors = { version = "1.1.1-toc.1", path = "mining/errors" }
-kaspa-muhash = { version = "1.1.1-toc.1", path = "crypto/muhash" }
-kaspa-notify = { version = "1.1.1-toc.1", path = "notify" }
-kaspa-p2p-flows = { version = "1.1.1-toc.1", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.1.1-toc.1", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.1.1-toc.1", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.1.1-toc.1", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.1.1-toc.1", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.1.1-toc.1", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.1.1-toc.1", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.1.1-toc.1", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.1.1-toc.1", path = "rpc/service" }
-kaspa-txscript = { version = "1.1.1-toc.1", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.1.1-toc.1", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.1.1-toc.1", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.1.1-toc.1", path = "utils/tower" }
-kaspa-utxoindex = { version = "1.1.1-toc.1", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.1.1-toc.1", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.1.1-toc.1", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.1.1-toc.1", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.1.1-toc.1", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.1.1-toc.1", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.1.1-toc.1", path = "wallet/macros" }
-kaspa-wasm = { version = "1.1.1-toc.1", path = "wasm" }
-kaspa-wasm-core = { version = "1.1.1-toc.1", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.1.1-toc.1", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.1.1-toc.1", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.1.1-toc.1", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.1.1-toc.1", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.1.1-toc.1", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.1.1-toc.1", path = "kaspad" }
-kaspa-alloc = { version = "1.1.1-toc.1", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.2.0-toc", path = "testing/integration" }
+kaspa-addresses = { version = "1.2.0-toc", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.2.0-toc", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.2.0-toc", path = "wallet/bip32" }
+kaspa-cli = { version = "1.2.0-toc", path = "cli" }
+kaspa-connectionmanager = { version = "1.2.0-toc", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.2.0-toc", path = "consensus" }
+kaspa-consensus-core = { version = "1.2.0-toc", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.2.0-toc", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.2.0-toc", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.2.0-toc", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.2.0-toc", path = "components/consensusmanager" }
+kaspa-core = { version = "1.2.0-toc", path = "core" }
+kaspa-daemon = { version = "1.2.0-toc", path = "daemon" }
+kaspa-database = { version = "1.2.0-toc", path = "database" }
+kaspa-grpc-client = { version = "1.2.0-toc", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.2.0-toc", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.2.0-toc", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.2.0-toc", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "1.2.0-toc", path = "indexes/core" }
+kaspa-index-processor = { version = "1.2.0-toc", path = "indexes/processor" }
+kaspa-math = { version = "1.2.0-toc", path = "math" }
+kaspa-merkle = { version = "1.2.0-toc", path = "crypto/merkle" }
+kaspa-smt = { version = "1.2.0-toc", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "1.2.0-toc", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "1.2.0-toc", path = "metrics/core" }
+kaspa-mining = { version = "1.2.0-toc", path = "mining" }
+kaspa-mining-errors = { version = "1.2.0-toc", path = "mining/errors" }
+kaspa-muhash = { version = "1.2.0-toc", path = "crypto/muhash" }
+kaspa-notify = { version = "1.2.0-toc", path = "notify" }
+kaspa-p2p-flows = { version = "1.2.0-toc", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.2.0-toc", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.2.0-toc", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.2.0-toc", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.2.0-toc", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.2.0-toc", path = "rpc/core" }
+kaspa-seq-commit = { version = "1.2.0-toc", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "1.2.0-toc", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.2.0-toc", path = "rpc/service" }
+kaspa-txscript = { version = "1.2.0-toc", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.2.0-toc", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.2.0-toc", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "1.2.0-toc", path = "utils/tower" }
+kaspa-utxoindex = { version = "1.2.0-toc", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.2.0-toc", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.2.0-toc", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.2.0-toc", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.2.0-toc", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.2.0-toc", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.2.0-toc", path = "wallet/macros" }
+kaspa-wasm = { version = "1.2.0-toc", path = "wasm" }
+kaspa-wasm-core = { version = "1.2.0-toc", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.2.0-toc", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.2.0-toc", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.2.0-toc", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.2.0-toc", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.2.0-toc", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.2.0-toc", path = "kaspad" }
+kaspa-alloc = { version = "1.2.0-toc", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -779,7 +779,8 @@ pub const TESTNET_PARAMS: Params = Params {
     crescendo_activation: ForkActivation::new(88_657_000),
 
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
-    toccata_activation: ForkActivation::never(),
+    // ~16:00 UTC, May 17, 2026
+    toccata_activation: ForkActivation::new(467_579_632),
 };
 
 pub const TESTNET12_PARAMS: Params = Params {

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -779,7 +779,7 @@ pub const TESTNET_PARAMS: Params = Params {
     crescendo_activation: ForkActivation::new(88_657_000),
 
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
-    // ~16:00 UTC, May 17, 2026
+    // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
 };
 

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -60,7 +60,7 @@ pub struct MultiConsensusMetadata {
     version: u32,
 }
 
-pub const LATEST_DB_VERSION: u32 = 6;
+pub const LATEST_DB_VERSION: u32 = 7;
 impl Default for MultiConsensusMetadata {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
- db version bump
- testnet-10 toccata activation at DAA `467_579_632` which is expected to roughly matches `16:00 UTC, May 18, 2026`
- bump crates to `1.2.0-toc`