### PR TITLE
dashboard session

### DIFF
--- a/bridge/src/client_handler.rs
+++ b/bridge/src/client_handler.rs
@@ -73,10 +73,18 @@ impl ClientHandler {
         let ctx_clone = Arc::clone(&ctx);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
-            if !ctx_clone.worker_name.lock().is_empty() {
+            if !ctx_clone.wallet_addr.lock().is_empty() {
                 share_handler.get_create_stats(&ctx_clone);
             }
         });
+    }
+
+    /// Sync Prometheus session metrics for an authorized worker (hashrate/uptime labels).
+    pub fn sync_worker_prom_metrics(&self, ctx: &StratumContext) {
+        if ctx.wallet_addr.lock().is_empty() {
+            return;
+        }
+        self.share_handler.get_create_stats(ctx);
     }
 
     /// Assign extranonce to a client based on detected miner type
@@ -145,13 +153,7 @@ impl ClientHandler {
 
         let is_unauthed = wallet_addr.is_empty() && worker_name.is_empty();
         if !is_unauthed {
-            record_disconnect(&crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: remote_app,
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            });
+            record_disconnect(&WorkerContext::from_stratum(&self.instance_id, ctx, &remote_app));
         }
     }
 
@@ -308,19 +310,7 @@ impl ClientHandler {
                 stratum_diff.set_diff_value_for_miner(min_diff, &remote_app_clone);
                 state.set_stratum_diff(stratum_diff);
 
-                // Update worker difficulty metric
-                let wallet_addr = client_clone.wallet_addr.lock().clone();
-                let worker_name = client_clone.worker_name.lock().clone();
-                update_worker_difficulty(
-                    &WorkerContext {
-                        instance_id: instance_id.clone(),
-                        worker_name: worker_name.clone(),
-                        miner: remote_app_clone.clone(),
-                        wallet: wallet_addr.clone(),
-                        ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                    },
-                    min_diff,
-                );
+                update_worker_difficulty(&WorkerContext::from_stratum(&instance_id, &client_clone, &remote_app_clone), min_diff);
 
                 let target = state.stratum_diff().map(|d| d.target_value.clone()).unwrap_or_else(BigUint::zero);
                 let target_bytes = target.to_bytes_be();
@@ -340,19 +330,7 @@ impl ClientHandler {
 
             // Update metric to ensure displayed difficulty matches what we're sending
             // (This handles the case where state was already initialized but metric wasn't updated)
-            let wallet_addr = client_clone.wallet_addr.lock().clone();
-            let worker_name = client_clone.worker_name.lock().clone();
-            let remote_app = client_clone.remote_app.lock().clone();
-            update_worker_difficulty(
-                &WorkerContext {
-                    instance_id: instance_id.clone(),
-                    worker_name: worker_name.clone(),
-                    miner: remote_app.clone(),
-                    wallet: wallet_addr.clone(),
-                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                },
-                current_diff,
-            );
+            update_worker_difficulty(&WorkerContext::from_stratum(&instance_id, &client_clone, &remote_app), current_diff);
 
             debug!("[DIFFICULTY] ===== SENDING DIFFICULTY TO {} =====", client_clone.remote_addr);
             debug!("[DIFFICULTY] Difficulty value: {} (from state: {})", current_diff, state.stratum_diff().is_some());
@@ -473,15 +451,7 @@ impl ClientHandler {
                 }
                 debug!("[JOB] ===== JOB SEND FAILED FOR {} =====", client_clone.remote_addr);
             } else {
-                let wallet_addr_str = wallet_addr.clone();
-                let worker_name = client_clone.worker_name.lock().clone();
-                record_new_job(&crate::prom::WorkerContext {
-                    instance_id: instance_id.clone(),
-                    worker_name: worker_name.clone(),
-                    miner: String::new(),
-                    wallet: wallet_addr_str.clone(),
-                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                });
+                record_new_job(&WorkerContext::from_stratum(&instance_id, &client_clone, ""));
                 debug!("[JOB] Successfully sent job ID {} to client {}", job_id, client_clone.remote_addr);
                 debug!("[JOB] ===== JOB SENT SUCCESSFULLY TO {} =====", client_clone.remote_addr);
             }
@@ -643,18 +613,7 @@ impl ClientHandler {
                     state.set_stratum_diff(stratum_diff);
 
                     // Update worker difficulty metric
-                    let wallet_addr = client_clone.wallet_addr.lock().clone();
-                    let worker_name = client_clone.worker_name.lock().clone();
-                    update_worker_difficulty(
-                        &WorkerContext {
-                            instance_id: instance_id.clone(),
-                            worker_name: worker_name.clone(),
-                            miner: remote_app.clone(),
-                            wallet: wallet_addr.clone(),
-                            ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                        },
-                        min_diff,
-                    );
+                    update_worker_difficulty(&WorkerContext::from_stratum(&instance_id, &client_clone, &remote_app), min_diff);
 
                     let target = state.stratum_diff().map(|d| d.target_value.clone()).unwrap_or_else(BigUint::zero);
                     let target_bytes = target.to_bytes_be();
@@ -688,19 +647,7 @@ impl ClientHandler {
                             stratum_diff.set_diff_value_for_miner(var_diff, &remote_app);
                             state.set_stratum_diff(stratum_diff);
 
-                            // Update worker difficulty metric
-                            let wallet_addr = client_clone.wallet_addr.lock().clone();
-                            let worker_name = client_clone.worker_name.lock().clone();
-                            update_worker_difficulty(
-                                &WorkerContext {
-                                    instance_id: instance_id.clone(),
-                                    worker_name: worker_name.clone(),
-                                    miner: remote_app.clone(),
-                                    wallet: wallet_addr.clone(),
-                                    ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                                },
-                                var_diff,
-                            );
+                            update_worker_difficulty(&WorkerContext::from_stratum(&instance_id, &client_clone, &remote_app), var_diff);
 
                             send_client_diff(&instance_id, &client_clone, &state, var_diff);
                             share_handler.start_client_vardiff(&client_clone);
@@ -802,15 +749,7 @@ impl ClientHandler {
                         error!("new_block_available: failed to send job {} to client {}: {}", job_id, client_clone.remote_addr, e);
                     }
                 } else {
-                    let wallet_addr_str = wallet_addr.clone();
-                    let worker_name = client_clone.worker_name.lock().clone();
-                    record_new_job(&crate::prom::WorkerContext {
-                        instance_id: instance_id.clone(),
-                        worker_name: worker_name.clone(),
-                        miner: String::new(),
-                        wallet: wallet_addr_str.clone(),
-                        ip: format!("{}:{}", client_clone.remote_addr(), client_clone.remote_port()),
-                    });
+                    record_new_job(&WorkerContext::from_stratum(&instance_id, &client_clone, ""));
                     debug!("new_block_available: successfully sent job ID {} to client {}", job_id, client_clone.remote_addr);
                 }
             });

