### PR TITLE
KIP-21: inactivity_shortcut

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -514,19 +514,12 @@ impl ConsensusSessionOwned {
     pub fn import_pruning_point_smt(
         &self,
         new_pruning_point: Hash,
-        lanes_root: Hash,
-        payload_and_ctx_digest: Hash,
-        expected_lane_count: u64,
+        metadata: kaspa_consensus_core::api::SmtExportMetadata,
+        inactivity_shortcut_block: Option<Hash>,
         mut rx: tokio::sync::mpsc::Receiver<Vec<ImportLane>>,
     ) -> PruningImportResult<()> {
         let lane_batches: ImportLaneBatchIterator = &mut std::iter::from_fn(move || rx.blocking_recv());
-        self.consensus.import_pruning_point_smt(
-            new_pruning_point,
-            lanes_root,
-            payload_and_ctx_digest,
-            expected_lane_count,
-            lane_batches,
-        )
+        self.consensus.import_pruning_point_smt(new_pruning_point, metadata, inactivity_shortcut_block, lane_batches)
     }
     pub async fn async_is_pruning_smt_stable(&self) -> bool {
         self.clone().spawn_blocking(move |c| c.is_pruning_smt_stable()).await
@@ -536,6 +529,10 @@ impl ConsensusSessionOwned {
         expected_pp: Hash,
     ) -> ConsensusResult<kaspa_consensus_core::api::SmtExportMetadata> {
         self.clone().spawn_blocking(move |c| c.get_pruning_point_smt_metadata(expected_pp)).await
+    }
+
+    pub async fn async_inactivity_shortcut_block_for_pov(&self, pov_block: Hash) -> ConsensusResult<Hash> {
+        self.clone().spawn_blocking(move |c| c.inactivity_shortcut_block_for_pov(pov_block)).await
     }
 
     /// Synchronous passthrough to [`ConsensusApi::open_pruning_point_smt_lane_stream`].

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -69,8 +69,12 @@ pub struct ImportLane {
 
 pub type ImportLaneBatchIterator<'a> = &'a mut (dyn Iterator<Item = Vec<ImportLane>> + Send);
 
-/// SMT metadata for IBD sync — verified against the pruning point header.
-#[derive(Clone, Debug)]
+/// SMT metadata for IBD sync, verified against the pruning point header.
+///
+/// Wire: `lanes_root || payload_and_ctx_digest || parent_seq_commit` (96 bytes).
+/// `inactivity_shortcut_block` is derived by the receiver from chain headers
+/// when needed (post-hardening); not transmitted.
+#[derive(Clone, Copy, Debug)]
 pub struct SmtExportMetadata {
     pub lanes_root: Hash,
     pub payload_and_ctx_digest: Hash,
@@ -299,14 +303,17 @@ pub trait ConsensusApi: Send + Sync {
     /// preimages, verifies root matches `lanes_root`, and flushes to DB.
     ///
     /// The iterator yields lane chunks already sized by the wire-level chunker
-    /// — each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
+    /// each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
     /// re-batch.
+    ///
+    /// `inactivity_shortcut_block` is `Some(block)` post-hardening (already
+    /// resolved by the caller during metadata verification) and `None`
+    /// pre-hardening. The importer stores it as-is in the V1 metadata row.
     fn import_pruning_point_smt(
         &self,
         _new_pruning_point: Hash,
-        _lanes_root: Hash,
-        _payload_and_ctx_digest: Hash,
-        _expected_lane_count: u64,
+        _metadata: SmtExportMetadata,
+        _inactivity_shortcut_block: Option<Hash>,
         _lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
         unimplemented!()
@@ -314,6 +321,15 @@ pub trait ConsensusApi: Send + Sync {
 
     /// Compute SMT metadata for the pruning point (for P2P streaming).
     fn get_pruning_point_smt_metadata(&self, _expected_pruning_point: Hash) -> ConsensusResult<SmtExportMetadata> {
+        unimplemented!()
+    }
+
+    /// Resolve the `inactivity_shortcut_block` (the block hash anchoring the
+    /// `activity_root` shortcut) from the POV of `pov_block`. Uses headers +
+    /// reachability only; safe to call at the IBD PP boundary before the SMT
+    /// is imported. Callers resolve to the seq_commit Hash themselves (the
+    /// block-to-seq_commit fold is just a header read + activation check).
+    fn inactivity_shortcut_block_for_pov(&self, _pov_block: Hash) -> ConsensusResult<Hash> {
         unimplemented!()
     }
 

--- a/consensus/seq-commit/src/hashing.rs
+++ b/consensus/seq-commit/src/hashing.rs
@@ -1,23 +1,35 @@
 //! Hash functions for sequencing commitments.
+//!
+//! Commitment tree shape:
+//!
+//! ```text
+//! SeqCommit(B)
+//! └── H_seq
+//!     ├── parent_seq_commit = SeqCommit(selected_parent(B))
+//!     └── state_root
+//!         └── H_seq
+//!             ├── activity_root
+//!             │   └── H_activity_root
+//!             │       ├── inactivity_shortcut
+//!             │       └── lanes_root
+//!             │           └── SMT root over active lanes
+//!             │
+//!             └── payload_and_ctx_digest
+//!                 └── H_seq
+//!                     ├── context_hash
+//!                     └── payload_root
+//! ```
+//!
+//! Pre-hardening: `activity_root == lanes_root` (identity, no wrap);
+//! post-hardening: `activity_root = H_activity_root(inactivity_shortcut, lanes_root)`.
 
 use kaspa_hashes::{
-    Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitLaneKey, SeqCommitLaneTip,
-    SeqCommitMergesetContext, SeqCommitMerkleBranch, SeqCommitMinerPayloadLeaf,
+    Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitActivityRoot, SeqCommitLaneKey,
+    SeqCommitLaneTip, SeqCommitMergesetContext, SeqCommitMerkleBranch, SeqCommitMinerPayloadLeaf,
 };
 use kaspa_merkle::{StreamingMerkleBuilder, calc_merkle_root_with_hasher};
 
 use crate::types::{LaneId, LaneTipInput, MergesetContext, MinerPayloadLeafInput, SeqCommitInput, SeqState, SmtLeafInput};
-
-/// Derive the timestamp used in `MergesetContextHash` for a given block.
-///
-/// Uses the selected parent's timestamp — a consensus-agreed deterministic
-/// value that doesn't depend on miner input. This ensures the seq_commit
-/// can be computed for the virtual block without knowing the final header
-/// timestamp.
-#[inline]
-pub fn seq_commit_timestamp(selected_parent_timestamp: u64) -> u64 {
-    selected_parent_timestamp
-}
 
 /// Compute the SMT key for a lane: `H_lane_key(lane_id)`.
 #[inline]
@@ -58,11 +70,23 @@ pub fn lane_tip_next(input: &LaneTipInput) -> Hash {
     hasher.finalize()
 }
 
-/// Compute the mergeset context hash: `H_mergeset_context(le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score))`.
+/// Compute the mergeset context hash:
+/// `H_mergeset_context(le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score))`.
 #[inline]
 pub fn mergeset_context_hash(ctx: &MergesetContext) -> Hash {
     let mut hasher = SeqCommitMergesetContext::new();
     hasher.update(ctx.timestamp.to_le_bytes()).update(ctx.daa_score.to_le_bytes()).update(ctx.blue_score.to_le_bytes());
+    hasher.finalize()
+}
+
+/// Compute the activity root: `H_activity_root(inactivity_shortcut, lanes_root)`.
+///
+/// Post-hardening only. Pre-hardening callers should pass `lanes_root` straight
+/// into [`seq_state_root`] without invoking this helper (identity).
+#[inline]
+pub fn activity_root_hash(inactivity_shortcut: &Hash, lanes_root: &Hash) -> Hash {
+    let mut hasher = SeqCommitActivityRoot::new();
+    hasher.update(inactivity_shortcut).update(lanes_root);
     hasher.finalize()
 }
 
@@ -131,11 +155,11 @@ pub fn payload_and_context_digest(context_hash: &Hash, payload_root: &Hash) -> H
     hasher.finalize()
 }
 
-/// Compute the seq-state root: `H_seq(lanes_root, payload_and_ctx_digest)`.
+/// Compute the seq-state root: `H_seq(activity_root, payload_and_ctx_digest)`.
 #[inline]
 pub fn seq_state_root(state: &SeqState<'_>) -> Hash {
     let mut hasher = SeqCommitMerkleBranch::new();
-    hasher.update(state.lanes_root).update(state.payload_and_ctx_digest);
+    hasher.update(state.activity_root).update(state.payload_and_ctx_digest);
     hasher.finalize()
 }
 
@@ -243,12 +267,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mergeset_context_hash_golden() {
-        let expected = Hash::from_bytes([
-            0x20, 0xd8, 0xeb, 0x88, 0xd6, 0x6b, 0xef, 0x8f, 0xee, 0xf3, 0x60, 0x24, 0x3e, 0xb5, 0x10, 0xee, 0x53, 0x3b, 0x4c, 0xe0,
-            0x07, 0x43, 0x2c, 0x29, 0xb4, 0xf5, 0x58, 0xb0, 0xdb, 0xf4, 0x75, 0x91,
-        ]);
-        assert_eq!(mergeset_context_hash(&MergesetContext { timestamp: 1000, daa_score: 500, blue_score: 250 }), expected);
+    fn test_mergeset_context_hash_determinism() {
+        let ctx = MergesetContext { timestamp: 1000, daa_score: 500, blue_score: 250 };
+        assert_eq!(mergeset_context_hash(&ctx), mergeset_context_hash(&ctx));
     }
 
     #[test]
@@ -261,6 +282,31 @@ mod tests {
         assert_ne!(ha, mergeset_context_hash(&b));
         assert_ne!(ha, mergeset_context_hash(&c));
         assert_ne!(ha, mergeset_context_hash(&d));
+    }
+
+    #[test]
+    fn test_activity_root_hash_golden() {
+        let result = activity_root_hash(&h(7), &h(9));
+        assert_eq!(result, activity_root_hash(&h(7), &h(9)));
+        assert_ne!(result, ZERO_HASH);
+    }
+
+    #[test]
+    fn test_activity_root_hash_different_inputs() {
+        let base = activity_root_hash(&h(7), &h(9));
+        assert_ne!(base, activity_root_hash(&h(8), &h(9)));
+        assert_ne!(base, activity_root_hash(&h(7), &h(10)));
+        // Order matters (domain-separated, but sanity-check).
+        assert_ne!(base, activity_root_hash(&h(9), &h(7)));
+    }
+
+    /// Identity vs wrap diverge: pre-hardening feeds `lanes_root` directly to
+    /// `seq_state_root`; post-hardening wraps via `activity_root_hash`. Hashes must differ.
+    #[test]
+    fn activity_root_identity_vs_wrap_diverges() {
+        let lanes_root = h(42);
+        let shortcut = ZERO_HASH;
+        assert_ne!(lanes_root, activity_root_hash(&shortcut, &lanes_root));
     }
 
     #[test]
@@ -390,19 +436,19 @@ mod tests {
             0x20, 0xd1, 0x35, 0x77, 0x5a, 0x39, 0xbe, 0x49, 0xfe, 0x34, 0x70, 0x9a, 0x55, 0xb0, 0xc7, 0xeb, 0x39, 0x05, 0xf5, 0xc9,
             0xbe, 0x27, 0xd1, 0xdc, 0x11, 0x50, 0xb8, 0xaf, 0x23, 0x9e, 0x56, 0xd9,
         ]);
-        let (lr, ch, pr) = (h(1), h(2), h(3));
+        let (ar, ch, pr) = (h(1), h(2), h(3));
         let pd = payload_and_context_digest(&ch, &pr);
-        assert_eq!(seq_state_root(&SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd }), expected);
+        assert_eq!(seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: &pd }), expected);
     }
 
     #[test]
     fn test_seq_state_root_structure() {
-        let (lr, ch, pr) = (h(1), h(2), h(3));
+        let (ar, ch, pr) = (h(1), h(2), h(3));
         let pd = payload_and_context_digest(&ch, &pr);
-        let state = SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd };
+        let state = SeqState { activity_root: &ar, payload_and_ctx_digest: &pd };
         let expected = {
             let mut hasher = SeqCommitMerkleBranch::new();
-            hasher.update(state.lanes_root).update(state.payload_and_ctx_digest);
+            hasher.update(state.activity_root).update(state.payload_and_ctx_digest);
             hasher.finalize()
         };
         assert_eq!(seq_state_root(&state), expected);
@@ -461,7 +507,9 @@ mod tests {
         let mpr = miner_payload_root(core::iter::once(mpl));
 
         let pd = payload_and_context_digest(&ctx, &mpr);
-        let state_root = seq_state_root(&SeqState { lanes_root: &smt_leaf, payload_and_ctx_digest: &pd });
+        // Post-hardening end-to-end: activity_root wraps lanes_root with the shortcut.
+        let activity_root = activity_root_hash(&ZERO_HASH, &smt_leaf);
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_commit, state_root: &state_root });
         assert_ne!(commitment, parent_commit);
     }

