### PR TITLE
Assimilate ZK hardening into Toccata

### DIFF
--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -515,7 +515,7 @@ impl ConsensusSessionOwned {
         &self,
         new_pruning_point: Hash,
         metadata: kaspa_consensus_core::api::SmtExportMetadata,
-        inactivity_shortcut_block: Option<Hash>,
+        inactivity_shortcut_block: Hash,
         mut rx: tokio::sync::mpsc::Receiver<Vec<ImportLane>>,
     ) -> PruningImportResult<()> {
         let lane_batches: ImportLaneBatchIterator = &mut std::iter::from_fn(move || rx.blocking_recv());

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -72,8 +72,7 @@ pub type ImportLaneBatchIterator<'a> = &'a mut (dyn Iterator<Item = Vec<ImportLa
 /// SMT metadata for IBD sync, verified against the pruning point header.
 ///
 /// Wire: `lanes_root || payload_and_ctx_digest || parent_seq_commit` (96 bytes).
-/// `inactivity_shortcut_block` is derived by the receiver from chain headers
-/// when needed (post-hardening); not transmitted.
+/// `inactivity_shortcut_block` is derived by the receiver from chain headers; not transmitted.
 #[derive(Clone, Copy, Debug)]
 pub struct SmtExportMetadata {
     pub lanes_root: Hash,
@@ -306,14 +305,12 @@ pub trait ConsensusApi: Send + Sync {
     /// each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
     /// re-batch.
     ///
-    /// `inactivity_shortcut_block` is `Some(block)` post-hardening (already
-    /// resolved by the caller during metadata verification) and `None`
-    /// pre-hardening. The importer stores it as-is in the V1 metadata row.
+    /// `inactivity_shortcut_block` is resolved by the caller during metadata verification.
     fn import_pruning_point_smt(
         &self,
         _new_pruning_point: Hash,
         _metadata: SmtExportMetadata,
-        _inactivity_shortcut_block: Option<Hash>,
+        _inactivity_shortcut_block: Hash,
         _lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
         unimplemented!()

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -260,8 +260,6 @@ pub struct OverrideParams {
     pub crescendo_activation: Option<ForkActivation>,
 
     pub toccata_activation: Option<ForkActivation>,
-
-    pub zk_hardening_activation: Option<ForkActivation>,
 }
 
 impl From<Params> for OverrideParams {
@@ -294,7 +292,6 @@ impl From<Params> for OverrideParams {
             blockrate: Some(p.blockrate),
             crescendo_activation: Some(p.crescendo_activation),
             toccata_activation: Some(p.toccata_activation),
-            zk_hardening_activation: Some(p.zk_hardening_activation),
         }
     }
 }
@@ -364,8 +361,6 @@ pub struct Params {
     pub crescendo_activation: ForkActivation,
 
     pub toccata_activation: ForkActivation,
-
-    pub zk_hardening_activation: ForkActivation,
 }
 
 impl Params {
@@ -604,7 +599,6 @@ impl Params {
 
             crescendo_activation: overrides.crescendo_activation.unwrap_or(self.crescendo_activation),
             toccata_activation: overrides.toccata_activation.unwrap_or(self.toccata_activation),
-            zk_hardening_activation: overrides.zk_hardening_activation.unwrap_or(self.zk_hardening_activation),
         }
     }
 }
@@ -719,7 +713,6 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {
@@ -782,8 +775,6 @@ pub const TESTNET_PARAMS: Params = Params {
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
-    // ~2026-05-28 16:00 UTC on TN10.
-    zk_hardening_activation: ForkActivation::new(476_232_000),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -829,7 +820,6 @@ pub const SIMNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::always(),
-    zk_hardening_activation: ForkActivation::always(),
 };
 
 pub const DEVNET_PARAMS: Params = Params {
@@ -874,7 +864,6 @@ pub const DEVNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::never(),
 };
 
 #[cfg(test)]

--- a/consensus/seq-commit/src/hashing.rs
+++ b/consensus/seq-commit/src/hashing.rs
@@ -20,8 +20,6 @@
 //!                     └── payload_root
 //! ```
 //!
-//! Pre-hardening: `activity_root == lanes_root` (identity, no wrap);
-//! post-hardening: `activity_root = H_activity_root(inactivity_shortcut, lanes_root)`.
 
 use kaspa_hashes::{
     Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitActivityRoot, SeqCommitLaneKey,
@@ -86,9 +84,6 @@ pub fn mergeset_context_hash(ctx: &MergesetContext) -> Hash {
 }
 
 /// Compute the activity root: `H_activity_root(inactivity_shortcut, lanes_root)`.
-///
-/// Post-hardening only. Pre-hardening callers should pass `lanes_root` straight
-/// into [`seq_state_root`] without invoking this helper (identity).
 #[inline]
 pub fn activity_root_hash(inactivity_shortcut: &Hash, lanes_root: &Hash) -> Hash {
     let mut hasher = SeqCommitActivityRoot::new();
@@ -311,8 +306,8 @@ mod tests {
         assert_ne!(base, activity_root_hash(&h(9), &h(7)));
     }
 
-    /// Identity vs wrap diverge: pre-hardening feeds `lanes_root` directly to
-    /// `seq_state_root`; post-hardening wraps via `activity_root_hash`. Hashes must differ.
+    /// The activity-root domain separates `(inactivity_shortcut, lanes_root)` from
+    /// the raw active-lanes SMT root.
     #[test]
     fn activity_root_identity_vs_wrap_diverges() {
         let lanes_root = h(42);
@@ -518,7 +513,6 @@ mod tests {
         let mpr = miner_payload_root(core::iter::once(mpl));
 
         let pd = payload_and_context_digest(&ctx, &mpr);
-        // Post-hardening end-to-end: activity_root wraps lanes_root with the shortcut.
         let activity_root = activity_root_hash(&ZERO_HASH, &smt_leaf);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_commit, state_root: &state_root });

--- a/consensus/seq-commit/src/types.rs
+++ b/consensus/seq-commit/src/types.rs
@@ -45,9 +45,6 @@ pub struct SmtLeafInput<'a> {
 }
 
 /// Components of the sequencing state root.
-///
-/// `activity_root`: pre-hardening identity = `lanes_root`; post-hardening
-/// = `H_activity_root(inactivity_shortcut, lanes_root)`.
 #[derive(Clone, Copy, Debug)]
 pub struct SeqState<'a> {
     pub activity_root: &'a Hash,

--- a/consensus/seq-commit/src/verify.rs
+++ b/consensus/seq-commit/src/verify.rs
@@ -35,12 +35,9 @@ pub enum SmtVerifyError {
 }
 
 /// Verify that the metadata is consistent with the header's `accepted_id_merkle_root` (= seq_commit).
-///
-/// `inactivity_shortcut`: `None` for pre-hardening (identity at the activity-root level);
-/// `Some(s)` for post-hardening, wrapping `lanes_root` into `activity_root_hash(s, lanes_root)`.
 pub fn verify_smt_metadata(
     metadata: &SmtMetadata<'_>,
-    inactivity_shortcut: Option<Hash>,
+    inactivity_shortcut: Hash,
     expected_seq_commit: Hash,
     expected_parent_seq_commit: Hash,
 ) -> Result<(), SmtVerifyError> {
@@ -51,10 +48,7 @@ pub fn verify_smt_metadata(
         });
     }
 
-    let activity_root = match inactivity_shortcut {
-        Some(s) => activity_root_hash(&s, metadata.lanes_root),
-        None => *metadata.lanes_root,
-    };
+    let activity_root = activity_root_hash(&inactivity_shortcut, metadata.lanes_root);
     let state_root =
         seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
     let computed = {
@@ -109,11 +103,8 @@ mod tests {
         Hash::from_bytes([7; 32])
     }
 
-    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Option<Hash>) -> Hash {
-        let ar = match shortcut {
-            Some(s) => activity_root_hash(&s, lr),
-            None => *lr,
-        };
+    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Hash) -> Hash {
+        let ar = activity_root_hash(&shortcut, lr);
         let sr = seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: pd });
         let mut h = SeqCommitMerkleBranch::new();
         h.update(ps).update(sr);
@@ -121,26 +112,15 @@ mod tests {
     }
 
     #[test]
-    fn metadata_correct_post_hardening() {
+    fn metadata_correct() {
         let lr = Hash::from_bytes([1; 32]);
         let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let shortcut = sample_shortcut();
 
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, shortcut);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, Some(shortcut), sc, ps).is_ok());
-    }
-
-    #[test]
-    fn metadata_correct_pre_hardening() {
-        let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([3; 32]);
-        let ps = Hash::from_bytes([4; 32]);
-
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, None);
-        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, None, sc, ps).is_ok());
+        assert!(verify_smt_metadata(&md, shortcut, sc, ps).is_ok());
     }
 
     #[test]