--- a/bridge/src/default_client.rs
+++ b/bridge/src/default_client.rs
@@ -226,6 +226,10 @@ pub async fn handle_authorize(
     *ctx.wallet_addr.lock() = address.clone();
     *ctx.worker_name.lock() = worker_name.clone();
 
+    if let Some(ref client_handler) = client_handler {
+        client_handler.sync_worker_prom_metrics(&ctx);
+    }
+
     let remote_app = ctx.remote_app.lock().clone();
     tracing::info!("[HANDSHAKE] authorized {}:{} worker='{}' app='{}'", ctx.remote_addr, ctx.remote_port, worker_name, remote_app);
 

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -496,6 +496,12 @@ pub async fn start_web_server_all(port: &str) -> Result<(), Box<dyn std::error::
     serve_http_loop(listener, HttpMode::Aggregated { web_bind: web_bind_for_status }).await
 }
 
+/// Worker label used for stats/metrics: explicit worker name, otherwise client IP.
+pub fn prom_worker_id(ctx: &crate::stratum_context::StratumContext) -> String {
+    let worker_name = ctx.worker_name.lock();
+    if !worker_name.is_empty() { worker_name.clone() } else { ctx.remote_addr().to_string() }
+}
+
 /// Worker context for metrics
 pub struct WorkerContext {
     pub instance_id: String,
@@ -508,6 +514,27 @@ pub struct WorkerContext {
 impl WorkerContext {
     pub fn labels(&self) -> Vec<&str> {
         vec![&self.instance_id, &self.worker_name, &self.miner, &self.wallet, &self.ip]
+    }
+
+    /// Build Prometheus worker labels from a live Stratum connection.
+    pub fn from_stratum(instance_id: &str, ctx: &crate::stratum_context::StratumContext, miner: &str) -> Self {
+        Self::from_stratum_parts(instance_id, &prom_worker_id(ctx), ctx, miner)
+    }
+
+    /// Build Prometheus worker labels when the stats key is already known.
+    pub fn from_stratum_parts(
+        instance_id: &str,
+        worker_name: &str,
+        ctx: &crate::stratum_context::StratumContext,
+        miner: &str,
+    ) -> Self {
+        Self {
+            instance_id: instance_id.to_string(),
+            worker_name: worker_name.to_string(),
+            miner: miner.to_string(),
+            wallet: ctx.wallet_addr.lock().clone(),
+            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
+        }
     }
 }
 
@@ -733,8 +760,8 @@ fn filter_metric_families_for_instance(metric_families: Vec<MetricFamily>, insta
     out
 }
 
-/// Initialize worker counters (set to 0 to create the metric)
-pub fn init_worker_counters(worker: &WorkerContext) {
+/// Register counter/gauge time series for a worker (idempotent).
+fn init_worker_counter_series(worker: &WorkerContext) {
     if let Some(counter) = SHARE_COUNTER.get() {
         counter.with_label_values(&worker.labels()).inc_by(0.0);
     }
@@ -763,19 +790,45 @@ pub fn init_worker_counters(worker: &WorkerContext) {
     if let Some(counter) = JOB_COUNTER.get() {
         counter.with_label_values(&worker.labels()).inc_by(0.0);
     }
-    // Set worker start time (Unix timestamp in seconds)
-    if let Some(gauge) = WORKER_START_TIME.get() {
-        let start_time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as f64;
-        gauge.with_label_values(&worker.labels()).set(start_time);
-    }
-    // Initialize worker difficulty to 0 (will be updated when difficulty is set)
     if let Some(gauge) = WORKER_CURRENT_DIFFICULTY.get() {
-        gauge.with_label_values(&worker.labels()).set(0.0);
+        let metric = gauge.with_label_values(&worker.labels());
+        if metric.get() <= 0.0 {
+            metric.set(0.0);
+        }
     }
+}
+
+/// Ensure Prometheus worker metrics exist for the current `(instance, worker, wallet)` labels.
+/// `session_start_unix` should be aligned with in-memory `WorkStats.start_time` when available so
+/// dashboard hashrate/uptime match the terminal table.
+pub fn ensure_worker_session_metrics(worker: &WorkerContext, session_start_unix: f64) {
+    if worker.wallet.is_empty() {
+        return;
+    }
+
+    init_worker_counter_series(worker);
+
+    if let Some(gauge) = WORKER_START_TIME.get() {
+        let metric = gauge.with_label_values(&worker.labels());
+        if metric.get() <= 0.0 {
+            metric.set(session_start_unix);
+        }
+    }
+
+    update_worker_activity(worker);
+}
+
+/// Initialize worker counters (set to 0 to create the metric)
+pub fn init_worker_counters(worker: &WorkerContext) {
+    let start_time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as f64;
+    ensure_worker_session_metrics(worker, start_time);
 }
 
 /// Update the current mining difficulty for a worker
 pub fn update_worker_difficulty(worker: &WorkerContext, difficulty: f64) {
+    let start_time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as f64;
+    ensure_worker_session_metrics(worker, start_time);
+
     if let Some(gauge) = WORKER_CURRENT_DIFFICULTY.get() {
         gauge.with_label_values(&worker.labels()).set(difficulty);
     }

--- a/bridge/src/share_handler.rs
+++ b/bridge/src/share_handler.rs
@@ -254,39 +254,45 @@ impl ShareHandler {
         format!("[{}]", self.instance_id)
     }
 
-    pub fn get_create_stats(&self, ctx: &StratumContext) -> WorkStats {
-        let mut stats_map = self.stats.lock();
+    fn worker_prom_context(&self, ctx: &StratumContext, miner: &str) -> crate::prom::WorkerContext {
+        crate::prom::WorkerContext::from_stratum(&self.instance_id, ctx, miner)
+    }
 
-        let worker_id = {
-            let worker_name = ctx.worker_name.lock();
-            if !worker_name.is_empty() { worker_name.clone() } else { ctx.remote_addr().to_string() }
+    fn workstats_session_start_unix(stats: &WorkStats) -> f64 {
+        let now_unix = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs_f64();
+        now_unix - stats.start_time.elapsed().as_secs_f64()
+    }
+
+    fn sync_worker_prom_session(&self, ctx: &StratumContext, stats: &WorkStats) {
+        if ctx.wallet_addr.lock().is_empty() {
+            return;
+        }
+        let worker = self.worker_prom_context(ctx, "");
+        ensure_worker_session_metrics(&worker, Self::workstats_session_start_unix(stats));
+    }
+
+    pub fn get_create_stats(&self, ctx: &StratumContext) -> WorkStats {
+        let worker_id = crate::prom::prom_worker_id(ctx);
+
+        let stats = {
+            let mut stats_map = self.stats.lock();
+
+            if let Some(stats) = stats_map.get(&worker_id) {
+                stats.clone()
+            } else {
+                let stats = WorkStats::new(worker_id.clone());
+                // Seed per-worker displayed diff from current mining state so recreated
+                // entries do not start at 0.0 and get stuck in terminal/UI.
+                let seeded_diff = GetMiningState(ctx).stratum_diff().map(|d| d.diff_value).unwrap_or(0.0);
+                if seeded_diff > 0.0 {
+                    *stats.min_diff.lock() = seeded_diff;
+                }
+                stats_map.insert(worker_id.clone(), stats.clone());
+                stats
+            }
         };
 
-        if let Some(stats) = stats_map.get(&worker_id) {
-            return stats.clone();
-        }
-
-        let stats = WorkStats::new(worker_id.clone());
-        // Seed per-worker displayed diff from current mining state so recreated
-        // entries do not start at 0.0 and get stuck in terminal/UI.
-        let seeded_diff = GetMiningState(ctx).stratum_diff().map(|d| d.diff_value).unwrap_or(0.0);
-        if seeded_diff > 0.0 {
-            *stats.min_diff.lock() = seeded_diff;
-        }
-        stats_map.insert(worker_id.clone(), stats.clone());
-        drop(stats_map);
-
-        // Initialize worker counters
-        let wallet_addr = ctx.wallet_addr.lock().clone();
-        let worker_name = stats.worker_name.lock().clone();
-        init_worker_counters(&crate::prom::WorkerContext {
-            instance_id: self.instance_id.clone(),
-            worker_name: worker_name.clone(),
-            miner: String::new(),
-            wallet: wallet_addr.clone(),
-            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-        });
-
+        self.sync_worker_prom_session(ctx, &stats);
         stats
     }
 
@@ -817,13 +823,7 @@ impl ShareHandler {
                         let stats = self.get_create_stats(&ctx);
                         let overall = self.overall.clone();
                         let instance_id = self.instance_id.clone();
-                        let prom_worker = crate::prom::WorkerContext {
-                            instance_id: self.instance_id.clone(),
-                            worker_name: worker_name.clone(),
-                            miner: String::new(),
-                            wallet: wallet_addr.clone(),
-                            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                        };
+                        let prom_worker = self.worker_prom_context(&ctx, "");
 
                         record_block_accepted_by_node(&prom_worker);
 
@@ -906,13 +906,7 @@ impl ShareHandler {
                             *stats.stale_shares.lock() += 1;
                             *self.overall.stale_shares.lock() += 1;
 
-                            record_stale_share(&crate::prom::WorkerContext {
-                                instance_id: self.instance_id.clone(),
-                                worker_name: worker_name.clone(),
-                                miner: String::new(),
-                                wallet: wallet_addr.clone(),
-                                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                            });
+                            record_stale_share(&self.worker_prom_context(&ctx, ""));
                             ctx.reply_stale_share(event.id.clone()).await?;
                             return Ok(());
                         } else {
@@ -936,13 +930,7 @@ impl ShareHandler {
                             *stats.invalid_shares.lock() += 1;
                             *self.overall.invalid_shares.lock() += 1;
 
-                            record_invalid_share(&crate::prom::WorkerContext {
-                                instance_id: self.instance_id.clone(),
-                                worker_name: worker_name.clone(),
-                                miner: String::new(),
-                                wallet: wallet_addr.clone(),
-                                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-                            });
+                            record_invalid_share(&self.worker_prom_context(&ctx, ""));
 
                             {
                                 let now = Instant::now();
@@ -1058,15 +1046,7 @@ impl ShareHandler {
             *stats.invalid_shares.lock() += 1;
             *self.overall.invalid_shares.lock() += 1;
 
-            let wallet_addr = ctx.wallet_addr.lock().clone();
-            let worker_name = ctx.worker_name.lock().clone();
-            record_weak_share(&crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: String::new(),
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            });
+            record_weak_share(&self.worker_prom_context(&ctx, ""));
 
             if let Some(id) = &event.id {
                 let _ = ctx.reply_low_diff_share(id).await;
@@ -1099,18 +1079,7 @@ impl ShareHandler {
         *stats.last_share.lock() = Instant::now();
         *self.overall.shares_found.lock() += 1;
 
-        let wallet_addr = ctx.wallet_addr.lock().clone();
-        let worker_name = ctx.worker_name.lock().clone();
-        record_share_found(
-            &crate::prom::WorkerContext {
-                instance_id: self.instance_id.clone(),
-                worker_name: worker_name.clone(),
-                miner: String::new(),
-                wallet: wallet_addr.clone(),
-                ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
-            },
-            hash_value,
-        );
+        record_share_found(&self.worker_prom_context(&ctx, ""), hash_value);
 
         {
             let now = Instant::now();

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -1717,6 +1717,50 @@ mod comprehensive_tests {
     }
 
     #[test]
+    fn test_worker_prom_session_syncs_start_time_for_current_wallet() {
+        use crate::prom::{WorkerContext, init_metrics, record_share_found};
+        use prometheus::gather;
+
+        init_metrics();
+
+        let handler = ShareHandler::new("Instance 1".to_string());
+        let ctx = create_test_context_sync();
+        *ctx.worker_name.lock() = "ks0".to_string();
+
+        // Stats entry created before wallet is known (no prom session yet).
+        let stats_before_wallet = handler.get_create_stats(&ctx);
+        assert_eq!(*stats_before_wallet.worker_name.lock(), "ks0");
+
+        let wallet = "kaspa:qr8example123456789012345678901234567890123456789012345678901234567890".to_string();
+        *ctx.wallet_addr.lock() = wallet.clone();
+
+        // Reusing the same in-memory stats entry must still sync prom start time for the wallet.
+        let stats_after_wallet = handler.get_create_stats(&ctx);
+        assert!(Arc::ptr_eq(&stats_before_wallet.worker_name, &stats_after_wallet.worker_name));
+
+        record_share_found(&WorkerContext::from_stratum("Instance 1", &ctx, ""), 8192.0);
+
+        let mut found_start_time = false;
+        for family in gather() {
+            if family.name() != "ks_worker_start_time" {
+                continue;
+            }
+            for metric in family.get_metric() {
+                let labels: std::collections::HashMap<&str, &str> = metric.get_label().iter().map(|l| (l.name(), l.value())).collect();
+                if labels.get("instance") == Some(&"Instance 1")
+                    && labels.get("worker") == Some(&"ks0")
+                    && labels.get("wallet") == Some(&wallet.as_str())
+                    && metric.get_gauge().value() > 0.0
+                {
+                    found_start_time = true;
+                }
+            }
+        }
+
+        assert!(found_start_time, "ks_worker_start_time must exist for the authorized wallet label set");
+    }
+
+    #[test]
     fn test_share_handler_vardiff_management() {
         // Test: VarDiff difficulty management
         let handler = ShareHandler::new("test-instance".to_string());


### PR DESCRIPTION
Dashboard hashrate/uptime needs both ks_valid_share_diff_counter and ks_worker_start_time on the same instance:worker:wallet key. Previously, ks_worker_start_time was only set when a new in-memory stats entry was created. Reused entries (reconnects, long-lived workers like ks0) could accumulate shares on one Prometheus label set while start time lived on another (e.g. empty wallet from an early init).

What the fix does
ensure_worker_session_metrics() (prom.rs)
Idempotently registers counter series and sets ks_worker_start_time when it is missing (<= 0) for the current label set. Uses the in-memory WorkStats.start_time converted to Unix time so dashboard hashrate/uptime match the terminal.

get_create_stats() always syncs (share_handler.rs) On both new and cache-hit paths, after wallet is known, Prometheus session metrics are aligned with the current (instance, worker, wallet).

Authorize hook (default_client.rs)
Immediately after wallet + worker are set, sync_worker_prom_metrics() runs so metrics are correct before the first share.

5-second connection hook (client_handler.rs)
Now requires wallet (not just worker name) before creating stats, avoiding early init with an empty wallet.

Unified WorkerContext::from_stratum() / prom_worker_id() All Prometheus paths use the same worker key logic as in-memory stats (explicit name or client IP). Instance ID is unchanged per ShareHandler, so multi-instance behavior is preserved.

update_worker_difficulty()
Also ensures session metrics exist so difficulty-only paths cannot leave a worker without start time.

Test added
test_worker_prom_session_syncs_start_time_for_current_wallet — verifies that reusing an in-memory stats entry after wallet is set still creates ks_worker_start_time on the correct wallet labels.

Files changed
bridge/src/prom.rs
bridge/src/share_handler.rs
bridge/src/client_handler.rs
bridge/src/default_client.rs
bridge/src/tests.rs

What this does not change
Instance aggregation / dashboard API (still one registry, instance label per stratum instance) Workerdisplay / unnamed ASIC behavior 

Which has workerdisplay PR to fix the issue in regards to unnamed ASIC, and their behavior 