--- a/consensus/seq-commit/src/hashing.rs
+++ b/consensus/seq-commit/src/hashing.rs
@@ -39,6 +39,12 @@ pub fn lane_key(lane_id: &LaneId) -> Hash {
     hasher.finalize()
 }
 
+/// Precomputed `lane_key(SUBNETWORK_ID_COINBASE)`.
+pub const COINBASE_LANE_KEY: Hash = Hash::from_bytes([
+    0x8a, 0xa7, 0x80, 0x27, 0xdb, 0x66, 0xa1, 0x6c, 0xb6, 0x96, 0x92, 0xee, 0x0a, 0xf5, 0xcb, 0x76, 0x73, 0x8e, 0xf8, 0x0a, 0xd1,
+    0x4c, 0x9d, 0x13, 0x92, 0x0d, 0x7f, 0xa3, 0xcc, 0x40, 0xb9, 0xe4,
+]);
+
 /// Compute an activity leaf: `H_activity_leaf(tx_id || le_u16(version) || le_u32(merge_idx))`.
 #[inline]
 pub fn activity_leaf(tx_id: &Hash, version: u16, merge_idx: u32) -> Hash {
@@ -174,7 +180,7 @@ pub fn seq_commit(input: &SeqCommitInput<'_>) -> Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kaspa_consensus_core::BlueWorkType;
+    use kaspa_consensus_core::{BlueWorkType, subnets::SUBNETWORK_ID_COINBASE};
     use kaspa_hashes::ZERO_HASH;
 
     fn h(b: u8) -> Hash {
@@ -195,6 +201,11 @@ mod tests {
     #[test]
     fn test_lane_key_different_ids() {
         assert_ne!(lane_key(&[0x01; 20]), lane_key(&[0x02; 20]));
+    }
+
+    #[test]
+    fn test_coinbase_lane_key_constant() {
+        assert_eq!(COINBASE_LANE_KEY, lane_key(&SUBNETWORK_ID_COINBASE.into_bytes()));
     }
 
     #[test]

--- a/consensus/seq-commit/src/types.rs
+++ b/consensus/seq-commit/src/types.rs
@@ -6,6 +6,8 @@ use kaspa_hashes::Hash;
 pub type LaneId = [u8; 20];
 
 /// Mergeset context fields hashed into the sequencing commitment.
+///
+/// Preimage is exactly `le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score)`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MergesetContext {
     pub timestamp: u64,
@@ -43,9 +45,12 @@ pub struct SmtLeafInput<'a> {
 }
 
 /// Components of the sequencing state root.
+///
+/// `activity_root`: pre-hardening identity = `lanes_root`; post-hardening
+/// = `H_activity_root(inactivity_shortcut, lanes_root)`.
 #[derive(Clone, Copy, Debug)]
 pub struct SeqState<'a> {
-    pub lanes_root: &'a Hash,
+    pub activity_root: &'a Hash,
     pub payload_and_ctx_digest: &'a Hash,
 }
 

--- a/consensus/seq-commit/src/verify.rs
+++ b/consensus/seq-commit/src/verify.rs
@@ -1,9 +1,9 @@
-//! IBD SMT verification — metadata check.
+//! IBD SMT verification: metadata check.
 //!
 //! Proof verification with branch caching uses [`SmtProof::compute_root_with_visitor`]
 //! from `kaspa-smt` with `&mut ProofBranchCache` as the visitor.
 
-use crate::hashing::seq_state_root;
+use crate::hashing::{activity_root_hash, seq_state_root};
 use crate::types::SeqState;
 use kaspa_hashes::{Hash, HasherBase, SeqCommitMerkleBranch};
 
@@ -35,8 +35,12 @@ pub enum SmtVerifyError {
 }
 
 /// Verify that the metadata is consistent with the header's `accepted_id_merkle_root` (= seq_commit).
+///
+/// `inactivity_shortcut`: `None` for pre-hardening (identity at the activity-root level);
+/// `Some(s)` for post-hardening, wrapping `lanes_root` into `activity_root_hash(s, lanes_root)`.
 pub fn verify_smt_metadata(
     metadata: &SmtMetadata<'_>,
+    inactivity_shortcut: Option<Hash>,
     expected_seq_commit: Hash,
     expected_parent_seq_commit: Hash,
 ) -> Result<(), SmtVerifyError> {
@@ -47,15 +51,17 @@ pub fn verify_smt_metadata(
         });
     }
 
+    let activity_root = match inactivity_shortcut {
+        Some(s) => activity_root_hash(&s, metadata.lanes_root),
+        None => *metadata.lanes_root,
+    };
     let state_root =
-        seq_state_root(&SeqState { lanes_root: metadata.lanes_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
-
+        seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
     let computed = {
         let mut h = SeqCommitMerkleBranch::new();
         h.update(metadata.parent_seq_commit).update(state_root);
         h.finalize()
     };
-
     if computed != expected_seq_commit {
         return Err(SmtVerifyError::SeqCommitMismatch { expected: expected_seq_commit, computed });
     }
@@ -67,7 +73,7 @@ mod tests {
     extern crate std;
 
     use super::*;
-    use crate::hashing::{lane_key, payload_and_context_digest, smt_leaf_hash};
+    use crate::hashing::{activity_root_hash, lane_key, smt_leaf_hash};
     use crate::types::{LaneId, SmtLeafInput};
     use kaspa_hashes::{SeqCommitActiveNode, ZERO_HASH};
     use kaspa_smt::proof::ProofBranchCache;
@@ -99,33 +105,52 @@ mod tests {
         (tree.root(), tree)
     }
 
+    fn sample_shortcut() -> Hash {
+        Hash::from_bytes([7; 32])
+    }
+
+    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Option<Hash>) -> Hash {
+        let ar = match shortcut {
+            Some(s) => activity_root_hash(&s, lr),
+            None => *lr,
+        };
+        let sr = seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: pd });
+        let mut h = SeqCommitMerkleBranch::new();
+        h.update(ps).update(sr);
+        h.finalize()
+    }
+
     #[test]
-    fn metadata_correct() {
+    fn metadata_correct_post_hardening() {
         let lr = Hash::from_bytes([1; 32]);
-        let ch = Hash::from_bytes([2; 32]);
-        let pr = Hash::from_bytes([3; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        assert!(verify_smt_metadata(&md, Some(shortcut), sc, ps).is_ok());
+    }
+
+    #[test]
+    fn metadata_correct_pre_hardening() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
 
-        let pd = payload_and_context_digest(&ch, &pr);
-        let sr = seq_state_root(&SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd });
-        let sc = {
-            let mut h = SeqCommitMerkleBranch::new();
-            h.update(ps).update(sr);
-            h.finalize()
-        };
-
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, None);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, sc, ps).is_ok());
+        assert!(verify_smt_metadata(&md, None, sc, ps).is_ok());
     }
 
     #[test]
     fn metadata_wrong_parent() {
         let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([2; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, ZERO_HASH, Hash::from_bytes([99; 32])),
+            verify_smt_metadata(&md, Some(sample_shortcut()), ZERO_HASH, Hash::from_bytes([99; 32])),
             Err(SmtVerifyError::ParentSeqCommitMismatch { .. })
         ));
     }
