### PR TITLE
fix/zero-share-worker-ui-retention

### DIFF
--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -806,7 +806,6 @@ fn init_worker_counter_series(worker: &WorkerContext) {
             metric.set(0.0);
         }
     }
-    update_worker_activity(worker);
 }
 
 /// Ensure Prometheus worker metrics exist for the current `(instance, worker, wallet)` labels.
@@ -835,10 +834,10 @@ pub fn init_worker_counters(worker: &WorkerContext) {
     ensure_worker_session_metrics(worker, start_time);
 }
 
-/// Update the current mining difficulty for a worker
+/// Update the current mining difficulty for a worker.
+/// Does not refresh dashboard activity — jobs alone must not keep 0-share workers "online".
 pub fn update_worker_difficulty(worker: &WorkerContext, difficulty: f64) {
-    let start_time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as f64;
-    ensure_worker_session_metrics(worker, start_time);
+    init_worker_counter_series(worker);
 
     if let Some(gauge) = WORKER_CURRENT_DIFFICULTY.get() {
         gauge.with_label_values(&worker.labels()).set(difficulty);
@@ -1377,7 +1376,7 @@ async fn get_stats_json_filtered(instance_id: Option<&str>) -> StatsResponse {
     });
 
     // Sort workers by blocks (most blocks first)
-    stats.workers.sort_by(|a, b| b.blocks.cmp(&a.blocks));
+    stats.workers.sort_by_key(|w| std::cmp::Reverse(w.blocks));
 
     // Calculate bridge uptime
     if let Some(&start_time) = BRIDGE_START_TIME.get() {

--- a/bridge/src/share_handler.rs
+++ b/bridge/src/share_handler.rs
@@ -271,6 +271,16 @@ impl ShareHandler {
         ensure_worker_session_metrics(&worker, Self::workstats_session_start_unix(stats));
     }
 
+    /// Return in-memory stats for a worker when already registered (authorize/submit lifecycle).
+    fn get_stats_if_exists(&self, ctx: &StratumContext) -> Option<WorkStats> {
+        let worker_id = ctx.effective_worker_name();
+        self.stats.lock().get(&worker_id).cloned()
+    }
+
+    fn current_stratum_diff(ctx: &StratumContext) -> f64 {
+        GetMiningState(ctx).stratum_diff().map(|d| d.diff_value).unwrap_or(0.0)
+    }
+
     pub fn get_create_stats(&self, ctx: &StratumContext) -> WorkStats {
         let worker_id = ctx.effective_worker_name();
 
@@ -1105,7 +1115,10 @@ impl ShareHandler {
     }
 
     pub fn set_client_vardiff(&self, ctx: &StratumContext, min_diff: f64) -> f64 {
-        let stats = self.get_create_stats(ctx);
+        let Some(stats) = self.get_stats_if_exists(ctx) else {
+            // Job/difficulty paths must not resurrect pruned 0-share workers in the terminal table.
+            return Self::current_stratum_diff(ctx);
+        };
         let previous = *stats.min_diff.lock();
         *stats.min_diff.lock() = min_diff;
         *stats.var_diff_start_time.lock() = Some(Instant::now());
@@ -1115,12 +1128,16 @@ impl ShareHandler {
     }
 
     pub fn get_client_vardiff(&self, ctx: &StratumContext) -> f64 {
-        let stats = self.get_create_stats(ctx);
-        *stats.min_diff.lock()
+        if let Some(stats) = self.get_stats_if_exists(ctx) {
+            return *stats.min_diff.lock();
+        }
+        Self::current_stratum_diff(ctx)
     }
 
     pub fn start_client_vardiff(&self, ctx: &StratumContext) {
-        let stats = self.get_create_stats(ctx);
+        let Some(stats) = self.get_stats_if_exists(ctx) else {
+            return;
+        };
         if stats.var_diff_start_time.lock().is_none() {
             *stats.var_diff_start_time.lock() = Some(Instant::now());
             *stats.var_diff_shares_found.lock() = 0;
@@ -1646,7 +1663,45 @@ pub trait KaspaApiTrait: Send + Sync {
     async fn get_current_block_color(&self, block_hash: &str) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
 }
 
-pub struct WorkerContext<'a> {
-    pub worker_name: &'a str,
-    pub wallet_addr: &'a str,
+#[cfg(test)]
+mod retention_tests {
+    use super::*;
+    use crate::mining_state::MiningState;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> Arc<StratumContext> {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let accept_handle = tokio::spawn(async move { listener.accept().await });
+            let _stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            let (accepted_stream, _) = accept_handle.await.unwrap().unwrap();
+            let state = Arc::new(MiningState::new());
+            let (tx, _rx) = mpsc::unbounded_channel();
+            StratumContext::new("127.0.0.1".to_string(), 12345, accepted_stream, state, tx)
+        })
+    }
+
+    #[test]
+    fn set_client_vardiff_does_not_recreate_pruned_stats() {
+        let handler = ShareHandler::new("test-instance".to_string());
+        let ctx = test_ctx();
+        *ctx.worker_name.lock() = "ghost".to_string();
+        *ctx.wallet_addr.lock() = "kaspatest:ghost".to_string();
+
+        handler.get_create_stats(&ctx);
+        assert_eq!(handler.stats.lock().len(), 1);
+
+        handler.stats.lock().clear();
+        assert!(handler.stats.lock().is_empty());
+
+        let previous = handler.set_client_vardiff(&ctx, 512.0);
+        assert_eq!(previous, 0.0, "vardiff should fall back to mining-state diff when stats were pruned");
+        assert!(handler.stats.lock().is_empty(), "job/vardiff paths must not recreate pruned stats");
+
+        handler.get_create_stats(&ctx);
+        assert_eq!(handler.stats.lock().len(), 1, "authorize/submit lifecycle may recreate stats");
+    }
 }

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -1,6 +1,7 @@
 // ============================================================================
 // TEST SUITE FOR RKSTRATUM BRIDGE
 // ============================================================================
+// This module is compiled from `main.rs` under `#[cfg(test)]` (stratum-bridge binary).
 // This file contains comprehensive tests for the RKStratum Bridge.
 // Tests are organized into several categories:
 //
@@ -950,7 +951,6 @@ fn test_unmarshal_event_with_very_long_string() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_with_all_fields() {
-    use crate::cli::parse_instance_spec;
     let spec = "port=:5555,diff=8192,prom=:9090,wait=1000,extranonce=4,log=true,var_diff=true,shares_per_min=30,var_diff_stats=true,pow2_clamp=false";
     let result = parse_instance_spec(spec, None);
     assert!(result.is_ok());
@@ -968,7 +968,6 @@ fn test_parse_instance_spec_with_all_fields() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_with_whitespace() {
-    use crate::cli::parse_instance_spec;
     let spec = "  port = :5555 , diff = 8192  ";
     let result = parse_instance_spec(spec, None);
     assert!(result.is_ok());
@@ -980,7 +979,6 @@ fn test_parse_instance_spec_with_whitespace() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_invalid_diff() {
-    use crate::cli::parse_instance_spec;
     let spec = "port=:5555,diff=not_a_number";
     let result = parse_instance_spec(spec, None);
     assert!(result.is_err());
@@ -989,7 +987,6 @@ fn test_parse_instance_spec_invalid_diff() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_invalid_wait() {
-    use crate::cli::parse_instance_spec;
     let spec = "port=:5555,diff=8192,wait=invalid";
     let result = parse_instance_spec(spec, None);
     assert!(result.is_err());
@@ -998,7 +995,6 @@ fn test_parse_instance_spec_invalid_wait() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_unknown_key() {
-    use crate::cli::parse_instance_spec;
     let spec = "port=:5555,diff=8192,unknown_key=value";
     let result = parse_instance_spec(spec, None);
     assert!(result.is_err());
@@ -1007,7 +1003,6 @@ fn test_parse_instance_spec_unknown_key() {
 #[cfg(test)]
 #[test]
 fn test_parse_instance_spec_multiple_ports() {
-    use crate::cli::parse_instance_spec;
     let spec = "port=:5555,port=:5556,diff=8192";
     let result = parse_instance_spec(spec, None);
     // Last port should win, or it should error
@@ -1186,16 +1181,6 @@ mod integration {
 // ============================================================================
 // COMPREHENSIVE TEST SUITE FOR BRIDGE FUNCTIONALITY
 // ============================================================================
-// These tests demonstrate how the bridge works and help developers understand
-// the codebase. They cover:
-// 1. Stratum protocol flow (subscribe, authorize, submit)
-// 2. Share validation and PoW checking
-// 3. Miner compatibility (IceRiver, Bitmain, BzMiner)
-// 4. Extranonce assignment and detection
-// 5. Job management and stale job handling
-// 6. Difficulty calculations
-// 7. VarDiff logic
-// ============================================================================
 
 #[cfg(test)]
 mod comprehensive_tests {
@@ -1210,6 +1195,7 @@ mod comprehensive_tests {
         hasher::KaspaDiff,
         jsonrpc_event::JsonRpcEvent,
         mining_state::{GetMiningState, Job, MiningState},
+        prom::{WorkerContext, init_metrics, record_share_found},
         share_handler::ShareHandler,
         stratum_context::StratumContext,
     };
@@ -1718,7 +1704,6 @@ mod comprehensive_tests {
 
     #[test]
     fn test_worker_prom_session_syncs_start_time_for_current_wallet() {
-        use crate::prom::{WorkerContext, init_metrics, record_share_found};
         use prometheus::gather;
 
         init_metrics();
@@ -1765,6 +1750,9 @@ mod comprehensive_tests {
         // Test: VarDiff difficulty management
         let handler = ShareHandler::new("test-instance".to_string());
         let ctx = create_test_context_sync();
+        *ctx.worker_name.lock() = "worker1".to_string();
+        *ctx.wallet_addr.lock() = "kaspatest:test".to_string();
+        handler.get_create_stats(&ctx);
 
         // Set initial difficulty
         let prev = handler.set_client_vardiff(&ctx, 8192.0);
@@ -1816,6 +1804,9 @@ mod comprehensive_tests {
         // This test verifies the ShareHandler can manage VarDiff
         let handler = ShareHandler::new("test-instance".to_string());
         let ctx = create_test_context_sync();
+        *ctx.worker_name.lock() = "worker1".to_string();
+        *ctx.wallet_addr.lock() = "kaspatest:test".to_string();
+        handler.get_create_stats(&ctx);
 
         // Set initial difficulty
         handler.set_client_vardiff(&ctx, 8192.0);
@@ -2640,6 +2631,9 @@ mod comprehensive_tests {
         // Note: set_client_vardiff stores the value as-is; clamping happens during VarDiff computation
         let handler = ShareHandler::new("test-instance".to_string());
         let ctx = create_test_context_sync();
+        *ctx.worker_name.lock() = "worker1".to_string();
+        *ctx.wallet_addr.lock() = "kaspatest:test".to_string();
+        handler.get_create_stats(&ctx);
 
         // Test minimum difficulty (1.0)
         handler.set_client_vardiff(&ctx, 1.0);
@@ -2663,6 +2657,9 @@ mod comprehensive_tests {
         // Test: Scenarios where VarDiff should not change
         let handler = ShareHandler::new("test-instance".to_string());
         let ctx = create_test_context_sync();
+        *ctx.worker_name.lock() = "worker1".to_string();
+        *ctx.wallet_addr.lock() = "kaspatest:test".to_string();
+        handler.get_create_stats(&ctx);
 
         // Set initial difficulty
         handler.set_client_vardiff(&ctx, 8192.0);


### PR DESCRIPTION
Problem
Workers with 0 shares stayed visible at 0 MH/s for hours in the terminal table and Prometheus dashboard while still receiving jobs. Hashrate was correct; prune + per-job updates kept recreating stats and refreshing “online” activity.

Solution
Split worker lifecycle (authorize / submit / shares) from job-only maintenance (vardiff / difficulty). Job paths update existing state only; they do not recreate pruned rows or reset dashboard activity.

bridge/src/share_handler.rs
get_stats_if_exists — return in-memory stats only if the worker is already registered. current_stratum_diff — fallback difficulty from mining state when stats were pruned. set_client_vardiff, get_client_vardiff, start_client_vardiff — use get_stats_if_exists; no get_create_stats on job-only paths (prevents resurrecting pruned rows). get_create_stats — unchanged for authorize / submit / share paths (creates stats when a worker legitimately enters or re-enters a session). Test: retention_tests::set_client_vardiff_does_not_recreate_pruned_stats Removed duplicate unused WorkerContext struct (shadowed prom::WorkerContext). bridge/src/prom.rs
init_worker_counter_series — removed update_worker_activity (metric init ≠ miner activity). update_worker_difficulty — only initializes counter series and sets WORKER_CURRENT_DIFFICULTY; does not call ensure_worker_session_metrics (jobs must not extend dashboard liveness). ensure_worker_session_metrics — still calls update_worker_activity on authorize / share paths (unchanged). Clippy: sort_by → sort_by_key(|w| std::cmp::Reverse(w.blocks)) (unnecessary_sort_by; sort order unchanged). bridge/src/tests.rs
Vardiff tests call get_create_stats before set_client_vardiff (matches authorize-before-jobs in production). Removed redundant use crate::cli::parse_instance_spec in instance-spec tests.