### PR TITLE
Clarify seqcommit tx validation contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prometheus",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -66,6 +66,7 @@ mimalloc = { version = "0.1.48", default-features = false }
 
 
 [dev-dependencies]
+rand = { workspace = true }
 tokio-test = "0.4"
 
 [[bin]]

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -1028,6 +1028,17 @@ mod integration {
     use tokio::sync::watch;
     use tokio::time::timeout;
 
+    // Mirrors testing/integration/src/common/daemon.rs::free_port.
+    fn free_port() -> u16 {
+        loop {
+            let port = rand::random::<u16>() % (u16::MAX - 1024) + 1024;
+            if let Ok(listener) = std::net::TcpListener::bind(format!("127.0.0.1:{port}")) {
+                drop(listener);
+                return port;
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_bridge_startup_with_inprocess_node() {
         init_allocator_with_default_settings();
@@ -1036,16 +1047,17 @@ mod integration {
         let temp_dir = std::env::temp_dir().join(format!("kaspad_test_{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&temp_dir).unwrap();
 
-        // Start an in-process node with simnet/testnet settings
-        // Use a random port to avoid conflicts
-        let rpc_port = 16110 + (std::process::id() % 1000) as u16;
-        let rpc_address = format!("127.0.0.1:{}", rpc_port);
+        // Start an in-process testnet node with random listener ports to avoid conflicts
+        // with a locally running node.
+        let rpc_address = format!("127.0.0.1:{}", free_port());
         let argv: Vec<OsString> = vec![
             "kaspad".into(),
             "--testnet".into(),
             "--appdir".into(),
             temp_dir.to_string_lossy().to_string().into(),
-            format!("--rpclisten={}", rpc_address).into(),
+            format!("--rpclisten={rpc_address}").into(),
+            format!("--listen=127.0.0.1:{}", free_port()).into(),
+            "--disable-upnp".into(),
             "--utxoindex".into(),
         ];
 
@@ -1107,16 +1119,18 @@ mod integration {
         let temp_dir = std::env::temp_dir().join(format!("kaspad_test_{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&temp_dir).unwrap();
 
-        // Start an in-process node with simnet/testnet settings
-        // Use a random port to avoid conflicts
-        let rpc_port = 16110 + (std::process::id() % 1000) as u16;
+        // Start an in-process testnet node with random listener ports to avoid conflicts
+        // with a locally running node.
+        let rpc_port = free_port();
         let rpc_address = format!("127.0.0.1:{}", rpc_port);
         let argv: Vec<OsString> = vec![
             "kaspad".into(),
             "--testnet".into(),
             "--appdir".into(),
             temp_dir.to_string_lossy().to_string().into(),
-            format!("--rpclisten={}", rpc_address).into(),
+            format!("--rpclisten={rpc_address}").into(),
+            format!("--listen=127.0.0.1:{}", free_port()).into(),
+            "--disable-upnp".into(),
             "--utxoindex".into(),
         ];
 

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -183,6 +183,7 @@ impl ConsensusServices {
             params.ghostdag_k(),
             params.skip_proof_of_work,
             params.toccata_activation,
+            params.net.is_mainnet(),
             is_consensus_exiting,
         ));
 

--- a/consensus/src/model/services/seq_commit_accessor.rs
+++ b/consensus/src/model/services/seq_commit_accessor.rs
@@ -13,7 +13,7 @@ pub fn seq_commit_within_threshold(high_blue_score: u64, low_blue_score: u64, th
 #[derive(Copy, Clone)]
 pub struct SeqCommitAccessor<'a> {
     pub threshold: u64,
-    pub sp: Hash,
+    pub selected_parent: Hash,
     pub reachability_service: &'a MTReachabilityService<DbReachabilityStore>,
     pub headers_store: &'a DbHeadersStore,
     pub toccata_activation: ForkActivation,
@@ -21,19 +21,19 @@ pub struct SeqCommitAccessor<'a> {
 
 impl<'a> SeqCommitAccessor<'a> {
     pub fn new(
-        sp: Hash,
+        selected_parent: Hash,
         reachability_service: &'a MTReachabilityService<DbReachabilityStore>,
         headers_store: &'a DbHeadersStore,
         toccata_activation: ForkActivation,
         threshold: u64,
     ) -> Self {
-        Self { threshold, sp, reachability_service, headers_store, toccata_activation }
+        Self { threshold, selected_parent, reachability_service, headers_store, toccata_activation }
     }
 }
 
 impl<'a> kaspa_txscript::SeqCommitAccessor for SeqCommitAccessor<'a> {
     fn is_chain_ancestor_from_pov(&self, block_hash: Hash) -> Option<bool> {
-        self.reachability_service.try_is_chain_ancestor_of(block_hash, self.sp).optional().unwrap()
+        self.reachability_service.try_is_chain_ancestor_of(block_hash, self.selected_parent).optional().unwrap()
     }
 
     fn seq_commitment_within_depth(&self, block_hash: Hash) -> Option<Hash> {
@@ -41,7 +41,7 @@ impl<'a> kaspa_txscript::SeqCommitAccessor for SeqCommitAccessor<'a> {
         if !self.toccata_activation.is_active(header.daa_score) {
             return None;
         }
-        let sp_blue_score = self.headers_store.get_blue_score(self.sp).unwrap();
+        let sp_blue_score = self.headers_store.get_blue_score(self.selected_parent).unwrap();
         if seq_commit_within_threshold(sp_blue_score, header.blue_score, self.threshold) {
             Some(header.accepted_id_merkle_root)
         } else {

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1083,7 +1083,7 @@ impl VirtualStateProcessor {
         virtual_daa_score: u64,
         virtual_past_median_time: u64,
         args: &TransactionValidationArgs,
-        sp: Hash,
+        selected_parent: Hash,
     ) -> TxResult<()> {
         self.transaction_validator.validate_tx_in_isolation(&mutable_tx.tx)?;
         self.transaction_validator.validate_tx_in_header_context_with_args(
@@ -1091,7 +1091,7 @@ impl VirtualStateProcessor {
             virtual_daa_score,
             virtual_past_median_time,
         )?;
-        self.validate_mempool_transaction_in_utxo_context(mutable_tx, virtual_utxo_view, virtual_daa_score, args, sp)?;
+        self.validate_mempool_transaction_in_utxo_context(mutable_tx, virtual_utxo_view, virtual_daa_score, args, selected_parent)?;
         Ok(())
     }
 

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1452,8 +1452,11 @@ impl VirtualStateProcessor {
         }
 
         let virtual_read = self.virtual_stores.upgradable_read();
-        let sp = virtual_read.state.get().unwrap().ghostdag_data.selected_parent;
-        // Validate transactions of the pruning point itself
+        // Seqcommit validation uses the pruning point's selected parent as context. Post-Toccata chain
+        // qualification enforces first parent = selected parent; for genesis imports, use genesis itself.
+        let sp = new_pruning_point_header.direct_parents().first().copied().unwrap_or(new_pruning_point);
+        // Validate transactions of the pruning point itself.
+        // Mirrors the same contextual info used by validate_block_template_transaction and verify_expected_utxo_state.
         let new_pruning_point_transactions = self.block_transactions_store.get(new_pruning_point).unwrap();
         let validated_transactions = self.validate_transactions_in_parallel(
             &new_pruning_point_transactions,
@@ -1464,7 +1467,13 @@ impl VirtualStateProcessor {
             sp,
         );
         if validated_transactions.len() < new_pruning_point_transactions.len() - 1 {
-            // Some non-coinbase transactions are invalid
+            // TODO: handle this failure together with pruning point body merkle validation, not as a
+            // plain UTXO-set validation failure. No alternate UTXO set can satisfy this pruning point
+            // commitment, so the node likely needs a DB reset.
+            warn!(
+                "Imported pruning point {} has transactions invalid under its imported UTXO set; node likely needs a DB reset",
+                new_pruning_point
+            );
             return Err(PruningImportError::NewPruningPointTxErrors);
         }
 

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1194,6 +1194,12 @@ impl VirtualStateProcessor {
             virtual_state.daa_score,
             virtual_state.past_median_time,
         )?;
+        // Template transaction validation uses virtual's DAA score. This score is carried into the block as its
+        // DAA score, and it must also serve as the POV DAA score because this is the only available POV at template time.
+        //
+        // For seqcommit, the template itself cannot be used as context: its hash is not available yet, and transactions
+        // cannot meaningfully depend on the seqcommit context of the block that is still being built. We therefore use
+        // the selected parent as the seqcommit context.
         let ValidatedTransaction { calculated_fee, .. } = self.validate_transaction_in_utxo_context(
             tx,
             utxo_view,

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -128,8 +128,14 @@ impl VirtualStateProcessor {
             // The first block in the mergeset is always the selected parent
             let is_selected_parent = i == 0;
 
-            // No need to fully validate selected parent transactions since selected parent txs were already validated
-            // as part of selected parent UTXO state verification with the exact same UTXO context.
+            // No need to fully validate selected parent transactions: they were already fully validated when
+            // the selected parent passed verify_expected_utxo_state, using its own DAA score for both POV and
+            // block DAA score, and its selected parent as the seqcommit context.
+            //
+            // Here we only replay them while building the child's UTXO state. The child's POV DAA score is
+            // safe for non-script checks because maturity and sequence-lock checks are monotonic. Seqcommit
+            // context is not monotonic (the threshold can be crossed), but it is only used by script checks,
+            // which we skip for selected-parent transactions.
             let validation_flags = if is_selected_parent { TxValidationFlags::SkipScriptChecks } else { TxValidationFlags::Full };
             let (validated_transactions, inner_multiset) = self.validate_transactions_with_muhash_in_parallel(
                 &txs,
@@ -239,7 +245,12 @@ impl VirtualStateProcessor {
             }
         }
 
-        // Verify all transactions are valid in context
+        // Final chain qualification condition: verify all transactions are valid in context.
+        //
+        // We verify this chain block's transactions in the same way they were built and checked by
+        // build_block_template -> validate_block_template_transaction: use the block DAA score as the
+        // POV DAA score, and use the selected parent as the seqcommit context. Later, calculate_utxo_state
+        // relies on this check when replaying this block as a selected parent.
         let current_utxo_view = selected_parent_utxo_view.compose(&ctx.mergeset_diff);
         let validated_transactions = self.validate_transactions_in_parallel(
             &txs,

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -307,7 +307,7 @@ impl VirtualStateProcessor {
         pov_daa_score: u64,
         block_daa_score: u64,
         flags: TxValidationFlags,
-        sp: Hash,
+        selected_parent: Hash,
     ) -> Vec<(ValidatedTransaction<'a>, u32)> {
         self.thread_pool.install(|| {
             txs
@@ -315,7 +315,7 @@ impl VirtualStateProcessor {
                             // that all txs within each block are independent
                 .enumerate()
                 .skip(1) // Skip the coinbase tx.
-                .filter_map(|(i, tx)| self.validate_transaction_in_utxo_context(tx, &utxo_view, pov_daa_score,block_daa_score, flags, sp).ok().map(|vtx| (vtx, i as u32)))
+                .filter_map(|(i, tx)| self.validate_transaction_in_utxo_context(tx, &utxo_view, pov_daa_score,block_daa_score, flags, selected_parent).ok().map(|vtx| (vtx, i as u32)))
                 .collect()
         })
     }
@@ -329,7 +329,7 @@ impl VirtualStateProcessor {
         pov_daa_score: u64,
         block_daa_score: u64,
         flags: TxValidationFlags,
-        sp: Hash,
+        selected_parent: Hash,
     ) -> (SmallVec<[(ValidatedTransaction<'a>, u32); 2]>, MuHash) {
         self.thread_pool.install(|| {
             txs
@@ -337,7 +337,7 @@ impl VirtualStateProcessor {
                             // that all txs within each block are independent
                 .enumerate()
                 .skip(1) // Skip the coinbase tx.
-                .filter_map(|(i, tx)| self.validate_transaction_in_utxo_context(tx, &utxo_view, pov_daa_score, block_daa_score, flags, sp).ok().map(|vtx| {
+                .filter_map(|(i, tx)| self.validate_transaction_in_utxo_context(tx, &utxo_view, pov_daa_score, block_daa_score, flags, selected_parent).ok().map(|vtx| {
                     let mh = MuHash::from_transaction(&vtx, pov_daa_score);
                     (smallvec![(vtx, i as u32)], mh)
                 }
@@ -361,7 +361,7 @@ impl VirtualStateProcessor {
         pov_daa_score: u64,
         block_daa_score: u64,
         flags: TxValidationFlags,
-        sp: Hash,
+        selected_parent: Hash,
     ) -> TxResult<ValidatedTransaction<'a>> {
         let mut entries = Vec::with_capacity(transaction.inputs.len());
         for input in transaction.inputs.iter() {
@@ -377,7 +377,7 @@ impl VirtualStateProcessor {
 
         let seq_commit_accessor = if self.toccata_activation.is_active(pov_daa_score) {
             Some(SeqCommitAccessor::new(
-                sp,
+                selected_parent,
                 &self.reachability_service,
                 &self.headers_store,
                 self.toccata_activation,
@@ -436,7 +436,7 @@ impl VirtualStateProcessor {
         utxo_view: &impl UtxoView,
         pov_daa_score: u64,
         args: &TransactionValidationArgs,
-        sp: Hash,
+        selected_parent: Hash,
     ) -> TxResult<()> {
         self.populate_mempool_transaction_in_utxo_context(mutable_tx, utxo_view)?;
 
@@ -458,7 +458,7 @@ impl VirtualStateProcessor {
 
         let seq_commit_accessor = if self.toccata_activation.is_active(pov_daa_score) {
             Some(SeqCommitAccessor::new(
-                sp,
+                selected_parent,
                 &self.reachability_service,
                 &self.headers_store,
                 self.toccata_activation,

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -308,19 +308,18 @@ impl PruningProofManager {
             //
             // Mainnet has no release prior to this fix, so measure against the correct context: the selected
             // parent's blue score.
-            let mut context_blue_score = pruning_point_header.blue_score;
-            let mut switch_to_pruning_point_sp_context = self.is_mainnet;
+            let context_blue_score = if self.is_mainnet {
+                let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
+                trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score
+            } else {
+                pruning_point_header.blue_score
+            };
+
             let threshold = self.finality_depth;
             let mut current = pruning_point;
             loop {
                 let current_header =
                     trusted_header_map.get(&current).ok_or(PruningImportError::MissingPruningPointChainSegment(current))?;
-
-                // This is reached only once, for the pruning point's selected parent.
-                if switch_to_pruning_point_sp_context && current != pruning_point {
-                    context_blue_score = current_header.blue_score;
-                    switch_to_pruning_point_sp_context = false;
-                }
 
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -300,14 +300,29 @@ impl PruningProofManager {
         let mut chain_segment_map: BlockHashMap<Hash> = BlockHashMap::new();
 
         if self.toccata_activation.is_active(pruning_point_header.daa_score) {
-            let pruning_point_blue_score = pruning_point_header.blue_score;
+            // Pruning point txs are validated with the pruning point selected parent as seqcommit context.
+            // Conceptually, this is the context from which the threshold should be measured on all networks.
+            //
+            // On non-mainnet networks, relax this and measure against the pruning point blue score, since
+            // deployed peers may already provide chain segments using the pruning point as context.
+            //
+            // Mainnet has no release prior to this fix, so measure against the correct context: the selected
+            // parent's blue score.
+            let mut context_blue_score = pruning_point_header.blue_score;
+            let mut switch_to_pruning_point_sp_context = self.is_mainnet;
             let threshold = self.finality_depth;
             let mut current = pruning_point;
             loop {
                 let current_header =
                     trusted_header_map.get(&current).ok_or(PruningImportError::MissingPruningPointChainSegment(current))?;
 
-                if !seq_commit_within_threshold(pruning_point_blue_score, current_header.blue_score, threshold) {
+                // This is reached only once, for the pruning point's selected parent.
+                if switch_to_pruning_point_sp_context && current != pruning_point {
+                    context_blue_score = current_header.blue_score;
+                    switch_to_pruning_point_sp_context = false;
+                }
+
+                if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -120,6 +120,7 @@ pub struct PruningProofManager {
     ghostdag_k: KType,
     skip_proof_of_work: bool,
     toccata_activation: ForkActivation,
+    is_mainnet: bool,
 
     is_consensus_exiting: Arc<AtomicBool>,
 }
@@ -142,6 +143,7 @@ impl PruningProofManager {
         ghostdag_k: KType,
         skip_proof_of_work: bool,
         toccata_activation: ForkActivation,
+        is_mainnet: bool,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -178,6 +180,7 @@ impl PruningProofManager {
             ghostdag_k,
             skip_proof_of_work,
             toccata_activation,
+            is_mainnet,
 
             is_consensus_exiting,
         }
@@ -341,7 +344,11 @@ impl PruningProofManager {
 
         if self.toccata_activation.is_active(self.headers_store.get_daa_score(pruning_point).unwrap()) {
             let pruning_point_header = self.headers_store.get_header(pruning_point).unwrap();
-            let pruning_point_blue_score = pruning_point_header.blue_score;
+            // Post-Toccata chain qualification enforces first parent = selected parent.
+            let pruning_point_sp = pruning_point_header.direct_parents().first().copied().expect("never called for genesis");
+            // Pruning point txs use this selected parent as seqcommit context, so the syncer must provide
+            // the selected-parent chain segment that can be queried from that context.
+            let context_blue_score = self.headers_store.get_blue_score(pruning_point_sp).unwrap();
 
             // We rely on the fact that finality depth is the interval between pruning points, so this chain segment
             // is always accessible and valid (this function is called before pruning above the prev pruning point)
@@ -354,7 +361,7 @@ impl PruningProofManager {
                 }
 
                 let current_header = self.headers_store.get_compact_header_data(current).unwrap();
-                if !seq_commit_within_threshold(pruning_point_blue_score, current_header.blue_score, threshold) {
+                if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }
 

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -80,9 +80,9 @@ const REQUEST_SCOPE_WAIT_TIME: Duration = Duration::from_secs(1);
 #[derive(Debug, PartialEq)]
 pub enum BlockLogEvent {
     /// Accepted block via *relay*
-    Relay(Hash),
+    Relay(Hash, u64),
     /// Accepted block via *submit block*
-    Submit(Hash),
+    Submit(Hash, u64),
     /// Orphaned block with x missing roots
     Orphaned(Hash, usize),
     /// Unorphaned x blocks with hash being a representative
@@ -91,14 +91,15 @@ pub enum BlockLogEvent {
 
 pub struct BlockEventLogger {
     bps: usize,
+    toccata_activation: ForkActivation,
     sender: UnboundedSender<BlockLogEvent>,
     receiver: Mutex<Option<UnboundedReceiver<BlockLogEvent>>>,
 }
 
 impl BlockEventLogger {
-    pub fn new(bps: usize) -> Self {
+    pub fn new(bps: usize, toccata_activation: ForkActivation) -> Self {
         let (sender, receiver) = unbounded_channel();
-        Self { bps, sender, receiver: Mutex::new(Some(receiver)) }
+        Self { bps, toccata_activation, sender, receiver: Mutex::new(Some(receiver)) }
     }
 
     pub fn log(&self, event: BlockLogEvent) {
@@ -109,6 +110,7 @@ impl BlockEventLogger {
     fn start(&self) {
         let chunk_limit = self.bps * 10; // We prefer that the 1 sec timeout forces the log, but nonetheless still want a reasonable bound on each chunk
         let receiver = self.receiver.lock().take().expect("expected to be called once");
+        let toccata_activation = self.toccata_activation;
         tokio::spawn(async move {
             let chunk_stream = UnboundedReceiverStream::new(receiver).chunks_timeout(chunk_limit, Duration::from_secs(1));
             tokio::pin!(chunk_stream);
@@ -116,8 +118,8 @@ impl BlockEventLogger {
                 #[derive(Default)]
                 struct LogSummary {
                     // Representatives
-                    relay_rep: Option<Hash>,
-                    submit_rep: Option<Hash>,
+                    relay_rep: Option<(Hash, u64)>,
+                    submit_rep: Option<(Hash, u64)>,
                     orphan_rep: Option<Hash>,
                     unorphan_rep: Option<Hash>,
                     // Counts
@@ -144,13 +146,28 @@ impl BlockEventLogger {
                     }
                 }
 
+                fn toccata_countdown_suffix(toccata_activation: ForkActivation, daa_score: Option<u64>) -> String {
+                    daa_score
+                        .and_then(|daa_score| toccata_activation.is_within_range_before_activation(daa_score, 36_000))
+                        .map(|dist| format!(" \t [Toccata countdown: -{}]", dist))
+                        .unwrap_or_default()
+                }
+
                 impl LogSummary {
                     fn relay(&self) -> LogHash {
-                        self.relay_rep.into()
+                        self.relay_rep.map(|(hash, _)| hash).into()
                     }
 
                     fn submit(&self) -> LogHash {
-                        self.submit_rep.into()
+                        self.submit_rep.map(|(hash, _)| hash).into()
+                    }
+
+                    fn relay_rep_daa_score(&self) -> Option<u64> {
+                        self.relay_rep.map(|(_, daa_score)| daa_score)
+                    }
+
+                    fn submit_rep_daa_score(&self) -> Option<u64> {
+                        self.submit_rep.map(|(_, daa_score)| daa_score)
                     }
 
                     fn orphan(&self) -> LogHash {
@@ -164,13 +181,13 @@ impl BlockEventLogger {
 
                 let summary = chunk.into_iter().fold(LogSummary::default(), |mut summary, ev| {
                     match ev {
-                        BlockLogEvent::Relay(hash) => {
+                        BlockLogEvent::Relay(hash, daa_score) => {
                             summary.relay_count += 1;
-                            summary.relay_rep = Some(hash)
+                            summary.relay_rep = Some((hash, daa_score));
                         }
-                        BlockLogEvent::Submit(hash) => {
+                        BlockLogEvent::Submit(hash, daa_score) => {
                             summary.submit_count += 1;
-                            summary.submit_rep = Some(hash)
+                            summary.submit_rep = Some((hash, daa_score));
                         }
                         BlockLogEvent::Orphaned(hash, roots_count) => {
                             summary.orphan_roots_count += roots_count;
@@ -187,10 +204,28 @@ impl BlockEventLogger {
 
                 match (summary.submit_count, summary.relay_count) {
                     (0, 0) => {}
-                    (1, 0) => info!("Accepted block {} via submit block", summary.submit()),
-                    (n, 0) => info!("Accepted {} blocks ...{} via submit block", n, summary.submit()),
-                    (0, 1) => info!("Accepted block {} via relay", summary.relay()),
-                    (0, m) => info!("Accepted {} blocks ...{} via relay", m, summary.relay()),
+                    (1, 0) => info!(
+                        "Accepted block {} via submit block{}",
+                        summary.submit(),
+                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                    ),
+                    (n, 0) => info!(
+                        "Accepted {} blocks ...{} via submit block{}",
+                        n,
+                        summary.submit(),
+                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                    ),
+                    (0, 1) => info!(
+                        "Accepted block {} via relay{}",
+                        summary.relay(),
+                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                    ),
+                    (0, m) => info!(
+                        "Accepted {} blocks ...{} via relay{}",
+                        m,
+                        summary.relay(),
+                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                    ),
                     (n, m) => {
                         info!("Accepted {} blocks ...{}, {} via relay and {} via submit block", n + m, summary.submit(), m, n)
                     }
@@ -339,7 +374,7 @@ impl FlowContext {
                 tick_service,
                 notification_root,
                 user_agent_rules,
-                block_event_logger: Some(BlockEventLogger::new(bps)),
+                block_event_logger: Some(BlockEventLogger::new(bps, config.toccata_activation)),
                 bps,
                 orphan_resolution_range,
                 max_orphans,
@@ -501,8 +536,9 @@ impl FlowContext {
         // Broadcast as soon as the block has been validated and inserted into the DAG
         self.hub.broadcast(make_message!(Payload::InvRelayBlock, InvRelayBlockMessage { hash: Some(hash.into()) }), None).await;
 
+        let daa_score = block.header.daa_score;
         self.on_new_block(consensus, Default::default(), block, virtual_state_task).await;
-        self.log_block_event(BlockLogEvent::Submit(hash));
+        self.log_block_event(BlockLogEvent::Submit(hash, daa_score));
 
         Ok(())
     }
@@ -512,8 +548,8 @@ impl FlowContext {
             logger.log(event)
         } else {
             match event {
-                BlockLogEvent::Relay(hash) => info!("Accepted block {} via relay", hash),
-                BlockLogEvent::Submit(hash) => info!("Accepted block {} via submit block", hash),
+                BlockLogEvent::Relay(hash, _) => info!("Accepted block {} via relay", hash),
+                BlockLogEvent::Submit(hash, _) => info!("Accepted block {} via submit block", hash),
                 BlockLogEvent::Orphaned(orphan, roots_count) => {
                     info!("Received a block with {} missing ancestors, adding to orphan pool: {}", roots_count, orphan)
                 }

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -227,7 +227,14 @@ impl BlockEventLogger {
                         toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
                     ),
                     (n, m) => {
-                        info!("Accepted {} blocks ...{}, {} via relay and {} via submit block", n + m, summary.submit(), m, n)
+                        info!(
+                            "Accepted {} blocks ...{}, {} via relay and {} via submit block{}",
+                            n + m,
+                            summary.submit(),
+                            m,
+                            n,
+                            toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                        )
                     }
                 }
 

--- a/protocol/flows/src/v7/blockrelay/flow.rs
+++ b/protocol/flows/src/v7/blockrelay/flow.rs
@@ -223,9 +223,10 @@ impl HandleRelayInvsFlow {
             // We spawn post-processing as a separate task so that this loop
             // can continue processing the following relay blocks
             let ctx = self.ctx.clone();
+            let daa_score = block.header.daa_score;
             tokio::spawn(async move {
                 ctx.on_new_block(&session, ancestor_batch, block, virtual_state_task).await;
-                ctx.log_block_event(BlockLogEvent::Relay(inv.hash));
+                ctx.log_block_event(BlockLogEvent::Relay(inv.hash, daa_score));
             });
         }
     }

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -7,6 +7,7 @@ use kaspa_alloc::init_allocator_with_default_settings;
 use kaspa_consensus::config::{Config, ConfigBuilder};
 use kaspa_consensus::consensus::factory::Factory as ConsensusFactory;
 use kaspa_consensus::consensus::test_consensus::{TestConsensus, TestConsensusFactory};
+use kaspa_consensus::model::services::seq_commit_accessor::seq_commit_within_threshold;
 use kaspa_consensus::model::stores::block_transactions::{
     BlockTransactionsStore, BlockTransactionsStoreReader, DbBlockTransactionsStore,
 };
@@ -79,7 +80,7 @@ use kaspa_math::Uint256;
 use kaspa_muhash::MuHash;
 use kaspa_notify::subscription::context::SubscriptionContext;
 use kaspa_txscript::caches::TxScriptCacheCounters;
-use kaspa_txscript::opcodes::codes::{Op0, OpCat, OpDrop, OpEqual, OpTrue, OpTxOutputSpk};
+use kaspa_txscript::opcodes::codes::{Op0, OpCat, OpChainblockSeqCommit, OpDrop, OpEqual, OpTrue, OpTxOutputSpk};
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
 use kaspa_txscript::{
     EngineCtx, EngineFlags, TxScriptEngine,
@@ -1530,6 +1531,124 @@ fn assert_tx_not_in_chain_seq_commit(consensus: &TestConsensus, accepting_block:
     let activity = chain_seq_commit_lane_activity_for_tx(consensus, accepting_block, tx);
     assert!(!activity.contains_tx, "tx {} unexpectedly appears in chain seq-commit activity input", tx.id());
     assert_chain_seq_commit_lane(consensus, accepting_block, &activity);
+}
+
+#[tokio::test]
+async fn seqcommit_sp_context_threshold_edge_test() {
+    init_allocator_with_default_settings();
+
+    // This test covers the selected-parent seqcommit context boundary documented in the comments around
+    // validate_block_template_transaction, verify_expected_utxo_state, and calculate_utxo_state.
+    //
+    // Three-block chain:
+    // target <- spend block with OpChainblockSeqCommit(target) <- child.
+    //
+    // The spend tx is valid when the spend block is built and chain-qualified, because both BBT and
+    // verify_expected_utxo_state validate scripts using the spend block's selected parent as seqcommit
+    // context. However, the spend block itself crosses the seqcommit threshold for the same target.
+    // Therefore, when the child later replays the spend block as its selected parent, the spend tx must
+    // remain accepted without re-running scripts in the child's UTXO-state calculation.
+    //
+    // If selected-parent transactions are replayed with full script checks, this test fails because the
+    // spend tx is filtered out of the child's acceptance data.
+    let target_hash: Hash = 1.into();
+    let spend_block_hash: Hash = 2.into();
+    let child_hash: Hash = 3.into();
+    let redeem_script = ScriptBuilder::new()
+        .add_data(&target_hash.as_bytes())
+        .unwrap()
+        .add_op(OpChainblockSeqCommit)
+        .unwrap()
+        .add_op(OpDrop)
+        .unwrap()
+        .add_op(OpTrue)
+        .unwrap()
+        .drain();
+    let seqcommit_spk = pay_to_script_hash_script(&redeem_script);
+    let initial_utxo = (
+        TransactionOutpoint::new(100.into(), 0),
+        UtxoEntry {
+            amount: SOMPI_PER_KASPA,
+            script_public_key: seqcommit_spk.clone(),
+            block_daa_score: 0,
+            is_coinbase: false,
+            covenant_id: None,
+        },
+    );
+    let initial_utxo_collection = [initial_utxo.clone()];
+
+    let config = ConfigBuilder::new(DEVNET_PARAMS)
+        .skip_proof_of_work()
+        .edit_consensus_params(|p| {
+            let mut genesis_multiset = MuHash::new();
+            initial_utxo_collection.iter().for_each(|(outpoint, utxo)| {
+                genesis_multiset.add_utxo(outpoint, utxo);
+            });
+            p.genesis.utxo_commitment = genesis_multiset.finalize();
+            let genesis_header: Header = (&p.genesis).into();
+            p.genesis.hash = genesis_header.hash;
+
+            // Keep the threshold minimal so the selected-parent edge is reached by the next block.
+            p.finality_depth = 1;
+            p.toccata_activation = ForkActivation::always();
+        })
+        .build();
+
+    let consensus = TestConsensus::new(&config);
+    let mut genesis_multiset = MuHash::new();
+    consensus.append_imported_pruning_point_utxos(&initial_utxo_collection, &mut genesis_multiset);
+    consensus.import_pruning_point_utxo_set(config.genesis.hash, genesis_multiset).unwrap();
+    let wait_handles = consensus.init();
+
+    let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
+
+    // Mine the target block first so the seqcommit opcode can refer to a real chain ancestor.
+    let status = consensus.add_utxo_valid_block_with_parents(target_hash, vec![config.genesis.hash], vec![]).await;
+    assert!(matches!(status, Ok(BlockStatus::StatusUTXOValid)), "status = {:?}", status);
+
+    let mut tx = Transaction::new(
+        0,
+        vec![TransactionInput::new(
+            initial_utxo.0,
+            pay_to_script_hash_signature_script(redeem_script, vec![]).expect("canonical signature script"),
+            0,
+            0,
+        )],
+        vec![TransactionOutput::new(initial_utxo.1.amount - 5000, ScriptPublicKey::from_vec(0, vec![OpTrue]))],
+        0,
+        SUBNETWORK_ID_NATIVE,
+        0,
+        vec![],
+    );
+    tx.finalize();
+    let tx_id = tx.id();
+    let mut tx = MutableTransaction::from_tx(tx);
+    consensus.validate_mempool_transaction(&mut tx, &TransactionValidationArgs::default()).unwrap();
+    let tx = tx.tx.unwrap_or_clone();
+
+    let target_blue_score = consensus.get_header(target_hash).unwrap().blue_score;
+    let threshold = config.finality_depth();
+    assert!(seq_commit_within_threshold(target_blue_score, target_blue_score, threshold));
+
+    // Build through the test BBT path. Since the spend block's selected parent is the target,
+    // the seqcommit target is still within threshold during template validation.
+    let spend_block = consensus.build_utxo_valid_block_with_parents(spend_block_hash, vec![target_hash], miner_data.clone(), vec![tx]);
+    let spend_block_blue_score = spend_block.header.blue_score;
+    assert_eq!(spend_block_blue_score, target_blue_score + threshold);
+    assert!(!seq_commit_within_threshold(spend_block_blue_score, target_blue_score, threshold));
+
+    let status = consensus.validate_and_insert_block(spend_block.to_immutable()).virtual_state_task.await;
+    assert!(matches!(status, Ok(BlockStatus::StatusUTXOValid)), "status = {:?}", status);
+
+    // The child accepts the spend block only if selected-parent tx replay skips script checks.
+    let status = consensus.add_utxo_valid_block_with_parents(child_hash, vec![spend_block_hash], vec![]).await;
+    assert!(matches!(status, Ok(BlockStatus::StatusUTXOValid)), "status = {:?}", status);
+    let child_acceptance = consensus.get_block_acceptance_data(child_hash).unwrap();
+    let spend_block_acceptance =
+        child_acceptance.iter().find(|data| data.block_hash == spend_block_hash).expect("missing spend block acceptance data");
+    assert!(spend_block_acceptance.accepted_transactions.iter().any(|accepted| accepted.transaction_id == tx_id));
+
+    consensus.shutdown(wait_handles);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Clarifies and tests the contextual validation rules for Toccata seqcommit scripts.

This PR documents the intended DAA-score and seqcommit-context choices across block-template validation, chain qualification, and selected-parent replay. It also adds a focused consensus integration test for the selected-parent replay boundary case, where a seqcommit spend is valid against the block’s selected parent but would fail if replayed later with full script checks.

The PR also fixes pruning-point import/proof handling for seqcommit access. Pruning point transactions are validated using the pruning point’s selected parent as seqcommit context, matching the same rule used for normal chain-block qualification. Mainnet pruning proof chain segments are therefore built and applied against that selected-parent context.

For non-mainnet networks, proof apply intentionally keeps accepting the legacy pruning-point-context segment rule for compatibility with already deployed testnet/devnet peers. This means the pruning-proof segment alignment is not critical for existing testnets; it is mainly a mainnet correctness/consistency fix before release.
