### PR TITLE
Schedule TN10 Toccata/ZK hardening activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-build-info"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duct",
  "faster-hex 0.9.0",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ahash",
  "borsh",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duration-string",
  "futures",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "criterion",
@@ -3363,14 +3363,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-system-info"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-utils",
  "mac_address",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "aes",
  "ahash",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6506,7 +6506,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -88,67 +88,67 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.2.0-toc.2", path = "testing/integration" }
-kaspa-addresses = { version = "1.2.0-toc.2", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.2.0-toc.2", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.2.0-toc.2", path = "wallet/bip32" }
-kaspa-cli = { version = "1.2.0-toc.2", path = "cli" }
-kaspa-connectionmanager = { version = "1.2.0-toc.2", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.2.0-toc.2", path = "consensus" }
-kaspa-consensus-core = { version = "1.2.0-toc.2", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.2.0-toc.2", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.2.0-toc.2", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.2.0-toc.2", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.2.0-toc.2", path = "components/consensusmanager" }
-kaspa-core = { version = "1.2.0-toc.2", path = "core" }
-kaspa-daemon = { version = "1.2.0-toc.2", path = "daemon" }
-kaspa-database = { version = "1.2.0-toc.2", path = "database" }
-kaspa-grpc-client = { version = "1.2.0-toc.2", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.2.0-toc.2", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.2.0-toc.2", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.2.0-toc.2", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.2.0-toc.2", path = "indexes/core" }
-kaspa-index-processor = { version = "1.2.0-toc.2", path = "indexes/processor" }
-kaspa-math = { version = "1.2.0-toc.2", path = "math" }
-kaspa-merkle = { version = "1.2.0-toc.2", path = "crypto/merkle" }
-kaspa-smt = { version = "1.2.0-toc.2", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.2.0-toc.2", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.2.0-toc.2", path = "metrics/core" }
-kaspa-mining = { version = "1.2.0-toc.2", path = "mining" }
-kaspa-mining-errors = { version = "1.2.0-toc.2", path = "mining/errors" }
-kaspa-muhash = { version = "1.2.0-toc.2", path = "crypto/muhash" }
-kaspa-notify = { version = "1.2.0-toc.2", path = "notify" }
-kaspa-p2p-flows = { version = "1.2.0-toc.2", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.2.0-toc.2", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.2.0-toc.2", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.2.0-toc.2", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.2.0-toc.2", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.2.0-toc.2", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.2.0-toc.2", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.2.0-toc.2", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.2.0-toc.2", path = "rpc/service" }
-kaspa-txscript = { version = "1.2.0-toc.2", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.2.0-toc.2", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.2.0-toc.2", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.2.0-toc.2", path = "utils/tower" }
-kaspa-system-info = { version = "1.2.0-toc.2", path = "system-info" }
-kaspa-build-info = { version = "1.2.0-toc.2", path = "build-info" }
-kaspa-utxoindex = { version = "1.2.0-toc.2", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.2.0-toc.2", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.2.0-toc.2", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.2.0-toc.2", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.2.0-toc.2", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.2.0-toc.2", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.2.0-toc.2", path = "wallet/macros" }
-kaspa-wasm = { version = "1.2.0-toc.2", path = "wasm" }
-kaspa-wasm-core = { version = "1.2.0-toc.2", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.2.0-toc.2", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.2.0-toc.2", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.2.0-toc.2", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.2.0-toc.2", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.2.0-toc.2", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.2.0-toc.2", path = "kaspad" }
-kaspa-alloc = { version = "1.2.0-toc.2", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.2.1-toc.3", path = "testing/integration" }
+kaspa-addresses = { version = "1.2.1-toc.3", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.2.1-toc.3", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.2.1-toc.3", path = "wallet/bip32" }
+kaspa-cli = { version = "1.2.1-toc.3", path = "cli" }
+kaspa-connectionmanager = { version = "1.2.1-toc.3", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.2.1-toc.3", path = "consensus" }
+kaspa-consensus-core = { version = "1.2.1-toc.3", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.2.1-toc.3", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.2.1-toc.3", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.2.1-toc.3", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.2.1-toc.3", path = "components/consensusmanager" }
+kaspa-core = { version = "1.2.1-toc.3", path = "core" }
+kaspa-daemon = { version = "1.2.1-toc.3", path = "daemon" }
+kaspa-database = { version = "1.2.1-toc.3", path = "database" }
+kaspa-grpc-client = { version = "1.2.1-toc.3", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.2.1-toc.3", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.2.1-toc.3", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.2.1-toc.3", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "1.2.1-toc.3", path = "indexes/core" }
+kaspa-index-processor = { version = "1.2.1-toc.3", path = "indexes/processor" }
+kaspa-math = { version = "1.2.1-toc.3", path = "math" }
+kaspa-merkle = { version = "1.2.1-toc.3", path = "crypto/merkle" }
+kaspa-smt = { version = "1.2.1-toc.3", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "1.2.1-toc.3", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "1.2.1-toc.3", path = "metrics/core" }
+kaspa-mining = { version = "1.2.1-toc.3", path = "mining" }
+kaspa-mining-errors = { version = "1.2.1-toc.3", path = "mining/errors" }
+kaspa-muhash = { version = "1.2.1-toc.3", path = "crypto/muhash" }
+kaspa-notify = { version = "1.2.1-toc.3", path = "notify" }
+kaspa-p2p-flows = { version = "1.2.1-toc.3", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.2.1-toc.3", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.2.1-toc.3", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.2.1-toc.3", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.2.1-toc.3", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.2.1-toc.3", path = "rpc/core" }
+kaspa-seq-commit = { version = "1.2.1-toc.3", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "1.2.1-toc.3", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.2.1-toc.3", path = "rpc/service" }
+kaspa-txscript = { version = "1.2.1-toc.3", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.2.1-toc.3", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.2.1-toc.3", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "1.2.1-toc.3", path = "utils/tower" }
+kaspa-system-info = { version = "1.2.1-toc.3", path = "system-info" }
+kaspa-build-info = { version = "1.2.1-toc.3", path = "build-info" }
+kaspa-utxoindex = { version = "1.2.1-toc.3", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.2.1-toc.3", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.2.1-toc.3", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.2.1-toc.3", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.2.1-toc.3", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.2.1-toc.3", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.2.1-toc.3", path = "wallet/macros" }
+kaspa-wasm = { version = "1.2.1-toc.3", path = "wasm" }
+kaspa-wasm-core = { version = "1.2.1-toc.3", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.2.1-toc.3", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.2.1-toc.3", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.2.1-toc.3", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.2.1-toc.3", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.2.1-toc.3", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.2.1-toc.3", path = "kaspad" }
+kaspa-alloc = { version = "1.2.1-toc.3", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/core/src/config/genesis.rs
+++ b/consensus/core/src/config/genesis.rs
@@ -146,30 +146,6 @@ pub const TESTNET_GENESIS: GenesisBlock = GenesisBlock {
     ],
 };
 
-pub const TESTNET12_GENESIS: GenesisBlock = GenesisBlock {
-    hash: Hash::from_bytes([
-        0x30, 0x0f, 0xe0, 0x20, 0x31, 0x11, 0x9f, 0x61, 0x32, 0xf3, 0x9e, 0xc0, 0x3c, 0x5c, 0xf7, 0xdd, 0xf1, 0x0c, 0xc2, 0x3d, 0x6f,
-        0x5c, 0x3e, 0x5f, 0xe4, 0x2d, 0x63, 0x91, 0xdc, 0x3d, 0x5c, 0x2a,
-    ]),
-    hash_merkle_root: Hash::from_bytes([
-        0xcd, 0x26, 0xc7, 0x3b, 0x25, 0x07, 0xb8, 0xa1, 0xf4, 0x9b, 0xab, 0x92, 0xd5, 0xa8, 0xeb, 0xc8, 0x3e, 0x37, 0xcf, 0xdf, 0x57,
-        0xe6, 0xcc, 0x98, 0x55, 0xef, 0x99, 0x90, 0x45, 0xeb, 0x76, 0xbf,
-    ]),
-    bits: 504155340, // see `gen_testnet12_genesis`
-    #[rustfmt::skip]
-    coinbase_payload: &[
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Blue score
-        0x00, 0xE1, 0xF5, 0x05, 0x00, 0x00, 0x00, 0x00, // Subsidy
-        0x00, 0x00, // Script version
-        0x01,                                                                         // Varint
-        0x00,                                                                         // OP-FALSE
-        0x6b, 0x61, 0x73, 0x70, 0x61, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x6e, 0x65, 0x74, // kaspa-testnet
-        0x54, 0x4F, 0x43, 0x43, 0x41, 0x54, 0x41,                                     // TOCCATA
-        12, 3                                                                         // TN12, Launch 3
-    ],
-    ..TESTNET_GENESIS
-};
-
 pub const SIMNET_GENESIS: GenesisBlock = GenesisBlock {
     hash: Hash::from_bytes([
         0x41, 0x1f, 0x8c, 0xd2, 0x6f, 0x3d, 0x41, 0xae, 0xa3, 0x9e, 0x78, 0x57, 0x39, 0x27, 0xda, 0x24, 0xd2, 0x39, 0x95, 0x70, 0x5b,
@@ -231,28 +207,15 @@ pub const DEVNET_GENESIS: GenesisBlock = GenesisBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::bps::TenBps, merkle::calc_hash_merkle_root};
+    use crate::merkle::calc_hash_merkle_root;
 
     #[test]
     fn test_genesis_hashes() {
-        [GENESIS, TESTNET_GENESIS, TESTNET12_GENESIS, SIMNET_GENESIS, DEVNET_GENESIS].into_iter().for_each(|genesis| {
+        [GENESIS, TESTNET_GENESIS, SIMNET_GENESIS, DEVNET_GENESIS].into_iter().for_each(|genesis| {
             let block: Block = (&genesis).into();
             assert_hashes_eq(calc_hash_merkle_root(block.transactions.iter()), block.header.hash_merkle_root, "hash_merkle_root");
             assert_hashes_eq(block.hash(), genesis.hash, "genesis hash");
         });
-    }
-
-    #[test]
-    fn gen_testnet12_genesis() {
-        let bps = TenBps::bps();
-        let mut genesis = TESTNET_GENESIS;
-        let target = kaspa_math::Uint256::from_compact_target_bits(genesis.bits);
-        let scaled_target = target * bps / 100;
-        let scaled_bits = scaled_target.compact_target_bits();
-        genesis.bits = scaled_bits;
-        if genesis.bits != TESTNET12_GENESIS.bits {
-            panic!("Testnet 12: new bits: {}\nnew hash: {:#04x?}", scaled_bits, Block::from(&genesis).hash().as_bytes());
-        }
     }
 
     fn assert_hashes_eq(got: Hash, expected: Hash, field: &str) {

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -1,7 +1,7 @@
 pub use super::{
     bps::{Bps, TenBps},
     constants::consensus::*,
-    genesis::{DEVNET_GENESIS, GENESIS, GenesisBlock, SIMNET_GENESIS, TESTNET_GENESIS, TESTNET12_GENESIS},
+    genesis::{DEVNET_GENESIS, GENESIS, GenesisBlock, SIMNET_GENESIS, TESTNET_GENESIS},
 };
 use crate::{
     BlockLevel, KType,
@@ -530,12 +530,7 @@ impl Params {
     }
 
     pub fn block_version(&self) -> ForkedParam<u16> {
-        if self.net == TESTNET12_PARAMS.net {
-            // The testnet12 hardfork was activated without a block version bump, so we return a constant value of 1 for compatibility with the existing testnet12 chain.
-            ForkedParam::new_const(BLOCK_VERSION)
-        } else {
-            ForkedParam::new(BLOCK_VERSION, TOCCATA_BLOCK_VERSION, self.toccata_activation)
-        }
+        ForkedParam::new(BLOCK_VERSION, TOCCATA_BLOCK_VERSION, self.toccata_activation)
     }
 
     pub fn network_name(&self) -> String {
@@ -645,7 +640,6 @@ impl From<NetworkId> for Params {
             NetworkType::Mainnet => MAINNET_PARAMS,
             NetworkType::Testnet => match value.suffix {
                 Some(10) => TESTNET_PARAMS,
-                Some(12) => TESTNET12_PARAMS,
                 Some(x) => panic!("Testnet suffix {} is not supported", x),
                 None => panic!("Testnet suffix not provided"),
             },
@@ -788,39 +782,8 @@ pub const TESTNET_PARAMS: Params = Params {
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
-    // ZK precompile hardening — activation TBD; default to never until scheduled.
-    zk_hardening_activation: ForkActivation::never(),
-};
-
-pub const TESTNET12_PARAMS: Params = Params {
-    dns_seeders: &[
-        // This DNS seeder is run by someone235
-        "tn12-dnsseed.kas.pa",
-        // This DNS seeder is run by iziodev
-        "tn12-dnsseed.kasia.fyi",
-        // This DNS seeder is run by supertypo
-        "n-testnet-12.kaspa.ws",
-        // This DNS seeder is run by Tiram
-        "seeder1-tn12.kaspad.net",
-    ],
-    net: NetworkId::with_suffix(NetworkType::Testnet, 12),
-    genesis: TESTNET12_GENESIS,
-
-    prior_max_signature_script_len: NEW_MAX_SIGNATURE_SCRIPT_LEN,
-    new_max_signature_script_len: NEW_MAX_SIGNATURE_SCRIPT_LEN,
-
-    // Transient mass is increased for stark proofs
-    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 1_000_000 },
-    new_transient_mass_limit: 1_000_000,
-
-    deflationary_phase_daa_score: TenBps::deflationary_phase_daa_score(),
-    pre_deflationary_phase_base_subsidy: TenBps::pre_deflationary_phase_base_subsidy(),
-    pre_crescendo_target_time_per_block: TenBps::target_time_per_block(),
-
-    crescendo_activation: ForkActivation::always(),
-    toccata_activation: ForkActivation::always(),
-    zk_hardening_activation: ForkActivation::never(),
-    ..TESTNET_PARAMS
+    // ~2026-05-28 16:00 UTC on TN10.
+    zk_hardening_activation: ForkActivation::new(476_232_000),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -911,7 +874,7 @@ pub const DEVNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::always(),
+    zk_hardening_activation: ForkActivation::never(),
 };
 
 #[cfg(test)]

--- a/consensus/src/pipeline/virtual_processor/fork_logger.rs
+++ b/consensus/src/pipeline/virtual_processor/fork_logger.rs
@@ -7,13 +7,24 @@ use std::sync::{
 #[derive(Clone)]
 pub(crate) struct ForkLogger {
     steps: Arc<AtomicU8>,
+    fork_name: &'static str,
+    banner_label: &'static str,
     module_name: &'static str,
     show_ascii_art: bool,
 }
 
 impl ForkLogger {
     pub fn new(module_name: &'static str, show_ascii_art: bool) -> Self {
-        Self { steps: Arc::new(AtomicU8::new(Self::ACTIVATE)), module_name, show_ascii_art }
+        Self::new_with_fork("Toccata", "TOCCATA", module_name, show_ascii_art)
+    }
+
+    pub fn new_with_fork(
+        fork_name: &'static str,
+        banner_label: &'static str,
+        module_name: &'static str,
+        show_ascii_art: bool,
+    ) -> Self {
+        Self { steps: Arc::new(AtomicU8::new(Self::ACTIVATE)), fork_name, banner_label, module_name, show_ascii_art }
     }
 
     const ACTIVATE: u8 = 0;
@@ -28,11 +39,12 @@ impl ForkLogger {
   | |/ _ \ / __/ __/ _` | __/ _` |
   | | (_) | (_| (_| (_| | || (_| |
   |_|\___/ \___\___\__,_|\__\__,_|
-                    TOCCATA
-"#
+                    {}
+"#,
+                    self.banner_label
                 );
             }
-            info!(target: FORK_KEYWORD, "[Toccata] Activated for {}", self.module_name);
+            info!(target: FORK_KEYWORD, "[{}] Activated for {}", self.fork_name, self.module_name);
             true
         } else {
             false

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -179,6 +179,7 @@ pub struct VirtualStateProcessor {
 
     // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
     pub(crate) zk_hardening_activation: ForkActivation,
+    pub(crate) zk_hardening_logger: ForkLogger,
 
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
@@ -255,6 +256,12 @@ impl VirtualStateProcessor {
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
             zk_hardening_activation: params.zk_hardening_activation,
+            zk_hardening_logger: ForkLogger::new_with_fork(
+                "Toccata ZK hardening",
+                "TOCCATA ZK HARDENING",
+                "virtual state processing rules",
+                true,
+            ),
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -588,6 +595,9 @@ impl VirtualStateProcessor {
 
         if self.toccata_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
             self.toccata_logger.report_activation();
+        }
+        if self.zk_hardening_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
+            self.zk_hardening_logger.report_activation();
         }
 
         // Compute accepted_id_digests

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -13,7 +13,6 @@ use kaspa_consensus_core::api::{BlockValidationFuture, BlockValidationFutures};
 use kaspa_consensus_core::block::Block;
 use kaspa_consensus_core::config::{Config, params::ForkActivation};
 use kaspa_consensus_core::errors::block::RuleError;
-use kaspa_consensus_core::network::{NetworkId, NetworkType};
 use kaspa_consensus_core::tx::{Transaction, TransactionId};
 use kaspa_consensus_notify::{
     notification::{Notification, PruningPointUtxoSetOverrideNotification},
@@ -62,10 +61,6 @@ use uuid::Uuid;
 
 /// The P2P protocol version.
 const PROTOCOL_VERSION: u32 = 10;
-
-/// Testnet 12 was launched with the Toccata flow set under protocol version 9.
-const TN12_LAUNCH_PROTOCOL_VERSION: u32 = 9;
-const TN12_NETWORK: NetworkId = NetworkId::with_suffix(NetworkType::Testnet, 12);
 
 /// See `check_orphan_resolution_range`
 const BASELINE_ORPHAN_RESOLUTION_RANGE: u32 = 5;
@@ -814,14 +809,7 @@ impl ConnectionInitializer for FlowContext {
 
         debug!("protocol versions - self: {}, peer: {}", PROTOCOL_VERSION, peer_version.protocol_version);
 
-        // TN12 launched Toccata flows under protocol 9. Normalize those peers to the current
-        // protocol locally while preserving the originally advertised version in peer properties.
-        let peer_protocol_version = if self.config.net == TN12_NETWORK && peer_version.protocol_version == TN12_LAUNCH_PROTOCOL_VERSION
-        {
-            PROTOCOL_VERSION
-        } else {
-            peer_version.protocol_version
-        };
+        let peer_protocol_version = peer_version.protocol_version;
 
         // One day before activation, upgraded nodes start disconnecting outdated peers from the P2P network.
         const ONE_DAY_SECONDS: u64 = 24 * 60 * 60;

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -86,15 +86,34 @@ pub enum BlockLogEvent {
 
 pub struct BlockEventLogger {
     bps: usize,
-    toccata_activation: ForkActivation,
+    countdown_activation: CountdownActivation,
     sender: UnboundedSender<BlockLogEvent>,
     receiver: Mutex<Option<UnboundedReceiver<BlockLogEvent>>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CountdownActivation {
+    name: &'static str,
+    activation: ForkActivation,
+}
+
+impl CountdownActivation {
+    fn latest(toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) -> Self {
+        [
+            Self { name: "Toccata", activation: toccata_activation },
+            Self { name: "Toccata ZK hardening", activation: zk_hardening_activation },
+        ]
+        .into_iter()
+        .filter(|candidate| candidate.activation != ForkActivation::never())
+        .max_by_key(|candidate| candidate.activation.daa_score())
+        .unwrap_or(Self { name: "Toccata", activation: ForkActivation::never() })
+    }
+}
+
 impl BlockEventLogger {
-    pub fn new(bps: usize, toccata_activation: ForkActivation) -> Self {
+    fn new(bps: usize, countdown_activation: CountdownActivation) -> Self {
         let (sender, receiver) = unbounded_channel();
-        Self { bps, toccata_activation, sender, receiver: Mutex::new(Some(receiver)) }
+        Self { bps, countdown_activation, sender, receiver: Mutex::new(Some(receiver)) }
     }
 
     pub fn log(&self, event: BlockLogEvent) {
@@ -105,7 +124,7 @@ impl BlockEventLogger {
     fn start(&self) {
         let chunk_limit = self.bps * 10; // We prefer that the 1 sec timeout forces the log, but nonetheless still want a reasonable bound on each chunk
         let receiver = self.receiver.lock().take().expect("expected to be called once");
-        let toccata_activation = self.toccata_activation;
+        let countdown_activation = self.countdown_activation;
         tokio::spawn(async move {
             let chunk_stream = UnboundedReceiverStream::new(receiver).chunks_timeout(chunk_limit, Duration::from_secs(1));
             tokio::pin!(chunk_stream);
@@ -141,10 +160,10 @@ impl BlockEventLogger {
                     }
                 }
 
-                fn toccata_countdown_suffix(toccata_activation: ForkActivation, daa_score: Option<u64>) -> String {
+                fn activation_countdown_suffix(countdown: CountdownActivation, daa_score: Option<u64>) -> String {
                     daa_score
-                        .and_then(|daa_score| toccata_activation.is_within_range_before_activation(daa_score, 36_000))
-                        .map(|dist| format!(" \t [Toccata countdown: -{}]", dist))
+                        .and_then(|daa_score| countdown.activation.is_within_range_before_activation(daa_score, 36_000))
+                        .map(|dist| format!(" \t [{} countdown: -{}]", countdown.name, dist))
                         .unwrap_or_default()
                 }
 
@@ -202,24 +221,24 @@ impl BlockEventLogger {
                     (1, 0) => info!(
                         "Accepted block {} via submit block{}",
                         summary.submit(),
-                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                     ),
                     (n, 0) => info!(
                         "Accepted {} blocks ...{} via submit block{}",
                         n,
                         summary.submit(),
-                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                     ),
                     (0, 1) => info!(
                         "Accepted block {} via relay{}",
                         summary.relay(),
-                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.relay_rep_daa_score())
                     ),
                     (0, m) => info!(
                         "Accepted {} blocks ...{} via relay{}",
                         m,
                         summary.relay(),
-                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.relay_rep_daa_score())
                     ),
                     (n, m) => {
                         info!(
@@ -228,7 +247,7 @@ impl BlockEventLogger {
                             summary.submit(),
                             m,
                             n,
-                            toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                            activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                         )
                     }
                 }
@@ -376,7 +395,10 @@ impl FlowContext {
                 tick_service,
                 notification_root,
                 user_agent_rules,
-                block_event_logger: Some(BlockEventLogger::new(bps, config.toccata_activation)),
+                block_event_logger: Some(BlockEventLogger::new(
+                    bps,
+                    CountdownActivation::latest(config.toccata_activation, config.zk_hardening_activation),
+                )),
                 bps,
                 orphan_resolution_range,
                 max_orphans,

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Arg, ArgAction, Command};
 use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
-    config::params::{TESTNET_PARAMS, TESTNET12_PARAMS},
+    config::params::TESTNET_PARAMS,
     constants::{SOMPI_PER_KASPA, TX_VERSION, TX_VERSION_TOCCATA},
     hashing::covenant_id::covenant_id,
     network::NetworkType,
@@ -289,11 +289,7 @@ async fn main() {
 
     let info = rpc_client.get_block_dag_info().await.expect("Failed to get block dag info.");
 
-    let coinbase_maturity = match info.network.suffix {
-        Some(11) => panic!("TN11 is not supported on this version"),
-        Some(12) => TESTNET12_PARAMS.coinbase_maturity(),
-        None | Some(_) => TESTNET_PARAMS.coinbase_maturity(),
-    };
+    let coinbase_maturity = TESTNET_PARAMS.coinbase_maturity();
     info!(
         "Node block-DAG info: \n\tNetwork: {}, \n\tBlock count: {}, \n\tHeader count: {}, \n\tDifficulty: {},
 \tMedian time: {}, \n\tDAA score: {}, \n\tPruning point: {}, \n\tTips: {}, \n\t{} virtual parents: ...{}, \n\tCoinbase maturity: {}",

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -16,7 +16,7 @@ use kaspa_consensus::model::stores::headers::HeaderStoreReader;
 use kaspa_consensus::model::stores::reachability::DbReachabilityStore;
 use kaspa_consensus::model::stores::relations::DbRelationsStore;
 use kaspa_consensus::model::stores::selected_chain::SelectedChainStoreReader;
-use kaspa_consensus::params::{DEVNET_PARAMS, ForkActivation, MAINNET_PARAMS, OverrideParams, TESTNET12_PARAMS};
+use kaspa_consensus::params::{DEVNET_PARAMS, ForkActivation, MAINNET_PARAMS, OverrideParams, TESTNET_PARAMS};
 use kaspa_consensus::pipeline::ProcessingCounters;
 use kaspa_consensus::pipeline::monitor::ConsensusMonitor;
 use kaspa_consensus::processes::reachability::tests::{DagBlock, DagBuilder, StoreValidationExtensions};
@@ -2280,7 +2280,7 @@ fn build_p2pk_block(
     (consensus, wait_handles, transactions, block.to_immutable())
 }
 
-fn init_testnet12_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<()>>, Hash, Vec<Transaction>) {
+fn init_toccata_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<()>>, Hash, Vec<Transaction>) {
     let redeem_script = ScriptBuilder::new().add_op(OpZkPrecompile).unwrap().drain();
     let stark_spk = pay_to_script_hash_script(&redeem_script);
     let output_spk = ScriptPublicKey::from_vec(0, vec![OpTrue]);
@@ -2351,7 +2351,12 @@ fn init_testnet12_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle
         })
         .collect::<Vec<_>>();
 
-    let config = ConfigBuilder::new(TESTNET12_PARAMS)
+    let mut params = TESTNET_PARAMS;
+    params.crescendo_activation = ForkActivation::always();
+    params.toccata_activation = ForkActivation::always();
+    params.zk_hardening_activation = ForkActivation::always();
+
+    let config = ConfigBuilder::new(params)
         .skip_proof_of_work()
         .edit_consensus_params(|p| {
             let mut genesis_multiset = MuHash::new();
@@ -2430,10 +2435,10 @@ async fn mass_per_sig_op_does_not_change_block_capacity() {
 }
 
 #[tokio::test]
-async fn testnet12_accepts_one_valid_stark_proof_but_rejects_two() {
+async fn toccata_accepts_one_valid_stark_proof_but_rejects_two() {
     init_allocator_with_default_settings();
 
-    let (consensus, wait_handles, genesis_hash, transactions) = init_testnet12_stark_fixture();
+    let (consensus, wait_handles, genesis_hash, transactions) = init_toccata_stark_fixture();
     let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
     let one_stark_block = consensus
         .build_utxo_valid_block_with_parents(new_unique(), vec![genesis_hash], miner_data.clone(), vec![transactions[0].clone()])
@@ -2450,7 +2455,7 @@ async fn testnet12_accepts_one_valid_stark_proof_but_rejects_two() {
         .to_immutable();
     assert_match!(
         consensus.validate_and_insert_block(two_stark_block).virtual_state_task.await,
-        Err(RuleError::ExceedsComputeMassLimit(_, limit)) if limit == TESTNET12_PARAMS.block_mass_limits().after().compute
+        Err(RuleError::ExceedsComputeMassLimit(_, limit)) if limit == consensus.params().block_mass_limits().after().compute
     );
     consensus.shutdown(wait_handles);
 }

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -577,8 +577,7 @@ async fn daemon_compute_budget_relay_test() {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/params/compute_budget_relay_test_params.json");
 
     let args = Args {
-        testnet: true,
-        testnet_suffix: 12,
+        simnet: true,
         unsafe_rpc: true,
         enable_unsynced_mining: true,
         disable_upnp: true,
@@ -814,8 +813,7 @@ async fn daemon_rejects_transactions_with_inconsistent_input_mass_and_version() 
     let compute_budget_relay_test_params =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/params/compute_budget_relay_test_params.json");
     let args = Args {
-        testnet: true,
-        testnet_suffix: 12,
+        simnet: true,
         unsafe_rpc: true,
         enable_unsynced_mining: true,
         disable_upnp: true,

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -4,6 +4,7 @@ use crate::{
         args::ArgsBuilder,
         client_notify::ChannelNotify,
         daemon::{ClientManager, Daemon},
+        fee::FEE_RATE,
         utils::CONTRACT_FACTOR,
     },
     tasks::{Stopper, TasksRunner, block::group::MinerGroupTask, daemon::DaemonTask, tx::group::TxSenderGroupTask},
@@ -680,7 +681,7 @@ fn generate_stark_tx_dag(
                     );
                     logged_first_provisional_tx = true;
                 }
-                let fee = provisional_tx_mass_normalized;
+                let fee = FEE_RATE * provisional_tx_mass_normalized;
                 let total_out = total_in.saturating_sub(fee);
                 let outputs = (0..num_outputs)
                     .map(|_| TransactionOutput {


### PR DESCRIPTION
- Set the TN10 ZK hardening activation DAA score for the planned activation window.
- Bump the workspace version to 1.2.1-toc.3.
- Remove TN12 runtime/config support from this branch while keeping TN12 docs pointing to the tn12 branch.