### PR TITLE
fix  IPv4-looking worker labels display as unnamed-asic

### DIFF
--- a/bridge/src/client_handler.rs
+++ b/bridge/src/client_handler.rs
@@ -73,7 +73,7 @@ impl ClientHandler {
         let ctx_clone = Arc::clone(&ctx);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
-            if !ctx_clone.worker_name.lock().is_empty() {
+            if !ctx_clone.wallet_addr.lock().is_empty() {
                 share_handler.get_create_stats(&ctx_clone);
             }
         });
@@ -140,18 +140,10 @@ impl ClientHandler {
             debug!("removed client {}", id);
         }
         let wallet_addr = ctx.wallet_addr.lock().clone();
-        let worker_name = ctx.worker_name.lock().clone();
         let remote_app = ctx.remote_app.lock().clone();
 
-        let is_unauthed = wallet_addr.is_empty() && worker_name.is_empty();
-        if !is_unauthed {
-            record_disconnect(&crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: remote_app,
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            });
+        if !wallet_addr.is_empty() {
+            record_disconnect(&worker_context(&self.instance_id, ctx, remote_app));
         }
     }
 
@@ -309,18 +301,7 @@ impl ClientHandler {
                 state.set_stratum_diff(stratum_diff);
 
                 // Update worker difficulty metric
-                let wallet_addr = client_clone.wallet_addr.lock().clone();
-                let worker_name = client_clone.worker_name.lock().clone();
-                update_worker_difficulty(
-                    &WorkerContext {
-                        instance_id: instance_id.clone(),
-                        worker_name: worker_name.clone(),
-                        miner: remote_app_clone.clone(),
-                        wallet: wallet_addr.clone(),
-                        ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                    },
-                    min_diff,
-                );
+                update_worker_difficulty(&worker_context(&instance_id, &client_clone, remote_app_clone.clone()), min_diff);
 
                 let target = state.stratum_diff().map(|d| d.target_value.clone()).unwrap_or_else(BigUint::zero);
                 let target_bytes = target.to_bytes_be();
@@ -340,19 +321,8 @@ impl ClientHandler {
 
             // Update metric to ensure displayed difficulty matches what we're sending
             // (This handles the case where state was already initialized but metric wasn't updated)
-            let wallet_addr = client_clone.wallet_addr.lock().clone();
-            let worker_name = client_clone.worker_name.lock().clone();
             let remote_app = client_clone.remote_app.lock().clone();
-            update_worker_difficulty(
-                &WorkerContext {
-                    instance_id: instance_id.clone(),
-                    worker_name: worker_name.clone(),
-                    miner: remote_app.clone(),
-                    wallet: wallet_addr.clone(),
-                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                },
-                current_diff,
-            );
+            update_worker_difficulty(&worker_context(&instance_id, &client_clone, remote_app.clone()), current_diff);
 
             debug!("[DIFFICULTY] ===== SENDING DIFFICULTY TO {} =====", client_clone.remote_addr);
             debug!("[DIFFICULTY] Difficulty value: {} (from state: {})", current_diff, state.stratum_diff().is_some());
@@ -473,15 +443,7 @@ impl ClientHandler {
                 }
                 debug!("[JOB] ===== JOB SEND FAILED FOR {} =====", client_clone.remote_addr);
             } else {
-                let wallet_addr_str = wallet_addr.clone();
-                let worker_name = client_clone.worker_name.lock().clone();
-                record_new_job(&crate::prom::WorkerContext {
-                    instance_id: instance_id.clone(),
-                    worker_name: worker_name.clone(),
-                    miner: String::new(),
-                    wallet: wallet_addr_str.clone(),
-                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                });
+                record_new_job(&worker_context(&instance_id, &client_clone, ""));
                 debug!("[JOB] Successfully sent job ID {} to client {}", job_id, client_clone.remote_addr);
                 debug!("[JOB] ===== JOB SENT SUCCESSFULLY TO {} =====", client_clone.remote_addr);
             }
@@ -643,18 +605,7 @@ impl ClientHandler {
                     state.set_stratum_diff(stratum_diff);
 
                     // Update worker difficulty metric
-                    let wallet_addr = client_clone.wallet_addr.lock().clone();
-                    let worker_name = client_clone.worker_name.lock().clone();
-                    update_worker_difficulty(
-                        &WorkerContext {
-                            instance_id: instance_id.clone(),
-                            worker_name: worker_name.clone(),
-                            miner: remote_app.clone(),
-                            wallet: wallet_addr.clone(),
-                            ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                        },
-                        min_diff,
-                    );
+                    update_worker_difficulty(&worker_context(&instance_id, &client_clone, remote_app.clone()), min_diff);
 
                     let target = state.stratum_diff().map(|d| d.target_value.clone()).unwrap_or_else(BigUint::zero);
                     let target_bytes = target.to_bytes_be();
@@ -689,18 +640,7 @@ impl ClientHandler {
                             state.set_stratum_diff(stratum_diff);
 
                             // Update worker difficulty metric
-                            let wallet_addr = client_clone.wallet_addr.lock().clone();
-                            let worker_name = client_clone.worker_name.lock().clone();
-                            update_worker_difficulty(
-                                &WorkerContext {
-                                    instance_id: instance_id.clone(),
-                                    worker_name: worker_name.clone(),
-                                    miner: remote_app.clone(),
-                                    wallet: wallet_addr.clone(),
-                                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                                },
-                                var_diff,
-                            );
+                            update_worker_difficulty(&worker_context(&instance_id, &client_clone, remote_app.clone()), var_diff);
 
                             send_client_diff(&instance_id, &client_clone, &state, var_diff);
                             share_handler.start_client_vardiff(&client_clone);
@@ -802,15 +742,7 @@ impl ClientHandler {
                         error!("new_block_available: failed to send job {} to client {}: {}", job_id, client_clone.remote_addr, e);
                     }
                 } else {
-                    let wallet_addr_str = wallet_addr.clone();
-                    let worker_name = client_clone.worker_name.lock().clone();
-                    record_new_job(&crate::prom::WorkerContext {
-                        instance_id: instance_id.clone(),
-                        worker_name: worker_name.clone(),
-                        miner: String::new(),
-                        wallet: wallet_addr_str.clone(),
-                        ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                    });
+                    record_new_job(&worker_context(&instance_id, &client_clone, ""));
                     debug!("new_block_available: successfully sent job ID {} to client {}", job_id, client_clone.remote_addr);
                 }
             });