@@ -133,10 +158,42 @@ mod tests {
     #[test]
     fn metadata_wrong_commit() {
         let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([2; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(matches!(verify_smt_metadata(&md, Hash::from_bytes([99; 32]), ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+        assert!(matches!(
+            verify_smt_metadata(&md, Some(sample_shortcut()), Hash::from_bytes([99; 32]), ps),
+            Err(SmtVerifyError::SeqCommitMismatch { .. })
+        ));
+    }
+
+    // Pre/post divergence: a verifier called with `None` on a post-hardening commit
+    // (or vice versa) must reject as a seq_commit mismatch.
+    #[test]
+    fn metadata_pre_post_mismatch_rejected() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+
+        let sc_post = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        // Wire was post-hardening but verifier was told pre-hardening: must mismatch.
+        assert!(matches!(verify_smt_metadata(&md, None, sc_post, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+    }
+
+    // A perturbed shortcut flows into `activity_root` and then `seq_state_root`,
+    // so the failure surfaces as `SeqCommitMismatch`.
+    #[test]
+    fn metadata_wrong_inactivity_shortcut_detected_via_seq_commit() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let bad_shortcut = Hash::from_bytes([0xAB; 32]);
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        assert!(matches!(verify_smt_metadata(&md, Some(bad_shortcut), sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     #[test]

--- a/consensus/seq-commit/tests/example_block.rs
+++ b/consensus/seq-commit/tests/example_block.rs
@@ -153,9 +153,10 @@ fn example_seq_commit_for_block() {
         .collect();
     let payload_root = miner_payload_root(payload_leaves.into_iter());
 
-    // --- State root and final commitment ---
+    // --- State root and final commitment (post-hardening: wrap lanes_root into activity_root). ---
     let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&ctx, &payload_root);
-    let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+    let activity_root = kaspa_seq_commit::hashing::activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
+    let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
 
     // Recomputing with the same inputs yields the same result

--- a/consensus/seq-commit/tests/prove_lane_activity.rs
+++ b/consensus/seq-commit/tests/prove_lane_activity.rs
@@ -46,6 +46,8 @@ struct CommitmentWitness {
     parent_seq_commit: Hash,
     smt_proof: OwnedSmtProof,
     blue_score: u64,
+    /// Post-hardening shortcut Hash. `None` pre-hardening (identity at activity_root).
+    inactivity_shortcut: Option<Hash>,
 }
 
 /// Chain `lane_tip_next` across blocks, starting from `parent_ref`.
@@ -68,11 +70,16 @@ fn compute_lane_tip(parent_ref: &Hash, lane_key: &Hash, blocks: &[BlockActivity]
 }
 
 /// Compute `seq_commit` from a lane tip: `smt_leaf → proof.compute_root
-/// → lanes_root → state_root → seq_commit`.
+/// → lanes_root → activity_root → state_root → seq_commit`.
 fn compute_seq_commit_for_lane(lane_key: &Hash, lane_tip: &Hash, witness: &CommitmentWitness) -> Hash {
     let leaf = smt_leaf_hash(&SmtLeafInput { lane_tip, blue_score: witness.blue_score });
     let lanes_root = witness.smt_proof.as_proof().compute_root::<SeqCommitActiveNode>(lane_key, Some(leaf)).unwrap();
-    let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
+    let activity_root = match witness.inactivity_shortcut {
+        Some(s) => activity_root_hash(&s, &lanes_root),
+        None => lanes_root,
+    };
+    let state_root =
+        seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
     seq_commit(&SeqCommitInput { parent_seq_commit: &witness.parent_seq_commit, state_root: &state_root })
 }
 
@@ -102,7 +109,9 @@ fn build_commitment(
     let payload_root = miner_payload_root(core::iter::once(pl));
     let lanes_root = smt.root();
     let pd = payload_and_context_digest(&ctx, &payload_root);
-    let sr = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+    // Post-hardening test fixture: wrap lanes_root into activity_root with ZERO_HASH shortcut.
+    let activity_root = activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
+    let sr = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let sc = seq_commit(&SeqCommitInput { parent_seq_commit, state_root: &sr });
     (sc, lanes_root, pd)
 }
@@ -203,6 +212,8 @@ fn build_chain(n: usize) -> (Hash, Hash, Hash, Vec<BlockActivity>, CommitmentWit
         parent_seq_commit: last_parent_sc,
         smt_proof: last_smt_proof.unwrap(),
         blue_score: last_blue_score,
+        // Mirrors `build_commitment`'s post-hardening wrap.
+        inactivity_shortcut: Some(kaspa_hashes::ZERO_HASH),
     };
 
     (last_sc, key_x, grandparent_commit, block_activities, witness)

--- a/consensus/smt-store/src/processor.rs
+++ b/consensus/smt-store/src/processor.rs
@@ -524,13 +524,21 @@ impl<'a> SmtProcessor<'a> {
                 lane_changes: self.lane_changes,
                 payload_and_ctx_digest: ZERO_HASH,
                 active_lanes_count: 0,
+                inactivity_shortcut_block: ZERO_HASH,
             });
         }
 
         let leaf_updates = self.lane_changes.to_leaf_updates();
         let reader = VersionedBranchReader { stores: self.stores, bounds: self.bounds, is_canonical };
         let (root, node_changes) = compute_root_update::<SeqCommitActiveNode, _>(&reader, self.current_lanes_root, leaf_updates)?;
-        Ok(SmtBuild { root, node_changes, lane_changes: self.lane_changes, payload_and_ctx_digest: ZERO_HASH, active_lanes_count: 0 })
+        Ok(SmtBuild {
+            root,
+            node_changes,
+            lane_changes: self.lane_changes,
+            payload_and_ctx_digest: ZERO_HASH,
+            active_lanes_count: 0,
+            inactivity_shortcut_block: ZERO_HASH,
+        })
     }
 }
 
@@ -539,9 +547,11 @@ pub struct SmtBuild {
     pub root: Hash,
     node_changes: SmtNodeChanges,
     lane_changes: BlockLaneChanges,
-    /// Set by `build_seq_commit` after computing the seq_commit components.
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
+    /// KIP-21: block hash whose seq_commit IS the `inactivity_shortcut`. Kept here
+    /// for the per-block parent-fallback path in `compute_inactivity_shortcut_block`.
+    pub inactivity_shortcut_block: Hash,
 }
 
 impl SmtBuild {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1153,13 +1153,23 @@ impl ConsensusApi for Consensus {
     fn import_pruning_point_smt(
         &self,
         new_pruning_point: Hash,
-        lanes_root: Hash,
-        payload_and_ctx_digest: Hash,
-        expected_lane_count: u64,
+        metadata: kaspa_consensus_core::api::SmtExportMetadata,
+        inactivity_shortcut_block: Option<Hash>,
         lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
+        use crate::model::stores::smt_metadata::{SmtBlockMetadata, ToccataV0};
         use kaspa_hashes::ZERO_HASH;
         use kaspa_smt_store::streaming_import::streaming_import;
+
+        let kaspa_consensus_core::api::SmtExportMetadata { lanes_root, payload_and_ctx_digest, active_lanes_count, .. } = metadata;
+        let expected_lane_count = active_lanes_count;
+
+        // `inactivity_shortcut_block` was already resolved by the caller during metadata
+        // verification: `Some` post-hardening, `None` pre-hardening. V1/V0 dispatch follows.
+        let row = match inactivity_shortcut_block {
+            Some(block) => SmtBlockMetadata::new(payload_and_ctx_digest, block, active_lanes_count),
+            None => SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest, active_lanes_count }),
+        };
 
         let result = self.virtual_processor.install(|| {
             streaming_import(
@@ -1187,12 +1197,9 @@ impl ConsensusApi for Consensus {
             )));
         }
 
+        // The wire's metadata was already authenticated by the caller via `verify_smt_metadata`.
         let mut batch = rocksdb::WriteBatch::default();
-        use crate::model::stores::smt_metadata::SmtBlockMetadata;
-        self.storage
-            .smt_metadata_store
-            .insert_batch(&mut batch, new_pruning_point, SmtBlockMetadata::new(payload_and_ctx_digest, actual_count))
-            .unwrap();
+        self.storage.smt_metadata_store.insert_batch(&mut batch, new_pruning_point, row).unwrap();
         self.db.write(batch).unwrap();
 
         info!("Imported SMT state for pruning point {}: {} lanes, root {}", new_pruning_point, actual_count, lanes_root);
@@ -1206,6 +1213,10 @@ impl ConsensusApi for Consensus {
         self.virtual_processor.get_pruning_point_smt_metadata(expected_pruning_point)
     }
 
+    fn inactivity_shortcut_block_for_pov(&self, pov_block: Hash) -> ConsensusResult<Hash> {
+        self.virtual_processor.inactivity_shortcut_block_for_pov(pov_block)
+    }
+
     fn open_pruning_point_smt_lane_stream(
         &self,
         expected_pruning_point: Hash,
@@ -1217,6 +1228,7 @@ impl ConsensusApi for Consensus {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
         let max_score = self.storage.headers_store.get_blue_score(pp).unwrap();
+        // KIP-21: IBD streams only the active-lanes window `[pp - finality_depth, pp]`.
         let min_score = max_score.saturating_sub(self.config.params.finality_depth());
 
         let smt_stores = self.storage.smt_stores.clone();

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -184,6 +184,7 @@ impl ConsensusServices {
             params.ghostdag_k(),
             params.skip_proof_of_work,
             params.toccata_activation,
+            params.zk_hardening_activation,
             params.net.is_mainnet(),
             is_consensus_exiting,
         ));

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -55,6 +55,8 @@ pub struct TestSeqCommitLaneProof {
     pub current_lane: Option<(Hash, u64)>,
     pub smt_proof: OwnedSmtProof,
     pub blue_score: u64,
+    /// Resolved shortcut Hash (None pre-hardening, Some(seq_commit-or-zero) post-hardening).
+    pub inactivity_shortcut: Option<Hash>,
 }
 
 impl TestConsensus {
@@ -219,6 +221,11 @@ impl TestConsensus {
         MutableBlock::from_header(self.build_header_with_parents(hash, parents))
     }
 
+    /// Read the stored SMT block metadata (KIP-21) for a block.
+    pub fn smt_block_metadata(&self, block_hash: Hash) -> crate::model::stores::smt_metadata::SmtBlockMetadata {
+        self.consensus.storage.smt_metadata_store.get(block_hash).unwrap()
+    }
+
     pub fn seq_commit_lane_proof(&self, block_hash: Hash, lane_key: Hash) -> TestSeqCommitLaneProof {
         let header = self.consensus.headers_store.get_header(block_hash).unwrap();
         let selected_parent = header.direct_parents()[0];
@@ -252,15 +259,24 @@ impl TestConsensus {
             .unwrap();
         let metadata = self.consensus.storage.smt_metadata_store.get(block_hash).unwrap();
 
+        let inactivity_shortcut = if self.params.zk_hardening_activation.is_active(header.daa_score) {
+            let shortcut_block =
+                metadata.inactivity_shortcut_block().expect("post-hardening row must carry inactivity_shortcut_block");
+            Some(self.consensus.virtual_processor.inactivity_shortcut(shortcut_block))
+        } else {
+            None
+        };
+
         TestSeqCommitLaneProof {
             lanes_root,
-            payload_and_ctx_digest: metadata.payload_and_ctx_digest,
+            payload_and_ctx_digest: metadata.payload_and_ctx_digest(),
             parent_seq_commit: parent_header.accepted_id_merkle_root,
             expected_seq_commit: header.accepted_id_merkle_root,
             parent_lane_tip,
             current_lane,
             smt_proof,
             blue_score: header.blue_score,
+            inactivity_shortcut,
         }
     }
 

--- a/consensus/src/model/stores/smt_metadata.rs
+++ b/consensus/src/model/stores/smt_metadata.rs
@@ -4,29 +4,114 @@ use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
 use std::sync::Arc;
 
-/// Per-block SMT metadata stored alongside the seq_commit.
-///
-/// `payload_and_ctx_digest` is `H_seq(context_hash, payload_root)` — the inner hash
-/// of `seq_state_root`. The `lanes_root` is stored in the branch version store
-/// at depth=0 and read via `SmtStores::get_lanes_root`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SmtBlockMetadata {
+/// Pre-anchor (Toccata) per-block SMT metadata. Wire: `[Hash || u64]` = 40 bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToccataV0 {
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
 }
 
+/// Post-anchor per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
+///
+/// Same first 40 bytes as `ToccataV0`; the trailing `inactivity_shortcut_block`
+/// is the only structural difference. `inactivity_shortcut_block` is retained
+/// per-row because `compute_inactivity_shortcut_block`'s parent-fallback path
+/// consults the parent's stored row; it does NOT feed `mergeset_context_hash`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToccataV1 {
+    pub payload_and_ctx_digest: Hash,
+    pub active_lanes_count: u64,
+    pub inactivity_shortcut_block: Hash,
+}
+
+/// Per-block SMT metadata, length-discriminated on the wire (40 vs 72 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SmtBlockMetadata {
+    ToccataV0(ToccataV0),
+    ToccataV1(ToccataV1),
+}
+
 impl SmtBlockMetadata {
-    pub fn new(payload_and_ctx_digest: Hash, active_lanes_count: u64) -> Self {
-        Self { payload_and_ctx_digest, active_lanes_count }
+    /// Construct a `ToccataV1` variant. The only variant new code ever writes.
+    pub fn new(payload_and_ctx_digest: Hash, inactivity_shortcut_block: Hash, active_lanes_count: u64) -> Self {
+        Self::ToccataV1(ToccataV1 { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block })
+    }
+
+    pub fn payload_and_ctx_digest(&self) -> Hash {
+        match self {
+            Self::ToccataV0(v) => v.payload_and_ctx_digest,
+            Self::ToccataV1(v) => v.payload_and_ctx_digest,
+        }
+    }
+
+    pub fn inactivity_shortcut_block(&self) -> Option<Hash> {
+        match self {
+            Self::ToccataV1(v) => Some(v.inactivity_shortcut_block),
+            Self::ToccataV0(_) => None,
+        }
+    }
+
+    pub fn active_lanes_count(&self) -> u64 {
+        match self {
+            Self::ToccataV1(v) => v.active_lanes_count,
+            Self::ToccataV0(v) => v.active_lanes_count,
+        }
     }
 }
 
 impl MemSizeEstimator for SmtBlockMetadata {}
 
-/// Block-hash-keyed metadata store with in-memory cache.
+impl Serialize for SmtBlockMetadata {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ToccataV0(v) => v.serialize(s),
+            Self::ToccataV1(v) => v.serialize(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SmtBlockMetadata {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = SmtBlockMetadata;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("SmtBlockMetadata: [Hash, u64] (ToccataV0) or [Hash, u64, Hash] (ToccataV1)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let first: Hash = seq.next_element()?.ok_or_else(|| A::Error::custom("missing first hash"))?;
+                let count: u64 = seq.next_element()?.ok_or_else(|| A::Error::custom("missing active_lanes_count"))?;
+                // Third element discriminates: a Hash present => V1; EOF on the
+                // third read => V0 (no trailing inactivity_shortcut_block). On a
+                // 40-byte V0 wire the buffer is empty before this read, so no
+                // bytes are partially consumed; the error path is safe.
+                match seq.next_element::<Hash>() {
+                    Ok(Some(inactivity_shortcut_block)) => Ok(SmtBlockMetadata::ToccataV1(ToccataV1 {
+                        payload_and_ctx_digest: first,
+                        active_lanes_count: count,
+                        inactivity_shortcut_block,
+                    })),
+                    Ok(None) | Err(_) => {
+                        Ok(SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: first, active_lanes_count: count }))
+                    }
+                }
+            }
+        }
+        d.deserialize_tuple(3, V)
+    }
+}
+
+/// Block-hash-keyed metadata store with in-memory cache. Key = `[prefix || hash]`.
 #[derive(Clone)]
 pub struct DbSmtMetadataStore {
     db: Arc<DB>,
@@ -56,5 +141,123 @@ impl DbSmtMetadataStore {
 
     pub fn delete_batch(&self, batch: &mut WriteBatch, block_hash: Hash) -> StoreResult<()> {
         self.access.delete(BatchDbWriter::new(batch), block_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_database::create_temp_db;
+    use kaspa_database::prelude::ConnBuilder;
+
+    fn row_key(hash: Hash) -> Vec<u8> {
+        let mut key = vec![DatabaseStorePrefixes::SmtSeqCommitMeta.into()];
+        key.extend_from_slice(hash.as_bytes().as_ref());
+        key
+    }
+
+    #[test]
+    fn round_trip_v1() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xDEAD_BEEF);
+        let meta = SmtBlockMetadata::new(Hash::from_bytes([1; 32]), Hash::from_bytes([2; 32]), 42);
+
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, meta).unwrap();
+        db.write(batch).unwrap();
+
+        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
+        assert_eq!(on_disk.len(), 72);
+        assert_eq!(store.get(hash).unwrap(), meta);
+    }
+
+    #[test]
+    fn round_trip_v0() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xABCD);
+        let meta =
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 });
+
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, meta).unwrap();
+        db.write(batch).unwrap();
+
+        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
+        assert_eq!(on_disk.len(), 40);
+        assert_eq!(store.get(hash).unwrap(), meta);
+    }
+
+    #[test]
+    fn decode_handcrafted_v0_wire() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xABCD);
+        let mut bytes = Vec::with_capacity(40);
+        bytes.extend_from_slice(&[0xAA; 32]);
+        bytes.extend_from_slice(&7u64.to_le_bytes());
+        db.put(row_key(hash), bytes).unwrap();
+
+        let decoded = store.get(hash).unwrap();
+        assert_eq!(
+            decoded,
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 })
+        );
+        assert_eq!(decoded.active_lanes_count(), 7);
+    }
+
+    #[test]
+    fn decode_handcrafted_v1_wire() {
+        let mut bytes = Vec::with_capacity(72);
+        bytes.extend_from_slice(&[0x11; 32]);
+        bytes.extend_from_slice(&42u64.to_le_bytes());
+        bytes.extend_from_slice(&[0x22; 32]);
+        let decoded: SmtBlockMetadata = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(
+            decoded,
+            SmtBlockMetadata::ToccataV1(ToccataV1 {
+                payload_and_ctx_digest: Hash::from_bytes([0x11; 32]),
+                active_lanes_count: 42,
+                inactivity_shortcut_block: Hash::from_bytes([0x22; 32]),
+            })
+        );
+    }
+
+    #[test]
+    fn payload_and_ctx_digest_accessor_works_for_both_variants() {
+        let v0 =
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 0 });
+        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 0);
+        assert_eq!(v0.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+        assert_eq!(v1.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+    }
+
+    #[test]
+    fn variant_wire_sizes() {
+        let v0 = SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0; 32]), active_lanes_count: 0 });
+        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
+        assert_eq!(bincode::serialize(&v0).unwrap().len(), 40);
+        assert_eq!(bincode::serialize(&v1).unwrap().len(), 72);
+    }
+
+    #[test]
+    fn delete_clears_row() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(1);
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, SmtBlockMetadata::new(Hash::from_bytes([1; 32]), Hash::from_bytes([2; 32]), 99)).unwrap();
+        db.write(batch).unwrap();
+
+        let mut batch = WriteBatch::default();
+        store.delete_batch(&mut batch, hash).unwrap();
+        db.write(batch).unwrap();
+
+        assert!(db.get_pinned(row_key(hash)).unwrap().is_none());
     }
 }

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -725,7 +725,7 @@ impl PruningProcessor {
         info!("Rebuilding pruning point SMT root after pruning data (sanity test)");
         let bounds = kaspa_smt_store::processor::SmtReadBounds::for_pov(pruning_point_blue_score, self.config.params.finality_depth());
         let expected_root = self.smt_stores.get_lanes_root(bounds, |bh| self.is_smt_canonical(bh, new_pruning_point));
-        let expected_count = self.smt_metadata_store.get(new_pruning_point).unwrap().active_lanes_count;
+        let expected_count = self.smt_metadata_store.get(new_pruning_point).unwrap().active_lanes_count();
         let (root, count) = self
             .smt_stores
             .recompute_lanes_root_from_leaf_stream(bounds, expected_count, |bh| self.is_smt_canonical(bh, new_pruning_point))

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -752,6 +752,10 @@ impl VirtualStateProcessor {
         if pp != expected_pruning_point {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
+        // Genesis has no SMT metadata row and no parent to index.
+        if pp == self.genesis.hash {
+            return Err(ConsensusError::GeneralOwned("cannot export SMT metadata: pruning point is genesis".to_string()));
+        }
 
         let meta = self
             .smt_metadata_store

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -177,6 +177,9 @@ pub struct VirtualStateProcessor {
     pub(crate) toccata_activation: ForkActivation,
     pub(crate) toccata_logger: ForkLogger,
 
+    // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
+    pub(crate) zk_hardening_activation: ForkActivation,
+
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
     pub(super) smt_metadata_store: Arc<crate::model::stores::smt_metadata::DbSmtMetadataStore>,
@@ -251,6 +254,7 @@ impl VirtualStateProcessor {
             counters,
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
+            zk_hardening_activation: params.zk_hardening_activation,
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -529,9 +533,10 @@ impl VirtualStateProcessor {
         if let Some(build) = smt_build {
             let pd = build.payload_and_ctx_digest;
             let alc = build.active_lanes_count;
+            let shortcut_block = build.inactivity_shortcut_block;
             build.flush(&self.smt_stores, &mut batch, blue_score, current).unwrap();
             use crate::model::stores::smt_metadata::SmtBlockMetadata;
-            self.smt_metadata_store.insert_batch(&mut batch, current, SmtBlockMetadata::new(pd, alc)).unwrap();
+            self.smt_metadata_store.insert_batch(&mut batch, current, SmtBlockMetadata::new(pd, shortcut_block, alc)).unwrap();
         }
         let write_guard = self.statuses_store.set_batch(&mut batch, current, StatusUTXOValid).unwrap();
         self.db.write(batch).unwrap();
@@ -589,7 +594,7 @@ impl VirtualStateProcessor {
         let accepted_id_digests = if self.toccata_activation.is_active(virtual_daa_window.daa_score) {
             let commit = self.compute_seq_commit(&ctx, &virtual_ghostdag_data, virtual_daa_window.daa_score);
             // Post-KIP21: single-element vec containing the seq_commit.
-            // The virtual's SmtBuild is ephemeral — only chain blocks persist SMT state.
+            // The virtual's SmtBuild is ephemeral - only chain blocks persist SMT state.
             vec![commit]
         } else {
             ctx.accepted_tx_ids.clone()
@@ -613,18 +618,18 @@ impl VirtualStateProcessor {
 
     /// KIP-21: Compute the sequencing commitment for the virtual block.
     fn compute_seq_commit(&self, ctx: &UtxoProcessingContext, virtual_ghostdag_data: &GhostdagData, daa_score: u64) -> Hash {
-        use kaspa_seq_commit::hashing::{mergeset_context_hash, seq_commit_timestamp};
+        use kaspa_seq_commit::hashing::mergeset_context_hash;
         use kaspa_seq_commit::types::MergesetContext;
 
         let selected_parent = ctx.selected_parent();
         let parent_header = self.headers_store.get_header(selected_parent).unwrap();
         let current_blue_score = virtual_ghostdag_data.blue_score;
 
-        let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(parent_header.timestamp),
-            daa_score,
-            blue_score: current_blue_score,
-        });
+        let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(virtual_ghostdag_data);
+        let context_hash =
+            mergeset_context_hash(&MergesetContext { timestamp: parent_header.timestamp, daa_score, blue_score: current_blue_score });
+        let inactivity_shortcut =
+            self.zk_hardening_activation.is_active(daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -636,18 +641,23 @@ impl VirtualStateProcessor {
             selected_parent,
             parent_seq_commit,
         );
-        let (parent_lanes_root, parent_active_lanes) = self.get_parent_smt_metadata(selected_parent, parent_header.blue_score);
+        let (parent_lanes_root, parent_active_lanes) = self.get_parent_lanes_root_and_count(selected_parent, parent_header.blue_score);
+        let parent_state = crate::pipeline::virtual_processor::utxo_validation::ParentBlockSeqState {
+            seq_commit: parent_seq_commit,
+            blue_score: parent_header.blue_score,
+            lanes_root: parent_lanes_root,
+            active_lanes_count: parent_active_lanes,
+        };
 
         let (commit, _build) = self.build_seq_commit(
-            parent_seq_commit,
+            &parent_state,
             context_hash,
             current_blue_score,
-            parent_header.blue_score,
-            parent_lanes_root,
-            parent_active_lanes,
             &lane_updates,
             data.miner_payload_leaves,
             selected_parent,
+            inactivity_shortcut_block,
+            inactivity_shortcut,
         );
         commit
     }
@@ -665,15 +675,15 @@ impl VirtualStateProcessor {
         use kaspa_consensus_core::BlueWorkType;
         use kaspa_hashes::SeqCommitActiveNode;
         use kaspa_seq_commit::hashing::{
-            activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, miner_payload_leaf,
-            miner_payload_root, payload_and_context_digest, seq_commit, seq_commit_timestamp, seq_state_root, smt_leaf_hash,
+            activity_digest_lane, activity_leaf, activity_root_hash, lane_key, lane_tip_next, mergeset_context_hash,
+            miner_payload_leaf, miner_payload_root, payload_and_context_digest, seq_commit, seq_state_root, smt_leaf_hash,
         };
         use kaspa_seq_commit::types::{LaneTipInput, MergesetContext, MinerPayloadLeafInput, SeqCommitInput, SeqState, SmtLeafInput};
         use kaspa_smt::SmtHasher;
 
         let blue_score = ghostdag_data.blue_score;
         let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(self.genesis.timestamp),
+            timestamp: self.genesis.timestamp,
             daa_score: self.genesis.daa_score,
             blue_score,
         });
@@ -692,7 +702,7 @@ impl VirtualStateProcessor {
         });
         let payload_root = miner_payload_root(std::iter::once(mpl));
 
-        // Build SMT over an in-memory store — new lanes anchor at ZERO_HASH.
+        // Build SMT over an in-memory store - new lanes anchor at ZERO_HASH.
         let parent_seq_commit = ZERO_HASH;
         let leaf_updates = kaspa_smt::store::SortedLeafUpdates::from_unsorted(lane_activities.iter().map(|(lane_id, leaves)| {
             let lk = lane_key(lane_id);
@@ -713,13 +723,24 @@ impl VirtualStateProcessor {
         )
         .unwrap();
 
+        // Pre-hardening: identity. Post-hardening (typically only simnet with activation=0):
+        // wrap with ZERO_HASH shortcut since no real shortcut block exists yet at genesis.
+        let activity_root = if self.zk_hardening_activation.is_active(self.genesis.daa_score) {
+            activity_root_hash(&ZERO_HASH, &lanes_root)
+        } else {
+            lanes_root
+        };
         let pd = payload_and_context_digest(&context_hash, &payload_root);
-        let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
         vec![commit]
     }
 
     /// Read stored SMT metadata for the pruning point.
+    ///
+    /// Both V0 and V1 rows carry `payload_and_ctx_digest` directly. The receiver
+    /// derives `inactivity_shortcut_block` from chain headers when needed, so the
+    /// wire shape is identical pre- and post-hardening.
     pub fn get_pruning_point_smt_metadata(
         &self,
         expected_pruning_point: Hash,
@@ -738,25 +759,26 @@ impl VirtualStateProcessor {
             .map_err(|_| ConsensusError::GeneralOwned(format!("SMT metadata not found for pruning point {pp}")))?;
 
         let pp_header = self.headers_store.get_header(pp).unwrap();
-        let parent_seq_commit = self.headers_store.get_header(pp_header.direct_parents()[0]).unwrap().accepted_id_merkle_root;
-
+        let parent = pp_header.direct_parents()[0];
+        let parent_header = self.headers_store.get_header(parent).unwrap();
+        let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let lanes_root = self
             .smt_stores
             .get_lanes_root(SmtReadBounds::for_pov(pp_header.blue_score, self.finality_depth), |bh| self.is_smt_canonical(bh, pp));
 
         Ok(SmtExportMetadata {
             lanes_root,
-            payload_and_ctx_digest: meta.payload_and_ctx_digest,
+            payload_and_ctx_digest: meta.payload_and_ctx_digest(),
             parent_seq_commit,
-            active_lanes_count: meta.active_lanes_count,
+            active_lanes_count: meta.active_lanes_count(),
         })
     }
 
     /// Check if `block_hash` is canonical for SMT lookups.
-    /// ZERO_HASH is treated as always canonical — it marks IBD-imported entries.
+    /// ZERO_HASH is treated as always canonical - it marks IBD-imported entries.
     ///
     /// After reachability pruning, blocks that were on the selected chain before
-    /// a reorg may have their reachability data deleted — their SMT lane entries
+    /// a reorg may have their reachability data deleted - their SMT lane entries
     /// remain but they are no longer canonical. `Err(KeyNotFound)` from
     /// `try_is_chain_ancestor_of` means the block's reachability was pruned,
     /// so it is definitively outside `future(retention_root)` and non-canonical.
@@ -764,10 +786,142 @@ impl VirtualStateProcessor {
         block_hash == ZERO_HASH || matches!(self.reachability_service.try_is_chain_ancestor_of(block_hash, selected_parent), Ok(true))
     }
 
-    /// Get the parent's lanes_root and active_lanes_count.
-    /// lanes_root comes from the branch version store; active_lanes_count from metadata.
-    pub(super) fn get_parent_smt_metadata(&self, selected_parent: Hash, parent_blue_score: u64) -> (Hash, u64) {
-        let active_lanes_count = self.smt_metadata_store.get(selected_parent).map(|meta| meta.active_lanes_count).unwrap_or(0);
+    /// KIP-21: block hash of the highest chain block at
+    /// `bs <= ghostdag_data.blue_score - finality_depth - 1`. The committed
+    /// `inactivity_shortcut` value is this block's seq_commit (see
+    /// [`Self::inactivity_shortcut`]).
+    ///
+    /// Never returns `ZERO_HASH`. Before a real shortcut block is reachable
+    /// (early chain, or within finality depth of hardening activation), a
+    /// pre-hardening stand-in is returned. Such stand-ins are valid for
+    /// context-hash recomputation but must not be exposed to provers or RPC
+    /// consumers as real shortcut targets.
+    pub(super) fn compute_inactivity_shortcut_block(&self, ghostdag_data: &GhostdagData) -> Hash {
+        let selected_parent = ghostdag_data.selected_parent;
+
+        if ghostdag_data.blue_score < self.finality_depth + 1 {
+            return self.genesis.hash;
+        }
+
+        let target_bs = ghostdag_data.blue_score - self.finality_depth - 1;
+
+        let coinbase_lk = kaspa_seq_commit::hashing::lane_key(&kaspa_consensus_core::subnets::SUBNETWORK_ID_COINBASE.into_bytes());
+        let bounds = SmtReadBounds::new(target_bs, 0);
+
+        match self.smt_stores.get_lane(coinbase_lk, bounds, |bh| self.is_smt_canonical(bh, selected_parent)).map(|l| l.block_hash()) {
+            // Live: the latest canonical coinbase touch already pins the highest
+            // chain block at `bs <= target_bs` since every chain block touches the
+            // coinbase lane. Return it directly.
+            Some(v) if v != ZERO_HASH => return v,
+            // Post-IBD boundary, "exact at pp": target_bs == pp.bs
+            Some(_zero) => {}
+            // Post-IBD boundary, "below pp": target_bs < pp.bs and no coinbase
+            // entry exists at that depth in our SMT. Fall through to seed the
+            // forward walk from the selected parent's recorded shortcut.
+            None => {}
+        };
+
+        // Reaching this point implies `target_bs <= pp.bs`. The coinbase lane is touched by every
+        // chain block, so for any `target_bs > pp.bs` we would have returned in the `Some(v) if
+        // v != ZERO_HASH` arm above. That gives us `current.bs <= pp.bs + finality_depth + 1`:
+        // we are in the narrow post-IBD window of at most `finality_depth + 1` blocks past pp.
+        //
+        // Inside that window, `selected_parent` is necessarily either pp itself or a post-IBD
+        // local descendant of pp, and both carry a V1 row with a real `inactivity_shortcut_block`:
+        //   - pp: inserted by `Consensus::import_pruning_point_smt` via `SmtBlockMetadata::new(...)`.
+        //   - local descendant: committed by `commit_virtual_state` via `SmtBlockMetadata::new(...)`.
+        // The other shapes are excluded:
+        //   - sp == genesis: excluded by the early-return clamp at the top of this function.
+        //   - sp pre-toccata: `compute_inactivity_shortcut_block` is only called from
+        //     `compute_seq_commit`/`recompute_seq_commit`, both gated on
+        //     `toccata_activation.is_active(current.daa_score)`. `sync_new_smt_state` is also a
+        //     no-op for pre-toccata pps (see `ibd/flow.rs`), so a pre-toccata sp cannot coexist
+        //     with the post-IBD-window precondition.
+        //   - sp's row being legacy ToccataV0 (pre-anchor tn10 data): the V0 row is a residue of
+        //     pre-anchor live processing, so it lives deep in the chain — but the post-IBD-window
+        //     precondition forces sp to be fresh (pp or its post-IBD descendant), which is always
+        //     written as V1 by this binary. Pre-anchor IBD did not exist (introduced by this PR),
+        //     so an upgrading tn10 node can only enter the narrow window via a post-upgrade IBD
+        //     whose pp is committed as V1, or by building locally past its existing chain (in
+        //     which case branch A above fires because the live coinbase lane is fully populated).
+        //
+        // The `.unwrap_or(selected_parent)` tail is therefore dead under correct operation. It is
+        // a defense-in-depth default: even if reached, the returned block hash only affects
+        // consensus when `zk_hardening_activation.is_active(current.daa_score)` (see
+        // `compute_seq_commit`'s gating of the `inactivity_shortcut` field), and the cases that
+        // would reach the tail (missing row, pre-anchor V0 row, pre-toccata sp) are all
+        // pre-hardening contexts where `inactivity_shortcut()` folds the result to `ZERO_HASH`
+        // regardless of which pre-hardening block is named.
+        let search_from = self
+            .smt_metadata_store
+            .get(selected_parent)
+            .optional()
+            .unwrap()
+            .and_then(|md| md.inactivity_shortcut_block())
+            .unwrap_or(selected_parent);
+
+        let mut current = search_from;
+        for chain_block in self.reachability_service.forward_chain_iterator(current, selected_parent, true).skip(1) {
+            if self.headers_store.get_blue_score(chain_block).unwrap() > target_bs {
+                break;
+            }
+            current = chain_block;
+        }
+        current
+    }
+
+    /// Derive the `inactivity_shortcut` value folded into `activity_root` from
+    /// its block hash. Folds to `ZERO_HASH` for pre-hardening blocks (whose
+    /// seq_commit does not encode a shortcut); genesis falls into this branch
+    /// naturally since its `accepted_id_merkle_root` is `ZERO_HASH`. Otherwise
+    /// returns the block's seq_commit.
+    ///
+    /// Panics on `ZERO_HASH` input — callers must pass a real block hash.
+    pub fn inactivity_shortcut(&self, inactivity_shortcut_block: Hash) -> Hash {
+        assert_ne!(inactivity_shortcut_block, ZERO_HASH, "inactivity_shortcut block must be a real block hash");
+        let header = self.headers_store.get_header(inactivity_shortcut_block).unwrap();
+        if !self.zk_hardening_activation.is_active(header.daa_score) {
+            return ZERO_HASH;
+        }
+        header.accepted_id_merkle_root
+    }
+
+    /// Resolve the `inactivity_shortcut_block` from the POV of an arbitrary chain
+    /// block, using only headers + reachability (no SMT). Used by the IBD receiver
+    /// at the PP boundary before the SMT is imported, and by `import_pruning_point_smt`
+    /// to populate the V1 metadata row.
+    ///
+    /// Algorithm: walks `pov_block`'s selected-chain ancestors backward by blue_score
+    /// until `bs <= pov.bs - finality_depth - 1`. Folds to genesis on shallow chains,
+    /// matching [`Self::compute_inactivity_shortcut_block`]'s shallow-chain rule.
+    pub fn inactivity_shortcut_block_for_pov(
+        &self,
+        pov_block: Hash,
+    ) -> kaspa_consensus_core::errors::consensus::ConsensusResult<Hash> {
+        use kaspa_consensus_core::errors::consensus::ConsensusError;
+
+        let pov_header = self
+            .headers_store
+            .get_header(pov_block)
+            .map_err(|_| ConsensusError::GeneralOwned(format!("header not found for {pov_block}")))?;
+
+        if pov_header.blue_score < self.finality_depth + 1 {
+            return Ok(self.genesis.hash);
+        }
+        let target_bs = pov_header.blue_score - self.finality_depth - 1;
+        Ok(self
+            .reachability_service
+            .default_backward_chain_iterator(pov_block)
+            .find(|&h| h == self.genesis.hash || self.headers_store.get_blue_score(h).unwrap() <= target_bs)
+            .unwrap_or(self.genesis.hash))
+    }
+
+    /// Get the parent's lanes_root, active_lanes_count.
+    /// lanes_root comes from the branch version store; the other two from metadata.
+    /// When the parent has no stored metadata (e.g. pre-toccata or origin predecessor),
+    /// returns `(empty_root, 0)`.
+    pub(super) fn get_parent_lanes_root_and_count(&self, selected_parent: Hash, parent_blue_score: u64) -> (Hash, u64) {
+        let active_lanes_count = self.smt_metadata_store.get(selected_parent).map(|meta| meta.active_lanes_count()).unwrap_or(0);
         let lanes_root = self.smt_stores.get_lanes_root(SmtReadBounds::for_pov(parent_blue_score, self.finality_depth), |bh| {
             self.is_smt_canonical(bh, selected_parent)
         });
@@ -1403,7 +1557,7 @@ impl VirtualStateProcessor {
         self.db.write(batch).unwrap();
         drop(selected_chain_write);
 
-        // Init virtual state — pre-compute accepted_id_digests here so
+        // Init virtual state - pre-compute accepted_id_digests here so
         // VirtualState::from_genesis stays a plain data constructor.
         let ghostdag_data = self.ghostdag_manager.ghostdag(&[self.genesis.hash]);
         let accepted_id_digests = self.compute_genesis_accepted_id_digests(&ghostdag_data);

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -805,10 +805,13 @@ impl VirtualStateProcessor {
 
         let target_bs = ghostdag_data.blue_score - self.finality_depth - 1;
 
-        let coinbase_lk = kaspa_seq_commit::hashing::lane_key(&kaspa_consensus_core::subnets::SUBNETWORK_ID_COINBASE.into_bytes());
         let bounds = SmtReadBounds::new(target_bs, 0);
 
-        match self.smt_stores.get_lane(coinbase_lk, bounds, |bh| self.is_smt_canonical(bh, selected_parent)).map(|l| l.block_hash()) {
+        match self
+            .smt_stores
+            .get_lane(kaspa_seq_commit::hashing::COINBASE_LANE_KEY, bounds, |bh| self.is_smt_canonical(bh, selected_parent))
+            .map(|l| l.block_hash())
+        {
             // Live: the latest canonical coinbase touch already pins the highest
             // chain block at `bs <= target_bs` since every chain block touches the
             // coinbase lane. Return it directly.

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -342,3 +342,83 @@ fn new_miner_data() -> MinerData {
     let script = ScriptVec::from_slice(&pk.serialize());
     MinerData::new(ScriptPublicKey::new(0, script), vec![])
 }
+
+fn inactivity_shortcut_config() -> kaspa_consensus_core::config::Config {
+    ConfigBuilder::new(MAINNET_PARAMS)
+        .skip_proof_of_work()
+        .edit_consensus_params(|p| {
+            p.finality_depth = 2;
+            p.toccata_activation = ForkActivation::always();
+        })
+        .build()
+}
+
+/// Blocks with `bs <= finality_depth` have no resolvable shortcut yet;
+/// the recorded `inactivity_shortcut_block` clamps to genesis, which folds
+/// to `ZERO_HASH` via `inactivity_shortcut()` and seeds forward walks
+/// correctly once descendants cross `bs = finality_depth + 1`.
+#[tokio::test]
+async fn inactivity_shortcut_block_clamps_to_genesis_within_finality_depth() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+    let finality_depth = config.finality_depth();
+    assert_eq!(finality_depth, 2);
+
+    let mut chain = vec![config.genesis.hash];
+    for _ in 0..2 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    for hash in chain.iter().copied().skip(1) {
+        let header = ctx.consensus.get_header(hash).unwrap();
+        assert!(header.blue_score <= finality_depth);
+        let meta = ctx.consensus.smt_block_metadata(hash);
+        assert_eq!(meta.inactivity_shortcut_block(), Some(config.genesis.hash), "bs={}", header.blue_score);
+    }
+}
+
+/// Tip at `bs = finality_depth + 4` records the chain block at
+/// `bs = target_bs = tip_bs - finality_depth - 1` as its
+/// inactivity_shortcut block hash.
+#[tokio::test]
+async fn inactivity_shortcut_resolves_to_chain_block_at_target_bs() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+    let finality_depth = config.finality_depth();
+
+    let mut chain = Vec::new();
+    for _ in 0..6 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    let tip = *chain.last().unwrap();
+    let tip_header = ctx.consensus.get_header(tip).unwrap();
+    assert_eq!(tip_header.blue_score, 6);
+    let target_bs = tip_header.blue_score - finality_depth - 1; // = 3
+
+    let expected_block = *chain.iter().find(|h| ctx.consensus.get_header(**h).unwrap().blue_score == target_bs).unwrap();
+    let recorded = ctx.consensus.smt_block_metadata(tip).inactivity_shortcut_block();
+    assert_eq!(recorded, Some(expected_block));
+}
+
+/// Consecutive chain blocks: the inactivity_shortcut advances by one chain
+/// block per parent-to-child step, since `target_bs` grows in lockstep with
+/// `blue_score` on a no-merge chain.
+#[tokio::test]
+async fn inactivity_shortcut_advances_one_block_per_chain_step() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+
+    let mut chain = vec![config.genesis.hash];
+    for _ in 0..6 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    for (i, hash) in chain.iter().copied().enumerate().skip(4) {
+        let expected = chain[i - 3];
+        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), Some(expected), "block index {i}");
+    }
+}

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -63,6 +63,15 @@ pub(super) struct ResolvedLaneUpdate {
     pub is_new: bool,
 }
 
+/// Selected-parent state the current block inherits when building its seq_commit.
+pub(super) struct ParentBlockSeqState {
+    /// `accepted_id_merkle_root` of the selected parent.
+    pub seq_commit: Hash,
+    pub blue_score: u64,
+    pub lanes_root: Hash,
+    pub active_lanes_count: u64,
+}
+
 /// A context for processing the UTXO state of a block with respect to its selected parent.
 /// Note this can also be the virtual block.
 pub(super) struct UtxoProcessingContext<'a> {
@@ -561,29 +570,30 @@ impl VirtualStateProcessor {
 
     /// Build the SMT from lane updates + expirations, compute the final seq_commit hash.
     ///
-    /// `parent_lanes_root` is the SMT root inherited from the selected parent block.
     /// Works with an immutable view of DB state. Returns the commit hash and an `SmtBuild`
     /// containing the diff (updated branches, lane versions, score index) for later persistence.
+    ///
+    /// `inactivity_shortcut`: `Some(hash)` post-hardening (wraps `lanes_root` into
+    /// `activity_root` via `H_activity_root`); `None` pre-hardening (identity).
     pub(super) fn build_seq_commit(
         &self,
-        parent_seq_commit: Hash,
+        parent: &ParentBlockSeqState,
         context_hash: Hash,
         current_blue_score: u64,
-        parent_blue_score: u64,
-        parent_lanes_root: Hash,
-        parent_active_lanes: u64,
         lane_updates: &[ResolvedLaneUpdate],
         miner_payload_leaves: Vec<Hash>,
         selected_parent: Hash,
+        inactivity_shortcut_block: Hash,
+        inactivity_shortcut: Option<Hash>,
     ) -> (Hash, kaspa_smt_store::processor::SmtBuild) {
-        use kaspa_seq_commit::hashing::{miner_payload_root, seq_commit, seq_state_root};
+        use kaspa_seq_commit::hashing::{activity_root_hash, miner_payload_root, seq_commit, seq_state_root};
         use kaspa_seq_commit::types::{SeqCommitInput, SeqState};
         use kaspa_smt_store::processor::SmtProcessor;
 
-        let bounds = SeqCommitBounds::new(parent_blue_score, current_blue_score, self.finality_depth);
+        let bounds = SeqCommitBounds::new(parent.blue_score, current_blue_score, self.finality_depth);
         // 1. Create processor starting from the parent's lanes root
         let mut proc =
-            SmtProcessor::new(&self.smt_stores, current_blue_score, bounds.selected_parent_read_bounds(), parent_lanes_root);
+            SmtProcessor::new(&self.smt_stores, current_blue_score, bounds.selected_parent_read_bounds(), parent.lanes_root);
 
         // 2. Expire stale lanes (scans [parent-F, current-F) for lanes with no newer version)
         let expired_count = self.expire_stale_lanes(&mut proc, bounds, selected_parent);
@@ -591,8 +601,8 @@ impl VirtualStateProcessor {
         // 3. Apply lane updates.
         // A lane at the boundary (bs = current-F-1) gets both expired (step 2) and re-added
         // here as is_new=true. This is not wasteful: BlockLaneChanges uses a BTreeMap keyed
-        // by lane_key, so update_lane overwrites the expire_lane entry — the walk sees only
-        // the final leaf. The two count operations cancel: expired+1, new+1 → net zero.
+        // by lane_key, so update_lane overwrites the expire_lane entry: the walk sees only
+        // the final leaf. The two count operations cancel: expired+1, new+1 net zero.
         let mut new_lane_count = 0;
         for lu in lane_updates {
             if lu.is_new {
@@ -601,18 +611,24 @@ impl VirtualStateProcessor {
             proc.update_lane(lu.lane_key, lu.new_tip);
         }
 
-        // 4. Build SMT (skips entirely when no pending leaves — no expirations, no touches)
+        // 4. Build SMT (skips entirely when no pending leaves: no expirations, no touches)
         let mut build = proc.build(|bh| self.is_smt_canonical(bh, selected_parent)).unwrap();
 
-        // 5. Compute final hash: payload_and_ctx_digest → state_root → seq_commit
+        // 5. Compute final hash: activity_root -> state_root -> seq_commit.
+        // Pre-hardening: identity (activity_root = lanes_root). Post-hardening: wrap.
         let payload_root = miner_payload_root(miner_payload_leaves.into_iter());
         let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&context_hash, &payload_root);
-        let state_root = seq_state_root(&SeqState { lanes_root: &build.root, payload_and_ctx_digest: &pd });
-        let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
+        let activity_root = match inactivity_shortcut {
+            Some(s) => activity_root_hash(&s, &build.root),
+            None => build.root,
+        };
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
+        let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent.seq_commit, state_root: &state_root });
 
         // 6. Store metadata on the build for persistence
         build.payload_and_ctx_digest = pd;
-        build.active_lanes_count = parent_active_lanes + new_lane_count - expired_count;
+        build.active_lanes_count = parent.active_lanes_count + new_lane_count - expired_count;
+        build.inactivity_shortcut_block = inactivity_shortcut_block;
 
         (commit, build)
     }
@@ -625,18 +641,21 @@ impl VirtualStateProcessor {
         ctx: &UtxoProcessingContext,
         header: &Header,
     ) -> BlockProcessResult<(Hash, kaspa_smt_store::processor::SmtBuild)> {
-        use kaspa_seq_commit::hashing::{mergeset_context_hash, seq_commit_timestamp};
+        use kaspa_seq_commit::hashing::mergeset_context_hash;
         use kaspa_seq_commit::types::MergesetContext;
 
         let selected_parent = ctx.selected_parent();
         let parent_header = self.headers_store.get_header(selected_parent).unwrap();
         let current_blue_score = ctx.ghostdag_data.blue_score;
 
+        let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(&ctx.ghostdag_data);
         let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(parent_header.timestamp),
+            timestamp: parent_header.timestamp,
             daa_score: header.daa_score,
             blue_score: current_blue_score,
         });
+        let inactivity_shortcut =
+            self.zk_hardening_activation.is_active(header.daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -648,18 +667,23 @@ impl VirtualStateProcessor {
             selected_parent,
             parent_seq_commit,
         );
-        let (parent_lanes_root, parent_active_lanes) = self.get_parent_smt_metadata(selected_parent, parent_header.blue_score);
+        let (parent_lanes_root, parent_active_lanes) = self.get_parent_lanes_root_and_count(selected_parent, parent_header.blue_score);
+        let parent_state = ParentBlockSeqState {
+            seq_commit: parent_seq_commit,
+            blue_score: parent_header.blue_score,
+            lanes_root: parent_lanes_root,
+            active_lanes_count: parent_active_lanes,
+        };
 
         let (hash, build) = self.build_seq_commit(
-            parent_seq_commit,
+            &parent_state,
             context_hash,
             current_blue_score,
-            parent_header.blue_score,
-            parent_lanes_root,
-            parent_active_lanes,
             &lane_updates,
             data.miner_payload_leaves,
             selected_parent,
+            inactivity_shortcut_block,
+            inactivity_shortcut,
         );
 
         Ok((hash, build))

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -303,12 +303,18 @@ impl PruningProofManager {
             // Pruning point txs are validated with the pruning point selected parent as seqcommit context.
             // Conceptually, this is the context from which the threshold should be measured on all networks.
             //
-            // On non-mainnet networks, relax this and measure against the pruning point blue score, since
-            // deployed peers may already provide chain segments using the pruning point as context.
+            // We must use pp.sp.bs whenever pp is post zk_hardening: the `inactivity_shortcut` anchor lives
+            // at `bs <= pp.bs - F - 1`. With pp.sp.bs as context, the threshold predicate continues down to
+            // `pp.bs - F - 1` and covers the anchor; with pp.bs as context it stops one block higher and
+            // misses it. Post-hardening syncers always send the segment from pp.sp, so this is safe.
             //
-            // Mainnet has no release prior to this fix, so measure against the correct context: the selected
-            // parent's blue score.
-            let context_blue_score = if self.is_mainnet {
+            // Pre zk_hardening on non-mainnet stays on pp.bs to keep compatibility with already-deployed
+            // peers that emit segments using pp.bs. Mainnet had no pre-fix release.
+            //
+            // TODO(post-zk-hardening): once all networks are past the hardening activation, use pp.sp.bs
+            // unconditionally and drop the is_mainnet/zk_hardening_activation branching.
+            let use_sp_context = self.is_mainnet || self.zk_hardening_activation.is_active(pruning_point_header.daa_score);
+            let context_blue_score = if use_sp_context {
                 let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
                 trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score
             } else {
@@ -321,14 +327,11 @@ impl PruningProofManager {
                 let current_header =
                     trusted_header_map.get(&current).ok_or(PruningImportError::MissingPruningPointChainSegment(current))?;
 
-                // This cutoff also covers the inactivity-shortcut anchor (mainnet path).
-                // Chain qualification gives pp.bs >= pp.sp.bs + 1, so a block failing the check
-                // satisfies `current.bs + F <= pp.sp.bs <= pp.bs - 1`, i.e. `current.bs <= pp.bs - F - 1`.
-                // pp.inactivity_shortcut is by definition the highest chain block with
-                // `bs <= pp.bs - F - 1` (see `compute_inactivity_shortcut_block`), so its bs is at
-                // least the break block's bs and it is reached by the iteration before (or at)
-                // the break. The non-mainnet branch uses pp.bs as context, which is strictly more
-                // permissive, so the shortcut remains covered.
+                // pp.sp.bs context: a block failing the check satisfies `current.bs + F <= pp.sp.bs`,
+                // and chain qualification gives pp.sp.bs = pp.bs - 1, so `current.bs <= pp.bs - F - 1`.
+                // `pp.inactivity_shortcut` is defined as the highest chain block with that property
+                // (see `compute_inactivity_shortcut_block`), so its bs is at least the break block's bs
+                // and is reached by the iteration before (or at) the break.
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -321,6 +321,14 @@ impl PruningProofManager {
                 let current_header =
                     trusted_header_map.get(&current).ok_or(PruningImportError::MissingPruningPointChainSegment(current))?;
 
+                // This cutoff also covers the inactivity-shortcut anchor (mainnet path).
+                // Chain qualification gives pp.bs >= pp.sp.bs + 1, so a block failing the check
+                // satisfies `current.bs + F <= pp.sp.bs <= pp.bs - 1`, i.e. `current.bs <= pp.bs - F - 1`.
+                // pp.inactivity_shortcut is by definition the highest chain block with
+                // `bs <= pp.bs - F - 1` (see `compute_inactivity_shortcut_block`), so its bs is at
+                // least the break block's bs and it is reached by the iteration before (or at)
+                // the break. The non-mainnet branch uses pp.bs as context, which is strictly more
+                // permissive, so the shortcut remains covered.
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -361,6 +361,13 @@ impl PruningProofManager {
                 }
 
                 let current_header = self.headers_store.get_compact_header_data(current).unwrap();
+                // This cutoff also covers the inactivity-shortcut anchor.
+                // Chain qualification gives pp.bs >= pp.sp.bs + 1, so a block failing the check
+                // satisfies `current.bs + F <= pp.sp.bs <= pp.bs - 1`, i.e. `current.bs <= pp.bs - F - 1`.
+                // pp.inactivity_shortcut is by definition the highest chain block with
+                // `bs <= pp.bs - F - 1` (see `compute_inactivity_shortcut_block`), so its bs is at
+                // least the break block's bs. The iteration walks the chain in decreasing bs and
+                // pushes before checking, so pp.inactivity_shortcut is always included in the segment.
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -120,6 +120,7 @@ pub struct PruningProofManager {
     ghostdag_k: KType,
     skip_proof_of_work: bool,
     toccata_activation: ForkActivation,
+    zk_hardening_activation: ForkActivation,
     is_mainnet: bool,
 
     is_consensus_exiting: Arc<AtomicBool>,
@@ -143,6 +144,7 @@ impl PruningProofManager {
         ghostdag_k: KType,
         skip_proof_of_work: bool,
         toccata_activation: ForkActivation,
+        zk_hardening_activation: ForkActivation,
         is_mainnet: bool,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
@@ -180,6 +182,7 @@ impl PruningProofManager {
             ghostdag_k,
             skip_proof_of_work,
             toccata_activation,
+            zk_hardening_activation,
             is_mainnet,
 
             is_consensus_exiting,

--- a/crypto/hashes/src/hashers.rs
+++ b/crypto/hashes/src/hashers.rs
@@ -46,6 +46,7 @@ blake3_hasher! {
     struct SeqCommitActivityLeaf => b"SeqCommitActivityLeaf",
     struct SeqCommitMergesetContext => b"SeqCommitMergesetContext",
     struct SeqCommitMinerPayloadLeaf => b"SeqCommitMinerPayloadLeaf",
+    struct SeqCommitActivityRoot => b"SeqCommitActivityRoot",
 
     struct SeqCommitActiveLeaf => b"SeqCommitActiveLeaf",
     struct SeqCommitActiveNode => b"SeqCommitActiveNode",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -16,7 +16,7 @@ faster-hex.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 kaspa-hashes.workspace = true
-kaspa-utils = { workspace = true, features = ["mem_size"]}
+kaspa-utils = { workspace = true, features = ["mem_size", "fd_budget"]}
 num_cpus.workspace = true
 num-traits.workspace = true
 parking_lot.workspace = true

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -760,8 +760,8 @@ impl ConnectionInitializer for FlowContext {
 
         let local_address = self.address_manager.lock().best_local_address();
 
-        // Networks with a scheduled Toccata activation advertise protocol 10. Other networks
-        // still support v10 locally, but advertise v9 so future Toccata-activated peers reject them.
+        // Networks with a scheduled Toccata activation advertise the current protocol version.
+        // Other networks still support v10 locally, but advertise v9 so future Toccata-activated peers reject them.
         let advertise_toccata_p2p = self.config.toccata_activation != ForkActivation::never();
         let advertised_protocol_version = if advertise_toccata_p2p { PROTOCOL_VERSION } else { 9 };
 

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -706,32 +706,57 @@ impl IbdFlow {
 
         let mut stream = SmtStream::new(&self.router, &mut self.incoming_route);
 
-        // Phase 0: receive and verify metadata
+        // Phase 0: receive and verify metadata. Single 96-byte wire.
         let md = stream.recv_metadata().await?;
         let parent_header = consensus.async_get_header(pp_header.direct_parents()[0]).await.unwrap();
+        let pp_is_post_hardening = self.ctx.config.zk_hardening_activation.is_active(pp_header.daa_score);
+
+        // Post-hardening: derive the shortcut block via consensus (uses reachability + headers
+        // only; safe at the PP boundary before the SMT is imported). Then resolve to the
+        // seq_commit hash with the same fold-to-zero rule used by `inactivity_shortcut(block)`.
+        // The block hash is also passed to `import_pruning_point_smt` for the V1 metadata row.
+        let (shortcut_block, inactivity_shortcut) = if pp_is_post_hardening {
+            let block = consensus
+                .async_inactivity_shortcut_block_for_pov(pruning_point)
+                .await
+                .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
+            let shortcut = if block == self.ctx.config.genesis.hash {
+                kaspa_hashes::ZERO_HASH
+            } else {
+                let shortcut_header = consensus
+                    .async_get_header(block)
+                    .await
+                    .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
+                if !self.ctx.config.zk_hardening_activation.is_active(shortcut_header.daa_score) {
+                    kaspa_hashes::ZERO_HASH
+                } else {
+                    shortcut_header.accepted_id_merkle_root
+                }
+            };
+            (Some(block), Some(shortcut))
+        } else {
+            (None, None)
+        };
+
         verify_smt_metadata(
             &SmtMetadata {
                 lanes_root: &md.lanes_root,
                 payload_and_ctx_digest: &md.payload_and_ctx_digest,
                 parent_seq_commit: &md.parent_seq_commit,
             },
+            inactivity_shortcut,
             pp_header.accepted_id_merkle_root,
             parent_header.accepted_id_merkle_root,
         )
         .map_err(|e| ProtocolError::OtherOwned(format!("SMT metadata verification failed: {e}")))?;
-
-        let lanes_root = md.lanes_root;
-        let payload_and_ctx_digest = md.payload_and_ctx_digest;
-        let expected_count = md.active_lanes_count;
 
         // Small queue of already-chunked batches: one in flight + one being processed
         // by the importer is enough headroom; each chunk holds up to SMT_CHUNK_SIZE lanes.
         let (tx, rx) = tokio::sync::mpsc::channel::<Vec<kaspa_consensus_core::api::ImportLane>>(2);
 
         let consensus_for_import = consensus.clone();
-        let builder_handle = tokio::task::spawn_blocking(move || {
-            consensus_for_import.import_pruning_point_smt(pruning_point, lanes_root, payload_and_ctx_digest, expected_count, rx)
-        });
+        let builder_handle =
+            tokio::task::spawn_blocking(move || consensus_for_import.import_pruning_point_smt(pruning_point, md, shortcut_block, rx));
 
         while let Some(chunk) = stream.next_chunk().await? {
             tx.send(chunk).await.map_err(|_| ProtocolError::Other("streaming SMT builder stopped unexpectedly"))?;

--- a/protocol/flows/src/ibd/streams.rs
+++ b/protocol/flows/src/ibd/streams.rs
@@ -239,22 +239,27 @@ impl<'a, 'b> SmtStream<'a, 'b> {
         match timeout(DEFAULT_TIMEOUT, self.incoming_route.recv()).await {
             Ok(Some(msg)) => match msg.payload {
                 Some(Payload::SmtMetadata(payload)) => {
+                    use kaspa_consensus_core::api::SmtExportMetadata;
+                    // Wire: 96 bytes = lanes_root || payload_and_ctx_digest || parent_seq_commit.
                     let (chunks, rem) = payload.data.as_chunks::<32>();
-                    let &[lanes_root, payload_and_ctx_digest, parent_seq_commit] = chunks else {
-                        return Err(ProtocolError::Other("SmtMetadata data must be exactly 96 bytes"));
-                    };
                     if !rem.is_empty() {
-                        return Err(ProtocolError::Other("SmtMetadata data must be exactly 96 bytes"));
+                        return Err(ProtocolError::Other("SmtMetadata data length not a multiple of 32 bytes"));
                     }
-                    let [lanes_root, payload_and_ctx_digest, parent_seq_commit] =
-                        [lanes_root, payload_and_ctx_digest, parent_seq_commit].map(Hash::from_bytes);
                     self.expected_count = payload.active_lanes_count;
-                    Ok(kaspa_consensus_core::api::SmtExportMetadata {
-                        lanes_root,
-                        payload_and_ctx_digest,
-                        parent_seq_commit,
-                        active_lanes_count: payload.active_lanes_count,
-                    })
+                    let md = match *chunks {
+                        [lanes_root, payload_and_ctx_digest, parent_seq_commit] => {
+                            let [lanes_root, payload_and_ctx_digest, parent_seq_commit] =
+                                [lanes_root, payload_and_ctx_digest, parent_seq_commit].map(Hash::from_bytes);
+                            SmtExportMetadata {
+                                lanes_root,
+                                payload_and_ctx_digest,
+                                parent_seq_commit,
+                                active_lanes_count: payload.active_lanes_count,
+                            }
+                        }
+                        _ => return Err(ProtocolError::Other("SmtMetadata data must be 96 bytes")),
+                    };
+                    Ok(md)
                 }
                 Some(Payload::UnexpectedPruningPoint(_)) => Err(ProtocolError::ConsensusError(ConsensusError::UnexpectedPruningPoint)),
                 _ => Err(ProtocolError::UnexpectedMessage(stringify!(Payload::SmtMetadata), msg.payload.as_ref().map(|v| v.into()))),

--- a/protocol/flows/src/v10/request_pruning_point_smt_state.rs
+++ b/protocol/flows/src/v10/request_pruning_point_smt_state.rs
@@ -3,7 +3,10 @@ use crate::{
     flow_trait::Flow,
     ibd::{SMT_CHUNK_SIZE, SMT_FLOW_CONTROL_WINDOW},
 };
-use kaspa_consensus_core::{api::ImportLane, errors::consensus::ConsensusError};
+use kaspa_consensus_core::{
+    api::{ImportLane, SmtExportMetadata},
+    errors::consensus::ConsensusError,
+};
 use kaspa_core::{debug, info};
 use kaspa_hashes::Hash;
 use kaspa_p2p_lib::{
@@ -56,10 +59,12 @@ impl RequestPruningPointSmtStateFlow {
 
         let expected_count = metadata.active_lanes_count;
 
+        // Wire: 96 bytes = lanes_root || payload_and_ctx_digest || parent_seq_commit.
+        let SmtExportMetadata { lanes_root, payload_and_ctx_digest, parent_seq_commit, .. } = metadata;
         let mut md_bytes = Vec::with_capacity(96);
-        md_bytes.extend_from_slice(&metadata.lanes_root.as_bytes());
-        md_bytes.extend_from_slice(&metadata.payload_and_ctx_digest.as_bytes());
-        md_bytes.extend_from_slice(&metadata.parent_seq_commit.as_bytes());
+        md_bytes.extend_from_slice(&lanes_root.as_bytes());
+        md_bytes.extend_from_slice(&payload_and_ctx_digest.as_bytes());
+        md_bytes.extend_from_slice(&parent_seq_commit.as_bytes());
         self.router
             .enqueue(make_message!(Payload::SmtMetadata, SmtMetadataMessage { data: md_bytes, active_lanes_count: expected_count }))
             .await?;
@@ -85,8 +90,7 @@ impl RequestPruningPointSmtStateFlow {
                 if batch.len() == SMT_CHUNK_SIZE {
                     count += batch.len() as u64;
                     if tx.blocking_send(std::mem::take(&mut batch)).is_err() {
-                        // Receiver went away — let the async side surface the error.
-                        return Ok(count);
+                        return Err(ConsensusError::General("receiver went away"));
                     }
                     batch.reserve(SMT_CHUNK_SIZE);
                 }

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -400,6 +400,7 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         params.pruning_depth = 100 * 2 * 2 + 50;
 
         params.toccata_activation = ForkActivation::new(1000);
+        params.zk_hardening_activation = ForkActivation::new(2000);
 
         info!("Setting pruning depth to {:?}", params.pruning_depth());
     }

--- a/simpa/tests/smt_repro.rs
+++ b/simpa/tests/smt_repro.rs
@@ -47,25 +47,44 @@ static REPRO_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_2() {
-    assert_pruning_point_smt_roundtrip(2);
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::always());
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_4() {
-    assert_pruning_point_smt_roundtrip(4);
+    assert_pruning_point_smt_roundtrip(4, ForkActivation::always(), ForkActivation::always());
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_5() {
-    assert_pruning_point_smt_roundtrip(5);
+    assert_pruning_point_smt_roundtrip(5, ForkActivation::always(), ForkActivation::always());
 }
 
-fn assert_pruning_point_smt_roundtrip(seed: u64) {
+/// Hardening activates mid-chain (DAA 400): chain crosses the hardening boundary
+/// while toccata stays always-active. Toccata cannot be gated here because the
+/// simulator's ChurningLaneProducer relies on toccata-era subnetwork txs from
+/// block 1; pre-toccata they would be rejected and panic OnetimeTxSelector.
+/// Pre-toccata crossing is covered by daemon_zk_hardening_activation_test.
+#[test]
+fn pruning_point_smt_export_import_repro_seed_2_hardening_mid_chain() {
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(400));
+}
+
+/// Hardening at DAA 1: chain is post-hardening from block 1 onward.
+/// Sanity-checks the "hardening fires almost immediately" boundary case.
+#[test]
+fn pruning_point_smt_export_import_repro_seed_2_hardening_at_1() {
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(1));
+}
+
+fn assert_pruning_point_smt_roundtrip(seed: u64, toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) {
     let _guard = REPRO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     kaspa_core::log::try_init_logger("warn");
 
     let mut params = DEVNET_PARAMS;
     apply_pruning_repro_params(&mut params);
+    params.toccata_activation = toccata_activation;
+    params.zk_hardening_activation = zk_hardening_activation;
     let config = Arc::new(
         ConfigBuilder::new(params)
             .apply_args(|config| apply_perf_params(&mut config.perf))
@@ -87,6 +106,7 @@ fn assert_pruning_point_smt_roundtrip(seed: u64) {
 
     let pp = consensus.pruning_point();
     let pp_blue_score = consensus.get_header(pp).unwrap().blue_score;
+    // KIP-21: pruning cutoff uses finality_depth.
     let smt_cutoff = pp_blue_score.saturating_sub(FINALITY_DEPTH).saturating_sub(1);
     let metadata = consensus.get_pruning_point_smt_metadata(pp).unwrap();
     let (imported_root, imported_lanes) =
@@ -166,7 +186,8 @@ fn apply_pruning_repro_params(params: &mut Params) {
     params.mergeset_size_limit = 32 * 2;
     params.pruning_depth = PRUNING_DEPTH;
 
-    params.toccata_activation = ForkActivation::always();
+    // toccata + hardening activations are set by the caller.
+    // (see assert_pruning_point_smt_roundtrip).
     params.storage_mass_parameter = 10_000;
 }
 

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -48,9 +48,7 @@ use kaspa_core::time::unix_now;
 use kaspa_database::utils::get_kaspa_tempdir;
 use kaspa_hashes::{Hash, SeqCommitActiveNode};
 use kaspa_rpc_core::RpcHeader;
-use kaspa_seq_commit::hashing::{
-    activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, seq_commit_timestamp, smt_leaf_hash,
-};
+use kaspa_seq_commit::hashing::{activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, smt_leaf_hash};
 use kaspa_seq_commit::types::{LaneTipInput, MergesetContext, SmtLeafInput};
 use kaspa_seq_commit::verify::{SmtMetadata, verify_smt_metadata};
 use kaspa_txscript::{MAX_SCRIPT_ELEMENT_SIZE_POST_TOCCATA, pay_to_script_hash_script};
@@ -1481,7 +1479,7 @@ fn chain_seq_commit_context_hash(consensus: &TestConsensus, accepting_block: Has
     let header = consensus.get_header(accepting_block).unwrap();
     let parent_header = consensus.get_header(header.direct_parents()[0]).unwrap();
     mergeset_context_hash(&MergesetContext {
-        timestamp: seq_commit_timestamp(parent_header.timestamp),
+        timestamp: parent_header.timestamp,
         daa_score: header.daa_score,
         blue_score: header.blue_score,
     })
@@ -1495,6 +1493,7 @@ fn assert_chain_seq_commit_lane(consensus: &TestConsensus, accepting_block: Hash
             payload_and_ctx_digest: &proof.payload_and_ctx_digest,
             parent_seq_commit: &proof.parent_seq_commit,
         },
+        proof.inactivity_shortcut,
         proof.expected_seq_commit,
         proof.parent_seq_commit,
     )
@@ -1589,6 +1588,8 @@ async fn seqcommit_sp_context_threshold_edge_test() {
             p.genesis.hash = genesis_header.hash;
 
             // Keep the threshold minimal so the selected-parent edge is reached by the next block.
+            // KIP-21: the seqcommit look-back equals `finality_depth`; set it to 1 so a
+            // single follow-up block is still within the threshold during template validation.
             p.finality_depth = 1;
             p.toccata_activation = ForkActivation::always();
         })

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -131,6 +131,63 @@ async fn daemon_toccata_activation_log_file_test() {
     );
 }
 
+/// KIP-21 zk_hardening_activation crossing: pre-activation blocks commit
+/// `seq_commit` with `inactivity_shortcut: None` (omitted from the mergeset
+/// context hash); post-activation blocks fold the shortcut in. Both layouts
+/// of `SmtBlockMetadata` (always-stored shortcut block) must roundtrip and
+/// the chain must continue to advance across the boundary.
+///
+/// If the activation gate were wired wrong on either side, `build_seq_commit`
+/// and `recompute_seq_commit` would diverge and the daemon would disqualify
+/// its own mined blocks; the assert on virtual_daa_score is the smoke test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn daemon_zk_hardening_activation_test() {
+    init_allocator_with_default_settings();
+
+    let test_dir = tempfile::tempdir().unwrap();
+    let params_path = test_dir.path().join("params.json");
+    // Activate at DAA score 3; mine across it.
+    fs::write(&params_path, r#"{"skip_proof_of_work":true,"zk_hardening_activation":3}"#).unwrap();
+
+    let args = Args {
+        simnet: true,
+        unsafe_rpc: true,
+        enable_unsynced_mining: true,
+        disable_upnp: true,
+        disable_dns_seeding: true,
+        outbound_target: 0,
+        override_params_file: Some(params_path.to_string_lossy().to_string()),
+        ..Default::default()
+    };
+
+    let _runtime = KaspadRuntime::from_args(&args);
+    let mut kaspad = Daemon::new_random_with_args(args, 10);
+    let rpc_client = kaspad.start().await;
+
+    let miner_address = Address::new(kaspad.network.into(), kaspa_addresses::Version::PubKey, &[0; 32]);
+    let target_daa_score: u64 = 6;
+    for _ in 1..=target_daa_score {
+        let template = rpc_client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        rpc_client.submit_block(template.block, false).await.unwrap();
+    }
+
+    let check_client = rpc_client.clone();
+    wait_for(
+        50,
+        100,
+        move || {
+            let client = check_client.clone();
+            Box::pin(async move { client.get_server_info().await.unwrap().virtual_daa_score >= target_daa_score })
+        },
+        "daemon did not cross zk_hardening_activation boundary",
+    )
+    .await;
+
+    rpc_client.disconnect().await.unwrap();
+    drop(rpc_client);
+    kaspad.shutdown();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_sanity_test() {
     init_allocator_with_default_settings();
@@ -856,7 +913,8 @@ async fn daemon_pruning_seqcommit_sync_test() {
 
     // Step 1: advance the chain to ~1.5 * finality depth from genesis.
     // We will create a seqcommit transaction at that height, referencing a block
-    // almost a full finality depth below the tip.
+    // almost a full finality_depth below the tip (KIP-21 seqcommit look-back is
+    // bounded by `finality_depth`).
     let finality_depth = params.finality_depth();
     let initial_blocks = finality_depth.saturating_mul(3).saturating_div(2) as usize;
     for _ in 0..initial_blocks {
@@ -876,7 +934,7 @@ async fn daemon_pruning_seqcommit_sync_test() {
     )
     .await;
 
-    // Choose a target almost a full finality depth below the current tip, leaving
+    // Choose a target almost a full finality_depth below the current tip, leaving
     // a small buffer for the confirmation and spend blocks.
     let dag_info = rpc_client1.get_block_dag_info().await.unwrap();
     let remaining = finality_depth.saturating_sub(3);
@@ -943,9 +1001,13 @@ async fn daemon_pruning_seqcommit_sync_test() {
 
     // Step 2: advance the pruning point so it moves off genesis and ends up above the
     // target block that the seqcommit script references.
+    //
+    // KIP-21: the seqcommit look-back is `finality_depth`, so the target sits at
+    // depth ≈ F below the initial tip. Pruning samples space by F in blue_score, so
+    // PP may need to advance to climb past the target.
     let mut dag_info = rpc_client1.get_block_dag_info().await.unwrap();
     let mut extra_blocks = 0usize;
-    let extra_blocks_limit = params.pruning_depth().saturating_add(30) as usize;
+    let extra_blocks_limit = params.pruning_depth().saturating_add(params.finality_depth()).saturating_add(30) as usize;
     while (dag_info.pruning_point_hash == SIMNET_GENESIS.hash
         || !is_ancestor_in_selected_parent_chain(&rpc_client1, dag_info.pruning_point_hash, target_block).await)
         && extra_blocks < extra_blocks_limit
@@ -1198,6 +1260,36 @@ async fn daemon_ibd_smt_state_sync_test() {
             })
         },
         "syncee did not complete SMT-era IBD within timeout (suspected sync_new_smt_state stall)",
+    )
+    .await;
+
+    // Phase 6: mine finality_depth + buffer blocks on the syncer and assert
+    // the syncee catches up. Verifies syncer/syncee shortcut agreement for live
+    // blocks whose target_bs lands in the IBD-imported lane range.
+    let finality_depth = params.finality_depth() as usize;
+    let post_ibd_blocks = finality_depth + 30;
+    for _ in 0..post_ibd_blocks {
+        let template = rpc_client1.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        rpc_client1.submit_block(template.block, false).await.unwrap();
+    }
+
+    let post_ibd_target_score = rpc_client1.get_server_info().await.unwrap().virtual_daa_score;
+    let post_ibd_target_pp = rpc_client1.get_block_dag_info().await.unwrap().pruning_point_hash;
+    let post_ibd_check = rpc_client2.clone();
+    wait_for(
+        100,
+        600,
+        move || {
+            let client = post_ibd_check.clone();
+            Box::pin(async move {
+                let server_info = client.get_server_info().await.unwrap();
+                if server_info.virtual_daa_score < post_ibd_target_score {
+                    return false;
+                }
+                client.get_block_dag_info().await.unwrap().pruning_point_hash == post_ibd_target_pp
+            })
+        },
+        "syncee did not accept post-IBD blocks",
     )
     .await;
 


### PR DESCRIPTION
## Summary

Adds `inactivity_shortcut` to the existing per-chain-block `seq_commit`
commitment (active-lanes SMT, miner-payload root, mergeset context).
Activated by `zk_hardening_activation`; pre-activation chain blocks are
unaffected.

Spec: https://github.com/kaspanet/vprogs/blob/feat/inactivity_proofs/docs/kaspa-inactivity-shortcut-spec.md

`inactivity_shortcut` is the `seq_commit` of the latest in-domain
non-genesis selected-parent-chain ancestor `A` with
`A.blue_score + min(F(A), F(B)) < B.blue_score`. It lets guests walk
inactivity spans in `O(N/F)` hops instead of `O(N)`, without knowing `F`.

## Commitment delta

The shortcut is folded one level above `lanes_root` via a new
`activity_root`:

```
state_root
└── H_seq
    ├── activity_root
    │   ├── pre-hardening:  = lanes_root  (identity)
    │   └── post-hardening: = H_activity_root(inactivity_shortcut, lanes_root)
    └── payload_and_ctx_digest
        └── H_seq
            ├── context_hash = H_mergeset_context(ts || daa || bs)
            └── payload_root
```

Lane tips stay shortcut-free; the mergeset context preimage is
unchanged.

## What's in this PR

- `consensus/seq-commit/`: new `SeqCommitActivityRoot` hasher and
  `activity_root_hash`; unified `verify_smt_metadata`.
- `consensus/src/`: `build_seq_commit` wraps `lanes_root` into
  `activity_root` post-hardening; `compute_inactivity_shortcut_block`
  resolves the anchor via SMT coinbase-lane fast-path with cascade
  fallback; `SmtBlockMetadata` gains a length-dispatched ToccataV0/V1
  enum carrying the shortcut block on V1.
- IBD: single 96-byte `SmtMetadataMessage` (unchanged shape); receiver
  derives the anchor block via header walk
  (`inactivity_shortcut_block_for_pov`) before importing the SMT.
  P2P v10 unchanged.
- Tests: daemon `zk_hardening_activation` crossing; simpa `test_pruning`
  activates toccata @ daa 1000 and `zk_hardening` @ daa 2000.