### PR TITLE
consensus: remove TRANSIENT_BYTE_TO_MASS_FACTOR (#996)

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -20,8 +20,8 @@ use std::{
 const MEMPOOL_BLOCK_MASS_ACTIVATION_DELAY_SECONDS: u64 = 24 * 60 * 60;
 const PRIOR_MAX_SIGNATURE_SCRIPT_LEN: usize = 10_000;
 // Increased for stark proofs. This value is effectively covered by the post-Toccata
-// transient block mass limit: 1_000_000 transient mass / 4 grams-per-byte = 250_000
-// bytes for the entire block, so a larger signature script cannot be accepted anyway.
+// transient block mass limit of 250_000 (charged 1:1 per byte), which caps the entire
+// block body at 250_000 bytes, so a larger signature script cannot be accepted anyway.
 // TODO(post-toccata): check whether this early signature-script length guard can be
 // removed entirely, or whether it remains useful as cheap early protection.
 const NEW_MAX_SIGNATURE_SCRIPT_LEN: usize = 250_000;
@@ -694,8 +694,8 @@ pub const MAINNET_PARAMS: Params = Params {
     mass_per_tx_byte: 1,
     mass_per_script_pub_key_byte: 10,
     mass_per_sig_op: 1000,
-    prior_block_mass_limits: BlockMassLimits::with_shared_limit(500_000),
-    new_transient_mass_limit: 1_000_000,
+    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 125_000 },
+    new_transient_mass_limit: 250_000,
     block_lane_limits: BlockLaneLimits { lanes_per_block: DEFAULT_LANES_PER_BLOCK_LIMIT, gas_per_lane: DEFAULT_GAS_PER_LANE_LIMIT },
 
     storage_mass_parameter: STORAGE_MASS_PARAMETER,
@@ -754,8 +754,8 @@ pub const TESTNET_PARAMS: Params = Params {
     mass_per_tx_byte: 1,
     mass_per_script_pub_key_byte: 10,
     mass_per_sig_op: 1000,
-    prior_block_mass_limits: BlockMassLimits::with_shared_limit(500_000),
-    new_transient_mass_limit: 1_000_000,
+    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 125_000 },
+    new_transient_mass_limit: 250_000,
     block_lane_limits: BlockLaneLimits { lanes_per_block: DEFAULT_LANES_PER_BLOCK_LIMIT, gas_per_lane: DEFAULT_GAS_PER_LANE_LIMIT },
 
     storage_mass_parameter: STORAGE_MASS_PARAMETER,
@@ -801,8 +801,8 @@ pub const TESTNET12_PARAMS: Params = Params {
     new_max_signature_script_len: NEW_MAX_SIGNATURE_SCRIPT_LEN,
 
     // Transient mass is increased for stark proofs
-    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 1_000_000 },
-    new_transient_mass_limit: 1_000_000,
+    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 250_000 },
+    new_transient_mass_limit: 250_000,
 
     deflationary_phase_daa_score: TenBps::deflationary_phase_daa_score(),
     pre_deflationary_phase_base_subsidy: TenBps::pre_deflationary_phase_base_subsidy(),
@@ -839,8 +839,8 @@ pub const SIMNET_PARAMS: Params = Params {
     mass_per_script_pub_key_byte: 10,
     mass_per_sig_op: 1000,
     // Transient mass is increased for stark proofs
-    prior_block_mass_limits: BlockMassLimits::with_shared_limit(500_000),
-    new_transient_mass_limit: 1_000_000,
+    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 125_000 },
+    new_transient_mass_limit: 250_000,
     block_lane_limits: BlockLaneLimits { lanes_per_block: DEFAULT_LANES_PER_BLOCK_LIMIT, gas_per_lane: DEFAULT_GAS_PER_LANE_LIMIT },
 
     storage_mass_parameter: STORAGE_MASS_PARAMETER,
@@ -882,8 +882,8 @@ pub const DEVNET_PARAMS: Params = Params {
     mass_per_sig_op: 1000,
 
     // Transient mass is increased for stark proofs
-    prior_block_mass_limits: BlockMassLimits::with_shared_limit(500_000),
-    new_transient_mass_limit: 1_000_000,
+    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 125_000 },
+    new_transient_mass_limit: 250_000,
     block_lane_limits: BlockLaneLimits { lanes_per_block: DEFAULT_LANES_PER_BLOCK_LIMIT, gas_per_lane: DEFAULT_GAS_PER_LANE_LIMIT },
 
     storage_mass_parameter: STORAGE_MASS_PARAMETER,
@@ -905,6 +905,29 @@ pub const DEVNET_PARAMS: Params = Params {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transient_mass_limits_are_byte_caps_with_unit_factor() {
+        // Transient mass is charged 1:1 per serialized byte (TRANSIENT_BYTE_TO_MASS_FACTOR was
+        // removed), so each transient block mass limit equals the block body byte cap directly.
+        // Compute and storage limits must remain unchanged at 500_000.
+        const COMPUTE: u64 = 500_000;
+        const STORAGE: u64 = 500_000;
+        // (network params, label, pre-fork transient byte cap, post-fork transient byte cap)
+        let cases = [
+            (&MAINNET_PARAMS, "mainnet", 125_000, 250_000),
+            (&TESTNET_PARAMS, "testnet", 125_000, 250_000),
+            (&TESTNET12_PARAMS, "testnet12", 250_000, 250_000),
+            (&SIMNET_PARAMS, "simnet", 125_000, 250_000),
+            (&DEVNET_PARAMS, "devnet", 125_000, 250_000),
+        ];
+        for (params, label, prior_transient, new_transient) in cases {
+            assert_eq!(params.prior_block_mass_limits.transient, prior_transient, "{label}: pre-fork transient byte cap");
+            assert_eq!(params.new_transient_mass_limit, new_transient, "{label}: post-fork transient byte cap");
+            assert_eq!(params.prior_block_mass_limits.compute, COMPUTE, "{label}: compute limit must be unchanged");
+            assert_eq!(params.prior_block_mass_limits.storage, STORAGE, "{label}: storage limit must be unchanged");
+        }
+    }
 
     #[test]
     fn override_params_deserializes_toccata_activation() {

--- a/consensus/core/src/constants.rs
+++ b/consensus/core/src/constants.rs
@@ -30,11 +30,6 @@ pub const SOMPI_PER_KASPA: u64 = 100_000_000;
 /// The parameter for scaling inverse KAS value to mass units (KIP-0009)
 pub const STORAGE_MASS_PARAMETER: u64 = SOMPI_PER_KASPA * 10_000;
 
-/// The parameter defining how much mass per byte to charge for when calculating
-/// transient storage mass. Since normally the block mass limit is 500_000, this limits
-/// block body byte size to 125_000 (KIP-0013).
-pub const TRANSIENT_BYTE_TO_MASS_FACTOR: u64 = 4;
-
 /// MaxSompi is the maximum transaction amount allowed in sompi.
 pub const MAX_SOMPI: u64 = 29_000_000_000 * SOMPI_PER_KASPA;
 

--- a/consensus/core/src/mass/mod.rs
+++ b/consensus/core/src/mass/mod.rs
@@ -7,7 +7,6 @@ pub use units::{
 
 use crate::{
     config::params::Params,
-    constants::TRANSIENT_BYTE_TO_MASS_FACTOR,
     mass::units::GRAMS_PER_SIGOP_COUNT_UNIT,
     subnets::SUBNETWORK_ID_SIZE,
     tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutput, TxInputMass, UtxoEntry, VerifiableTransaction},
@@ -362,7 +361,9 @@ impl MassCalculator {
         };
 
         let compute_mass = compute_mass_for_size + total_script_public_key_mass + script_mass;
-        let transient_mass = size * TRANSIENT_BYTE_TO_MASS_FACTOR;
+        // Transient storage mass is charged 1:1 per serialized byte; the block transient mass limit
+        // therefore directly bounds the block body byte size (KIP-0013).
+        let transient_mass = size;
 
         NonContextualMasses::new(compute_mass, transient_mass)
     }
@@ -523,6 +524,15 @@ mod tests {
 
     const UTXO_CONST_STORAGE: u64 = 63;
     const UTXO_UNIT_SIZE: u64 = 100;
+
+    #[test]
+    fn transient_mass_equals_serialized_size() {
+        // Transient mass is charged 1:1 per serialized byte, so it must equal the estimated
+        // serialized size of a (non-coinbase) transaction.
+        let tx = generate_tx_from_amounts(&[100, 200, 300], &[300, 300]);
+        let masses = MassCalculator::new(1, 10, STORAGE_MASS_PARAMETER).calc_non_contextual_masses(&tx.tx);
+        assert_eq!(masses.transient_mass, transaction_estimated_serialized_size(&tx.tx));
+    }
 
     #[test]
     fn verify_utxo_plurality_limits() {

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -34,7 +34,8 @@ use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
 use smallvec::SmallVec;
 
 const BLOCK_COMPUTE_MASS_LIMIT: u64 = 500_000;
-const BLOCK_TRANSIENT_MASS_LIMIT: u64 = 1_000_000;
+// Transient mass is charged 1:1 per byte, so this equals the block body byte cap.
+const BLOCK_TRANSIENT_MASS_LIMIT: u64 = 250_000;
 const ADVERSARIAL_SLICE_LEN: i64 = 64;
 const ADVERSARIAL_SIGSCRIPT_DATA_LEN: usize = 192;
 const ADVERSARIAL_OUTPUT_SPK_DATA_LEN: usize = 160;

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -4,7 +4,6 @@ use async_channel::unbounded;
 use kaspa_build_info::git;
 use kaspa_consensus_core::{
     config::ConfigBuilder,
-    constants::TRANSIENT_BYTE_TO_MASS_FACTOR,
     errors::config::{ConfigError, ConfigResult},
     mining_rules::MiningRules,
 };
@@ -381,11 +380,10 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         if MINIMUM_RETENTION_PERIOD_DAYS <= retention_period_days {
             let total_blocks = retention_period_milliseconds / target_time_per_block;
             // This worst case usage only considers block space. It does not account for usage of
-            // other stores (reachability, block status, mempool, etc.)
-            let worst_case_usage = ((total_blocks + finality_depth)
-                * (config.block_mass_limits().after().transient / TRANSIENT_BYTE_TO_MASS_FACTOR))
-                as f64
-                / ONE_GIGABYTE;
+            // other stores (reachability, block status, mempool, etc.).
+            // The transient mass limit is charged 1:1 per byte, so it equals the block body byte cap.
+            let worst_case_usage =
+                ((total_blocks + finality_depth) * config.block_mass_limits().after().transient) as f64 / ONE_GIGABYTE;
 
             info!(
                 "Retention period is set to {} days. Disk usage may be up to {:.2} GB for block space required for this period.",

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -103,7 +103,7 @@ mod tests {
     use kaspa_addresses::{Address, Prefix, Version};
     use kaspa_consensus_core::{
         config::params::{ForkActivation, Params},
-        constants::{MAX_TX_IN_SEQUENCE_NUM, SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR, TX_VERSION},
+        constants::{MAX_TX_IN_SEQUENCE_NUM, SOMPI_PER_KASPA, TX_VERSION},
         mass::NonContextualMasses,
         network::NetworkType,
         subnets::SUBNETWORK_ID_NATIVE,
@@ -362,8 +362,8 @@ mod tests {
         let params: Params = NetworkType::Simnet.into();
         assert_ne!(params.toccata_activation, ForkActivation::never(), "this test requires post-activation cofactors");
         let cofactors = params.mempool_block_mass_cofactors().after();
-        let transient = |bytes| bytes * TRANSIENT_BYTE_TO_MASS_FACTOR;
-        let normalized_transient = |bytes| NonContextualMasses::new(0, transient(bytes)).normalized_transient(&cofactors);
+        // Transient mass is charged 1:1 per byte, so the transient mass equals the byte size.
+        let normalized_transient = |bytes| NonContextualMasses::new(0, bytes).normalized_transient(&cofactors);
 
         let bytes = 5_000;
         let compute = normalized_transient(bytes);
@@ -373,7 +373,7 @@ mod tests {
         let tests = vec![
             Test {
                 name: "standard input with exactly sufficient relay fee",
-                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(compute, transient(bytes)), boundary_fee),
+                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(compute, bytes), boundary_fee),
                 expected: Expected::Standard,
             },
             Test {
@@ -387,11 +387,7 @@ mod tests {
             },
             Test {
                 name: "compute mass triggers insufficient relay fee",
-                mtx: new_mtx(
-                    standard_script_public_key.clone(),
-                    NonContextualMasses::new(compute, transient(bytes - 1)),
-                    insufficient_fee,
-                ),
+                mtx: new_mtx(standard_script_public_key.clone(), NonContextualMasses::new(compute, bytes - 1), insufficient_fee),
                 expected: Expected::RejectInsufficientComputeFee {
                     fee: insufficient_fee,
                     minimum_fee: boundary_fee,
@@ -400,7 +396,7 @@ mod tests {
             },
             Test {
                 name: "transient mass triggers insufficient relay fee",
-                mtx: new_mtx(standard_script_public_key, NonContextualMasses::new(compute - 1, transient(bytes)), insufficient_fee),
+                mtx: new_mtx(standard_script_public_key, NonContextualMasses::new(compute - 1, bytes), insufficient_fee),
                 expected: Expected::RejectInsufficientTransientFee {
                     fee: insufficient_fee,
                     minimum_fee: boundary_fee,

--- a/testing/integration/src/common/fee.rs
+++ b/testing/integration/src/common/fee.rs
@@ -1,8 +1,4 @@
-use kaspa_consensus_core::{
-    constants::{STORAGE_MASS_PARAMETER, TRANSIENT_BYTE_TO_MASS_FACTOR},
-    mass::MassCalculator,
-    tx::Transaction,
-};
+use kaspa_consensus_core::{constants::STORAGE_MASS_PARAMETER, mass::MassCalculator, tx::Transaction};
 
 // Minimum standard relay fee is 100 sompi/gram; use 101 for fixture slack.
 pub(crate) const FEE_RATE: u64 = 101;
@@ -32,7 +28,8 @@ pub const fn calc_for_plain_standard_tx_with_extra_serialized_bytes(
 /// Calculates relay fee from a transaction probe using the real non-contextual mass calculator.
 pub fn calc_for_transaction(tx: &Transaction) -> u64 {
     let masses = MassCalculator::new(1, 10, STORAGE_MASS_PARAMETER).calc_non_contextual_masses(tx);
-    let serialized_bytes = masses.transient_mass / TRANSIENT_BYTE_TO_MASS_FACTOR;
+    // Transient mass is charged 1:1 per byte, so it equals the serialized byte size.
+    let serialized_bytes = masses.transient_mass;
     let normalized_transient_mass = serialized_bytes * NORMALIZED_TRANSIENT_BYTE_FACTOR;
     FEE_RATE * masses.compute_mass.max(normalized_transient_mass)
 }

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -27,7 +27,7 @@ use kaspa_consensus_core::block::{Block, MutableBlock};
 use kaspa_consensus_core::blockhash::{self, new_unique};
 use kaspa_consensus_core::blockstatus::BlockStatus;
 use kaspa_consensus_core::coinbase::MinerData;
-use kaspa_consensus_core::constants::{BLOCK_VERSION, SOMPI_PER_KASPA, TOCCATA_BLOCK_VERSION, TRANSIENT_BYTE_TO_MASS_FACTOR};
+use kaspa_consensus_core::constants::{BLOCK_VERSION, SOMPI_PER_KASPA, TOCCATA_BLOCK_VERSION};
 use kaspa_consensus_core::errors::block::{BlockProcessResult, RuleError};
 use kaspa_consensus_core::errors::tx::TxRuleError;
 use kaspa_consensus_core::hashing;
@@ -2106,11 +2106,11 @@ async fn payload_test() {
         0,
         SubnetworkId::default(),
         0,
-        vec![0; (transient_limit / TRANSIENT_BYTE_TO_MASS_FACTOR / 2) as usize],
+        vec![0; (transient_limit / 2) as usize],
     );
 
     // Create a tx with transient mass over the block limit
-    txx.payload = vec![0; (transient_limit / TRANSIENT_BYTE_TO_MASS_FACTOR + 100) as usize];
+    txx.payload = vec![0; (transient_limit + 100) as usize];
     let mut tx = MutableTransaction::from_tx(txx.clone());
     // This triggers storage mass population
     consensus.validate_mempool_transaction(&mut tx, &TransactionValidationArgs::default()).unwrap();
@@ -2118,7 +2118,7 @@ async fn payload_test() {
     assert_match!(consensus_res, Err(RuleError::ExceedsTransientMassLimit(_, _)));
 
     // Fix the payload to be below the limit
-    txx.payload = vec![0; (transient_limit / TRANSIENT_BYTE_TO_MASS_FACTOR / 2) as usize];
+    txx.payload = vec![0; (transient_limit / 2) as usize];
     let mut tx = MutableTransaction::from_tx(txx.clone());
     // This triggers storage mass population
     consensus.validate_mempool_transaction(&mut tx, &TransactionValidationArgs::default()).unwrap();
@@ -2170,7 +2170,7 @@ async fn payload_for_native_tx_test() {
 
     // Create transaction with large payload
     let transient_limit = config.params.block_mass_limits().before().transient;
-    let large_payload = vec![0u8; (transient_limit / TRANSIENT_BYTE_TO_MASS_FACTOR / 2) as usize];
+    let large_payload = vec![0u8; (transient_limit / 2) as usize];
     let mut tx_with_payload = Transaction::new(
         0,
         vec![TransactionInput::new(


### PR DESCRIPTION
Closes #996. Targeting `toccata` for now per coderofstuff; can rebase to `master` once toccata merges.

Transient mass was charged at 4 grams/byte and compared against a limit expressed in those units. Now that transient mass is its own block-mass dimension, the factor is redundant. This charges transient mass 1:1 per byte and sets the transient limits directly as byte caps.

To keep it behavior-preserving, every transient limit is divided by 4 while compute and storage stay at 500,000:

- prior transient limit: 500,000 -> 125,000 (testnet12: 1,000,000 -> 250,000)
- post-fork transient limit: 1,000,000 -> 250,000

Byte caps are unchanged (125,000 pre-fork, 250,000 post-fork). Normalized transient mass is also unchanged, since the per-dimension cofactor scales inversely with the limit (4 * 0.5 == 1 * 2.0), so mempool standardness and template selection see the same values.

Tests: consensus-core and mining suites pass, including the transient-mass activation tests. Added tests pinning the 1:1 charge and the per-network byte caps.

Note: raw `transient_mass` metric counters now read 4x smaller (internal metric only, no behavioral effect).