--- a/bridge/src/default_client.rs
+++ b/bridge/src/default_client.rs
@@ -224,7 +224,9 @@ pub async fn handle_authorize(
     tracing::debug!("[AUTHORIZE] Final parsed - address: '{}', worker: '{}', canxium: '{}'", address, worker_name, canxium_address);
 
     *ctx.wallet_addr.lock() = address.clone();
-    *ctx.worker_name.lock() = worker_name.clone();
+    *ctx.worker_name.lock() = worker_name;
+    ctx.ensure_default_worker_name();
+    let worker_name = ctx.effective_worker_name();
 
     let remote_app = ctx.remote_app.lock().clone();
     tracing::info!("[HANDSHAKE] authorized {}:{} worker='{}' app='{}'", ctx.remote_addr, ctx.remote_port, worker_name, remote_app);

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -511,6 +511,17 @@ impl WorkerContext {
     }
 }
 
+/// Build Prometheus worker labels from a Stratum session (stable name, no empty `worker` label).
+pub fn worker_context(instance_id: &str, ctx: &crate::stratum_context::StratumContext, miner: impl Into<String>) -> WorkerContext {
+    WorkerContext {
+        instance_id: instance_id.to_string(),
+        worker_name: ctx.effective_worker_name(),
+        miner: miner.into(),
+        wallet: ctx.wallet_addr.lock().clone(),
+        ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
+    }
+}
+
 pub fn record_block_accepted_by_node(worker: &WorkerContext) {
     if let Some(counter) = BLOCK_ACCEPTED_COUNTER.get() {
         counter.with_label_values(&worker.labels()).inc();
@@ -772,6 +783,7 @@ pub fn init_worker_counters(worker: &WorkerContext) {
     if let Some(gauge) = WORKER_CURRENT_DIFFICULTY.get() {
         gauge.with_label_values(&worker.labels()).set(0.0);
     }
+    update_worker_activity(worker);
 }
 
 /// Update the current mining difficulty for a worker

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -496,10 +496,9 @@ pub async fn start_web_server_all(port: &str) -> Result<(), Box<dyn std::error::
     serve_http_loop(listener, HttpMode::Aggregated { web_bind: web_bind_for_status }).await
 }
 
-/// Worker label used for stats/metrics: explicit worker name, otherwise client IP.
+/// Worker label used for stats/metrics: explicit name or stable default (`asic-{id}`).
 pub fn prom_worker_id(ctx: &crate::stratum_context::StratumContext) -> String {
-    let worker_name = ctx.worker_name.lock();
-    if !worker_name.is_empty() { worker_name.clone() } else { ctx.remote_addr().to_string() }
+    ctx.effective_worker_name()
 }
 
 /// Worker context for metrics

--- a/bridge/src/share_handler.rs
+++ b/bridge/src/share_handler.rs
@@ -257,10 +257,7 @@ impl ShareHandler {
     pub fn get_create_stats(&self, ctx: &StratumContext) -> WorkStats {
         let mut stats_map = self.stats.lock();
 
-        let worker_id = {
-            let worker_name = ctx.worker_name.lock();
-            if !worker_name.is_empty() { worker_name.clone() } else { ctx.remote_addr().to_string() }
-        };
+        let worker_id = ctx.effective_worker_name();
 
         if let Some(stats) = stats_map.get(&worker_id) {
             return stats.clone();
@@ -276,16 +273,8 @@ impl ShareHandler {
         stats_map.insert(worker_id.clone(), stats.clone());
         drop(stats_map);
 
-        // Initialize worker counters
-        let wallet_addr = ctx.wallet_addr.lock().clone();
-        let worker_name = stats.worker_name.lock().clone();
-        init_worker_counters(&crate::prom::WorkerContext {
-            instance_id: self.instance_id.clone(),
-            worker_name: worker_name.clone(),
-            miner: String::new(),
-            wallet: wallet_addr.clone(),
-            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-        });
+        // Initialize worker counters (same worker label as share/block metrics).
+        init_worker_counters(&crate::prom::worker_context(&self.instance_id, ctx, ""));
 
         stats
     }
@@ -454,10 +443,7 @@ impl ShareHandler {
         debug!("[SUBMIT] Parsed nonce value (u64): {}", nonce_val);
         debug!("[SUBMIT] Nonce hex: {:016x}", nonce_val);
 
-        let worker_id = {
-            let worker_name = ctx.worker_name.lock();
-            if !worker_name.is_empty() { worker_name.clone() } else { format!("{}:{}", ctx.remote_addr(), ctx.remote_port()) }
-        };
+        let worker_id = ctx.effective_worker_name();
         let submit_key = format!("{}|{}|{}", worker_id, job_id, final_nonce_str);
 
         let duplicate_outcome = {
@@ -650,7 +636,7 @@ impl ShareHandler {
             // This ensures we use the correct target for each job, as different jobs may have different header.bits
             if meets_network_target {
                 let wallet_addr = ctx.wallet_addr.lock().clone();
-                let worker_name = ctx.worker_name.lock().clone();
+                let worker_name = ctx.effective_worker_name();
                 let prefix = self.log_prefix();
 
                 info!(
@@ -817,13 +803,7 @@ impl ShareHandler {
                         let stats = self.get_create_stats(&ctx);
                         let overall = self.overall.clone();
                         let instance_id = self.instance_id.clone();
-                        let prom_worker = crate::prom::WorkerContext {
-                            instance_id: self.instance_id.clone(),
-                            worker_name: worker_name.clone(),
-                            miner: String::new(),
-                            wallet: wallet_addr.clone(),
-                            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                        };
+                        let prom_worker = crate::prom::worker_context(&self.instance_id, &ctx, "");
 
                         record_block_accepted_by_node(&prom_worker);
 
@@ -906,13 +886,7 @@ impl ShareHandler {
                             *stats.stale_shares.lock() += 1;
                             *self.overall.stale_shares.lock() += 1;
 
-                            record_stale_share(&crate::prom::WorkerContext {
-                                instance_id: self.instance_id.clone(),
-                                worker_name: worker_name.clone(),
-                                miner: String::new(),
-                                wallet: wallet_addr.clone(),
-                                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                            });
+                            record_stale_share(&crate::prom::worker_context(&self.instance_id, &ctx, ""));
                             ctx.reply_stale_share(event.id.clone()).await?;
                             return Ok(());
                         } else {
@@ -936,13 +910,7 @@ impl ShareHandler {
                             *stats.invalid_shares.lock() += 1;
                             *self.overall.invalid_shares.lock() += 1;
 
-                            record_invalid_share(&crate::prom::WorkerContext {
-                                instance_id: self.instance_id.clone(),
-                                worker_name: worker_name.clone(),
-                                miner: String::new(),
-                                wallet: wallet_addr.clone(),
-                                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                            });
+                            record_invalid_share(&crate::prom::worker_context(&self.instance_id, &ctx, ""));
 
                             {
                                 let now = Instant::now();
@@ -1058,15 +1026,7 @@ impl ShareHandler {
             *stats.invalid_shares.lock() += 1;
             *self.overall.invalid_shares.lock() += 1;
 
-            let wallet_addr = ctx.wallet_addr.lock().clone();
-            let worker_name = ctx.worker_name.lock().clone();
-            record_weak_share(&crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: String::new(),
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            });
+            record_weak_share(&crate::prom::worker_context(&self.instance_id, &ctx, ""));
 
             if let Some(id) = &event.id {
                 let _ = ctx.reply_low_diff_share(id).await;
@@ -1099,18 +1059,7 @@ impl ShareHandler {
         *stats.last_share.lock() = Instant::now();
         *self.overall.shares_found.lock() += 1;
 
-        let wallet_addr = ctx.wallet_addr.lock().clone();
-        let worker_name = ctx.worker_name.lock().clone();
-        record_share_found(
-            &crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: String::new(),
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            },
-            hash_value,
-        );
+        record_share_found(&crate::prom::worker_context(&self.instance_id, &ctx, ""), hash_value);
 
         {
             let now = Instant::now();

--- a/bridge/src/stratum_context.rs
+++ b/bridge/src/stratum_context.rs
@@ -106,6 +106,24 @@ impl StratumContext {
         self.remote_port
     }
 
+    /// Assign a stable display label when the miner omits `wallet.worker` in authorize.
+    ///
+    /// Uses connection id (`asic-3`), not IP, so Prometheus/dashboard metrics stay non-empty and
+    /// do not leak addresses.
+    pub fn ensure_default_worker_name(&self) {
+        let mut name = self.worker_name.lock();
+        if !name.trim().is_empty() {
+            return;
+        }
+        *name = if let Some(id) = self.id() { format!("asic-{}", id) } else { format!("asic-{}", self.remote_port) };
+    }
+
+    /// Worker label for stats, Prometheus, and dashboard (never empty after authorize).
+    pub fn effective_worker_name(&self) -> String {
+        self.ensure_default_worker_name();
+        self.worker_name.lock().clone()
+    }
+
     /// Send a JSON-RPC response
     pub async fn reply(&self, response: JsonRpcResponse) -> Result<(), ErrorDisconnected> {
         if self.disconnecting.load(Ordering::Acquire) {

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -2839,6 +2839,20 @@ mod comprehensive_tests {
     }
 
     #[test]
+    fn test_default_worker_name_when_miner_omits_dot_worker() {
+        let ctx = create_test_context_sync();
+        ctx.set_id(9);
+        assert!(ctx.worker_name.lock().is_empty());
+
+        ctx.ensure_default_worker_name();
+        assert_eq!(ctx.effective_worker_name(), "asic-9");
+        assert!(!ctx.effective_worker_name().contains("127.0.0.1"));
+
+        *ctx.worker_name.lock() = "rig-a".to_string();
+        assert_eq!(ctx.effective_worker_name(), "rig-a");
+    }
+
+    #[test]
     fn test_stratum_context_summary() {
         // Test: Context summary generation
         let ctx = create_test_context_sync();

--- a/bridge/static/js/dashboard.js
+++ b/bridge/static/js/dashboard.js
@@ -286,6 +286,10 @@ function filterBlocksByDays(blocks, days) {
 function displayWorkerName(worker) {
   const w = String(worker ?? '').trim();
   if (w === 'InternalCPU') return 'RKStratum CPU Miner';
+  // Legacy Prometheus rows keyed by miner IP (pre-default-name fix).
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(w) || /^\d{1,3}(\.\d{1,3}){3}:\d+$/.test(w)) {
+    return 'unnamed-asic';
+  }
   return w || '-';
 }
 


### PR DESCRIPTION
Default worker label (stratum_context.rs) — On authorize, empty names become asic-{connection_id} (not IP). Example: asic-9.

Single label everywhere — get_create_stats, share/block metrics, jobs, difficulty, and disconnect all use effective_worker_name() via prom::worker_context().

Earlier stats registration (client_handler.rs) — After 5s, stats are created when wallet is set (not only when worker_name is non-empty).

Activity on connect (prom.rs) — init_worker_counters calls update_worker_activity so workers can appear before the first share.

Dashboard legacy rows (dashboard.js) — IPv4-looking worker labels display as unnamed-asic for old metrics still keyed by IP.