@@ -150,7 +130,7 @@ mod tests {
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, Some(sample_shortcut()), ZERO_HASH, Hash::from_bytes([99; 32])),
+            verify_smt_metadata(&md, sample_shortcut(), ZERO_HASH, Hash::from_bytes([99; 32])),
             Err(SmtVerifyError::ParentSeqCommitMismatch { .. })
         ));
     }
@@ -162,24 +142,9 @@ mod tests {
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, Some(sample_shortcut()), Hash::from_bytes([99; 32]), ps),
+            verify_smt_metadata(&md, sample_shortcut(), Hash::from_bytes([99; 32]), ps),
             Err(SmtVerifyError::SeqCommitMismatch { .. })
         ));
-    }
-
-    // Pre/post divergence: a verifier called with `None` on a post-hardening commit
-    // (or vice versa) must reject as a seq_commit mismatch.
-    #[test]
-    fn metadata_pre_post_mismatch_rejected() {
-        let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([3; 32]);
-        let ps = Hash::from_bytes([4; 32]);
-        let shortcut = sample_shortcut();
-
-        let sc_post = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
-        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        // Wire was post-hardening but verifier was told pre-hardening: must mismatch.
-        assert!(matches!(verify_smt_metadata(&md, None, sc_post, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     // A perturbed shortcut flows into `activity_root` and then `seq_state_root`,
@@ -190,10 +155,10 @@ mod tests {
         let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let shortcut = sample_shortcut();
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, shortcut);
         let bad_shortcut = Hash::from_bytes([0xAB; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(matches!(verify_smt_metadata(&md, Some(bad_shortcut), sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+        assert!(matches!(verify_smt_metadata(&md, bad_shortcut, sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     #[test]

--- a/consensus/seq-commit/tests/example_block.rs
+++ b/consensus/seq-commit/tests/example_block.rs
@@ -153,7 +153,7 @@ fn example_seq_commit_for_block() {
         .collect();
     let payload_root = miner_payload_root(payload_leaves.into_iter());
 
-    // --- State root and final commitment (post-hardening: wrap lanes_root into activity_root). ---
+    // --- State root and final commitment. ---
     let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&ctx, &payload_root);
     let activity_root = kaspa_seq_commit::hashing::activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
     let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });

--- a/consensus/seq-commit/tests/prove_lane_activity.rs
+++ b/consensus/seq-commit/tests/prove_lane_activity.rs
@@ -46,8 +46,7 @@ struct CommitmentWitness {
     parent_seq_commit: Hash,
     smt_proof: OwnedSmtProof,
     blue_score: u64,
-    /// Post-hardening shortcut Hash. `None` pre-hardening (identity at activity_root).
-    inactivity_shortcut: Option<Hash>,
+    inactivity_shortcut: Hash,
 }
 
 /// Chain `lane_tip_next` across blocks, starting from `parent_ref`.
@@ -74,10 +73,7 @@ fn compute_lane_tip(parent_ref: &Hash, lane_key: &Hash, blocks: &[BlockActivity]
 fn compute_seq_commit_for_lane(lane_key: &Hash, lane_tip: &Hash, witness: &CommitmentWitness) -> Hash {
     let leaf = smt_leaf_hash(&SmtLeafInput { lane_tip, blue_score: witness.blue_score });
     let lanes_root = witness.smt_proof.as_proof().compute_root::<SeqCommitActiveNode>(lane_key, Some(leaf)).unwrap();
-    let activity_root = match witness.inactivity_shortcut {
-        Some(s) => activity_root_hash(&s, &lanes_root),
-        None => lanes_root,
-    };
+    let activity_root = activity_root_hash(&witness.inactivity_shortcut, &lanes_root);
     let state_root =
         seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
     seq_commit(&SeqCommitInput { parent_seq_commit: &witness.parent_seq_commit, state_root: &state_root })
@@ -109,7 +105,6 @@ fn build_commitment(
     let payload_root = miner_payload_root(core::iter::once(pl));
     let lanes_root = smt.root();
     let pd = payload_and_context_digest(&ctx, &payload_root);
-    // Post-hardening test fixture: wrap lanes_root into activity_root with ZERO_HASH shortcut.
     let activity_root = activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
     let sr = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let sc = seq_commit(&SeqCommitInput { parent_seq_commit, state_root: &sr });
@@ -212,8 +207,7 @@ fn build_chain(n: usize) -> (Hash, Hash, Hash, Vec<BlockActivity>, CommitmentWit
         parent_seq_commit: last_parent_sc,
         smt_proof: last_smt_proof.unwrap(),
         blue_score: last_blue_score,
-        // Mirrors `build_commitment`'s post-hardening wrap.
-        inactivity_shortcut: Some(kaspa_hashes::ZERO_HASH),
+        inactivity_shortcut: kaspa_hashes::ZERO_HASH,
     };
 
     (last_sc, key_x, grandparent_commit, block_activities, witness)

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1154,22 +1154,18 @@ impl ConsensusApi for Consensus {
         &self,
         new_pruning_point: Hash,
         metadata: kaspa_consensus_core::api::SmtExportMetadata,
-        inactivity_shortcut_block: Option<Hash>,
+        inactivity_shortcut_block: Hash,
         lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
-        use crate::model::stores::smt_metadata::{SmtBlockMetadata, ToccataV0};
+        use crate::model::stores::smt_metadata::SmtBlockMetadata;
         use kaspa_hashes::ZERO_HASH;
         use kaspa_smt_store::streaming_import::streaming_import;
 
         let kaspa_consensus_core::api::SmtExportMetadata { lanes_root, payload_and_ctx_digest, active_lanes_count, .. } = metadata;
         let expected_lane_count = active_lanes_count;
 
-        // `inactivity_shortcut_block` was already resolved by the caller during metadata
-        // verification: `Some` post-hardening, `None` pre-hardening. V1/V0 dispatch follows.
-        let row = match inactivity_shortcut_block {
-            Some(block) => SmtBlockMetadata::new(payload_and_ctx_digest, block, active_lanes_count),
-            None => SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest, active_lanes_count }),
-        };
+        // `inactivity_shortcut_block` was already resolved by the caller during metadata verification.
+        let row = SmtBlockMetadata::new(payload_and_ctx_digest, inactivity_shortcut_block, active_lanes_count);
 
         let result = self.virtual_processor.install(|| {
             streaming_import(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -144,7 +144,6 @@ impl ConsensusServices {
             tx_script_cache_counters,
             mass_calculator.clone(),
             params.toccata_activation,
-            params.zk_hardening_activation,
             params.mass_per_sig_op,
         );
 
@@ -184,8 +183,6 @@ impl ConsensusServices {
             params.ghostdag_k(),
             params.skip_proof_of_work,
             params.toccata_activation,
-            params.zk_hardening_activation,
-            params.net.is_mainnet(),
             is_consensus_exiting,
         ));
 

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -55,8 +55,7 @@ pub struct TestSeqCommitLaneProof {
     pub current_lane: Option<(Hash, u64)>,
     pub smt_proof: OwnedSmtProof,
     pub blue_score: u64,
-    /// Resolved shortcut Hash (None pre-hardening, Some(seq_commit-or-zero) post-hardening).
-    pub inactivity_shortcut: Option<Hash>,
+    pub inactivity_shortcut: Hash,
 }
 
 impl TestConsensus {
@@ -259,13 +258,8 @@ impl TestConsensus {
             .unwrap();
         let metadata = self.consensus.storage.smt_metadata_store.get(block_hash).unwrap();
 
-        let inactivity_shortcut = if self.params.zk_hardening_activation.is_active(header.daa_score) {
-            let shortcut_block =
-                metadata.inactivity_shortcut_block().expect("post-hardening row must carry inactivity_shortcut_block");
-            Some(self.consensus.virtual_processor.inactivity_shortcut(shortcut_block))
-        } else {
-            None
-        };
+        let shortcut_block = metadata.inactivity_shortcut_block();
+        let inactivity_shortcut = self.consensus.virtual_processor.inactivity_shortcut(shortcut_block);
 
         TestSeqCommitLaneProof {
             lanes_root,

--- a/consensus/src/model/stores/smt_metadata.rs
+++ b/consensus/src/model/stores/smt_metadata.rs
@@ -4,112 +4,40 @@ use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
-use serde::de::{Error as DeError, SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Pre-anchor (Toccata) per-block SMT metadata. Wire: `[Hash || u64]` = 40 bytes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToccataV0 {
-    pub payload_and_ctx_digest: Hash,
-    pub active_lanes_count: u64,
-}
-
-/// Post-anchor per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
+/// Per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
 ///
-/// Same first 40 bytes as `ToccataV0`; the trailing `inactivity_shortcut_block`
-/// is the only structural difference. `inactivity_shortcut_block` is retained
-/// per-row because `compute_inactivity_shortcut_block`'s parent-fallback path
-/// consults the parent's stored row; it does NOT feed `mergeset_context_hash`.
+/// `inactivity_shortcut_block` is retained per-row because
+/// `compute_inactivity_shortcut_block`'s parent-fallback path consults the
+/// parent's stored row.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToccataV1 {
+pub struct SmtBlockMetadata {
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
     pub inactivity_shortcut_block: Hash,
 }
 
-/// Per-block SMT metadata, length-discriminated on the wire (40 vs 72 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SmtBlockMetadata {
-    ToccataV0(ToccataV0),
-    ToccataV1(ToccataV1),
-}
-
 impl SmtBlockMetadata {
-    /// Construct a `ToccataV1` variant. The only variant new code ever writes.
     pub fn new(payload_and_ctx_digest: Hash, inactivity_shortcut_block: Hash, active_lanes_count: u64) -> Self {
-        Self::ToccataV1(ToccataV1 { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block })
+        Self { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block }
     }
 
     pub fn payload_and_ctx_digest(&self) -> Hash {
-        match self {
-            Self::ToccataV0(v) => v.payload_and_ctx_digest,
-            Self::ToccataV1(v) => v.payload_and_ctx_digest,
-        }
+        self.payload_and_ctx_digest
     }
 
-    pub fn inactivity_shortcut_block(&self) -> Option<Hash> {
-        match self {
-            Self::ToccataV1(v) => Some(v.inactivity_shortcut_block),
-            Self::ToccataV0(_) => None,
-        }
+    pub fn inactivity_shortcut_block(&self) -> Hash {
+        self.inactivity_shortcut_block
     }
 
     pub fn active_lanes_count(&self) -> u64 {
-        match self {
-            Self::ToccataV1(v) => v.active_lanes_count,
-            Self::ToccataV0(v) => v.active_lanes_count,
-        }
+        self.active_lanes_count
     }
 }
 
 impl MemSizeEstimator for SmtBlockMetadata {}
-
-impl Serialize for SmtBlockMetadata {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        match self {
-            Self::ToccataV0(v) => v.serialize(s),
-            Self::ToccataV1(v) => v.serialize(s),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for SmtBlockMetadata {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        struct V;
-        impl<'de> Visitor<'de> for V {
-            type Value = SmtBlockMetadata;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("SmtBlockMetadata: [Hash, u64] (ToccataV0) or [Hash, u64, Hash] (ToccataV1)")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let first: Hash = seq.next_element()?.ok_or_else(|| A::Error::custom("missing first hash"))?;
-                let count: u64 = seq.next_element()?.ok_or_else(|| A::Error::custom("missing active_lanes_count"))?;
-                // Third element discriminates: a Hash present => V1; EOF on the
-                // third read => V0 (no trailing inactivity_shortcut_block). On a
-                // 40-byte V0 wire the buffer is empty before this read, so no
-                // bytes are partially consumed; the error path is safe.
-                match seq.next_element::<Hash>() {
-                    Ok(Some(inactivity_shortcut_block)) => Ok(SmtBlockMetadata::ToccataV1(ToccataV1 {
-                        payload_and_ctx_digest: first,
-                        active_lanes_count: count,
-                        inactivity_shortcut_block,
-                    })),
-                    Ok(None) | Err(_) => {
-                        Ok(SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: first, active_lanes_count: count }))
-                    }
-                }
-            }
-        }
-        d.deserialize_tuple(3, V)
-    }
-}
 
 /// Block-hash-keyed metadata store with in-memory cache. Key = `[prefix || hash]`.
 #[derive(Clone)]
@@ -157,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_v1() {
+    fn round_trip() {
         let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
         let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
 
@@ -174,44 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_v0() {
-        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
-
-        let hash = Hash::from_u64_word(0xABCD);
-        let meta =
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 });
-
-        let mut batch = WriteBatch::default();
-        store.insert_batch(&mut batch, hash, meta).unwrap();
-        db.write(batch).unwrap();
-
-        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
-        assert_eq!(on_disk.len(), 40);
-        assert_eq!(store.get(hash).unwrap(), meta);
-    }
-
-    #[test]
-    fn decode_handcrafted_v0_wire() {
-        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
-
-        let hash = Hash::from_u64_word(0xABCD);
-        let mut bytes = Vec::with_capacity(40);
-        bytes.extend_from_slice(&[0xAA; 32]);
-        bytes.extend_from_slice(&7u64.to_le_bytes());
-        db.put(row_key(hash), bytes).unwrap();
-
-        let decoded = store.get(hash).unwrap();
-        assert_eq!(
-            decoded,
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 })
-        );
-        assert_eq!(decoded.active_lanes_count(), 7);
-    }
-
-    #[test]
-    fn decode_handcrafted_v1_wire() {
+    fn decode_handcrafted_wire() {
         let mut bytes = Vec::with_capacity(72);
         bytes.extend_from_slice(&[0x11; 32]);
         bytes.extend_from_slice(&42u64.to_le_bytes());
@@ -219,29 +110,26 @@ mod tests {
         let decoded: SmtBlockMetadata = bincode::deserialize(&bytes).unwrap();
         assert_eq!(
             decoded,
-            SmtBlockMetadata::ToccataV1(ToccataV1 {
+            SmtBlockMetadata {
                 payload_and_ctx_digest: Hash::from_bytes([0x11; 32]),
                 active_lanes_count: 42,
                 inactivity_shortcut_block: Hash::from_bytes([0x22; 32]),
-            })
+            }
         );
     }
 
     #[test]
-    fn payload_and_ctx_digest_accessor_works_for_both_variants() {
-        let v0 =
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 0 });
-        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 0);
-        assert_eq!(v0.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
-        assert_eq!(v1.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+    fn accessors_work() {
+        let metadata = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 7);
+        assert_eq!(metadata.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+        assert_eq!(metadata.inactivity_shortcut_block(), Hash::from_bytes([0x22; 32]));
+        assert_eq!(metadata.active_lanes_count(), 7);
     }
 
     #[test]
-    fn variant_wire_sizes() {
-        let v0 = SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0; 32]), active_lanes_count: 0 });
-        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
-        assert_eq!(bincode::serialize(&v0).unwrap().len(), 40);
-        assert_eq!(bincode::serialize(&v1).unwrap().len(), 72);
+    fn wire_size() {
+        let metadata = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
+        assert_eq!(bincode::serialize(&metadata).unwrap().len(), 72);
     }
 
     #[test]

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -177,10 +177,6 @@ pub struct VirtualStateProcessor {
     pub(crate) toccata_activation: ForkActivation,
     pub(crate) toccata_logger: ForkLogger,
 
-    // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
-    pub(crate) zk_hardening_activation: ForkActivation,
-    pub(crate) zk_hardening_logger: ForkLogger,
-
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
     pub(super) smt_metadata_store: Arc<crate::model::stores::smt_metadata::DbSmtMetadataStore>,
@@ -255,13 +251,6 @@ impl VirtualStateProcessor {
             counters,
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
-            zk_hardening_activation: params.zk_hardening_activation,
-            zk_hardening_logger: ForkLogger::new_with_fork(
-                "Toccata ZK hardening",
-                "TOCCATA ZK HARDENING",
-                "virtual state processing rules",
-                true,
-            ),
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -596,9 +585,6 @@ impl VirtualStateProcessor {
         if self.toccata_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
             self.toccata_logger.report_activation();
         }
-        if self.zk_hardening_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
-            self.zk_hardening_logger.report_activation();
-        }
 
         // Compute accepted_id_digests
         let accepted_id_digests = if self.toccata_activation.is_active(virtual_daa_window.daa_score) {
@@ -638,8 +624,7 @@ impl VirtualStateProcessor {
         let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(virtual_ghostdag_data);
         let context_hash =
             mergeset_context_hash(&MergesetContext { timestamp: parent_header.timestamp, daa_score, blue_score: current_blue_score });
-        let inactivity_shortcut =
-            self.zk_hardening_activation.is_active(daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
+        let inactivity_shortcut = self.inactivity_shortcut(inactivity_shortcut_block);
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -733,13 +718,8 @@ impl VirtualStateProcessor {
         )
         .unwrap();
 
-        // Pre-hardening: identity. Post-hardening (typically only simnet with activation=0):
-        // wrap with ZERO_HASH shortcut since no real shortcut block exists yet at genesis.
-        let activity_root = if self.zk_hardening_activation.is_active(self.genesis.daa_score) {
-            activity_root_hash(&ZERO_HASH, &lanes_root)
-        } else {
-            lanes_root
-        };
+        // Genesis has no shortcut target, so Toccata commits ZERO_HASH at the activity-root level.
+        let activity_root = activity_root_hash(&ZERO_HASH, &lanes_root);
         let pd = payload_and_context_digest(&context_hash, &payload_root);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
@@ -748,9 +728,8 @@ impl VirtualStateProcessor {
 
     /// Read stored SMT metadata for the pruning point.
     ///
-    /// Both V0 and V1 rows carry `payload_and_ctx_digest` directly. The receiver
-    /// derives `inactivity_shortcut_block` from chain headers when needed, so the
-    /// wire shape is identical pre- and post-hardening.
+    /// The receiver derives `inactivity_shortcut_block` from chain headers, so it
+    /// is not transmitted on the wire.
     pub fn get_pruning_point_smt_metadata(
         &self,
         expected_pruning_point: Hash,
@@ -805,11 +784,9 @@ impl VirtualStateProcessor {
     /// `inactivity_shortcut` value is this block's seq_commit (see
     /// [`Self::inactivity_shortcut`]).
     ///
-    /// Never returns `ZERO_HASH`. Before a real shortcut block is reachable
-    /// (early chain, or within finality depth of hardening activation), a
-    /// pre-hardening stand-in is returned. Such stand-ins are valid for
-    /// context-hash recomputation but must not be exposed to provers or RPC
-    /// consumers as real shortcut targets.
+    /// Never returns `ZERO_HASH`. Before a real seqcommit-bearing shortcut block
+    /// is reachable, the returned block can be genesis or another pre-Toccata
+    /// ancestor and [`Self::inactivity_shortcut`] folds it to `ZERO_HASH`.
     pub(super) fn compute_inactivity_shortcut_block(&self, ghostdag_data: &GhostdagData) -> Hash {
         let selected_parent = ghostdag_data.selected_parent;
 
@@ -843,38 +820,19 @@ impl VirtualStateProcessor {
         // v != ZERO_HASH` arm above. That gives us `current.bs <= pp.bs + finality_depth + 1`:
         // we are in the narrow post-IBD window of at most `finality_depth + 1` blocks past pp.
         //
-        // Inside that window, `selected_parent` is necessarily either pp itself or a post-IBD
-        // local descendant of pp, and both carry a V1 row with a real `inactivity_shortcut_block`:
+        // Inside that window, `selected_parent` is either pp itself, a post-IBD local
+        // descendant of pp, or a pre-Toccata selected parent right after activation:
         //   - pp: inserted by `Consensus::import_pruning_point_smt` via `SmtBlockMetadata::new(...)`.
         //   - local descendant: committed by `commit_virtual_state` via `SmtBlockMetadata::new(...)`.
-        // The other shapes are excluded:
-        //   - sp == genesis: excluded by the early-return clamp at the top of this function.
-        //   - sp pre-toccata: `compute_inactivity_shortcut_block` is only called from
-        //     `compute_seq_commit`/`recompute_seq_commit`, both gated on
-        //     `toccata_activation.is_active(current.daa_score)`. `sync_new_smt_state` is also a
-        //     no-op for pre-toccata pps (see `ibd/flow.rs`), so a pre-toccata sp cannot coexist
-        //     with the post-IBD-window precondition.
-        //   - sp's row being legacy ToccataV0 (pre-anchor tn10 data): the V0 row is a residue of
-        //     pre-anchor live processing, so it lives deep in the chain — but the post-IBD-window
-        //     precondition forces sp to be fresh (pp or its post-IBD descendant), which is always
-        //     written as V1 by this binary. Pre-anchor IBD did not exist (introduced by this PR),
-        //     so an upgrading tn10 node can only enter the narrow window via a post-upgrade IBD
-        //     whose pp is committed as V1, or by building locally past its existing chain (in
-        //     which case branch A above fires because the live coinbase lane is fully populated).
-        //
-        // The `.unwrap_or(selected_parent)` tail is therefore dead under correct operation. It is
-        // a defense-in-depth default: even if reached, the returned block hash only affects
-        // consensus when `zk_hardening_activation.is_active(current.daa_score)` (see
-        // `compute_seq_commit`'s gating of the `inactivity_shortcut` field), and the cases that
-        // would reach the tail (missing row, pre-anchor V0 row, pre-toccata sp) are all
-        // pre-hardening contexts where `inactivity_shortcut()` folds the result to `ZERO_HASH`
-        // regardless of which pre-hardening block is named.
+        //   - pre-Toccata sp: has no metadata row, so it is used directly and
+        //     folded to ZERO_HASH by `inactivity_shortcut` until a later chain
+        //     child is deep enough for the coinbase-lane fast path.
         let search_from = self
             .smt_metadata_store
             .get(selected_parent)
             .optional()
             .unwrap()
-            .and_then(|md| md.inactivity_shortcut_block())
+            .map(|md| md.inactivity_shortcut_block())
             .unwrap_or(selected_parent);
 
         let mut current = search_from;
@@ -888,16 +846,14 @@ impl VirtualStateProcessor {
     }
 
     /// Derive the `inactivity_shortcut` value folded into `activity_root` from
-    /// its block hash. Folds to `ZERO_HASH` for pre-hardening blocks (whose
-    /// seq_commit does not encode a shortcut); genesis falls into this branch
-    /// naturally since its `accepted_id_merkle_root` is `ZERO_HASH`. Otherwise
-    /// returns the block's seq_commit.
+    /// its block hash. Folds to `ZERO_HASH` for pre-Toccata blocks, whose
+    /// headers do not encode a seqcommit. Otherwise returns the block's seqcommit.
     ///
     /// Panics on `ZERO_HASH` input — callers must pass a real block hash.
     pub fn inactivity_shortcut(&self, inactivity_shortcut_block: Hash) -> Hash {
         assert_ne!(inactivity_shortcut_block, ZERO_HASH, "inactivity_shortcut block must be a real block hash");
         let header = self.headers_store.get_header(inactivity_shortcut_block).unwrap();
-        if !self.zk_hardening_activation.is_active(header.daa_score) {
+        if !self.toccata_activation.is_active(header.daa_score) {
             return ZERO_HASH;
         }
         header.accepted_id_merkle_root
@@ -906,7 +862,7 @@ impl VirtualStateProcessor {
     /// Resolve the `inactivity_shortcut_block` from the POV of an arbitrary chain
     /// block, using only headers + reachability (no SMT). Used by the IBD receiver
     /// at the PP boundary before the SMT is imported, and by `import_pruning_point_smt`
-    /// to populate the V1 metadata row.
+    /// to populate the pruning point metadata row.
     ///
     /// Algorithm: walks `pov_block`'s selected-chain ancestors backward by blue_score
     /// until `bs <= pov.bs - finality_depth - 1`. Folds to genesis on shallow chains,

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -374,7 +374,7 @@ async fn inactivity_shortcut_block_clamps_to_genesis_within_finality_depth() {
         let header = ctx.consensus.get_header(hash).unwrap();
         assert!(header.blue_score <= finality_depth);
         let meta = ctx.consensus.smt_block_metadata(hash);
-        assert_eq!(meta.inactivity_shortcut_block(), Some(config.genesis.hash), "bs={}", header.blue_score);
+        assert_eq!(meta.inactivity_shortcut_block(), config.genesis.hash, "bs={}", header.blue_score);
     }
 }
 
@@ -400,7 +400,7 @@ async fn inactivity_shortcut_resolves_to_chain_block_at_target_bs() {
 
     let expected_block = *chain.iter().find(|h| ctx.consensus.get_header(**h).unwrap().blue_score == target_bs).unwrap();
     let recorded = ctx.consensus.smt_block_metadata(tip).inactivity_shortcut_block();
-    assert_eq!(recorded, Some(expected_block));
+    assert_eq!(recorded, expected_block);
 }
 
 /// Consecutive chain blocks: the inactivity_shortcut advances by one chain
@@ -419,6 +419,6 @@ async fn inactivity_shortcut_advances_one_block_per_chain_step() {
 
     for (i, hash) in chain.iter().copied().enumerate().skip(4) {
         let expected = chain[i - 3];
-        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), Some(expected), "block index {i}");
+        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), expected, "block index {i}");
     }
 }

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -573,8 +573,7 @@ impl VirtualStateProcessor {
     /// Works with an immutable view of DB state. Returns the commit hash and an `SmtBuild`
     /// containing the diff (updated branches, lane versions, score index) for later persistence.
     ///
-    /// `inactivity_shortcut`: `Some(hash)` post-hardening (wraps `lanes_root` into
-    /// `activity_root` via `H_activity_root`); `None` pre-hardening (identity).
+    /// `inactivity_shortcut` is folded into `activity_root` next to the active-lanes root.
     pub(super) fn build_seq_commit(
         &self,
         parent: &ParentBlockSeqState,
@@ -584,7 +583,7 @@ impl VirtualStateProcessor {
         miner_payload_leaves: Vec<Hash>,
         selected_parent: Hash,
         inactivity_shortcut_block: Hash,
-        inactivity_shortcut: Option<Hash>,
+        inactivity_shortcut: Hash,
     ) -> (Hash, kaspa_smt_store::processor::SmtBuild) {
         use kaspa_seq_commit::hashing::{activity_root_hash, miner_payload_root, seq_commit, seq_state_root};
         use kaspa_seq_commit::types::{SeqCommitInput, SeqState};
@@ -615,13 +614,9 @@ impl VirtualStateProcessor {
         let mut build = proc.build(|bh| self.is_smt_canonical(bh, selected_parent)).unwrap();
 
         // 5. Compute final hash: activity_root -> state_root -> seq_commit.
-        // Pre-hardening: identity (activity_root = lanes_root). Post-hardening: wrap.
         let payload_root = miner_payload_root(miner_payload_leaves.into_iter());
         let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&context_hash, &payload_root);
-        let activity_root = match inactivity_shortcut {
-            Some(s) => activity_root_hash(&s, &build.root),
-            None => build.root,
-        };
+        let activity_root = activity_root_hash(&inactivity_shortcut, &build.root);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent.seq_commit, state_root: &state_root });
 
@@ -654,8 +649,7 @@ impl VirtualStateProcessor {
             daa_score: header.daa_score,
             blue_score: current_blue_score,
         });
-        let inactivity_shortcut =
-            self.zk_hardening_activation.is_active(header.daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
+        let inactivity_shortcut = self.inactivity_shortcut(inactivity_shortcut_block);
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -301,25 +301,11 @@ impl PruningProofManager {
 
         if self.toccata_activation.is_active(pruning_point_header.daa_score) {
             // Pruning point txs are validated with the pruning point selected parent as seqcommit context.
-            // Conceptually, this is the context from which the threshold should be measured on all networks.
-            //
-            // We must use pp.sp.bs whenever pp is post zk_hardening: the `inactivity_shortcut` anchor lives
-            // at `bs <= pp.bs - F - 1`. With pp.sp.bs as context, the threshold predicate continues down to
-            // `pp.bs - F - 1` and covers the anchor; with pp.bs as context it stops one block higher and
-            // misses it. Post-hardening syncers always send the segment from pp.sp, so this is safe.
-            //
-            // Pre zk_hardening on non-mainnet stays on pp.bs to keep compatibility with already-deployed
-            // peers that emit segments using pp.bs. Mainnet had no pre-fix release.
-            //
-            // TODO(post-zk-hardening): once all networks are past the hardening activation, use pp.sp.bs
-            // unconditionally and drop the is_mainnet/zk_hardening_activation branching.
-            let use_sp_context = self.is_mainnet || self.zk_hardening_activation.is_active(pruning_point_header.daa_score);
-            let context_blue_score = if use_sp_context {
-                let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
-                trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score
-            } else {
-                pruning_point_header.blue_score
-            };
+            // The selected-parent context carries the full threshold range needed for both
+            // seqcommit access and the inactivity shortcut anchor.
+            let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
+            let context_blue_score =
+                trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score;
 
             let threshold = self.finality_depth;
             let mut current = pruning_point;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -120,8 +120,6 @@ pub struct PruningProofManager {
     ghostdag_k: KType,
     skip_proof_of_work: bool,
     toccata_activation: ForkActivation,
-    zk_hardening_activation: ForkActivation,
-    is_mainnet: bool,
 
     is_consensus_exiting: Arc<AtomicBool>,
 }
@@ -144,8 +142,6 @@ impl PruningProofManager {
         ghostdag_k: KType,
         skip_proof_of_work: bool,
         toccata_activation: ForkActivation,
-        zk_hardening_activation: ForkActivation,
-        is_mainnet: bool,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -182,8 +178,6 @@ impl PruningProofManager {
             ghostdag_k,
             skip_proof_of_work,
             toccata_activation,
-            zk_hardening_activation,
-            is_mainnet,
 
             is_consensus_exiting,
         }

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -26,7 +26,6 @@ pub struct TransactionValidator {
     ghostdag_k: KType,
     sig_cache: Cache<SigCacheKey, bool>,
     toccata_activation: ForkActivation,
-    zk_hardening_activation: ForkActivation,
     mass_per_sig_op: u64,
 
     pub(crate) mass_calculator: MassCalculator,
@@ -45,7 +44,6 @@ impl TransactionValidator {
         counters: Arc<TxScriptCacheCounters>,
         mass_calculator: MassCalculator,
         toccata_activation: ForkActivation,
-        zk_hardening_activation: ForkActivation,
         mass_per_sig_op: u64,
     ) -> Self {
         Self {
@@ -59,7 +57,6 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator,
             toccata_activation,
-            zk_hardening_activation,
             mass_per_sig_op,
         }
     }
@@ -85,7 +82,6 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator: MassCalculator::new(0, 0, 0),
             toccata_activation: ForkActivation::never(),
-            zk_hardening_activation: ForkActivation::never(),
             mass_per_sig_op: 0,
         }
     }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -169,9 +169,7 @@ impl TransactionValidator {
     ) -> TxResult<()> {
         let ctx = EngineCtx::new(&self.sig_cache).with_covenants_ctx(&covenants_ctx).with_seq_commit_accessor_opt(seq_commit_accessor);
         let covenants_enabled = self.toccata_activation.is_active(block_daa_score);
-        let zk_hardening_enabled = self.zk_hardening_activation.is_active(block_daa_score);
-        let flags: EngineFlags =
-            EngineFlags { covenants_enabled, zk_hardening_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
+        let flags: EngineFlags = EngineFlags { covenants_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
 
         check_scripts(tx, ctx, flags)
     }
@@ -361,7 +359,6 @@ mod tests {
             Default::default(),
             MassCalculator::new(0, 0, 0),
             ForkActivation::always(),
-            ForkActivation::always(),
             params.mass_per_sig_op,
         );
 
@@ -498,7 +495,7 @@ mod tests {
             check_scripts(
                 &verifiable_tx,
                 EngineCtx::new(&sig_cache),
-                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 5_000.into() }
+                EngineFlags { covenants_enabled: true, sigop_script_units: 5_000.into() }
             ),
             Ok(())
         );

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -108,7 +108,7 @@ type RoundTxBuilder = fn(u32, usize) -> (Transaction, Vec<UtxoEntry>);
 type ResultCheck = fn(Result<(), TxScriptError>) -> Result<(), String>;
 
 fn pricing_flags(covenants_enabled: bool) -> EngineFlags {
-    EngineFlags { covenants_enabled, zk_hardening_enabled: covenants_enabled, sigop_script_units: Gram(1000).into() }
+    EngineFlags { covenants_enabled, sigop_script_units: Gram(1000).into() }
 }
 
 fn new_script_builder() -> ScriptBuilder {

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -125,13 +125,12 @@ enum ScriptSource<'a, T: VerifiableTransaction> {
 #[derive(Copy, Clone)]
 pub struct EngineFlags {
     pub covenants_enabled: bool,
-    pub zk_hardening_enabled: bool,
     pub sigop_script_units: ScriptUnits,
 }
 
 impl Default for EngineFlags {
     fn default() -> Self {
-        Self { covenants_enabled: false, zk_hardening_enabled: false, sigop_script_units: Gram(1000).into() }
+        Self { covenants_enabled: false, sigop_script_units: Gram(1000).into() }
     }
 }
 
@@ -1183,7 +1182,7 @@ mod tests {
     fn test_used_script_units_can_drive_compute_budget_selection() {
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let flags = EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() };
+        let flags = EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() };
         let script = ScriptBuilder::with_flags(flags)
             .add_data(&vec![42u8; SCRIPT_UNITS_PER_COMPUTE_BUDGET_UNIT as usize])
             .unwrap()
@@ -1340,7 +1339,7 @@ mod tests {
                 0,
                 &utxo_entry,
                 EngineCtx::new(&sig_cache).with_reused(&reused_values),
-                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+                EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
             );
 
             assert_eq!(vm.execute(), Ok(()), "execution failed for SPK_LEN={expected_script_len}");
@@ -1460,7 +1459,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, sigop_script_units },
             budget_allows_one_sigop_only,
         );
         assert_match!(
@@ -1475,7 +1474,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, sigop_script_units },
             (budget_allows_one_sigop_only.0 * 2).into(),
         );
         assert_eq!(vm_with_doubled_budget.execute(), Ok(()), "expected tx to pass when budget is doubled");
@@ -2150,7 +2149,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));
@@ -2216,7 +2215,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));

--- a/crypto/txscript/src/zk_precompiles/fields/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/mod.rs
@@ -52,39 +52,9 @@ impl OpcodeData<Fr> for StackEntry {
     }
 }
 
-#[derive(Clone, Debug)]
-/// Legacy that truncates to the first 32 bytes and accepts trailing bytes.
-pub struct TruncFr(ark_bn254::Fr);
-
-impl From<TruncFr> for Fr {
-    fn from(prev: TruncFr) -> Self {
-        Fr(prev.0)
-    }
-}
-
-impl TryFrom<&[u8]> for TruncFr {
-    type Error = FieldsError;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Ok(TruncFr(ark_bn254::Fr::deserialize_uncompressed(bytes)?))
-    }
-}
-
-impl OpcodeData<TruncFr> for StackEntry {
-    fn deserialize(&self, _: bool) -> Result<TruncFr, TxScriptError> {
-        TruncFr::try_from(self.as_slice()).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))
-    }
-
-    fn serialize(from: &TruncFr) -> Result<Self, SerializationError> {
-        let mut bytes = Vec::new();
-        from.0.serialize_uncompressed(&mut bytes).map_err(|_| SerializationError::ArkSerialization)?;
-        Ok(SmallVec::from_vec(bytes))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{FR_BYTES, Fr, TruncFr};
+    use super::{FR_BYTES, Fr};
     use crate::zk_precompiles::fields::error::FieldsError;
 
     #[test]
@@ -110,20 +80,5 @@ mod tests {
             Err(FieldsError::InvalidLength(16)) => {}
             other => panic!("expected InvalidLength(16), got {other:?}"),
         }
-    }
-
-    /// TruncFr (legacy)
-    #[test]
-    fn prev_fr_accepts_oversized_buffer() {
-        let mut bytes = vec![0u8; 64];
-        bytes[0] = 0x01;
-        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 64-byte buffer");
-    }
-
-    #[test]
-    fn prev_fr_accepts_exactly_32_bytes() {
-        let mut bytes = [0u8; FR_BYTES];
-        bytes[0] = 0x01;
-        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 32-byte buffer");
     }
 }

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -11,10 +11,7 @@ use crate::{
     data_stack::Stack,
     opcodes::i32s_to_usizes,
     runtime_resource_meter::RuntimeResourceMeter,
-    zk_precompiles::{
-        ZkPrecompile,
-        fields::{Fr, TruncFr},
-    },
+    zk_precompiles::{ZkPrecompile, fields::Fr},
 };
 
 /// Empirically determined script unit cost per gamma_abc_g1 element in the VK
@@ -72,7 +69,7 @@ impl ZkPrecompile for Groth16Precompile {
     ///
     /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
     ///
-    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
         // Retrieve the compressed VK
         let [unprepared_compressed_key] = dstack.pop_raw()?;
 
@@ -92,30 +89,12 @@ impl ZkPrecompile for Groth16Precompile {
         //
         // Note: public input count is bounded by the script stack depth limit.
         for _ in 0..n_inputs {
-            // convert bytes to Fr according to whether we're in hardened mode or not
-            let fr = if flags.zk_hardening_enabled {
-                let [fr] = dstack.pop_items::<1, Fr>()?;
-                fr
-            } else {
-                let [trunc_fr] = dstack.pop_items::<1, TruncFr>()?;
-                Fr::from(trunc_fr)
-            };
+            let [fr] = dstack.pop_items::<1, Fr>()?;
             unprepared_public_inputs.push(fr.into_field());
         }
 
-        // Deserialize the verifying key. Post-activation: streamed deserialize
-        // that arity-checks and meters per gamma_abc_g1 element inline. Pre-
-        // activation: plain ark deserialize plus the historical empty-gamma_abc
-        // check, no per-element charge.
-        let vk = if flags.zk_hardening_enabled {
-            deserialize_verifying_key_with_metering(&unprepared_compressed_key, unprepared_public_inputs.len(), meter)?
-        } else {
-            let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
-            if vk.gamma_abc_g1.is_empty() {
-                return Err(Groth16Error::EmptyGammaAbc);
-            }
-            vk
-        };
+        // Deserialize the verifying key with arity checking and per-public-input pricing.
+        let vk = deserialize_verifying_key_with_metering(&unprepared_compressed_key, unprepared_public_inputs.len(), meter)?;
 
         // Prepare verifying key
         let pvk = ark_groth16::prepare_verifying_key(&vk);
@@ -123,7 +102,7 @@ impl ZkPrecompile for Groth16Precompile {
         // Deserialize proof
         let mut proof_reader = proof_bytes.as_slice();
         let proof = Proof::<Bn254>::deserialize_compressed(&mut proof_reader)?;
-        if flags.zk_hardening_enabled && !proof_reader.is_empty() {
+        if !proof_reader.is_empty() {
             return Err(Groth16Error::TrailingProofBytes);
         }
 
@@ -154,12 +133,8 @@ mod tests {
     use kaspa_consensus_core::mass::ScriptUnits;
     use kaspa_txscript_errors::TxScriptError;
 
-    fn hardened_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
-    }
-
-    fn legacy_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
+    fn test_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, ..Default::default() }
     }
 
     fn stack_with_groth_fields(vk: Vec<u8>, proof: Vec<u8>, inputs: Vec<Vec<u8>>) -> Stack {
@@ -235,7 +210,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("arity mismatch must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("arity mismatch must be rejected");
         match err {
             Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch) => {}
             other => panic!("expected ArityMismatch before meter charge, got: {other:?}"),
@@ -262,7 +237,7 @@ mod tests {
         let expected_charge = (COUNT as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
         assert!(expected_charge > PER_INPUT_BUDGET.0, "gamma_abc charge {expected_charge} must exceed budget {}", PER_INPUT_BUDGET.0);
 
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("over-budget VK must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("over-budget VK must be rejected");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
                 assert_eq!(limit, PER_INPUT_BUDGET.0);
@@ -273,47 +248,15 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_accepts_canonical_proof() {
+    fn verify_path_accepts_canonical_proof() {
         let (vk, proof, inputs) = load_groth_fields();
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).unwrap();
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).unwrap();
     }
 
     #[test]
-    fn legacy_verify_path_accepts_canonical_proof_without_metering() {
-        let (vk, proof, inputs) = load_groth_fields();
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept canonical proof");
-        assert_eq!(meter.used_script_units(), ScriptUnits(0), "legacy path must not consume meter units");
-    }
-
-    #[test]
-    fn legacy_verify_path_tolerates_oversized_fr_push() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs[0].extend_from_slice(&[0xAB; 32]);
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags())
-            .expect("legacy path must accept 64-byte Fr push (silent truncation)");
-    }
-
-    #[test]
-    fn legacy_verify_path_tolerates_trailing_vk_and_proof_bytes() {
-        let (mut vk, mut proof, inputs) = load_groth_fields();
-        vk.push(0xAB);
-        proof.push(0xCD);
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept trailing VK/proof bytes");
-    }
-
-    #[test]
-    fn hardened_verify_path_rejects_oversized_fr_push() {
+    fn verify_path_rejects_oversized_fr_push() {
         let vk_bytes = vk_with_gamma_abc_count(6); // 5 pub inputs + 1
         let oversized_input = vec![0u8; 64];
 
@@ -327,8 +270,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject oversized Fr push");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject oversized Fr push");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ZkIntegrity(msg)) if msg.contains("Invalid Fr length") => {}
             other => panic!("expected Invalid Fr length error, got: {other:?}"),
@@ -336,14 +278,13 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_rejects_trailing_vk_bytes() {
+    fn verify_path_rejects_trailing_vk_bytes() {
         let (mut vk, proof, inputs) = load_groth_fields();
         vk.push(0xAB);
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject trailing VK bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing VK bytes");
         match err {
             Groth16Error::TrailingVerifyingKeyBytes => {}
             other => panic!("expected trailing VK error, got: {other:?}"),
@@ -351,14 +292,13 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_rejects_trailing_proof_bytes() {
+    fn verify_path_rejects_trailing_proof_bytes() {
         let (vk, mut proof, inputs) = load_groth_fields();
         proof.push(0xCD);
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject trailing proof bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing proof bytes");
         match err {
             Groth16Error::TrailingProofBytes => {}
             other => panic!("expected trailing proof error, got: {other:?}"),

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -92,7 +92,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     /// - control inclusion proof digests (bytes)
     /// - control index (bytes, u32 le)
     /// - claim (bytes)
-    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
         let [claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn] = dstack.pop_raw()?;
 
         let control_id = parse_digest(control_id)?;
@@ -110,7 +110,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
         let control_digests = parse_digest_list(control_digests)?;
 
         let max_control_proof_len = control_merkle_depth_for(hashfn);
-        if flags.zk_hardening_enabled && control_digests.len() > max_control_proof_len {
+        if control_digests.len() > max_control_proof_len {
             return Err(R0Error::ControlInclusionProofTooLong { actual: control_digests.len(), max: max_control_proof_len });
         }
 

--- a/crypto/txscript/src/zk_precompiles/tests/helpers.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/helpers.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub fn zk_test_flags() -> EngineFlags {
-    EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
+    EngineFlags { covenants_enabled: true, ..Default::default() }
 }
 
 pub fn build_zk_script(elements: &[&[u8]]) -> ScriptBuilderResult<Vec<u8>> {
@@ -32,12 +32,7 @@ pub fn execute_zk_script(
     sig_cache: &Cache<SigCacheKey, bool>,
     reused_values: &SigHashReusedValuesUnsync,
 ) -> Result<(), TxScriptError> {
-    execute_zk_script_with_flags(
-        script,
-        sig_cache,
-        reused_values,
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() },
-    )
+    execute_zk_script_with_flags(script, sig_cache, reused_values, EngineFlags { covenants_enabled: true, ..Default::default() })
 }
 
 pub fn execute_zk_script_with_flags(

--- a/crypto/txscript/src/zk_precompiles/tests/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/mod.rs
@@ -4,10 +4,9 @@ pub mod helpers;
 mod fast_zk_tests {
     use super::helpers::{
         Groth16Fields, R0Fields, build_groth_script, build_groth_script_from_fields, build_stark_script, execute_p2sh_script,
-        execute_zk_script, execute_zk_script_with_flags, load_groth_fields, load_stark_fields,
+        execute_zk_script, load_groth_fields, load_stark_fields,
     };
     use crate::{
-        EngineFlags,
         caches::Cache,
         get_zk_script_units_upper_bound,
         zk_precompiles::{groth16::Groth16Error, tags::ZkTag},
@@ -694,7 +693,7 @@ mod fast_zk_tests {
     }
 
     #[test]
-    fn verify_r0_succinct_long_control_proof_gated() {
+    fn verify_r0_succinct_long_control_proof_rejected() {
         let mut fields = R0Fields::from_fixture();
         fields.control_digests.extend_from_slice(&[0; risc0_zkp::core::digest::DIGEST_BYTES]);
         let script = fields.script();
@@ -702,72 +701,9 @@ mod fast_zk_tests {
         let reused_values = SigHashReusedValuesUnsync::new();
 
         expect_zk_err(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()),
-            "legacy long control proof",
-            ExpectedZkError::StartsWith("R0: control_id mismatch:"),
-        );
-        expect_zk_err(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened long control proof",
+            execute_zk_script(&script, &cache, &reused_values),
+            "long control proof",
             ExpectedZkError::Exact("Control inclusion proof length 9 exceeds maximum 8"),
         );
-    }
-
-    fn legacy_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
-    }
-
-    fn hardened_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
-    }
-
-    #[test]
-    fn groth16_extra_public_input_silently_accepted_pre_activation_rejected_post() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs.push(inputs[0].clone()); // extra public input that ark will silently drop
-
-        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-
-        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
-            .expect("legacy path silently accepts the extra public input (the bug)");
-
-        expect_groth16_arity_mismatch(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened arity",
-        );
-    }
-
-    #[test]
-    fn groth16_missing_public_input_gated_error_kind() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs.pop();
-
-        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-
-        match execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()) {
-            Err(TxScriptError::ZkIntegrity(msg)) => {
-                let arity = Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string();
-                assert_ne!(msg, arity, "legacy path must not surface ArityMismatch (no upfront check)");
-            }
-            other => panic!("legacy: expected ZkIntegrity error from verify failure, got {other:?}"),
-        }
-
-        expect_groth16_arity_mismatch(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened missing input",
-        );
-    }
-
-    #[test]
-    fn groth16_canonical_proof_verifies_under_legacy_flags() {
-        let script = build_groth_script();
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
-            .expect("legacy Groth16 path must accept canonical proof");
     }
 }

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -98,15 +98,8 @@ struct CountdownActivation {
 }
 
 impl CountdownActivation {
-    fn latest(toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) -> Self {
-        [
-            Self { name: "Toccata", activation: toccata_activation },
-            Self { name: "Toccata ZK hardening", activation: zk_hardening_activation },
-        ]
-        .into_iter()
-        .filter(|candidate| candidate.activation != ForkActivation::never())
-        .max_by_key(|candidate| candidate.activation.daa_score())
-        .unwrap_or(Self { name: "Toccata", activation: ForkActivation::never() })
+    fn toccata(toccata_activation: ForkActivation) -> Self {
+        Self { name: "Toccata", activation: toccata_activation }
     }
 }
 
@@ -395,10 +388,7 @@ impl FlowContext {
                 tick_service,
                 notification_root,
                 user_agent_rules,
-                block_event_logger: Some(BlockEventLogger::new(
-                    bps,
-                    CountdownActivation::latest(config.toccata_activation, config.zk_hardening_activation),
-                )),
+                block_event_logger: Some(BlockEventLogger::new(bps, CountdownActivation::toccata(config.toccata_activation))),
                 bps,
                 orphan_resolution_range,
                 max_orphans,
@@ -840,7 +830,7 @@ impl ConnectionInitializer for FlowContext {
         let connect_only_new_versions = self.config.toccata_activation.is_active(virtual_daa_score.saturating_add(daa_threshold));
 
         // Until the one-day pre-activation threshold is reached, older protocol versions remain accepted.
-        // Once it is reached, peers must advertise protocol 10 (TN12 launch peers were normalized above).
+        // Once it is reached, peers must advertise protocol 10.
         //
         // Note: post-activation fresh nodes with virtual DAA score near genesis are not covered here and
         // are guarded later during IBD by `validate_pruning_point_freshness_for_toccata`.

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -709,33 +709,22 @@ impl IbdFlow {
         // Phase 0: receive and verify metadata. Single 96-byte wire.
         let md = stream.recv_metadata().await?;
         let parent_header = consensus.async_get_header(pp_header.direct_parents()[0]).await.unwrap();
-        let pp_is_post_hardening = self.ctx.config.zk_hardening_activation.is_active(pp_header.daa_score);
 
-        // Post-hardening: derive the shortcut block via consensus (uses reachability + headers
-        // only; safe at the PP boundary before the SMT is imported). Then resolve to the
-        // seq_commit hash with the same fold-to-zero rule used by `inactivity_shortcut(block)`.
-        // The block hash is also passed to `import_pruning_point_smt` for the V1 metadata row.
-        let (shortcut_block, inactivity_shortcut) = if pp_is_post_hardening {
-            let block = consensus
-                .async_inactivity_shortcut_block_for_pov(pruning_point)
-                .await
-                .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
-            let shortcut = if block == self.ctx.config.genesis.hash {
-                kaspa_hashes::ZERO_HASH
-            } else {
-                let shortcut_header = consensus
-                    .async_get_header(block)
-                    .await
-                    .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
-                if !self.ctx.config.zk_hardening_activation.is_active(shortcut_header.daa_score) {
-                    kaspa_hashes::ZERO_HASH
-                } else {
-                    shortcut_header.accepted_id_merkle_root
-                }
-            };
-            (Some(block), Some(shortcut))
+        // Derive the shortcut block via consensus (uses reachability + headers only; safe at the PP
+        // boundary before the SMT is imported). Then resolve to the seqcommit hash with the same
+        // fold-to-zero rule used by `inactivity_shortcut(block)`.
+        let shortcut_block = consensus
+            .async_inactivity_shortcut_block_for_pov(pruning_point)
+            .await
+            .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
+        let shortcut_header = consensus
+            .async_get_header(shortcut_block)
+            .await
+            .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
+        let inactivity_shortcut = if !self.ctx.config.toccata_activation.is_active(shortcut_header.daa_score) {
+            kaspa_hashes::ZERO_HASH
         } else {
-            (None, None)
+            shortcut_header.accepted_id_merkle_root
         };
 
         verify_smt_metadata(

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -400,7 +400,6 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         params.pruning_depth = 100 * 2 * 2 + 50;
 
         params.toccata_activation = ForkActivation::new(1000);
-        params.zk_hardening_activation = ForkActivation::new(2000);
 
         info!("Setting pruning depth to {:?}", params.pruning_depth());
     }

--- a/simpa/tests/smt_repro.rs
+++ b/simpa/tests/smt_repro.rs
@@ -47,44 +47,26 @@ static REPRO_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_2() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(2);
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_4() {
-    assert_pruning_point_smt_roundtrip(4, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(4);
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_5() {
-    assert_pruning_point_smt_roundtrip(5, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(5);
 }
 
-/// Hardening activates mid-chain (DAA 400): chain crosses the hardening boundary
-/// while toccata stays always-active. Toccata cannot be gated here because the
-/// simulator's ChurningLaneProducer relies on toccata-era subnetwork txs from
-/// block 1; pre-toccata they would be rejected and panic OnetimeTxSelector.
-/// Pre-toccata crossing is covered by daemon_zk_hardening_activation_test.
-#[test]
-fn pruning_point_smt_export_import_repro_seed_2_hardening_mid_chain() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(400));
-}
-
-/// Hardening at DAA 1: chain is post-hardening from block 1 onward.
-/// Sanity-checks the "hardening fires almost immediately" boundary case.
-#[test]
-fn pruning_point_smt_export_import_repro_seed_2_hardening_at_1() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(1));
-}
-
-fn assert_pruning_point_smt_roundtrip(seed: u64, toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) {
+fn assert_pruning_point_smt_roundtrip(seed: u64) {
     let _guard = REPRO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     kaspa_core::log::try_init_logger("warn");
 
     let mut params = DEVNET_PARAMS;
     apply_pruning_repro_params(&mut params);
-    params.toccata_activation = toccata_activation;
-    params.zk_hardening_activation = zk_hardening_activation;
+    params.toccata_activation = ForkActivation::always();
     let config = Arc::new(
         ConfigBuilder::new(params)
             .apply_args(|config| apply_perf_params(&mut config.perf))
@@ -186,8 +168,7 @@ fn apply_pruning_repro_params(params: &mut Params) {
     params.mergeset_size_limit = 32 * 2;
     params.pruning_depth = PRUNING_DEPTH;
 
-    // toccata + hardening activations are set by the caller.
-    // (see assert_pruning_point_smt_roundtrip).
+    // Toccata activation is set by the caller.
     params.storage_mass_parameter = 10_000;
 }
 

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -1653,7 +1653,7 @@ async fn seqcommit_sp_context_threshold_edge_test() {
 }
 
 #[tokio::test]
-async fn staging_consensus_test() {
+async fn staging_consensus_lifecycle_test() {
     init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).build();
 
@@ -1690,8 +1690,26 @@ async fn staging_consensus_test() {
     let joins = core.start();
 
     let staging = consensus_manager.new_staging_consensus();
-    staging.commit();
+    let staging_session = staging.session().await;
+    let genesis_hash = config.genesis.hash;
 
+    // A fresh staging consensus skips normal genesis processing, so genesis is
+    // absent from both the headers store and the status store before import.
+    assert!(staging_session.async_get_header(genesis_hash).await.is_err());
+    assert_eq!(staging_session.async_get_block_status(genesis_hash).await, None);
+
+    let mut genesis_header: Header = (&config.genesis).into();
+    genesis_header.hash = genesis_hash;
+    let genesis_header = Arc::new(genesis_header);
+    staging_session.clone().spawn_blocking(move |c| c.import_pruning_points(vec![genesis_header])).await.unwrap();
+
+    // Importing pruning points stores headers without assigning block statuses.
+    // Header access must keep working for headers-proof IBD in this state.
+    assert_eq!(staging_session.async_get_header(genesis_hash).await.unwrap().hash, genesis_hash);
+    assert_eq!(staging_session.async_get_block_status(genesis_hash).await, None);
+
+    drop(staging_session);
+    staging.commit();
     core.shutdown();
     core.join(joins);
 }
@@ -2354,7 +2372,6 @@ fn init_toccata_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<(
     let mut params = TESTNET_PARAMS;
     params.crescendo_activation = ForkActivation::always();
     params.toccata_activation = ForkActivation::always();
-    params.zk_hardening_activation = ForkActivation::always();
 
     let config = ConfigBuilder::new(params)
         .skip_proof_of_work()

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -131,63 +131,6 @@ async fn daemon_toccata_activation_log_file_test() {
     );
 }
 
-/// KIP-21 zk_hardening_activation crossing: pre-activation blocks commit
-/// `seq_commit` with `inactivity_shortcut: None` (omitted from the mergeset
-/// context hash); post-activation blocks fold the shortcut in. Both layouts
-/// of `SmtBlockMetadata` (always-stored shortcut block) must roundtrip and
-/// the chain must continue to advance across the boundary.
-///
-/// If the activation gate were wired wrong on either side, `build_seq_commit`
-/// and `recompute_seq_commit` would diverge and the daemon would disqualify
-/// its own mined blocks; the assert on virtual_daa_score is the smoke test.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn daemon_zk_hardening_activation_test() {
-    init_allocator_with_default_settings();
-
-    let test_dir = tempfile::tempdir().unwrap();
-    let params_path = test_dir.path().join("params.json");
-    // Activate at DAA score 3; mine across it.
-    fs::write(&params_path, r#"{"skip_proof_of_work":true,"zk_hardening_activation":3}"#).unwrap();
-
-    let args = Args {
-        simnet: true,
-        unsafe_rpc: true,
-        enable_unsynced_mining: true,
-        disable_upnp: true,
-        disable_dns_seeding: true,
-        outbound_target: 0,
-        override_params_file: Some(params_path.to_string_lossy().to_string()),
-        ..Default::default()
-    };
-
-    let _runtime = KaspadRuntime::from_args(&args);
-    let mut kaspad = Daemon::new_random_with_args(args, 10);
-    let rpc_client = kaspad.start().await;
-
-    let miner_address = Address::new(kaspad.network.into(), kaspa_addresses::Version::PubKey, &[0; 32]);
-    let target_daa_score: u64 = 6;
-    for _ in 1..=target_daa_score {
-        let template = rpc_client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
-        rpc_client.submit_block(template.block, false).await.unwrap();
-    }
-
-    let check_client = rpc_client.clone();
-    wait_for(
-        50,
-        100,
-        move || {
-            let client = check_client.clone();
-            Box::pin(async move { client.get_server_info().await.unwrap().virtual_daa_score >= target_daa_score })
-        },
-        "daemon did not cross zk_hardening_activation boundary",
-    )
-    .await;
-
-    rpc_client.disconnect().await.unwrap();
-    drop(rpc_client);
-    kaspad.shutdown();
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_sanity_test() {
     init_allocator_with_default_settings();


### PR DESCRIPTION
Remove temporary zk_hardening_activation plumbing and make the hardened Groth16/Risc0 and seqcommit activity-root paths unconditional under Toccata.

Collapse SMT metadata to the V1 shape with a required inactivity_shortcut_block, and update IBD/pruning SMT import and verification accordingly.

Trim activation/legacy tests while preserving real Toccata coverage for SMT sync, staging header access, Groth16 arity rejection, and lane activity proofs.