### PR TITLE
fix(consensus/db): bump meta version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "ahash",
  "borsh",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "duration-string",
  "futures",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "criterion",
@@ -3355,14 +3355,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "aes",
  "ahash",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.2.0-toc"
+version = "1.2.0-toc.2"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -86,65 +86,65 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.2.0-toc", path = "testing/integration" }
-kaspa-addresses = { version = "1.2.0-toc", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.2.0-toc", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.2.0-toc", path = "wallet/bip32" }
-kaspa-cli = { version = "1.2.0-toc", path = "cli" }
-kaspa-connectionmanager = { version = "1.2.0-toc", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.2.0-toc", path = "consensus" }
-kaspa-consensus-core = { version = "1.2.0-toc", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.2.0-toc", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.2.0-toc", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.2.0-toc", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.2.0-toc", path = "components/consensusmanager" }
-kaspa-core = { version = "1.2.0-toc", path = "core" }
-kaspa-daemon = { version = "1.2.0-toc", path = "daemon" }
-kaspa-database = { version = "1.2.0-toc", path = "database" }
-kaspa-grpc-client = { version = "1.2.0-toc", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.2.0-toc", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.2.0-toc", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.2.0-toc", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.2.0-toc", path = "indexes/core" }
-kaspa-index-processor = { version = "1.2.0-toc", path = "indexes/processor" }
-kaspa-math = { version = "1.2.0-toc", path = "math" }
-kaspa-merkle = { version = "1.2.0-toc", path = "crypto/merkle" }
-kaspa-smt = { version = "1.2.0-toc", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.2.0-toc", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.2.0-toc", path = "metrics/core" }
-kaspa-mining = { version = "1.2.0-toc", path = "mining" }
-kaspa-mining-errors = { version = "1.2.0-toc", path = "mining/errors" }
-kaspa-muhash = { version = "1.2.0-toc", path = "crypto/muhash" }
-kaspa-notify = { version = "1.2.0-toc", path = "notify" }
-kaspa-p2p-flows = { version = "1.2.0-toc", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.2.0-toc", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.2.0-toc", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.2.0-toc", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.2.0-toc", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.2.0-toc", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.2.0-toc", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.2.0-toc", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.2.0-toc", path = "rpc/service" }
-kaspa-txscript = { version = "1.2.0-toc", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.2.0-toc", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.2.0-toc", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.2.0-toc", path = "utils/tower" }
-kaspa-utxoindex = { version = "1.2.0-toc", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.2.0-toc", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.2.0-toc", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.2.0-toc", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.2.0-toc", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.2.0-toc", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.2.0-toc", path = "wallet/macros" }
-kaspa-wasm = { version = "1.2.0-toc", path = "wasm" }
-kaspa-wasm-core = { version = "1.2.0-toc", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.2.0-toc", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.2.0-toc", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.2.0-toc", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.2.0-toc", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.2.0-toc", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.2.0-toc", path = "kaspad" }
-kaspa-alloc = { version = "1.2.0-toc", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.2.0-toc.2", path = "testing/integration" }
+kaspa-addresses = { version = "1.2.0-toc.2", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.2.0-toc.2", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.2.0-toc.2", path = "wallet/bip32" }
+kaspa-cli = { version = "1.2.0-toc.2", path = "cli" }
+kaspa-connectionmanager = { version = "1.2.0-toc.2", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.2.0-toc.2", path = "consensus" }
+kaspa-consensus-core = { version = "1.2.0-toc.2", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.2.0-toc.2", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.2.0-toc.2", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.2.0-toc.2", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.2.0-toc.2", path = "components/consensusmanager" }
+kaspa-core = { version = "1.2.0-toc.2", path = "core" }
+kaspa-daemon = { version = "1.2.0-toc.2", path = "daemon" }
+kaspa-database = { version = "1.2.0-toc.2", path = "database" }
+kaspa-grpc-client = { version = "1.2.0-toc.2", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.2.0-toc.2", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.2.0-toc.2", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.2.0-toc.2", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "1.2.0-toc.2", path = "indexes/core" }
+kaspa-index-processor = { version = "1.2.0-toc.2", path = "indexes/processor" }
+kaspa-math = { version = "1.2.0-toc.2", path = "math" }
+kaspa-merkle = { version = "1.2.0-toc.2", path = "crypto/merkle" }
+kaspa-smt = { version = "1.2.0-toc.2", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "1.2.0-toc.2", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "1.2.0-toc.2", path = "metrics/core" }
+kaspa-mining = { version = "1.2.0-toc.2", path = "mining" }
+kaspa-mining-errors = { version = "1.2.0-toc.2", path = "mining/errors" }
+kaspa-muhash = { version = "1.2.0-toc.2", path = "crypto/muhash" }
+kaspa-notify = { version = "1.2.0-toc.2", path = "notify" }
+kaspa-p2p-flows = { version = "1.2.0-toc.2", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.2.0-toc.2", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.2.0-toc.2", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.2.0-toc.2", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.2.0-toc.2", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.2.0-toc.2", path = "rpc/core" }
+kaspa-seq-commit = { version = "1.2.0-toc.2", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "1.2.0-toc.2", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.2.0-toc.2", path = "rpc/service" }
+kaspa-txscript = { version = "1.2.0-toc.2", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.2.0-toc.2", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.2.0-toc.2", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "1.2.0-toc.2", path = "utils/tower" }
+kaspa-utxoindex = { version = "1.2.0-toc.2", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.2.0-toc.2", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.2.0-toc.2", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.2.0-toc.2", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.2.0-toc.2", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.2.0-toc.2", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.2.0-toc.2", path = "wallet/macros" }
+kaspa-wasm = { version = "1.2.0-toc.2", path = "wasm" }
+kaspa-wasm-core = { version = "1.2.0-toc.2", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.2.0-toc.2", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.2.0-toc.2", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.2.0-toc.2", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.2.0-toc.2", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.2.0-toc.2", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.2.0-toc.2", path = "kaspad" }
+kaspa-alloc = { version = "1.2.0-toc.2", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -512,6 +512,10 @@ Do you confirm? (y/n)";
                 }
             }
         }
+        // no manual migration needed, but internal schema changes
+        if version <= 6 {
+            mcms.set_version(7).unwrap();
+        }
         // if we reached here, db should be upgraded fully and we should exit the loop next
         assert_eq!(mcms.version().unwrap(), LATEST_DB_VERSION);
     }


### PR DESCRIPTION
what has been tested:
- start on tn10 on `master` with fresh db
- move to `IzioDev:fix/consensus-db-meta-bump`, triggering db update without assert fails
- move back to `master` observe the assert failing (local 7 but expected 6)

temporary release for getting pre-built binaries on my fork: https://github.com/IzioDev/rusty-kaspa/releases/tag/v1.2.0-toc.2

docker images:
- master: kkluster/rusty-kaspa:master
- this branch: kkluster/rusty-kaspa:toccata-tn10