### PR TITLE
Integrate finalized ZK hardening and KIP-21 shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-build-info"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duct",
  "faster-hex 0.9.0",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ahash",
  "borsh",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "duration-string",
  "futures",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "criterion",
@@ -3363,14 +3363,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-system-info"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "kaspa-utils",
  "mac_address",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "aes",
  "ahash",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6506,7 +6506,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.2.0-toc.2"
+version = "1.2.1-toc.3"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -88,67 +88,67 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.2.0-toc.2", path = "testing/integration" }
-kaspa-addresses = { version = "1.2.0-toc.2", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.2.0-toc.2", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.2.0-toc.2", path = "wallet/bip32" }
-kaspa-cli = { version = "1.2.0-toc.2", path = "cli" }
-kaspa-connectionmanager = { version = "1.2.0-toc.2", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.2.0-toc.2", path = "consensus" }
-kaspa-consensus-core = { version = "1.2.0-toc.2", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.2.0-toc.2", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.2.0-toc.2", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.2.0-toc.2", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.2.0-toc.2", path = "components/consensusmanager" }
-kaspa-core = { version = "1.2.0-toc.2", path = "core" }
-kaspa-daemon = { version = "1.2.0-toc.2", path = "daemon" }
-kaspa-database = { version = "1.2.0-toc.2", path = "database" }
-kaspa-grpc-client = { version = "1.2.0-toc.2", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.2.0-toc.2", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.2.0-toc.2", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.2.0-toc.2", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.2.0-toc.2", path = "indexes/core" }
-kaspa-index-processor = { version = "1.2.0-toc.2", path = "indexes/processor" }
-kaspa-math = { version = "1.2.0-toc.2", path = "math" }
-kaspa-merkle = { version = "1.2.0-toc.2", path = "crypto/merkle" }
-kaspa-smt = { version = "1.2.0-toc.2", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.2.0-toc.2", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.2.0-toc.2", path = "metrics/core" }
-kaspa-mining = { version = "1.2.0-toc.2", path = "mining" }
-kaspa-mining-errors = { version = "1.2.0-toc.2", path = "mining/errors" }
-kaspa-muhash = { version = "1.2.0-toc.2", path = "crypto/muhash" }
-kaspa-notify = { version = "1.2.0-toc.2", path = "notify" }
-kaspa-p2p-flows = { version = "1.2.0-toc.2", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.2.0-toc.2", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.2.0-toc.2", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.2.0-toc.2", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.2.0-toc.2", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.2.0-toc.2", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.2.0-toc.2", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.2.0-toc.2", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.2.0-toc.2", path = "rpc/service" }
-kaspa-txscript = { version = "1.2.0-toc.2", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.2.0-toc.2", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.2.0-toc.2", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.2.0-toc.2", path = "utils/tower" }
-kaspa-system-info = { version = "1.2.0-toc.2", path = "system-info" }
-kaspa-build-info = { version = "1.2.0-toc.2", path = "build-info" }
-kaspa-utxoindex = { version = "1.2.0-toc.2", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.2.0-toc.2", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.2.0-toc.2", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.2.0-toc.2", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.2.0-toc.2", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.2.0-toc.2", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.2.0-toc.2", path = "wallet/macros" }
-kaspa-wasm = { version = "1.2.0-toc.2", path = "wasm" }
-kaspa-wasm-core = { version = "1.2.0-toc.2", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.2.0-toc.2", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.2.0-toc.2", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.2.0-toc.2", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.2.0-toc.2", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.2.0-toc.2", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.2.0-toc.2", path = "kaspad" }
-kaspa-alloc = { version = "1.2.0-toc.2", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.2.1-toc.3", path = "testing/integration" }
+kaspa-addresses = { version = "1.2.1-toc.3", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.2.1-toc.3", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.2.1-toc.3", path = "wallet/bip32" }
+kaspa-cli = { version = "1.2.1-toc.3", path = "cli" }
+kaspa-connectionmanager = { version = "1.2.1-toc.3", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.2.1-toc.3", path = "consensus" }
+kaspa-consensus-core = { version = "1.2.1-toc.3", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.2.1-toc.3", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.2.1-toc.3", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.2.1-toc.3", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.2.1-toc.3", path = "components/consensusmanager" }
+kaspa-core = { version = "1.2.1-toc.3", path = "core" }
+kaspa-daemon = { version = "1.2.1-toc.3", path = "daemon" }
+kaspa-database = { version = "1.2.1-toc.3", path = "database" }
+kaspa-grpc-client = { version = "1.2.1-toc.3", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.2.1-toc.3", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.2.1-toc.3", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.2.1-toc.3", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "1.2.1-toc.3", path = "indexes/core" }
+kaspa-index-processor = { version = "1.2.1-toc.3", path = "indexes/processor" }
+kaspa-math = { version = "1.2.1-toc.3", path = "math" }
+kaspa-merkle = { version = "1.2.1-toc.3", path = "crypto/merkle" }
+kaspa-smt = { version = "1.2.1-toc.3", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "1.2.1-toc.3", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "1.2.1-toc.3", path = "metrics/core" }
+kaspa-mining = { version = "1.2.1-toc.3", path = "mining" }
+kaspa-mining-errors = { version = "1.2.1-toc.3", path = "mining/errors" }
+kaspa-muhash = { version = "1.2.1-toc.3", path = "crypto/muhash" }
+kaspa-notify = { version = "1.2.1-toc.3", path = "notify" }
+kaspa-p2p-flows = { version = "1.2.1-toc.3", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.2.1-toc.3", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.2.1-toc.3", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.2.1-toc.3", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.2.1-toc.3", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.2.1-toc.3", path = "rpc/core" }
+kaspa-seq-commit = { version = "1.2.1-toc.3", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "1.2.1-toc.3", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.2.1-toc.3", path = "rpc/service" }
+kaspa-txscript = { version = "1.2.1-toc.3", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.2.1-toc.3", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.2.1-toc.3", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "1.2.1-toc.3", path = "utils/tower" }
+kaspa-system-info = { version = "1.2.1-toc.3", path = "system-info" }
+kaspa-build-info = { version = "1.2.1-toc.3", path = "build-info" }
+kaspa-utxoindex = { version = "1.2.1-toc.3", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.2.1-toc.3", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.2.1-toc.3", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.2.1-toc.3", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.2.1-toc.3", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.2.1-toc.3", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.2.1-toc.3", path = "wallet/macros" }
+kaspa-wasm = { version = "1.2.1-toc.3", path = "wasm" }
+kaspa-wasm-core = { version = "1.2.1-toc.3", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.2.1-toc.3", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.2.1-toc.3", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.2.1-toc.3", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.2.1-toc.3", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.2.1-toc.3", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.2.1-toc.3", path = "kaspad" }
+kaspa-alloc = { version = "1.2.1-toc.3", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -514,19 +514,12 @@ impl ConsensusSessionOwned {
     pub fn import_pruning_point_smt(
         &self,
         new_pruning_point: Hash,
-        lanes_root: Hash,
-        payload_and_ctx_digest: Hash,
-        expected_lane_count: u64,
+        metadata: kaspa_consensus_core::api::SmtExportMetadata,
+        inactivity_shortcut_block: Option<Hash>,
         mut rx: tokio::sync::mpsc::Receiver<Vec<ImportLane>>,
     ) -> PruningImportResult<()> {
         let lane_batches: ImportLaneBatchIterator = &mut std::iter::from_fn(move || rx.blocking_recv());
-        self.consensus.import_pruning_point_smt(
-            new_pruning_point,
-            lanes_root,
-            payload_and_ctx_digest,
-            expected_lane_count,
-            lane_batches,
-        )
+        self.consensus.import_pruning_point_smt(new_pruning_point, metadata, inactivity_shortcut_block, lane_batches)
     }
     pub async fn async_is_pruning_smt_stable(&self) -> bool {
         self.clone().spawn_blocking(move |c| c.is_pruning_smt_stable()).await
@@ -536,6 +529,10 @@ impl ConsensusSessionOwned {
         expected_pp: Hash,
     ) -> ConsensusResult<kaspa_consensus_core::api::SmtExportMetadata> {
         self.clone().spawn_blocking(move |c| c.get_pruning_point_smt_metadata(expected_pp)).await
+    }
+
+    pub async fn async_inactivity_shortcut_block_for_pov(&self, pov_block: Hash) -> ConsensusResult<Hash> {
+        self.clone().spawn_blocking(move |c| c.inactivity_shortcut_block_for_pov(pov_block)).await
     }
 
     /// Synchronous passthrough to [`ConsensusApi::open_pruning_point_smt_lane_stream`].

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -515,7 +515,7 @@ impl ConsensusSessionOwned {
         &self,
         new_pruning_point: Hash,
         metadata: kaspa_consensus_core::api::SmtExportMetadata,
-        inactivity_shortcut_block: Option<Hash>,
+        inactivity_shortcut_block: Hash,
         mut rx: tokio::sync::mpsc::Receiver<Vec<ImportLane>>,
     ) -> PruningImportResult<()> {
         let lane_batches: ImportLaneBatchIterator = &mut std::iter::from_fn(move || rx.blocking_recv());

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -72,8 +72,7 @@ pub type ImportLaneBatchIterator<'a> = &'a mut (dyn Iterator<Item = Vec<ImportLa
 /// SMT metadata for IBD sync, verified against the pruning point header.
 ///
 /// Wire: `lanes_root || payload_and_ctx_digest || parent_seq_commit` (96 bytes).
-/// `inactivity_shortcut_block` is derived by the receiver from chain headers
-/// when needed (post-hardening); not transmitted.
+/// `inactivity_shortcut_block` is derived by the receiver from chain headers; not transmitted.
 #[derive(Clone, Copy, Debug)]
 pub struct SmtExportMetadata {
     pub lanes_root: Hash,
@@ -306,14 +305,12 @@ pub trait ConsensusApi: Send + Sync {
     /// each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
     /// re-batch.
     ///
-    /// `inactivity_shortcut_block` is `Some(block)` post-hardening (already
-    /// resolved by the caller during metadata verification) and `None`
-    /// pre-hardening. The importer stores it as-is in the V1 metadata row.
+    /// `inactivity_shortcut_block` is resolved by the caller during metadata verification.
     fn import_pruning_point_smt(
         &self,
         _new_pruning_point: Hash,
         _metadata: SmtExportMetadata,
-        _inactivity_shortcut_block: Option<Hash>,
+        _inactivity_shortcut_block: Hash,
         _lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
         unimplemented!()

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -69,8 +69,12 @@ pub struct ImportLane {
 
 pub type ImportLaneBatchIterator<'a> = &'a mut (dyn Iterator<Item = Vec<ImportLane>> + Send);
 
-/// SMT metadata for IBD sync — verified against the pruning point header.
-#[derive(Clone, Debug)]
+/// SMT metadata for IBD sync, verified against the pruning point header.
+///
+/// Wire: `lanes_root || payload_and_ctx_digest || parent_seq_commit` (96 bytes).
+/// `inactivity_shortcut_block` is derived by the receiver from chain headers
+/// when needed (post-hardening); not transmitted.
+#[derive(Clone, Copy, Debug)]
 pub struct SmtExportMetadata {
     pub lanes_root: Hash,
     pub payload_and_ctx_digest: Hash,
@@ -299,14 +303,17 @@ pub trait ConsensusApi: Send + Sync {
     /// preimages, verifies root matches `lanes_root`, and flushes to DB.
     ///
     /// The iterator yields lane chunks already sized by the wire-level chunker
-    /// — each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
+    /// each element is up to `SMT_CHUNK_SIZE` lanes. The importer does not
     /// re-batch.
+    ///
+    /// `inactivity_shortcut_block` is `Some(block)` post-hardening (already
+    /// resolved by the caller during metadata verification) and `None`
+    /// pre-hardening. The importer stores it as-is in the V1 metadata row.
     fn import_pruning_point_smt(
         &self,
         _new_pruning_point: Hash,
-        _lanes_root: Hash,
-        _payload_and_ctx_digest: Hash,
-        _expected_lane_count: u64,
+        _metadata: SmtExportMetadata,
+        _inactivity_shortcut_block: Option<Hash>,
         _lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
         unimplemented!()
@@ -314,6 +321,15 @@ pub trait ConsensusApi: Send + Sync {
 
     /// Compute SMT metadata for the pruning point (for P2P streaming).
     fn get_pruning_point_smt_metadata(&self, _expected_pruning_point: Hash) -> ConsensusResult<SmtExportMetadata> {
+        unimplemented!()
+    }
+
+    /// Resolve the `inactivity_shortcut_block` (the block hash anchoring the
+    /// `activity_root` shortcut) from the POV of `pov_block`. Uses headers +
+    /// reachability only; safe to call at the IBD PP boundary before the SMT
+    /// is imported. Callers resolve to the seq_commit Hash themselves (the
+    /// block-to-seq_commit fold is just a header read + activation check).
+    fn inactivity_shortcut_block_for_pov(&self, _pov_block: Hash) -> ConsensusResult<Hash> {
         unimplemented!()
     }
 

--- a/consensus/core/src/config/genesis.rs
+++ b/consensus/core/src/config/genesis.rs
@@ -146,30 +146,6 @@ pub const TESTNET_GENESIS: GenesisBlock = GenesisBlock {
     ],
 };
 
-pub const TESTNET12_GENESIS: GenesisBlock = GenesisBlock {
-    hash: Hash::from_bytes([
-        0x30, 0x0f, 0xe0, 0x20, 0x31, 0x11, 0x9f, 0x61, 0x32, 0xf3, 0x9e, 0xc0, 0x3c, 0x5c, 0xf7, 0xdd, 0xf1, 0x0c, 0xc2, 0x3d, 0x6f,
-        0x5c, 0x3e, 0x5f, 0xe4, 0x2d, 0x63, 0x91, 0xdc, 0x3d, 0x5c, 0x2a,
-    ]),
-    hash_merkle_root: Hash::from_bytes([
-        0xcd, 0x26, 0xc7, 0x3b, 0x25, 0x07, 0xb8, 0xa1, 0xf4, 0x9b, 0xab, 0x92, 0xd5, 0xa8, 0xeb, 0xc8, 0x3e, 0x37, 0xcf, 0xdf, 0x57,
-        0xe6, 0xcc, 0x98, 0x55, 0xef, 0x99, 0x90, 0x45, 0xeb, 0x76, 0xbf,
-    ]),
-    bits: 504155340, // see `gen_testnet12_genesis`
-    #[rustfmt::skip]
-    coinbase_payload: &[
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Blue score
-        0x00, 0xE1, 0xF5, 0x05, 0x00, 0x00, 0x00, 0x00, // Subsidy
-        0x00, 0x00, // Script version
-        0x01,                                                                         // Varint
-        0x00,                                                                         // OP-FALSE
-        0x6b, 0x61, 0x73, 0x70, 0x61, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x6e, 0x65, 0x74, // kaspa-testnet
-        0x54, 0x4F, 0x43, 0x43, 0x41, 0x54, 0x41,                                     // TOCCATA
-        12, 3                                                                         // TN12, Launch 3
-    ],
-    ..TESTNET_GENESIS
-};
-
 pub const SIMNET_GENESIS: GenesisBlock = GenesisBlock {
     hash: Hash::from_bytes([
         0x41, 0x1f, 0x8c, 0xd2, 0x6f, 0x3d, 0x41, 0xae, 0xa3, 0x9e, 0x78, 0x57, 0x39, 0x27, 0xda, 0x24, 0xd2, 0x39, 0x95, 0x70, 0x5b,
@@ -231,28 +207,15 @@ pub const DEVNET_GENESIS: GenesisBlock = GenesisBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::bps::TenBps, merkle::calc_hash_merkle_root};
+    use crate::merkle::calc_hash_merkle_root;
 
     #[test]
     fn test_genesis_hashes() {
-        [GENESIS, TESTNET_GENESIS, TESTNET12_GENESIS, SIMNET_GENESIS, DEVNET_GENESIS].into_iter().for_each(|genesis| {
+        [GENESIS, TESTNET_GENESIS, SIMNET_GENESIS, DEVNET_GENESIS].into_iter().for_each(|genesis| {
             let block: Block = (&genesis).into();
             assert_hashes_eq(calc_hash_merkle_root(block.transactions.iter()), block.header.hash_merkle_root, "hash_merkle_root");
             assert_hashes_eq(block.hash(), genesis.hash, "genesis hash");
         });
-    }
-
-    #[test]
-    fn gen_testnet12_genesis() {
-        let bps = TenBps::bps();
-        let mut genesis = TESTNET_GENESIS;
-        let target = kaspa_math::Uint256::from_compact_target_bits(genesis.bits);
-        let scaled_target = target * bps / 100;
-        let scaled_bits = scaled_target.compact_target_bits();
-        genesis.bits = scaled_bits;
-        if genesis.bits != TESTNET12_GENESIS.bits {
-            panic!("Testnet 12: new bits: {}\nnew hash: {:#04x?}", scaled_bits, Block::from(&genesis).hash().as_bytes());
-        }
     }
 
     fn assert_hashes_eq(got: Hash, expected: Hash, field: &str) {

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -260,8 +260,6 @@ pub struct OverrideParams {
     pub crescendo_activation: Option<ForkActivation>,
 
     pub toccata_activation: Option<ForkActivation>,
-
-    pub zk_hardening_activation: Option<ForkActivation>,
 }
 
 impl From<Params> for OverrideParams {
@@ -294,7 +292,6 @@ impl From<Params> for OverrideParams {
             blockrate: Some(p.blockrate),
             crescendo_activation: Some(p.crescendo_activation),
             toccata_activation: Some(p.toccata_activation),
-            zk_hardening_activation: Some(p.zk_hardening_activation),
         }
     }
 }
@@ -364,8 +361,6 @@ pub struct Params {
     pub crescendo_activation: ForkActivation,
 
     pub toccata_activation: ForkActivation,
-
-    pub zk_hardening_activation: ForkActivation,
 }
 
 impl Params {
@@ -604,7 +599,6 @@ impl Params {
 
             crescendo_activation: overrides.crescendo_activation.unwrap_or(self.crescendo_activation),
             toccata_activation: overrides.toccata_activation.unwrap_or(self.toccata_activation),
-            zk_hardening_activation: overrides.zk_hardening_activation.unwrap_or(self.zk_hardening_activation),
         }
     }
 }
@@ -719,7 +713,6 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {
@@ -782,8 +775,6 @@ pub const TESTNET_PARAMS: Params = Params {
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
-    // ~2026-05-28 16:00 UTC on TN10.
-    zk_hardening_activation: ForkActivation::new(476_232_000),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -829,7 +820,6 @@ pub const SIMNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::always(),
-    zk_hardening_activation: ForkActivation::always(),
 };
 
 pub const DEVNET_PARAMS: Params = Params {
@@ -874,7 +864,6 @@ pub const DEVNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::never(),
 };
 
 #[cfg(test)]

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -260,6 +260,8 @@ pub struct OverrideParams {
     pub crescendo_activation: Option<ForkActivation>,
 
     pub toccata_activation: Option<ForkActivation>,
+
+    pub zk_hardening_activation: Option<ForkActivation>,
 }
 
 impl From<Params> for OverrideParams {
@@ -292,6 +294,7 @@ impl From<Params> for OverrideParams {
             blockrate: Some(p.blockrate),
             crescendo_activation: Some(p.crescendo_activation),
             toccata_activation: Some(p.toccata_activation),
+            zk_hardening_activation: Some(p.zk_hardening_activation),
         }
     }
 }
@@ -361,6 +364,8 @@ pub struct Params {
     pub crescendo_activation: ForkActivation,
 
     pub toccata_activation: ForkActivation,
+
+    pub zk_hardening_activation: ForkActivation,
 }
 
 impl Params {
@@ -604,6 +609,7 @@ impl Params {
 
             crescendo_activation: overrides.crescendo_activation.unwrap_or(self.crescendo_activation),
             toccata_activation: overrides.toccata_activation.unwrap_or(self.toccata_activation),
+            zk_hardening_activation: overrides.zk_hardening_activation.unwrap_or(self.zk_hardening_activation),
         }
     }
 }
@@ -719,6 +725,7 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
     toccata_activation: ForkActivation::never(),
+    zk_hardening_activation: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {
@@ -781,6 +788,8 @@ pub const TESTNET_PARAMS: Params = Params {
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
+    // ZK precompile hardening — activation TBD; default to never until scheduled.
+    zk_hardening_activation: ForkActivation::never(),
 };
 
 pub const TESTNET12_PARAMS: Params = Params {
@@ -810,6 +819,7 @@ pub const TESTNET12_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::always(),
+    zk_hardening_activation: ForkActivation::never(),
     ..TESTNET_PARAMS
 };
 
@@ -856,6 +866,7 @@ pub const SIMNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::always(),
+    zk_hardening_activation: ForkActivation::always(),
 };
 
 pub const DEVNET_PARAMS: Params = Params {
@@ -900,6 +911,7 @@ pub const DEVNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::never(),
+    zk_hardening_activation: ForkActivation::always(),
 };
 
 #[cfg(test)]

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -1,7 +1,7 @@
 pub use super::{
     bps::{Bps, TenBps},
     constants::consensus::*,
-    genesis::{DEVNET_GENESIS, GENESIS, GenesisBlock, SIMNET_GENESIS, TESTNET_GENESIS, TESTNET12_GENESIS},
+    genesis::{DEVNET_GENESIS, GENESIS, GenesisBlock, SIMNET_GENESIS, TESTNET_GENESIS},
 };
 use crate::{
     BlockLevel, KType,
@@ -530,12 +530,7 @@ impl Params {
     }
 
     pub fn block_version(&self) -> ForkedParam<u16> {
-        if self.net == TESTNET12_PARAMS.net {
-            // The testnet12 hardfork was activated without a block version bump, so we return a constant value of 1 for compatibility with the existing testnet12 chain.
-            ForkedParam::new_const(BLOCK_VERSION)
-        } else {
-            ForkedParam::new(BLOCK_VERSION, TOCCATA_BLOCK_VERSION, self.toccata_activation)
-        }
+        ForkedParam::new(BLOCK_VERSION, TOCCATA_BLOCK_VERSION, self.toccata_activation)
     }
 
     pub fn network_name(&self) -> String {
@@ -645,7 +640,6 @@ impl From<NetworkId> for Params {
             NetworkType::Mainnet => MAINNET_PARAMS,
             NetworkType::Testnet => match value.suffix {
                 Some(10) => TESTNET_PARAMS,
-                Some(12) => TESTNET12_PARAMS,
                 Some(x) => panic!("Testnet suffix {} is not supported", x),
                 None => panic!("Testnet suffix not provided"),
             },
@@ -788,39 +782,8 @@ pub const TESTNET_PARAMS: Params = Params {
     // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
-    // ZK precompile hardening — activation TBD; default to never until scheduled.
-    zk_hardening_activation: ForkActivation::never(),
-};
-
-pub const TESTNET12_PARAMS: Params = Params {
-    dns_seeders: &[
-        // This DNS seeder is run by someone235
-        "tn12-dnsseed.kas.pa",
-        // This DNS seeder is run by iziodev
-        "tn12-dnsseed.kasia.fyi",
-        // This DNS seeder is run by supertypo
-        "n-testnet-12.kaspa.ws",
-        // This DNS seeder is run by Tiram
-        "seeder1-tn12.kaspad.net",
-    ],
-    net: NetworkId::with_suffix(NetworkType::Testnet, 12),
-    genesis: TESTNET12_GENESIS,
-
-    prior_max_signature_script_len: NEW_MAX_SIGNATURE_SCRIPT_LEN,
-    new_max_signature_script_len: NEW_MAX_SIGNATURE_SCRIPT_LEN,
-
-    // Transient mass is increased for stark proofs
-    prior_block_mass_limits: BlockMassLimits { compute: 500_000, storage: 500_000, transient: 1_000_000 },
-    new_transient_mass_limit: 1_000_000,
-
-    deflationary_phase_daa_score: TenBps::deflationary_phase_daa_score(),
-    pre_deflationary_phase_base_subsidy: TenBps::pre_deflationary_phase_base_subsidy(),
-    pre_crescendo_target_time_per_block: TenBps::target_time_per_block(),
-
-    crescendo_activation: ForkActivation::always(),
-    toccata_activation: ForkActivation::always(),
-    zk_hardening_activation: ForkActivation::never(),
-    ..TESTNET_PARAMS
+    // ~2026-05-28 16:00 UTC on TN10.
+    zk_hardening_activation: ForkActivation::new(476_232_000),
 };
 
 pub const SIMNET_PARAMS: Params = Params {
@@ -911,7 +874,7 @@ pub const DEVNET_PARAMS: Params = Params {
 
     crescendo_activation: ForkActivation::always(),
     toccata_activation: ForkActivation::never(),
-    zk_hardening_activation: ForkActivation::always(),
+    zk_hardening_activation: ForkActivation::never(),
 };
 
 #[cfg(test)]

--- a/consensus/seq-commit/src/hashing.rs
+++ b/consensus/seq-commit/src/hashing.rs
@@ -1,23 +1,35 @@
 //! Hash functions for sequencing commitments.
+//!
+//! Commitment tree shape:
+//!
+//! ```text
+//! SeqCommit(B)
+//! └── H_seq
+//!     ├── parent_seq_commit = SeqCommit(selected_parent(B))
+//!     └── state_root
+//!         └── H_seq
+//!             ├── activity_root
+//!             │   └── H_activity_root
+//!             │       ├── inactivity_shortcut
+//!             │       └── lanes_root
+//!             │           └── SMT root over active lanes
+//!             │
+//!             └── payload_and_ctx_digest
+//!                 └── H_seq
+//!                     ├── context_hash
+//!                     └── payload_root
+//! ```
+//!
+//! Pre-hardening: `activity_root == lanes_root` (identity, no wrap);
+//! post-hardening: `activity_root = H_activity_root(inactivity_shortcut, lanes_root)`.
 
 use kaspa_hashes::{
-    Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitLaneKey, SeqCommitLaneTip,
-    SeqCommitMergesetContext, SeqCommitMerkleBranch, SeqCommitMinerPayloadLeaf,
+    Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitActivityRoot, SeqCommitLaneKey,
+    SeqCommitLaneTip, SeqCommitMergesetContext, SeqCommitMerkleBranch, SeqCommitMinerPayloadLeaf,
 };
 use kaspa_merkle::{StreamingMerkleBuilder, calc_merkle_root_with_hasher};
 
 use crate::types::{LaneId, LaneTipInput, MergesetContext, MinerPayloadLeafInput, SeqCommitInput, SeqState, SmtLeafInput};
-
-/// Derive the timestamp used in `MergesetContextHash` for a given block.
-///
-/// Uses the selected parent's timestamp — a consensus-agreed deterministic
-/// value that doesn't depend on miner input. This ensures the seq_commit
-/// can be computed for the virtual block without knowing the final header
-/// timestamp.
-#[inline]
-pub fn seq_commit_timestamp(selected_parent_timestamp: u64) -> u64 {
-    selected_parent_timestamp
-}
 
 /// Compute the SMT key for a lane: `H_lane_key(lane_id)`.
 #[inline]
@@ -26,6 +38,12 @@ pub fn lane_key(lane_id: &LaneId) -> Hash {
     hasher.update(lane_id);
     hasher.finalize()
 }
+
+/// Precomputed `lane_key(SUBNETWORK_ID_COINBASE)`.
+pub const COINBASE_LANE_KEY: Hash = Hash::from_bytes([
+    0x8a, 0xa7, 0x80, 0x27, 0xdb, 0x66, 0xa1, 0x6c, 0xb6, 0x96, 0x92, 0xee, 0x0a, 0xf5, 0xcb, 0x76, 0x73, 0x8e, 0xf8, 0x0a, 0xd1,
+    0x4c, 0x9d, 0x13, 0x92, 0x0d, 0x7f, 0xa3, 0xcc, 0x40, 0xb9, 0xe4,
+]);
 
 /// Compute an activity leaf: `H_activity_leaf(tx_id || le_u16(version) || le_u32(merge_idx))`.
 #[inline]
@@ -58,11 +76,23 @@ pub fn lane_tip_next(input: &LaneTipInput) -> Hash {
     hasher.finalize()
 }
 
-/// Compute the mergeset context hash: `H_mergeset_context(le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score))`.
+/// Compute the mergeset context hash:
+/// `H_mergeset_context(le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score))`.
 #[inline]
 pub fn mergeset_context_hash(ctx: &MergesetContext) -> Hash {
     let mut hasher = SeqCommitMergesetContext::new();
     hasher.update(ctx.timestamp.to_le_bytes()).update(ctx.daa_score.to_le_bytes()).update(ctx.blue_score.to_le_bytes());
+    hasher.finalize()
+}
+
+/// Compute the activity root: `H_activity_root(inactivity_shortcut, lanes_root)`.
+///
+/// Post-hardening only. Pre-hardening callers should pass `lanes_root` straight
+/// into [`seq_state_root`] without invoking this helper (identity).
+#[inline]
+pub fn activity_root_hash(inactivity_shortcut: &Hash, lanes_root: &Hash) -> Hash {
+    let mut hasher = SeqCommitActivityRoot::new();
+    hasher.update(inactivity_shortcut).update(lanes_root);
     hasher.finalize()
 }
 
@@ -131,11 +161,11 @@ pub fn payload_and_context_digest(context_hash: &Hash, payload_root: &Hash) -> H
     hasher.finalize()
 }
 
-/// Compute the seq-state root: `H_seq(lanes_root, payload_and_ctx_digest)`.
+/// Compute the seq-state root: `H_seq(activity_root, payload_and_ctx_digest)`.
 #[inline]
 pub fn seq_state_root(state: &SeqState<'_>) -> Hash {
     let mut hasher = SeqCommitMerkleBranch::new();
-    hasher.update(state.lanes_root).update(state.payload_and_ctx_digest);
+    hasher.update(state.activity_root).update(state.payload_and_ctx_digest);
     hasher.finalize()
 }
 
@@ -150,7 +180,7 @@ pub fn seq_commit(input: &SeqCommitInput<'_>) -> Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kaspa_consensus_core::BlueWorkType;
+    use kaspa_consensus_core::{BlueWorkType, subnets::SUBNETWORK_ID_COINBASE};
     use kaspa_hashes::ZERO_HASH;
 
     fn h(b: u8) -> Hash {
@@ -171,6 +201,11 @@ mod tests {
     #[test]
     fn test_lane_key_different_ids() {
         assert_ne!(lane_key(&[0x01; 20]), lane_key(&[0x02; 20]));
+    }
+
+    #[test]
+    fn test_coinbase_lane_key_constant() {
+        assert_eq!(COINBASE_LANE_KEY, lane_key(&SUBNETWORK_ID_COINBASE.into_bytes()));
     }
 
     #[test]
@@ -243,12 +278,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mergeset_context_hash_golden() {
-        let expected = Hash::from_bytes([
-            0x20, 0xd8, 0xeb, 0x88, 0xd6, 0x6b, 0xef, 0x8f, 0xee, 0xf3, 0x60, 0x24, 0x3e, 0xb5, 0x10, 0xee, 0x53, 0x3b, 0x4c, 0xe0,
-            0x07, 0x43, 0x2c, 0x29, 0xb4, 0xf5, 0x58, 0xb0, 0xdb, 0xf4, 0x75, 0x91,
-        ]);
-        assert_eq!(mergeset_context_hash(&MergesetContext { timestamp: 1000, daa_score: 500, blue_score: 250 }), expected);
+    fn test_mergeset_context_hash_determinism() {
+        let ctx = MergesetContext { timestamp: 1000, daa_score: 500, blue_score: 250 };
+        assert_eq!(mergeset_context_hash(&ctx), mergeset_context_hash(&ctx));
     }
 
     #[test]
@@ -261,6 +293,31 @@ mod tests {
         assert_ne!(ha, mergeset_context_hash(&b));
         assert_ne!(ha, mergeset_context_hash(&c));
         assert_ne!(ha, mergeset_context_hash(&d));
+    }
+
+    #[test]
+    fn test_activity_root_hash_golden() {
+        let result = activity_root_hash(&h(7), &h(9));
+        assert_eq!(result, activity_root_hash(&h(7), &h(9)));
+        assert_ne!(result, ZERO_HASH);
+    }
+
+    #[test]
+    fn test_activity_root_hash_different_inputs() {
+        let base = activity_root_hash(&h(7), &h(9));
+        assert_ne!(base, activity_root_hash(&h(8), &h(9)));
+        assert_ne!(base, activity_root_hash(&h(7), &h(10)));
+        // Order matters (domain-separated, but sanity-check).
+        assert_ne!(base, activity_root_hash(&h(9), &h(7)));
+    }
+
+    /// Identity vs wrap diverge: pre-hardening feeds `lanes_root` directly to
+    /// `seq_state_root`; post-hardening wraps via `activity_root_hash`. Hashes must differ.
+    #[test]
+    fn activity_root_identity_vs_wrap_diverges() {
+        let lanes_root = h(42);
+        let shortcut = ZERO_HASH;
+        assert_ne!(lanes_root, activity_root_hash(&shortcut, &lanes_root));
     }
 
     #[test]
@@ -390,19 +447,19 @@ mod tests {
             0x20, 0xd1, 0x35, 0x77, 0x5a, 0x39, 0xbe, 0x49, 0xfe, 0x34, 0x70, 0x9a, 0x55, 0xb0, 0xc7, 0xeb, 0x39, 0x05, 0xf5, 0xc9,
             0xbe, 0x27, 0xd1, 0xdc, 0x11, 0x50, 0xb8, 0xaf, 0x23, 0x9e, 0x56, 0xd9,
         ]);
-        let (lr, ch, pr) = (h(1), h(2), h(3));
+        let (ar, ch, pr) = (h(1), h(2), h(3));
         let pd = payload_and_context_digest(&ch, &pr);
-        assert_eq!(seq_state_root(&SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd }), expected);
+        assert_eq!(seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: &pd }), expected);
     }
 
     #[test]
     fn test_seq_state_root_structure() {
-        let (lr, ch, pr) = (h(1), h(2), h(3));
+        let (ar, ch, pr) = (h(1), h(2), h(3));
         let pd = payload_and_context_digest(&ch, &pr);
-        let state = SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd };
+        let state = SeqState { activity_root: &ar, payload_and_ctx_digest: &pd };
         let expected = {
             let mut hasher = SeqCommitMerkleBranch::new();
-            hasher.update(state.lanes_root).update(state.payload_and_ctx_digest);
+            hasher.update(state.activity_root).update(state.payload_and_ctx_digest);
             hasher.finalize()
         };
         assert_eq!(seq_state_root(&state), expected);
@@ -461,7 +518,9 @@ mod tests {
         let mpr = miner_payload_root(core::iter::once(mpl));
 
         let pd = payload_and_context_digest(&ctx, &mpr);
-        let state_root = seq_state_root(&SeqState { lanes_root: &smt_leaf, payload_and_ctx_digest: &pd });
+        // Post-hardening end-to-end: activity_root wraps lanes_root with the shortcut.
+        let activity_root = activity_root_hash(&ZERO_HASH, &smt_leaf);
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_commit, state_root: &state_root });
         assert_ne!(commitment, parent_commit);
     }

--- a/consensus/seq-commit/src/hashing.rs
+++ b/consensus/seq-commit/src/hashing.rs
@@ -20,8 +20,6 @@
 //!                     └── payload_root
 //! ```
 //!
-//! Pre-hardening: `activity_root == lanes_root` (identity, no wrap);
-//! post-hardening: `activity_root = H_activity_root(inactivity_shortcut, lanes_root)`.
 
 use kaspa_hashes::{
     Hash, HasherBase, PayloadDigest, SeqCommitActiveLeaf, SeqCommitActivityLeaf, SeqCommitActivityRoot, SeqCommitLaneKey,
@@ -86,9 +84,6 @@ pub fn mergeset_context_hash(ctx: &MergesetContext) -> Hash {
 }
 
 /// Compute the activity root: `H_activity_root(inactivity_shortcut, lanes_root)`.
-///
-/// Post-hardening only. Pre-hardening callers should pass `lanes_root` straight
-/// into [`seq_state_root`] without invoking this helper (identity).
 #[inline]
 pub fn activity_root_hash(inactivity_shortcut: &Hash, lanes_root: &Hash) -> Hash {
     let mut hasher = SeqCommitActivityRoot::new();
@@ -311,8 +306,8 @@ mod tests {
         assert_ne!(base, activity_root_hash(&h(9), &h(7)));
     }
 
-    /// Identity vs wrap diverge: pre-hardening feeds `lanes_root` directly to
-    /// `seq_state_root`; post-hardening wraps via `activity_root_hash`. Hashes must differ.
+    /// The activity-root domain separates `(inactivity_shortcut, lanes_root)` from
+    /// the raw active-lanes SMT root.
     #[test]
     fn activity_root_identity_vs_wrap_diverges() {
         let lanes_root = h(42);
@@ -518,7 +513,6 @@ mod tests {
         let mpr = miner_payload_root(core::iter::once(mpl));
 
         let pd = payload_and_context_digest(&ctx, &mpr);
-        // Post-hardening end-to-end: activity_root wraps lanes_root with the shortcut.
         let activity_root = activity_root_hash(&ZERO_HASH, &smt_leaf);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_commit, state_root: &state_root });

--- a/consensus/seq-commit/src/types.rs
+++ b/consensus/seq-commit/src/types.rs
@@ -6,6 +6,8 @@ use kaspa_hashes::Hash;
 pub type LaneId = [u8; 20];
 
 /// Mergeset context fields hashed into the sequencing commitment.
+///
+/// Preimage is exactly `le_u64(timestamp) || le_u64(daa_score) || le_u64(blue_score)`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MergesetContext {
     pub timestamp: u64,
@@ -43,9 +45,12 @@ pub struct SmtLeafInput<'a> {
 }
 
 /// Components of the sequencing state root.
+///
+/// `activity_root`: pre-hardening identity = `lanes_root`; post-hardening
+/// = `H_activity_root(inactivity_shortcut, lanes_root)`.
 #[derive(Clone, Copy, Debug)]
 pub struct SeqState<'a> {
-    pub lanes_root: &'a Hash,
+    pub activity_root: &'a Hash,
     pub payload_and_ctx_digest: &'a Hash,
 }
 

--- a/consensus/seq-commit/src/types.rs
+++ b/consensus/seq-commit/src/types.rs
@@ -45,9 +45,6 @@ pub struct SmtLeafInput<'a> {
 }
 
 /// Components of the sequencing state root.
-///
-/// `activity_root`: pre-hardening identity = `lanes_root`; post-hardening
-/// = `H_activity_root(inactivity_shortcut, lanes_root)`.
 #[derive(Clone, Copy, Debug)]
 pub struct SeqState<'a> {
     pub activity_root: &'a Hash,

--- a/consensus/seq-commit/src/verify.rs
+++ b/consensus/seq-commit/src/verify.rs
@@ -35,12 +35,9 @@ pub enum SmtVerifyError {
 }
 
 /// Verify that the metadata is consistent with the header's `accepted_id_merkle_root` (= seq_commit).
-///
-/// `inactivity_shortcut`: `None` for pre-hardening (identity at the activity-root level);
-/// `Some(s)` for post-hardening, wrapping `lanes_root` into `activity_root_hash(s, lanes_root)`.
 pub fn verify_smt_metadata(
     metadata: &SmtMetadata<'_>,
-    inactivity_shortcut: Option<Hash>,
+    inactivity_shortcut: Hash,
     expected_seq_commit: Hash,
     expected_parent_seq_commit: Hash,
 ) -> Result<(), SmtVerifyError> {
@@ -51,10 +48,7 @@ pub fn verify_smt_metadata(
         });
     }
 
-    let activity_root = match inactivity_shortcut {
-        Some(s) => activity_root_hash(&s, metadata.lanes_root),
-        None => *metadata.lanes_root,
-    };
+    let activity_root = activity_root_hash(&inactivity_shortcut, metadata.lanes_root);
     let state_root =
         seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
     let computed = {
@@ -109,11 +103,8 @@ mod tests {
         Hash::from_bytes([7; 32])
     }
 
-    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Option<Hash>) -> Hash {
-        let ar = match shortcut {
-            Some(s) => activity_root_hash(&s, lr),
-            None => *lr,
-        };
+    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Hash) -> Hash {
+        let ar = activity_root_hash(&shortcut, lr);
         let sr = seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: pd });
         let mut h = SeqCommitMerkleBranch::new();
         h.update(ps).update(sr);
@@ -121,26 +112,15 @@ mod tests {
     }
 
     #[test]
-    fn metadata_correct_post_hardening() {
+    fn metadata_correct() {
         let lr = Hash::from_bytes([1; 32]);
         let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let shortcut = sample_shortcut();
 
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, shortcut);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, Some(shortcut), sc, ps).is_ok());
-    }
-
-    #[test]
-    fn metadata_correct_pre_hardening() {
-        let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([3; 32]);
-        let ps = Hash::from_bytes([4; 32]);
-
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, None);
-        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, None, sc, ps).is_ok());
+        assert!(verify_smt_metadata(&md, shortcut, sc, ps).is_ok());
     }
 
     #[test]
@@ -150,7 +130,7 @@ mod tests {
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, Some(sample_shortcut()), ZERO_HASH, Hash::from_bytes([99; 32])),
+            verify_smt_metadata(&md, sample_shortcut(), ZERO_HASH, Hash::from_bytes([99; 32])),
             Err(SmtVerifyError::ParentSeqCommitMismatch { .. })
         ));
     }
@@ -162,24 +142,9 @@ mod tests {
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, Some(sample_shortcut()), Hash::from_bytes([99; 32]), ps),
+            verify_smt_metadata(&md, sample_shortcut(), Hash::from_bytes([99; 32]), ps),
             Err(SmtVerifyError::SeqCommitMismatch { .. })
         ));
-    }
-
-    // Pre/post divergence: a verifier called with `None` on a post-hardening commit
-    // (or vice versa) must reject as a seq_commit mismatch.
-    #[test]
-    fn metadata_pre_post_mismatch_rejected() {
-        let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([3; 32]);
-        let ps = Hash::from_bytes([4; 32]);
-        let shortcut = sample_shortcut();
-
-        let sc_post = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
-        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        // Wire was post-hardening but verifier was told pre-hardening: must mismatch.
-        assert!(matches!(verify_smt_metadata(&md, None, sc_post, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     // A perturbed shortcut flows into `activity_root` and then `seq_state_root`,
@@ -190,10 +155,10 @@ mod tests {
         let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let shortcut = sample_shortcut();
-        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, shortcut);
         let bad_shortcut = Hash::from_bytes([0xAB; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(matches!(verify_smt_metadata(&md, Some(bad_shortcut), sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+        assert!(matches!(verify_smt_metadata(&md, bad_shortcut, sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     #[test]

--- a/consensus/seq-commit/src/verify.rs
+++ b/consensus/seq-commit/src/verify.rs
@@ -1,9 +1,9 @@
-//! IBD SMT verification — metadata check.
+//! IBD SMT verification: metadata check.
 //!
 //! Proof verification with branch caching uses [`SmtProof::compute_root_with_visitor`]
 //! from `kaspa-smt` with `&mut ProofBranchCache` as the visitor.
 
-use crate::hashing::seq_state_root;
+use crate::hashing::{activity_root_hash, seq_state_root};
 use crate::types::SeqState;
 use kaspa_hashes::{Hash, HasherBase, SeqCommitMerkleBranch};
 
@@ -35,8 +35,12 @@ pub enum SmtVerifyError {
 }
 
 /// Verify that the metadata is consistent with the header's `accepted_id_merkle_root` (= seq_commit).
+///
+/// `inactivity_shortcut`: `None` for pre-hardening (identity at the activity-root level);
+/// `Some(s)` for post-hardening, wrapping `lanes_root` into `activity_root_hash(s, lanes_root)`.
 pub fn verify_smt_metadata(
     metadata: &SmtMetadata<'_>,
+    inactivity_shortcut: Option<Hash>,
     expected_seq_commit: Hash,
     expected_parent_seq_commit: Hash,
 ) -> Result<(), SmtVerifyError> {
@@ -47,15 +51,17 @@ pub fn verify_smt_metadata(
         });
     }
 
+    let activity_root = match inactivity_shortcut {
+        Some(s) => activity_root_hash(&s, metadata.lanes_root),
+        None => *metadata.lanes_root,
+    };
     let state_root =
-        seq_state_root(&SeqState { lanes_root: metadata.lanes_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
-
+        seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: metadata.payload_and_ctx_digest });
     let computed = {
         let mut h = SeqCommitMerkleBranch::new();
         h.update(metadata.parent_seq_commit).update(state_root);
         h.finalize()
     };
-
     if computed != expected_seq_commit {
         return Err(SmtVerifyError::SeqCommitMismatch { expected: expected_seq_commit, computed });
     }
@@ -67,7 +73,7 @@ mod tests {
     extern crate std;
 
     use super::*;
-    use crate::hashing::{lane_key, payload_and_context_digest, smt_leaf_hash};
+    use crate::hashing::{activity_root_hash, lane_key, smt_leaf_hash};
     use crate::types::{LaneId, SmtLeafInput};
     use kaspa_hashes::{SeqCommitActiveNode, ZERO_HASH};
     use kaspa_smt::proof::ProofBranchCache;
@@ -99,33 +105,52 @@ mod tests {
         (tree.root(), tree)
     }
 
+    fn sample_shortcut() -> Hash {
+        Hash::from_bytes([7; 32])
+    }
+
+    fn build_expected_seq_commit(lr: &Hash, pd: &Hash, ps: &Hash, shortcut: Option<Hash>) -> Hash {
+        let ar = match shortcut {
+            Some(s) => activity_root_hash(&s, lr),
+            None => *lr,
+        };
+        let sr = seq_state_root(&SeqState { activity_root: &ar, payload_and_ctx_digest: pd });
+        let mut h = SeqCommitMerkleBranch::new();
+        h.update(ps).update(sr);
+        h.finalize()
+    }
+
     #[test]
-    fn metadata_correct() {
+    fn metadata_correct_post_hardening() {
         let lr = Hash::from_bytes([1; 32]);
-        let ch = Hash::from_bytes([2; 32]);
-        let pr = Hash::from_bytes([3; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        assert!(verify_smt_metadata(&md, Some(shortcut), sc, ps).is_ok());
+    }
+
+    #[test]
+    fn metadata_correct_pre_hardening() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
 
-        let pd = payload_and_context_digest(&ch, &pr);
-        let sr = seq_state_root(&SeqState { lanes_root: &lr, payload_and_ctx_digest: &pd });
-        let sc = {
-            let mut h = SeqCommitMerkleBranch::new();
-            h.update(ps).update(sr);
-            h.finalize()
-        };
-
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, None);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(verify_smt_metadata(&md, sc, ps).is_ok());
+        assert!(verify_smt_metadata(&md, None, sc, ps).is_ok());
     }
 
     #[test]
     fn metadata_wrong_parent() {
         let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([2; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
         assert!(matches!(
-            verify_smt_metadata(&md, ZERO_HASH, Hash::from_bytes([99; 32])),
+            verify_smt_metadata(&md, Some(sample_shortcut()), ZERO_HASH, Hash::from_bytes([99; 32])),
             Err(SmtVerifyError::ParentSeqCommitMismatch { .. })
         ));
     }
@@ -133,10 +158,42 @@ mod tests {
     #[test]
     fn metadata_wrong_commit() {
         let lr = Hash::from_bytes([1; 32]);
-        let pd = Hash::from_bytes([2; 32]);
+        let pd = Hash::from_bytes([3; 32]);
         let ps = Hash::from_bytes([4; 32]);
         let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
-        assert!(matches!(verify_smt_metadata(&md, Hash::from_bytes([99; 32]), ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+        assert!(matches!(
+            verify_smt_metadata(&md, Some(sample_shortcut()), Hash::from_bytes([99; 32]), ps),
+            Err(SmtVerifyError::SeqCommitMismatch { .. })
+        ));
+    }
+
+    // Pre/post divergence: a verifier called with `None` on a post-hardening commit
+    // (or vice versa) must reject as a seq_commit mismatch.
+    #[test]
+    fn metadata_pre_post_mismatch_rejected() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+
+        let sc_post = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        // Wire was post-hardening but verifier was told pre-hardening: must mismatch.
+        assert!(matches!(verify_smt_metadata(&md, None, sc_post, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
+    }
+
+    // A perturbed shortcut flows into `activity_root` and then `seq_state_root`,
+    // so the failure surfaces as `SeqCommitMismatch`.
+    #[test]
+    fn metadata_wrong_inactivity_shortcut_detected_via_seq_commit() {
+        let lr = Hash::from_bytes([1; 32]);
+        let pd = Hash::from_bytes([3; 32]);
+        let ps = Hash::from_bytes([4; 32]);
+        let shortcut = sample_shortcut();
+        let sc = build_expected_seq_commit(&lr, &pd, &ps, Some(shortcut));
+        let bad_shortcut = Hash::from_bytes([0xAB; 32]);
+        let md = SmtMetadata { lanes_root: &lr, payload_and_ctx_digest: &pd, parent_seq_commit: &ps };
+        assert!(matches!(verify_smt_metadata(&md, Some(bad_shortcut), sc, ps), Err(SmtVerifyError::SeqCommitMismatch { .. })));
     }
 
     #[test]

--- a/consensus/seq-commit/tests/example_block.rs
+++ b/consensus/seq-commit/tests/example_block.rs
@@ -153,9 +153,10 @@ fn example_seq_commit_for_block() {
         .collect();
     let payload_root = miner_payload_root(payload_leaves.into_iter());
 
-    // --- State root and final commitment ---
+    // --- State root and final commitment (post-hardening: wrap lanes_root into activity_root). ---
     let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&ctx, &payload_root);
-    let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+    let activity_root = kaspa_seq_commit::hashing::activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
+    let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let commitment = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
 
     // Recomputing with the same inputs yields the same result

--- a/consensus/seq-commit/tests/example_block.rs
+++ b/consensus/seq-commit/tests/example_block.rs
@@ -153,7 +153,7 @@ fn example_seq_commit_for_block() {
         .collect();
     let payload_root = miner_payload_root(payload_leaves.into_iter());
 
-    // --- State root and final commitment (post-hardening: wrap lanes_root into activity_root). ---
+    // --- State root and final commitment. ---
     let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&ctx, &payload_root);
     let activity_root = kaspa_seq_commit::hashing::activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
     let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });

--- a/consensus/seq-commit/tests/prove_lane_activity.rs
+++ b/consensus/seq-commit/tests/prove_lane_activity.rs
@@ -46,6 +46,8 @@ struct CommitmentWitness {
     parent_seq_commit: Hash,
     smt_proof: OwnedSmtProof,
     blue_score: u64,
+    /// Post-hardening shortcut Hash. `None` pre-hardening (identity at activity_root).
+    inactivity_shortcut: Option<Hash>,
 }
 
 /// Chain `lane_tip_next` across blocks, starting from `parent_ref`.
@@ -68,11 +70,16 @@ fn compute_lane_tip(parent_ref: &Hash, lane_key: &Hash, blocks: &[BlockActivity]
 }
 
 /// Compute `seq_commit` from a lane tip: `smt_leaf → proof.compute_root
-/// → lanes_root → state_root → seq_commit`.
+/// → lanes_root → activity_root → state_root → seq_commit`.
 fn compute_seq_commit_for_lane(lane_key: &Hash, lane_tip: &Hash, witness: &CommitmentWitness) -> Hash {
     let leaf = smt_leaf_hash(&SmtLeafInput { lane_tip, blue_score: witness.blue_score });
     let lanes_root = witness.smt_proof.as_proof().compute_root::<SeqCommitActiveNode>(lane_key, Some(leaf)).unwrap();
-    let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
+    let activity_root = match witness.inactivity_shortcut {
+        Some(s) => activity_root_hash(&s, &lanes_root),
+        None => lanes_root,
+    };
+    let state_root =
+        seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
     seq_commit(&SeqCommitInput { parent_seq_commit: &witness.parent_seq_commit, state_root: &state_root })
 }
 
@@ -102,7 +109,9 @@ fn build_commitment(
     let payload_root = miner_payload_root(core::iter::once(pl));
     let lanes_root = smt.root();
     let pd = payload_and_context_digest(&ctx, &payload_root);
-    let sr = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+    // Post-hardening test fixture: wrap lanes_root into activity_root with ZERO_HASH shortcut.
+    let activity_root = activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
+    let sr = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let sc = seq_commit(&SeqCommitInput { parent_seq_commit, state_root: &sr });
     (sc, lanes_root, pd)
 }
@@ -203,6 +212,8 @@ fn build_chain(n: usize) -> (Hash, Hash, Hash, Vec<BlockActivity>, CommitmentWit
         parent_seq_commit: last_parent_sc,
         smt_proof: last_smt_proof.unwrap(),
         blue_score: last_blue_score,
+        // Mirrors `build_commitment`'s post-hardening wrap.
+        inactivity_shortcut: Some(kaspa_hashes::ZERO_HASH),
     };
 
     (last_sc, key_x, grandparent_commit, block_activities, witness)

--- a/consensus/seq-commit/tests/prove_lane_activity.rs
+++ b/consensus/seq-commit/tests/prove_lane_activity.rs
@@ -46,8 +46,7 @@ struct CommitmentWitness {
     parent_seq_commit: Hash,
     smt_proof: OwnedSmtProof,
     blue_score: u64,
-    /// Post-hardening shortcut Hash. `None` pre-hardening (identity at activity_root).
-    inactivity_shortcut: Option<Hash>,
+    inactivity_shortcut: Hash,
 }
 
 /// Chain `lane_tip_next` across blocks, starting from `parent_ref`.
@@ -74,10 +73,7 @@ fn compute_lane_tip(parent_ref: &Hash, lane_key: &Hash, blocks: &[BlockActivity]
 fn compute_seq_commit_for_lane(lane_key: &Hash, lane_tip: &Hash, witness: &CommitmentWitness) -> Hash {
     let leaf = smt_leaf_hash(&SmtLeafInput { lane_tip, blue_score: witness.blue_score });
     let lanes_root = witness.smt_proof.as_proof().compute_root::<SeqCommitActiveNode>(lane_key, Some(leaf)).unwrap();
-    let activity_root = match witness.inactivity_shortcut {
-        Some(s) => activity_root_hash(&s, &lanes_root),
-        None => lanes_root,
-    };
+    let activity_root = activity_root_hash(&witness.inactivity_shortcut, &lanes_root);
     let state_root =
         seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &witness.payload_and_ctx_digest });
     seq_commit(&SeqCommitInput { parent_seq_commit: &witness.parent_seq_commit, state_root: &state_root })
@@ -109,7 +105,6 @@ fn build_commitment(
     let payload_root = miner_payload_root(core::iter::once(pl));
     let lanes_root = smt.root();
     let pd = payload_and_context_digest(&ctx, &payload_root);
-    // Post-hardening test fixture: wrap lanes_root into activity_root with ZERO_HASH shortcut.
     let activity_root = activity_root_hash(&kaspa_hashes::ZERO_HASH, &lanes_root);
     let sr = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
     let sc = seq_commit(&SeqCommitInput { parent_seq_commit, state_root: &sr });
@@ -212,8 +207,7 @@ fn build_chain(n: usize) -> (Hash, Hash, Hash, Vec<BlockActivity>, CommitmentWit
         parent_seq_commit: last_parent_sc,
         smt_proof: last_smt_proof.unwrap(),
         blue_score: last_blue_score,
-        // Mirrors `build_commitment`'s post-hardening wrap.
-        inactivity_shortcut: Some(kaspa_hashes::ZERO_HASH),
+        inactivity_shortcut: kaspa_hashes::ZERO_HASH,
     };
 
     (last_sc, key_x, grandparent_commit, block_activities, witness)

--- a/consensus/smt-store/src/processor.rs
+++ b/consensus/smt-store/src/processor.rs
@@ -524,13 +524,21 @@ impl<'a> SmtProcessor<'a> {
                 lane_changes: self.lane_changes,
                 payload_and_ctx_digest: ZERO_HASH,
                 active_lanes_count: 0,
+                inactivity_shortcut_block: ZERO_HASH,
             });
         }
 
         let leaf_updates = self.lane_changes.to_leaf_updates();
         let reader = VersionedBranchReader { stores: self.stores, bounds: self.bounds, is_canonical };
         let (root, node_changes) = compute_root_update::<SeqCommitActiveNode, _>(&reader, self.current_lanes_root, leaf_updates)?;
-        Ok(SmtBuild { root, node_changes, lane_changes: self.lane_changes, payload_and_ctx_digest: ZERO_HASH, active_lanes_count: 0 })
+        Ok(SmtBuild {
+            root,
+            node_changes,
+            lane_changes: self.lane_changes,
+            payload_and_ctx_digest: ZERO_HASH,
+            active_lanes_count: 0,
+            inactivity_shortcut_block: ZERO_HASH,
+        })
     }
 }
 
@@ -539,9 +547,11 @@ pub struct SmtBuild {
     pub root: Hash,
     node_changes: SmtNodeChanges,
     lane_changes: BlockLaneChanges,
-    /// Set by `build_seq_commit` after computing the seq_commit components.
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
+    /// KIP-21: block hash whose seq_commit IS the `inactivity_shortcut`. Kept here
+    /// for the per-block parent-fallback path in `compute_inactivity_shortcut_block`.
+    pub inactivity_shortcut_block: Hash,
 }
 
 impl SmtBuild {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1153,13 +1153,23 @@ impl ConsensusApi for Consensus {
     fn import_pruning_point_smt(
         &self,
         new_pruning_point: Hash,
-        lanes_root: Hash,
-        payload_and_ctx_digest: Hash,
-        expected_lane_count: u64,
+        metadata: kaspa_consensus_core::api::SmtExportMetadata,
+        inactivity_shortcut_block: Option<Hash>,
         lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
+        use crate::model::stores::smt_metadata::{SmtBlockMetadata, ToccataV0};
         use kaspa_hashes::ZERO_HASH;
         use kaspa_smt_store::streaming_import::streaming_import;
+
+        let kaspa_consensus_core::api::SmtExportMetadata { lanes_root, payload_and_ctx_digest, active_lanes_count, .. } = metadata;
+        let expected_lane_count = active_lanes_count;
+
+        // `inactivity_shortcut_block` was already resolved by the caller during metadata
+        // verification: `Some` post-hardening, `None` pre-hardening. V1/V0 dispatch follows.
+        let row = match inactivity_shortcut_block {
+            Some(block) => SmtBlockMetadata::new(payload_and_ctx_digest, block, active_lanes_count),
+            None => SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest, active_lanes_count }),
+        };
 
         let result = self.virtual_processor.install(|| {
             streaming_import(
@@ -1187,12 +1197,9 @@ impl ConsensusApi for Consensus {
             )));
         }
 
+        // The wire's metadata was already authenticated by the caller via `verify_smt_metadata`.
         let mut batch = rocksdb::WriteBatch::default();
-        use crate::model::stores::smt_metadata::SmtBlockMetadata;
-        self.storage
-            .smt_metadata_store
-            .insert_batch(&mut batch, new_pruning_point, SmtBlockMetadata::new(payload_and_ctx_digest, actual_count))
-            .unwrap();
+        self.storage.smt_metadata_store.insert_batch(&mut batch, new_pruning_point, row).unwrap();
         self.db.write(batch).unwrap();
 
         info!("Imported SMT state for pruning point {}: {} lanes, root {}", new_pruning_point, actual_count, lanes_root);
@@ -1206,6 +1213,10 @@ impl ConsensusApi for Consensus {
         self.virtual_processor.get_pruning_point_smt_metadata(expected_pruning_point)
     }
 
+    fn inactivity_shortcut_block_for_pov(&self, pov_block: Hash) -> ConsensusResult<Hash> {
+        self.virtual_processor.inactivity_shortcut_block_for_pov(pov_block)
+    }
+
     fn open_pruning_point_smt_lane_stream(
         &self,
         expected_pruning_point: Hash,
@@ -1217,6 +1228,7 @@ impl ConsensusApi for Consensus {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
         let max_score = self.storage.headers_store.get_blue_score(pp).unwrap();
+        // KIP-21: IBD streams only the active-lanes window `[pp - finality_depth, pp]`.
         let min_score = max_score.saturating_sub(self.config.params.finality_depth());
 
         let smt_stores = self.storage.smt_stores.clone();

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1154,22 +1154,18 @@ impl ConsensusApi for Consensus {
         &self,
         new_pruning_point: Hash,
         metadata: kaspa_consensus_core::api::SmtExportMetadata,
-        inactivity_shortcut_block: Option<Hash>,
+        inactivity_shortcut_block: Hash,
         lane_batches: ImportLaneBatchIterator<'_>,
     ) -> PruningImportResult<()> {
-        use crate::model::stores::smt_metadata::{SmtBlockMetadata, ToccataV0};
+        use crate::model::stores::smt_metadata::SmtBlockMetadata;
         use kaspa_hashes::ZERO_HASH;
         use kaspa_smt_store::streaming_import::streaming_import;
 
         let kaspa_consensus_core::api::SmtExportMetadata { lanes_root, payload_and_ctx_digest, active_lanes_count, .. } = metadata;
         let expected_lane_count = active_lanes_count;
 
-        // `inactivity_shortcut_block` was already resolved by the caller during metadata
-        // verification: `Some` post-hardening, `None` pre-hardening. V1/V0 dispatch follows.
-        let row = match inactivity_shortcut_block {
-            Some(block) => SmtBlockMetadata::new(payload_and_ctx_digest, block, active_lanes_count),
-            None => SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest, active_lanes_count }),
-        };
+        // `inactivity_shortcut_block` was already resolved by the caller during metadata verification.
+        let row = SmtBlockMetadata::new(payload_and_ctx_digest, inactivity_shortcut_block, active_lanes_count);
 
         let result = self.virtual_processor.install(|| {
             streaming_import(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -184,6 +184,7 @@ impl ConsensusServices {
             params.ghostdag_k(),
             params.skip_proof_of_work,
             params.toccata_activation,
+            params.zk_hardening_activation,
             params.net.is_mainnet(),
             is_consensus_exiting,
         ));

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -144,7 +144,6 @@ impl ConsensusServices {
             tx_script_cache_counters,
             mass_calculator.clone(),
             params.toccata_activation,
-            params.zk_hardening_activation,
             params.mass_per_sig_op,
         );
 
@@ -184,8 +183,6 @@ impl ConsensusServices {
             params.ghostdag_k(),
             params.skip_proof_of_work,
             params.toccata_activation,
-            params.zk_hardening_activation,
-            params.net.is_mainnet(),
             is_consensus_exiting,
         ));
 

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -144,6 +144,7 @@ impl ConsensusServices {
             tx_script_cache_counters,
             mass_calculator.clone(),
             params.toccata_activation,
+            params.zk_hardening_activation,
             params.mass_per_sig_op,
         );
 

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -55,6 +55,8 @@ pub struct TestSeqCommitLaneProof {
     pub current_lane: Option<(Hash, u64)>,
     pub smt_proof: OwnedSmtProof,
     pub blue_score: u64,
+    /// Resolved shortcut Hash (None pre-hardening, Some(seq_commit-or-zero) post-hardening).
+    pub inactivity_shortcut: Option<Hash>,
 }
 
 impl TestConsensus {
@@ -219,6 +221,11 @@ impl TestConsensus {
         MutableBlock::from_header(self.build_header_with_parents(hash, parents))
     }
 
+    /// Read the stored SMT block metadata (KIP-21) for a block.
+    pub fn smt_block_metadata(&self, block_hash: Hash) -> crate::model::stores::smt_metadata::SmtBlockMetadata {
+        self.consensus.storage.smt_metadata_store.get(block_hash).unwrap()
+    }
+
     pub fn seq_commit_lane_proof(&self, block_hash: Hash, lane_key: Hash) -> TestSeqCommitLaneProof {
         let header = self.consensus.headers_store.get_header(block_hash).unwrap();
         let selected_parent = header.direct_parents()[0];
@@ -252,15 +259,24 @@ impl TestConsensus {
             .unwrap();
         let metadata = self.consensus.storage.smt_metadata_store.get(block_hash).unwrap();
 
+        let inactivity_shortcut = if self.params.zk_hardening_activation.is_active(header.daa_score) {
+            let shortcut_block =
+                metadata.inactivity_shortcut_block().expect("post-hardening row must carry inactivity_shortcut_block");
+            Some(self.consensus.virtual_processor.inactivity_shortcut(shortcut_block))
+        } else {
+            None
+        };
+
         TestSeqCommitLaneProof {
             lanes_root,
-            payload_and_ctx_digest: metadata.payload_and_ctx_digest,
+            payload_and_ctx_digest: metadata.payload_and_ctx_digest(),
             parent_seq_commit: parent_header.accepted_id_merkle_root,
             expected_seq_commit: header.accepted_id_merkle_root,
             parent_lane_tip,
             current_lane,
             smt_proof,
             blue_score: header.blue_score,
+            inactivity_shortcut,
         }
     }
 

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -55,8 +55,7 @@ pub struct TestSeqCommitLaneProof {
     pub current_lane: Option<(Hash, u64)>,
     pub smt_proof: OwnedSmtProof,
     pub blue_score: u64,
-    /// Resolved shortcut Hash (None pre-hardening, Some(seq_commit-or-zero) post-hardening).
-    pub inactivity_shortcut: Option<Hash>,
+    pub inactivity_shortcut: Hash,
 }
 
 impl TestConsensus {
@@ -259,13 +258,8 @@ impl TestConsensus {
             .unwrap();
         let metadata = self.consensus.storage.smt_metadata_store.get(block_hash).unwrap();
 
-        let inactivity_shortcut = if self.params.zk_hardening_activation.is_active(header.daa_score) {
-            let shortcut_block =
-                metadata.inactivity_shortcut_block().expect("post-hardening row must carry inactivity_shortcut_block");
-            Some(self.consensus.virtual_processor.inactivity_shortcut(shortcut_block))
-        } else {
-            None
-        };
+        let shortcut_block = metadata.inactivity_shortcut_block();
+        let inactivity_shortcut = self.consensus.virtual_processor.inactivity_shortcut(shortcut_block);
 
         TestSeqCommitLaneProof {
             lanes_root,

--- a/consensus/src/model/stores/smt_metadata.rs
+++ b/consensus/src/model/stores/smt_metadata.rs
@@ -4,29 +4,114 @@ use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
 use std::sync::Arc;
 
-/// Per-block SMT metadata stored alongside the seq_commit.
-///
-/// `payload_and_ctx_digest` is `H_seq(context_hash, payload_root)` — the inner hash
-/// of `seq_state_root`. The `lanes_root` is stored in the branch version store
-/// at depth=0 and read via `SmtStores::get_lanes_root`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SmtBlockMetadata {
+/// Pre-anchor (Toccata) per-block SMT metadata. Wire: `[Hash || u64]` = 40 bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToccataV0 {
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
 }
 
+/// Post-anchor per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
+///
+/// Same first 40 bytes as `ToccataV0`; the trailing `inactivity_shortcut_block`
+/// is the only structural difference. `inactivity_shortcut_block` is retained
+/// per-row because `compute_inactivity_shortcut_block`'s parent-fallback path
+/// consults the parent's stored row; it does NOT feed `mergeset_context_hash`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToccataV1 {
+    pub payload_and_ctx_digest: Hash,
+    pub active_lanes_count: u64,
+    pub inactivity_shortcut_block: Hash,
+}
+
+/// Per-block SMT metadata, length-discriminated on the wire (40 vs 72 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SmtBlockMetadata {
+    ToccataV0(ToccataV0),
+    ToccataV1(ToccataV1),
+}
+
 impl SmtBlockMetadata {
-    pub fn new(payload_and_ctx_digest: Hash, active_lanes_count: u64) -> Self {
-        Self { payload_and_ctx_digest, active_lanes_count }
+    /// Construct a `ToccataV1` variant. The only variant new code ever writes.
+    pub fn new(payload_and_ctx_digest: Hash, inactivity_shortcut_block: Hash, active_lanes_count: u64) -> Self {
+        Self::ToccataV1(ToccataV1 { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block })
+    }
+
+    pub fn payload_and_ctx_digest(&self) -> Hash {
+        match self {
+            Self::ToccataV0(v) => v.payload_and_ctx_digest,
+            Self::ToccataV1(v) => v.payload_and_ctx_digest,
+        }
+    }
+
+    pub fn inactivity_shortcut_block(&self) -> Option<Hash> {
+        match self {
+            Self::ToccataV1(v) => Some(v.inactivity_shortcut_block),
+            Self::ToccataV0(_) => None,
+        }
+    }
+
+    pub fn active_lanes_count(&self) -> u64 {
+        match self {
+            Self::ToccataV1(v) => v.active_lanes_count,
+            Self::ToccataV0(v) => v.active_lanes_count,
+        }
     }
 }
 
 impl MemSizeEstimator for SmtBlockMetadata {}
 
-/// Block-hash-keyed metadata store with in-memory cache.
+impl Serialize for SmtBlockMetadata {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ToccataV0(v) => v.serialize(s),
+            Self::ToccataV1(v) => v.serialize(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SmtBlockMetadata {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = SmtBlockMetadata;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("SmtBlockMetadata: [Hash, u64] (ToccataV0) or [Hash, u64, Hash] (ToccataV1)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let first: Hash = seq.next_element()?.ok_or_else(|| A::Error::custom("missing first hash"))?;
+                let count: u64 = seq.next_element()?.ok_or_else(|| A::Error::custom("missing active_lanes_count"))?;
+                // Third element discriminates: a Hash present => V1; EOF on the
+                // third read => V0 (no trailing inactivity_shortcut_block). On a
+                // 40-byte V0 wire the buffer is empty before this read, so no
+                // bytes are partially consumed; the error path is safe.
+                match seq.next_element::<Hash>() {
+                    Ok(Some(inactivity_shortcut_block)) => Ok(SmtBlockMetadata::ToccataV1(ToccataV1 {
+                        payload_and_ctx_digest: first,
+                        active_lanes_count: count,
+                        inactivity_shortcut_block,
+                    })),
+                    Ok(None) | Err(_) => {
+                        Ok(SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: first, active_lanes_count: count }))
+                    }
+                }
+            }
+        }
+        d.deserialize_tuple(3, V)
+    }
+}
+
+/// Block-hash-keyed metadata store with in-memory cache. Key = `[prefix || hash]`.
 #[derive(Clone)]
 pub struct DbSmtMetadataStore {
     db: Arc<DB>,
@@ -56,5 +141,123 @@ impl DbSmtMetadataStore {
 
     pub fn delete_batch(&self, batch: &mut WriteBatch, block_hash: Hash) -> StoreResult<()> {
         self.access.delete(BatchDbWriter::new(batch), block_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_database::create_temp_db;
+    use kaspa_database::prelude::ConnBuilder;
+
+    fn row_key(hash: Hash) -> Vec<u8> {
+        let mut key = vec![DatabaseStorePrefixes::SmtSeqCommitMeta.into()];
+        key.extend_from_slice(hash.as_bytes().as_ref());
+        key
+    }
+
+    #[test]
+    fn round_trip_v1() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xDEAD_BEEF);
+        let meta = SmtBlockMetadata::new(Hash::from_bytes([1; 32]), Hash::from_bytes([2; 32]), 42);
+
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, meta).unwrap();
+        db.write(batch).unwrap();
+
+        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
+        assert_eq!(on_disk.len(), 72);
+        assert_eq!(store.get(hash).unwrap(), meta);
+    }
+
+    #[test]
+    fn round_trip_v0() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xABCD);
+        let meta =
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 });
+
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, meta).unwrap();
+        db.write(batch).unwrap();
+
+        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
+        assert_eq!(on_disk.len(), 40);
+        assert_eq!(store.get(hash).unwrap(), meta);
+    }
+
+    #[test]
+    fn decode_handcrafted_v0_wire() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(0xABCD);
+        let mut bytes = Vec::with_capacity(40);
+        bytes.extend_from_slice(&[0xAA; 32]);
+        bytes.extend_from_slice(&7u64.to_le_bytes());
+        db.put(row_key(hash), bytes).unwrap();
+
+        let decoded = store.get(hash).unwrap();
+        assert_eq!(
+            decoded,
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 })
+        );
+        assert_eq!(decoded.active_lanes_count(), 7);
+    }
+
+    #[test]
+    fn decode_handcrafted_v1_wire() {
+        let mut bytes = Vec::with_capacity(72);
+        bytes.extend_from_slice(&[0x11; 32]);
+        bytes.extend_from_slice(&42u64.to_le_bytes());
+        bytes.extend_from_slice(&[0x22; 32]);
+        let decoded: SmtBlockMetadata = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(
+            decoded,
+            SmtBlockMetadata::ToccataV1(ToccataV1 {
+                payload_and_ctx_digest: Hash::from_bytes([0x11; 32]),
+                active_lanes_count: 42,
+                inactivity_shortcut_block: Hash::from_bytes([0x22; 32]),
+            })
+        );
+    }
+
+    #[test]
+    fn payload_and_ctx_digest_accessor_works_for_both_variants() {
+        let v0 =
+            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 0 });
+        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 0);
+        assert_eq!(v0.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+        assert_eq!(v1.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+    }
+
+    #[test]
+    fn variant_wire_sizes() {
+        let v0 = SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0; 32]), active_lanes_count: 0 });
+        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
+        assert_eq!(bincode::serialize(&v0).unwrap().len(), 40);
+        assert_eq!(bincode::serialize(&v1).unwrap().len(), 72);
+    }
+
+    #[test]
+    fn delete_clears_row() {
+        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
+
+        let hash = Hash::from_u64_word(1);
+        let mut batch = WriteBatch::default();
+        store.insert_batch(&mut batch, hash, SmtBlockMetadata::new(Hash::from_bytes([1; 32]), Hash::from_bytes([2; 32]), 99)).unwrap();
+        db.write(batch).unwrap();
+
+        let mut batch = WriteBatch::default();
+        store.delete_batch(&mut batch, hash).unwrap();
+        db.write(batch).unwrap();
+
+        assert!(db.get_pinned(row_key(hash)).unwrap().is_none());
     }
 }

--- a/consensus/src/model/stores/smt_metadata.rs
+++ b/consensus/src/model/stores/smt_metadata.rs
@@ -4,112 +4,40 @@ use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
-use serde::de::{Error as DeError, SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Pre-anchor (Toccata) per-block SMT metadata. Wire: `[Hash || u64]` = 40 bytes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToccataV0 {
-    pub payload_and_ctx_digest: Hash,
-    pub active_lanes_count: u64,
-}
-
-/// Post-anchor per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
+/// Per-block SMT metadata. Wire: `[Hash || u64 || Hash]` = 72 bytes.
 ///
-/// Same first 40 bytes as `ToccataV0`; the trailing `inactivity_shortcut_block`
-/// is the only structural difference. `inactivity_shortcut_block` is retained
-/// per-row because `compute_inactivity_shortcut_block`'s parent-fallback path
-/// consults the parent's stored row; it does NOT feed `mergeset_context_hash`.
+/// `inactivity_shortcut_block` is retained per-row because
+/// `compute_inactivity_shortcut_block`'s parent-fallback path consults the
+/// parent's stored row.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ToccataV1 {
+pub struct SmtBlockMetadata {
     pub payload_and_ctx_digest: Hash,
     pub active_lanes_count: u64,
     pub inactivity_shortcut_block: Hash,
 }
 
-/// Per-block SMT metadata, length-discriminated on the wire (40 vs 72 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SmtBlockMetadata {
-    ToccataV0(ToccataV0),
-    ToccataV1(ToccataV1),
-}
-
 impl SmtBlockMetadata {
-    /// Construct a `ToccataV1` variant. The only variant new code ever writes.
     pub fn new(payload_and_ctx_digest: Hash, inactivity_shortcut_block: Hash, active_lanes_count: u64) -> Self {
-        Self::ToccataV1(ToccataV1 { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block })
+        Self { payload_and_ctx_digest, active_lanes_count, inactivity_shortcut_block }
     }
 
     pub fn payload_and_ctx_digest(&self) -> Hash {
-        match self {
-            Self::ToccataV0(v) => v.payload_and_ctx_digest,
-            Self::ToccataV1(v) => v.payload_and_ctx_digest,
-        }
+        self.payload_and_ctx_digest
     }
 
-    pub fn inactivity_shortcut_block(&self) -> Option<Hash> {
-        match self {
-            Self::ToccataV1(v) => Some(v.inactivity_shortcut_block),
-            Self::ToccataV0(_) => None,
-        }
+    pub fn inactivity_shortcut_block(&self) -> Hash {
+        self.inactivity_shortcut_block
     }
 
     pub fn active_lanes_count(&self) -> u64 {
-        match self {
-            Self::ToccataV1(v) => v.active_lanes_count,
-            Self::ToccataV0(v) => v.active_lanes_count,
-        }
+        self.active_lanes_count
     }
 }
 
 impl MemSizeEstimator for SmtBlockMetadata {}
-
-impl Serialize for SmtBlockMetadata {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        match self {
-            Self::ToccataV0(v) => v.serialize(s),
-            Self::ToccataV1(v) => v.serialize(s),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for SmtBlockMetadata {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        struct V;
-        impl<'de> Visitor<'de> for V {
-            type Value = SmtBlockMetadata;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("SmtBlockMetadata: [Hash, u64] (ToccataV0) or [Hash, u64, Hash] (ToccataV1)")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let first: Hash = seq.next_element()?.ok_or_else(|| A::Error::custom("missing first hash"))?;
-                let count: u64 = seq.next_element()?.ok_or_else(|| A::Error::custom("missing active_lanes_count"))?;
-                // Third element discriminates: a Hash present => V1; EOF on the
-                // third read => V0 (no trailing inactivity_shortcut_block). On a
-                // 40-byte V0 wire the buffer is empty before this read, so no
-                // bytes are partially consumed; the error path is safe.
-                match seq.next_element::<Hash>() {
-                    Ok(Some(inactivity_shortcut_block)) => Ok(SmtBlockMetadata::ToccataV1(ToccataV1 {
-                        payload_and_ctx_digest: first,
-                        active_lanes_count: count,
-                        inactivity_shortcut_block,
-                    })),
-                    Ok(None) | Err(_) => {
-                        Ok(SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: first, active_lanes_count: count }))
-                    }
-                }
-            }
-        }
-        d.deserialize_tuple(3, V)
-    }
-}
 
 /// Block-hash-keyed metadata store with in-memory cache. Key = `[prefix || hash]`.
 #[derive(Clone)]
@@ -157,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_v1() {
+    fn round_trip() {
         let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
         let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
 
@@ -174,44 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_v0() {
-        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
-
-        let hash = Hash::from_u64_word(0xABCD);
-        let meta =
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 });
-
-        let mut batch = WriteBatch::default();
-        store.insert_batch(&mut batch, hash, meta).unwrap();
-        db.write(batch).unwrap();
-
-        let on_disk = db.get_pinned(row_key(hash)).unwrap().unwrap();
-        assert_eq!(on_disk.len(), 40);
-        assert_eq!(store.get(hash).unwrap(), meta);
-    }
-
-    #[test]
-    fn decode_handcrafted_v0_wire() {
-        let (_lifetime, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbSmtMetadataStore::new(Arc::clone(&db), CachePolicy::Count(16));
-
-        let hash = Hash::from_u64_word(0xABCD);
-        let mut bytes = Vec::with_capacity(40);
-        bytes.extend_from_slice(&[0xAA; 32]);
-        bytes.extend_from_slice(&7u64.to_le_bytes());
-        db.put(row_key(hash), bytes).unwrap();
-
-        let decoded = store.get(hash).unwrap();
-        assert_eq!(
-            decoded,
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 7 })
-        );
-        assert_eq!(decoded.active_lanes_count(), 7);
-    }
-
-    #[test]
-    fn decode_handcrafted_v1_wire() {
+    fn decode_handcrafted_wire() {
         let mut bytes = Vec::with_capacity(72);
         bytes.extend_from_slice(&[0x11; 32]);
         bytes.extend_from_slice(&42u64.to_le_bytes());
@@ -219,29 +110,26 @@ mod tests {
         let decoded: SmtBlockMetadata = bincode::deserialize(&bytes).unwrap();
         assert_eq!(
             decoded,
-            SmtBlockMetadata::ToccataV1(ToccataV1 {
+            SmtBlockMetadata {
                 payload_and_ctx_digest: Hash::from_bytes([0x11; 32]),
                 active_lanes_count: 42,
                 inactivity_shortcut_block: Hash::from_bytes([0x22; 32]),
-            })
+            }
         );
     }
 
     #[test]
-    fn payload_and_ctx_digest_accessor_works_for_both_variants() {
-        let v0 =
-            SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0xAA; 32]), active_lanes_count: 0 });
-        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 0);
-        assert_eq!(v0.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
-        assert_eq!(v1.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+    fn accessors_work() {
+        let metadata = SmtBlockMetadata::new(Hash::from_bytes([0xAA; 32]), Hash::from_bytes([0x22; 32]), 7);
+        assert_eq!(metadata.payload_and_ctx_digest(), Hash::from_bytes([0xAA; 32]));
+        assert_eq!(metadata.inactivity_shortcut_block(), Hash::from_bytes([0x22; 32]));
+        assert_eq!(metadata.active_lanes_count(), 7);
     }
 
     #[test]
-    fn variant_wire_sizes() {
-        let v0 = SmtBlockMetadata::ToccataV0(ToccataV0 { payload_and_ctx_digest: Hash::from_bytes([0; 32]), active_lanes_count: 0 });
-        let v1 = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
-        assert_eq!(bincode::serialize(&v0).unwrap().len(), 40);
-        assert_eq!(bincode::serialize(&v1).unwrap().len(), 72);
+    fn wire_size() {
+        let metadata = SmtBlockMetadata::new(Hash::from_bytes([0; 32]), Hash::from_bytes([0; 32]), 0);
+        assert_eq!(bincode::serialize(&metadata).unwrap().len(), 72);
     }
 
     #[test]

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -725,7 +725,7 @@ impl PruningProcessor {
         info!("Rebuilding pruning point SMT root after pruning data (sanity test)");
         let bounds = kaspa_smt_store::processor::SmtReadBounds::for_pov(pruning_point_blue_score, self.config.params.finality_depth());
         let expected_root = self.smt_stores.get_lanes_root(bounds, |bh| self.is_smt_canonical(bh, new_pruning_point));
-        let expected_count = self.smt_metadata_store.get(new_pruning_point).unwrap().active_lanes_count;
+        let expected_count = self.smt_metadata_store.get(new_pruning_point).unwrap().active_lanes_count();
         let (root, count) = self
             .smt_stores
             .recompute_lanes_root_from_leaf_stream(bounds, expected_count, |bh| self.is_smt_canonical(bh, new_pruning_point))

--- a/consensus/src/pipeline/virtual_processor/fork_logger.rs
+++ b/consensus/src/pipeline/virtual_processor/fork_logger.rs
@@ -7,13 +7,24 @@ use std::sync::{
 #[derive(Clone)]
 pub(crate) struct ForkLogger {
     steps: Arc<AtomicU8>,
+    fork_name: &'static str,
+    banner_label: &'static str,
     module_name: &'static str,
     show_ascii_art: bool,
 }
 
 impl ForkLogger {
     pub fn new(module_name: &'static str, show_ascii_art: bool) -> Self {
-        Self { steps: Arc::new(AtomicU8::new(Self::ACTIVATE)), module_name, show_ascii_art }
+        Self::new_with_fork("Toccata", "TOCCATA", module_name, show_ascii_art)
+    }
+
+    pub fn new_with_fork(
+        fork_name: &'static str,
+        banner_label: &'static str,
+        module_name: &'static str,
+        show_ascii_art: bool,
+    ) -> Self {
+        Self { steps: Arc::new(AtomicU8::new(Self::ACTIVATE)), fork_name, banner_label, module_name, show_ascii_art }
     }
 
     const ACTIVATE: u8 = 0;
@@ -28,11 +39,12 @@ impl ForkLogger {
   | |/ _ \ / __/ __/ _` | __/ _` |
   | | (_) | (_| (_| (_| | || (_| |
   |_|\___/ \___\___\__,_|\__\__,_|
-                    TOCCATA
-"#
+                    {}
+"#,
+                    self.banner_label
                 );
             }
-            info!(target: FORK_KEYWORD, "[Toccata] Activated for {}", self.module_name);
+            info!(target: FORK_KEYWORD, "[{}] Activated for {}", self.fork_name, self.module_name);
             true
         } else {
             false

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -177,10 +177,6 @@ pub struct VirtualStateProcessor {
     pub(crate) toccata_activation: ForkActivation,
     pub(crate) toccata_logger: ForkLogger,
 
-    // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
-    pub(crate) zk_hardening_activation: ForkActivation,
-    pub(crate) zk_hardening_logger: ForkLogger,
-
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
     pub(super) smt_metadata_store: Arc<crate::model::stores::smt_metadata::DbSmtMetadataStore>,
@@ -255,13 +251,6 @@ impl VirtualStateProcessor {
             counters,
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
-            zk_hardening_activation: params.zk_hardening_activation,
-            zk_hardening_logger: ForkLogger::new_with_fork(
-                "Toccata ZK hardening",
-                "TOCCATA ZK HARDENING",
-                "virtual state processing rules",
-                true,
-            ),
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -596,9 +585,6 @@ impl VirtualStateProcessor {
         if self.toccata_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
             self.toccata_logger.report_activation();
         }
-        if self.zk_hardening_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
-            self.zk_hardening_logger.report_activation();
-        }
 
         // Compute accepted_id_digests
         let accepted_id_digests = if self.toccata_activation.is_active(virtual_daa_window.daa_score) {
@@ -638,8 +624,7 @@ impl VirtualStateProcessor {
         let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(virtual_ghostdag_data);
         let context_hash =
             mergeset_context_hash(&MergesetContext { timestamp: parent_header.timestamp, daa_score, blue_score: current_blue_score });
-        let inactivity_shortcut =
-            self.zk_hardening_activation.is_active(daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
+        let inactivity_shortcut = self.inactivity_shortcut(inactivity_shortcut_block);
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -733,13 +718,8 @@ impl VirtualStateProcessor {
         )
         .unwrap();
 
-        // Pre-hardening: identity. Post-hardening (typically only simnet with activation=0):
-        // wrap with ZERO_HASH shortcut since no real shortcut block exists yet at genesis.
-        let activity_root = if self.zk_hardening_activation.is_active(self.genesis.daa_score) {
-            activity_root_hash(&ZERO_HASH, &lanes_root)
-        } else {
-            lanes_root
-        };
+        // Genesis has no shortcut target, so Toccata commits ZERO_HASH at the activity-root level.
+        let activity_root = activity_root_hash(&ZERO_HASH, &lanes_root);
         let pd = payload_and_context_digest(&context_hash, &payload_root);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
@@ -748,9 +728,8 @@ impl VirtualStateProcessor {
 
     /// Read stored SMT metadata for the pruning point.
     ///
-    /// Both V0 and V1 rows carry `payload_and_ctx_digest` directly. The receiver
-    /// derives `inactivity_shortcut_block` from chain headers when needed, so the
-    /// wire shape is identical pre- and post-hardening.
+    /// The receiver derives `inactivity_shortcut_block` from chain headers, so it
+    /// is not transmitted on the wire.
     pub fn get_pruning_point_smt_metadata(
         &self,
         expected_pruning_point: Hash,
@@ -805,11 +784,9 @@ impl VirtualStateProcessor {
     /// `inactivity_shortcut` value is this block's seq_commit (see
     /// [`Self::inactivity_shortcut`]).
     ///
-    /// Never returns `ZERO_HASH`. Before a real shortcut block is reachable
-    /// (early chain, or within finality depth of hardening activation), a
-    /// pre-hardening stand-in is returned. Such stand-ins are valid for
-    /// context-hash recomputation but must not be exposed to provers or RPC
-    /// consumers as real shortcut targets.
+    /// Never returns `ZERO_HASH`. Before a real seqcommit-bearing shortcut block
+    /// is reachable, the returned block can be genesis or another pre-Toccata
+    /// ancestor and [`Self::inactivity_shortcut`] folds it to `ZERO_HASH`.
     pub(super) fn compute_inactivity_shortcut_block(&self, ghostdag_data: &GhostdagData) -> Hash {
         let selected_parent = ghostdag_data.selected_parent;
 
@@ -843,38 +820,19 @@ impl VirtualStateProcessor {
         // v != ZERO_HASH` arm above. That gives us `current.bs <= pp.bs + finality_depth + 1`:
         // we are in the narrow post-IBD window of at most `finality_depth + 1` blocks past pp.
         //
-        // Inside that window, `selected_parent` is necessarily either pp itself or a post-IBD
-        // local descendant of pp, and both carry a V1 row with a real `inactivity_shortcut_block`:
+        // Inside that window, `selected_parent` is either pp itself, a post-IBD local
+        // descendant of pp, or a pre-Toccata selected parent right after activation:
         //   - pp: inserted by `Consensus::import_pruning_point_smt` via `SmtBlockMetadata::new(...)`.
         //   - local descendant: committed by `commit_virtual_state` via `SmtBlockMetadata::new(...)`.
-        // The other shapes are excluded:
-        //   - sp == genesis: excluded by the early-return clamp at the top of this function.
-        //   - sp pre-toccata: `compute_inactivity_shortcut_block` is only called from
-        //     `compute_seq_commit`/`recompute_seq_commit`, both gated on
-        //     `toccata_activation.is_active(current.daa_score)`. `sync_new_smt_state` is also a
-        //     no-op for pre-toccata pps (see `ibd/flow.rs`), so a pre-toccata sp cannot coexist
-        //     with the post-IBD-window precondition.
-        //   - sp's row being legacy ToccataV0 (pre-anchor tn10 data): the V0 row is a residue of
-        //     pre-anchor live processing, so it lives deep in the chain — but the post-IBD-window
-        //     precondition forces sp to be fresh (pp or its post-IBD descendant), which is always
-        //     written as V1 by this binary. Pre-anchor IBD did not exist (introduced by this PR),
-        //     so an upgrading tn10 node can only enter the narrow window via a post-upgrade IBD
-        //     whose pp is committed as V1, or by building locally past its existing chain (in
-        //     which case branch A above fires because the live coinbase lane is fully populated).
-        //
-        // The `.unwrap_or(selected_parent)` tail is therefore dead under correct operation. It is
-        // a defense-in-depth default: even if reached, the returned block hash only affects
-        // consensus when `zk_hardening_activation.is_active(current.daa_score)` (see
-        // `compute_seq_commit`'s gating of the `inactivity_shortcut` field), and the cases that
-        // would reach the tail (missing row, pre-anchor V0 row, pre-toccata sp) are all
-        // pre-hardening contexts where `inactivity_shortcut()` folds the result to `ZERO_HASH`
-        // regardless of which pre-hardening block is named.
+        //   - pre-Toccata sp: has no metadata row, so it is used directly and
+        //     folded to ZERO_HASH by `inactivity_shortcut` until a later chain
+        //     child is deep enough for the coinbase-lane fast path.
         let search_from = self
             .smt_metadata_store
             .get(selected_parent)
             .optional()
             .unwrap()
-            .and_then(|md| md.inactivity_shortcut_block())
+            .map(|md| md.inactivity_shortcut_block())
             .unwrap_or(selected_parent);
 
         let mut current = search_from;
@@ -888,16 +846,14 @@ impl VirtualStateProcessor {
     }
 
     /// Derive the `inactivity_shortcut` value folded into `activity_root` from
-    /// its block hash. Folds to `ZERO_HASH` for pre-hardening blocks (whose
-    /// seq_commit does not encode a shortcut); genesis falls into this branch
-    /// naturally since its `accepted_id_merkle_root` is `ZERO_HASH`. Otherwise
-    /// returns the block's seq_commit.
+    /// its block hash. Folds to `ZERO_HASH` for pre-Toccata blocks, whose
+    /// headers do not encode a seqcommit. Otherwise returns the block's seqcommit.
     ///
     /// Panics on `ZERO_HASH` input — callers must pass a real block hash.
     pub fn inactivity_shortcut(&self, inactivity_shortcut_block: Hash) -> Hash {
         assert_ne!(inactivity_shortcut_block, ZERO_HASH, "inactivity_shortcut block must be a real block hash");
         let header = self.headers_store.get_header(inactivity_shortcut_block).unwrap();
-        if !self.zk_hardening_activation.is_active(header.daa_score) {
+        if !self.toccata_activation.is_active(header.daa_score) {
             return ZERO_HASH;
         }
         header.accepted_id_merkle_root
@@ -906,7 +862,7 @@ impl VirtualStateProcessor {
     /// Resolve the `inactivity_shortcut_block` from the POV of an arbitrary chain
     /// block, using only headers + reachability (no SMT). Used by the IBD receiver
     /// at the PP boundary before the SMT is imported, and by `import_pruning_point_smt`
-    /// to populate the V1 metadata row.
+    /// to populate the pruning point metadata row.
     ///
     /// Algorithm: walks `pov_block`'s selected-chain ancestors backward by blue_score
     /// until `bs <= pov.bs - finality_depth - 1`. Folds to genesis on shallow chains,

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -177,6 +177,9 @@ pub struct VirtualStateProcessor {
     pub(crate) toccata_activation: ForkActivation,
     pub(crate) toccata_logger: ForkLogger,
 
+    // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
+    pub(crate) zk_hardening_activation: ForkActivation,
+
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
     pub(super) smt_metadata_store: Arc<crate::model::stores::smt_metadata::DbSmtMetadataStore>,
@@ -251,6 +254,7 @@ impl VirtualStateProcessor {
             counters,
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
+            zk_hardening_activation: params.zk_hardening_activation,
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -529,9 +533,10 @@ impl VirtualStateProcessor {
         if let Some(build) = smt_build {
             let pd = build.payload_and_ctx_digest;
             let alc = build.active_lanes_count;
+            let shortcut_block = build.inactivity_shortcut_block;
             build.flush(&self.smt_stores, &mut batch, blue_score, current).unwrap();
             use crate::model::stores::smt_metadata::SmtBlockMetadata;
-            self.smt_metadata_store.insert_batch(&mut batch, current, SmtBlockMetadata::new(pd, alc)).unwrap();
+            self.smt_metadata_store.insert_batch(&mut batch, current, SmtBlockMetadata::new(pd, shortcut_block, alc)).unwrap();
         }
         let write_guard = self.statuses_store.set_batch(&mut batch, current, StatusUTXOValid).unwrap();
         self.db.write(batch).unwrap();
@@ -589,7 +594,7 @@ impl VirtualStateProcessor {
         let accepted_id_digests = if self.toccata_activation.is_active(virtual_daa_window.daa_score) {
             let commit = self.compute_seq_commit(&ctx, &virtual_ghostdag_data, virtual_daa_window.daa_score);
             // Post-KIP21: single-element vec containing the seq_commit.
-            // The virtual's SmtBuild is ephemeral — only chain blocks persist SMT state.
+            // The virtual's SmtBuild is ephemeral - only chain blocks persist SMT state.
             vec![commit]
         } else {
             ctx.accepted_tx_ids.clone()
@@ -613,18 +618,18 @@ impl VirtualStateProcessor {
 
     /// KIP-21: Compute the sequencing commitment for the virtual block.
     fn compute_seq_commit(&self, ctx: &UtxoProcessingContext, virtual_ghostdag_data: &GhostdagData, daa_score: u64) -> Hash {
-        use kaspa_seq_commit::hashing::{mergeset_context_hash, seq_commit_timestamp};
+        use kaspa_seq_commit::hashing::mergeset_context_hash;
         use kaspa_seq_commit::types::MergesetContext;
 
         let selected_parent = ctx.selected_parent();
         let parent_header = self.headers_store.get_header(selected_parent).unwrap();
         let current_blue_score = virtual_ghostdag_data.blue_score;
 
-        let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(parent_header.timestamp),
-            daa_score,
-            blue_score: current_blue_score,
-        });
+        let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(virtual_ghostdag_data);
+        let context_hash =
+            mergeset_context_hash(&MergesetContext { timestamp: parent_header.timestamp, daa_score, blue_score: current_blue_score });
+        let inactivity_shortcut =
+            self.zk_hardening_activation.is_active(daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -636,18 +641,23 @@ impl VirtualStateProcessor {
             selected_parent,
             parent_seq_commit,
         );
-        let (parent_lanes_root, parent_active_lanes) = self.get_parent_smt_metadata(selected_parent, parent_header.blue_score);
+        let (parent_lanes_root, parent_active_lanes) = self.get_parent_lanes_root_and_count(selected_parent, parent_header.blue_score);
+        let parent_state = crate::pipeline::virtual_processor::utxo_validation::ParentBlockSeqState {
+            seq_commit: parent_seq_commit,
+            blue_score: parent_header.blue_score,
+            lanes_root: parent_lanes_root,
+            active_lanes_count: parent_active_lanes,
+        };
 
         let (commit, _build) = self.build_seq_commit(
-            parent_seq_commit,
+            &parent_state,
             context_hash,
             current_blue_score,
-            parent_header.blue_score,
-            parent_lanes_root,
-            parent_active_lanes,
             &lane_updates,
             data.miner_payload_leaves,
             selected_parent,
+            inactivity_shortcut_block,
+            inactivity_shortcut,
         );
         commit
     }
@@ -665,15 +675,15 @@ impl VirtualStateProcessor {
         use kaspa_consensus_core::BlueWorkType;
         use kaspa_hashes::SeqCommitActiveNode;
         use kaspa_seq_commit::hashing::{
-            activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, miner_payload_leaf,
-            miner_payload_root, payload_and_context_digest, seq_commit, seq_commit_timestamp, seq_state_root, smt_leaf_hash,
+            activity_digest_lane, activity_leaf, activity_root_hash, lane_key, lane_tip_next, mergeset_context_hash,
+            miner_payload_leaf, miner_payload_root, payload_and_context_digest, seq_commit, seq_state_root, smt_leaf_hash,
         };
         use kaspa_seq_commit::types::{LaneTipInput, MergesetContext, MinerPayloadLeafInput, SeqCommitInput, SeqState, SmtLeafInput};
         use kaspa_smt::SmtHasher;
 
         let blue_score = ghostdag_data.blue_score;
         let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(self.genesis.timestamp),
+            timestamp: self.genesis.timestamp,
             daa_score: self.genesis.daa_score,
             blue_score,
         });
@@ -692,7 +702,7 @@ impl VirtualStateProcessor {
         });
         let payload_root = miner_payload_root(std::iter::once(mpl));
 
-        // Build SMT over an in-memory store — new lanes anchor at ZERO_HASH.
+        // Build SMT over an in-memory store - new lanes anchor at ZERO_HASH.
         let parent_seq_commit = ZERO_HASH;
         let leaf_updates = kaspa_smt::store::SortedLeafUpdates::from_unsorted(lane_activities.iter().map(|(lane_id, leaves)| {
             let lk = lane_key(lane_id);
@@ -713,13 +723,24 @@ impl VirtualStateProcessor {
         )
         .unwrap();
 
+        // Pre-hardening: identity. Post-hardening (typically only simnet with activation=0):
+        // wrap with ZERO_HASH shortcut since no real shortcut block exists yet at genesis.
+        let activity_root = if self.zk_hardening_activation.is_active(self.genesis.daa_score) {
+            activity_root_hash(&ZERO_HASH, &lanes_root)
+        } else {
+            lanes_root
+        };
         let pd = payload_and_context_digest(&context_hash, &payload_root);
-        let state_root = seq_state_root(&SeqState { lanes_root: &lanes_root, payload_and_ctx_digest: &pd });
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
         vec![commit]
     }
 
     /// Read stored SMT metadata for the pruning point.
+    ///
+    /// Both V0 and V1 rows carry `payload_and_ctx_digest` directly. The receiver
+    /// derives `inactivity_shortcut_block` from chain headers when needed, so the
+    /// wire shape is identical pre- and post-hardening.
     pub fn get_pruning_point_smt_metadata(
         &self,
         expected_pruning_point: Hash,
@@ -731,6 +752,10 @@ impl VirtualStateProcessor {
         if pp != expected_pruning_point {
             return Err(ConsensusError::UnexpectedPruningPoint);
         }
+        // Genesis has no SMT metadata row and no parent to index.
+        if pp == self.genesis.hash {
+            return Err(ConsensusError::GeneralOwned("cannot export SMT metadata: pruning point is genesis".to_string()));
+        }
 
         let meta = self
             .smt_metadata_store
@@ -738,25 +763,26 @@ impl VirtualStateProcessor {
             .map_err(|_| ConsensusError::GeneralOwned(format!("SMT metadata not found for pruning point {pp}")))?;
 
         let pp_header = self.headers_store.get_header(pp).unwrap();
-        let parent_seq_commit = self.headers_store.get_header(pp_header.direct_parents()[0]).unwrap().accepted_id_merkle_root;
-
+        let parent = pp_header.direct_parents()[0];
+        let parent_header = self.headers_store.get_header(parent).unwrap();
+        let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let lanes_root = self
             .smt_stores
             .get_lanes_root(SmtReadBounds::for_pov(pp_header.blue_score, self.finality_depth), |bh| self.is_smt_canonical(bh, pp));
 
         Ok(SmtExportMetadata {
             lanes_root,
-            payload_and_ctx_digest: meta.payload_and_ctx_digest,
+            payload_and_ctx_digest: meta.payload_and_ctx_digest(),
             parent_seq_commit,
-            active_lanes_count: meta.active_lanes_count,
+            active_lanes_count: meta.active_lanes_count(),
         })
     }
 
     /// Check if `block_hash` is canonical for SMT lookups.
-    /// ZERO_HASH is treated as always canonical — it marks IBD-imported entries.
+    /// ZERO_HASH is treated as always canonical - it marks IBD-imported entries.
     ///
     /// After reachability pruning, blocks that were on the selected chain before
-    /// a reorg may have their reachability data deleted — their SMT lane entries
+    /// a reorg may have their reachability data deleted - their SMT lane entries
     /// remain but they are no longer canonical. `Err(KeyNotFound)` from
     /// `try_is_chain_ancestor_of` means the block's reachability was pruned,
     /// so it is definitively outside `future(retention_root)` and non-canonical.
@@ -764,10 +790,145 @@ impl VirtualStateProcessor {
         block_hash == ZERO_HASH || matches!(self.reachability_service.try_is_chain_ancestor_of(block_hash, selected_parent), Ok(true))
     }
 
-    /// Get the parent's lanes_root and active_lanes_count.
-    /// lanes_root comes from the branch version store; active_lanes_count from metadata.
-    pub(super) fn get_parent_smt_metadata(&self, selected_parent: Hash, parent_blue_score: u64) -> (Hash, u64) {
-        let active_lanes_count = self.smt_metadata_store.get(selected_parent).map(|meta| meta.active_lanes_count).unwrap_or(0);
+    /// KIP-21: block hash of the highest chain block at
+    /// `bs <= ghostdag_data.blue_score - finality_depth - 1`. The committed
+    /// `inactivity_shortcut` value is this block's seq_commit (see
+    /// [`Self::inactivity_shortcut`]).
+    ///
+    /// Never returns `ZERO_HASH`. Before a real shortcut block is reachable
+    /// (early chain, or within finality depth of hardening activation), a
+    /// pre-hardening stand-in is returned. Such stand-ins are valid for
+    /// context-hash recomputation but must not be exposed to provers or RPC
+    /// consumers as real shortcut targets.
+    pub(super) fn compute_inactivity_shortcut_block(&self, ghostdag_data: &GhostdagData) -> Hash {
+        let selected_parent = ghostdag_data.selected_parent;
+
+        if ghostdag_data.blue_score < self.finality_depth + 1 {
+            return self.genesis.hash;
+        }
+
+        let target_bs = ghostdag_data.blue_score - self.finality_depth - 1;
+
+        let bounds = SmtReadBounds::new(target_bs, 0);
+
+        match self
+            .smt_stores
+            .get_lane(kaspa_seq_commit::hashing::COINBASE_LANE_KEY, bounds, |bh| self.is_smt_canonical(bh, selected_parent))
+            .map(|l| l.block_hash())
+        {
+            // Live: the latest canonical coinbase touch already pins the highest
+            // chain block at `bs <= target_bs` since every chain block touches the
+            // coinbase lane. Return it directly.
+            Some(v) if v != ZERO_HASH => return v,
+            // Post-IBD boundary, "exact at pp": target_bs == pp.bs
+            Some(_zero) => {}
+            // Post-IBD boundary, "below pp": target_bs < pp.bs and no coinbase
+            // entry exists at that depth in our SMT. Fall through to seed the
+            // forward walk from the selected parent's recorded shortcut.
+            None => {}
+        };
+
+        // Reaching this point implies `target_bs <= pp.bs`. The coinbase lane is touched by every
+        // chain block, so for any `target_bs > pp.bs` we would have returned in the `Some(v) if
+        // v != ZERO_HASH` arm above. That gives us `current.bs <= pp.bs + finality_depth + 1`:
+        // we are in the narrow post-IBD window of at most `finality_depth + 1` blocks past pp.
+        //
+        // Inside that window, `selected_parent` is necessarily either pp itself or a post-IBD
+        // local descendant of pp, and both carry a V1 row with a real `inactivity_shortcut_block`:
+        //   - pp: inserted by `Consensus::import_pruning_point_smt` via `SmtBlockMetadata::new(...)`.
+        //   - local descendant: committed by `commit_virtual_state` via `SmtBlockMetadata::new(...)`.
+        // The other shapes are excluded:
+        //   - sp == genesis: excluded by the early-return clamp at the top of this function.
+        //   - sp pre-toccata: `compute_inactivity_shortcut_block` is only called from
+        //     `compute_seq_commit`/`recompute_seq_commit`, both gated on
+        //     `toccata_activation.is_active(current.daa_score)`. `sync_new_smt_state` is also a
+        //     no-op for pre-toccata pps (see `ibd/flow.rs`), so a pre-toccata sp cannot coexist
+        //     with the post-IBD-window precondition.
+        //   - sp's row being legacy ToccataV0 (pre-anchor tn10 data): the V0 row is a residue of
+        //     pre-anchor live processing, so it lives deep in the chain — but the post-IBD-window
+        //     precondition forces sp to be fresh (pp or its post-IBD descendant), which is always
+        //     written as V1 by this binary. Pre-anchor IBD did not exist (introduced by this PR),
+        //     so an upgrading tn10 node can only enter the narrow window via a post-upgrade IBD
+        //     whose pp is committed as V1, or by building locally past its existing chain (in
+        //     which case branch A above fires because the live coinbase lane is fully populated).
+        //
+        // The `.unwrap_or(selected_parent)` tail is therefore dead under correct operation. It is
+        // a defense-in-depth default: even if reached, the returned block hash only affects
+        // consensus when `zk_hardening_activation.is_active(current.daa_score)` (see
+        // `compute_seq_commit`'s gating of the `inactivity_shortcut` field), and the cases that
+        // would reach the tail (missing row, pre-anchor V0 row, pre-toccata sp) are all
+        // pre-hardening contexts where `inactivity_shortcut()` folds the result to `ZERO_HASH`
+        // regardless of which pre-hardening block is named.
+        let search_from = self
+            .smt_metadata_store
+            .get(selected_parent)
+            .optional()
+            .unwrap()
+            .and_then(|md| md.inactivity_shortcut_block())
+            .unwrap_or(selected_parent);
+
+        let mut current = search_from;
+        for chain_block in self.reachability_service.forward_chain_iterator(current, selected_parent, true).skip(1) {
+            if self.headers_store.get_blue_score(chain_block).unwrap() > target_bs {
+                break;
+            }
+            current = chain_block;
+        }
+        current
+    }
+
+    /// Derive the `inactivity_shortcut` value folded into `activity_root` from
+    /// its block hash. Folds to `ZERO_HASH` for pre-hardening blocks (whose
+    /// seq_commit does not encode a shortcut); genesis falls into this branch
+    /// naturally since its `accepted_id_merkle_root` is `ZERO_HASH`. Otherwise
+    /// returns the block's seq_commit.
+    ///
+    /// Panics on `ZERO_HASH` input — callers must pass a real block hash.
+    pub fn inactivity_shortcut(&self, inactivity_shortcut_block: Hash) -> Hash {
+        assert_ne!(inactivity_shortcut_block, ZERO_HASH, "inactivity_shortcut block must be a real block hash");
+        let header = self.headers_store.get_header(inactivity_shortcut_block).unwrap();
+        if !self.zk_hardening_activation.is_active(header.daa_score) {
+            return ZERO_HASH;
+        }
+        header.accepted_id_merkle_root
+    }
+
+    /// Resolve the `inactivity_shortcut_block` from the POV of an arbitrary chain
+    /// block, using only headers + reachability (no SMT). Used by the IBD receiver
+    /// at the PP boundary before the SMT is imported, and by `import_pruning_point_smt`
+    /// to populate the V1 metadata row.
+    ///
+    /// Algorithm: walks `pov_block`'s selected-chain ancestors backward by blue_score
+    /// until `bs <= pov.bs - finality_depth - 1`. Folds to genesis on shallow chains,
+    /// matching [`Self::compute_inactivity_shortcut_block`]'s shallow-chain rule.
+    pub fn inactivity_shortcut_block_for_pov(
+        &self,
+        pov_block: Hash,
+    ) -> kaspa_consensus_core::errors::consensus::ConsensusResult<Hash> {
+        use kaspa_consensus_core::errors::consensus::ConsensusError;
+
+        let pov_header = self
+            .headers_store
+            .get_header(pov_block)
+            .map_err(|_| ConsensusError::GeneralOwned(format!("header not found for {pov_block}")))?;
+
+        if pov_header.blue_score < self.finality_depth + 1 {
+            return Ok(self.genesis.hash);
+        }
+        let target_bs = pov_header.blue_score - self.finality_depth - 1;
+        Ok(self
+            .reachability_service
+            .default_backward_chain_iterator(pov_block)
+            .find(|&h| h == self.genesis.hash || self.headers_store.get_blue_score(h).unwrap() <= target_bs)
+            .unwrap_or(self.genesis.hash))
+    }
+
+    /// Get the parent's lanes_root, active_lanes_count.
+    /// lanes_root comes from the branch version store; the other two from metadata.
+    /// When the parent has no stored metadata (e.g. pre-toccata or origin predecessor),
+    /// returns `(empty_root, 0)`.
+    pub(super) fn get_parent_lanes_root_and_count(&self, selected_parent: Hash, parent_blue_score: u64) -> (Hash, u64) {
+        let active_lanes_count = self.smt_metadata_store.get(selected_parent).map(|meta| meta.active_lanes_count()).unwrap_or(0);
         let lanes_root = self.smt_stores.get_lanes_root(SmtReadBounds::for_pov(parent_blue_score, self.finality_depth), |bh| {
             self.is_smt_canonical(bh, selected_parent)
         });
@@ -1403,7 +1564,7 @@ impl VirtualStateProcessor {
         self.db.write(batch).unwrap();
         drop(selected_chain_write);
 
-        // Init virtual state — pre-compute accepted_id_digests here so
+        // Init virtual state - pre-compute accepted_id_digests here so
         // VirtualState::from_genesis stays a plain data constructor.
         let ghostdag_data = self.ghostdag_manager.ghostdag(&[self.genesis.hash]);
         let accepted_id_digests = self.compute_genesis_accepted_id_digests(&ghostdag_data);

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -179,6 +179,7 @@ pub struct VirtualStateProcessor {
 
     // KIP-21 finality-anchor activation: gates inactivity_shortcut inclusion in mergeset_context_hash.
     pub(crate) zk_hardening_activation: ForkActivation,
+    pub(crate) zk_hardening_logger: ForkLogger,
 
     // SMT stores
     pub(super) smt_stores: Arc<kaspa_smt_store::processor::SmtStores>,
@@ -255,6 +256,12 @@ impl VirtualStateProcessor {
             toccata_activation: params.toccata_activation,
             toccata_logger: ForkLogger::new("virtual state processing rules", true),
             zk_hardening_activation: params.zk_hardening_activation,
+            zk_hardening_logger: ForkLogger::new_with_fork(
+                "Toccata ZK hardening",
+                "TOCCATA ZK HARDENING",
+                "virtual state processing rules",
+                true,
+            ),
             smt_stores: storage.smt_stores.clone(),
             smt_metadata_store: storage.smt_metadata_store.clone(),
             _mining_rules: mining_rules,
@@ -588,6 +595,9 @@ impl VirtualStateProcessor {
 
         if self.toccata_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
             self.toccata_logger.report_activation();
+        }
+        if self.zk_hardening_activation.is_within_range_from_activation(virtual_daa_window.daa_score, 10_000) {
+            self.zk_hardening_logger.report_activation();
         }
 
         // Compute accepted_id_digests

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -374,7 +374,7 @@ async fn inactivity_shortcut_block_clamps_to_genesis_within_finality_depth() {
         let header = ctx.consensus.get_header(hash).unwrap();
         assert!(header.blue_score <= finality_depth);
         let meta = ctx.consensus.smt_block_metadata(hash);
-        assert_eq!(meta.inactivity_shortcut_block(), Some(config.genesis.hash), "bs={}", header.blue_score);
+        assert_eq!(meta.inactivity_shortcut_block(), config.genesis.hash, "bs={}", header.blue_score);
     }
 }
 
@@ -400,7 +400,7 @@ async fn inactivity_shortcut_resolves_to_chain_block_at_target_bs() {
 
     let expected_block = *chain.iter().find(|h| ctx.consensus.get_header(**h).unwrap().blue_score == target_bs).unwrap();
     let recorded = ctx.consensus.smt_block_metadata(tip).inactivity_shortcut_block();
-    assert_eq!(recorded, Some(expected_block));
+    assert_eq!(recorded, expected_block);
 }
 
 /// Consecutive chain blocks: the inactivity_shortcut advances by one chain
@@ -419,6 +419,6 @@ async fn inactivity_shortcut_advances_one_block_per_chain_step() {
 
     for (i, hash) in chain.iter().copied().enumerate().skip(4) {
         let expected = chain[i - 3];
-        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), Some(expected), "block index {i}");
+        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), expected, "block index {i}");
     }
 }

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -342,3 +342,83 @@ fn new_miner_data() -> MinerData {
     let script = ScriptVec::from_slice(&pk.serialize());
     MinerData::new(ScriptPublicKey::new(0, script), vec![])
 }
+
+fn inactivity_shortcut_config() -> kaspa_consensus_core::config::Config {
+    ConfigBuilder::new(MAINNET_PARAMS)
+        .skip_proof_of_work()
+        .edit_consensus_params(|p| {
+            p.finality_depth = 2;
+            p.toccata_activation = ForkActivation::always();
+        })
+        .build()
+}
+
+/// Blocks with `bs <= finality_depth` have no resolvable shortcut yet;
+/// the recorded `inactivity_shortcut_block` clamps to genesis, which folds
+/// to `ZERO_HASH` via `inactivity_shortcut()` and seeds forward walks
+/// correctly once descendants cross `bs = finality_depth + 1`.
+#[tokio::test]
+async fn inactivity_shortcut_block_clamps_to_genesis_within_finality_depth() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+    let finality_depth = config.finality_depth();
+    assert_eq!(finality_depth, 2);
+
+    let mut chain = vec![config.genesis.hash];
+    for _ in 0..2 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    for hash in chain.iter().copied().skip(1) {
+        let header = ctx.consensus.get_header(hash).unwrap();
+        assert!(header.blue_score <= finality_depth);
+        let meta = ctx.consensus.smt_block_metadata(hash);
+        assert_eq!(meta.inactivity_shortcut_block(), Some(config.genesis.hash), "bs={}", header.blue_score);
+    }
+}
+
+/// Tip at `bs = finality_depth + 4` records the chain block at
+/// `bs = target_bs = tip_bs - finality_depth - 1` as its
+/// inactivity_shortcut block hash.
+#[tokio::test]
+async fn inactivity_shortcut_resolves_to_chain_block_at_target_bs() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+    let finality_depth = config.finality_depth();
+
+    let mut chain = Vec::new();
+    for _ in 0..6 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    let tip = *chain.last().unwrap();
+    let tip_header = ctx.consensus.get_header(tip).unwrap();
+    assert_eq!(tip_header.blue_score, 6);
+    let target_bs = tip_header.blue_score - finality_depth - 1; // = 3
+
+    let expected_block = *chain.iter().find(|h| ctx.consensus.get_header(**h).unwrap().blue_score == target_bs).unwrap();
+    let recorded = ctx.consensus.smt_block_metadata(tip).inactivity_shortcut_block();
+    assert_eq!(recorded, Some(expected_block));
+}
+
+/// Consecutive chain blocks: the inactivity_shortcut advances by one chain
+/// block per parent-to-child step, since `target_bs` grows in lockstep with
+/// `blue_score` on a no-merge chain.
+#[tokio::test]
+async fn inactivity_shortcut_advances_one_block_per_chain_step() {
+    let config = inactivity_shortcut_config();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+
+    let mut chain = vec![config.genesis.hash];
+    for _ in 0..6 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        chain.push(ctx.consensus.get_sink());
+    }
+
+    for (i, hash) in chain.iter().copied().enumerate().skip(4) {
+        let expected = chain[i - 3];
+        assert_eq!(ctx.consensus.smt_block_metadata(hash).inactivity_shortcut_block(), Some(expected), "block index {i}");
+    }
+}

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -63,6 +63,15 @@ pub(super) struct ResolvedLaneUpdate {
     pub is_new: bool,
 }
 
+/// Selected-parent state the current block inherits when building its seq_commit.
+pub(super) struct ParentBlockSeqState {
+    /// `accepted_id_merkle_root` of the selected parent.
+    pub seq_commit: Hash,
+    pub blue_score: u64,
+    pub lanes_root: Hash,
+    pub active_lanes_count: u64,
+}
+
 /// A context for processing the UTXO state of a block with respect to its selected parent.
 /// Note this can also be the virtual block.
 pub(super) struct UtxoProcessingContext<'a> {
@@ -561,29 +570,30 @@ impl VirtualStateProcessor {
 
     /// Build the SMT from lane updates + expirations, compute the final seq_commit hash.
     ///
-    /// `parent_lanes_root` is the SMT root inherited from the selected parent block.
     /// Works with an immutable view of DB state. Returns the commit hash and an `SmtBuild`
     /// containing the diff (updated branches, lane versions, score index) for later persistence.
+    ///
+    /// `inactivity_shortcut`: `Some(hash)` post-hardening (wraps `lanes_root` into
+    /// `activity_root` via `H_activity_root`); `None` pre-hardening (identity).
     pub(super) fn build_seq_commit(
         &self,
-        parent_seq_commit: Hash,
+        parent: &ParentBlockSeqState,
         context_hash: Hash,
         current_blue_score: u64,
-        parent_blue_score: u64,
-        parent_lanes_root: Hash,
-        parent_active_lanes: u64,
         lane_updates: &[ResolvedLaneUpdate],
         miner_payload_leaves: Vec<Hash>,
         selected_parent: Hash,
+        inactivity_shortcut_block: Hash,
+        inactivity_shortcut: Option<Hash>,
     ) -> (Hash, kaspa_smt_store::processor::SmtBuild) {
-        use kaspa_seq_commit::hashing::{miner_payload_root, seq_commit, seq_state_root};
+        use kaspa_seq_commit::hashing::{activity_root_hash, miner_payload_root, seq_commit, seq_state_root};
         use kaspa_seq_commit::types::{SeqCommitInput, SeqState};
         use kaspa_smt_store::processor::SmtProcessor;
 
-        let bounds = SeqCommitBounds::new(parent_blue_score, current_blue_score, self.finality_depth);
+        let bounds = SeqCommitBounds::new(parent.blue_score, current_blue_score, self.finality_depth);
         // 1. Create processor starting from the parent's lanes root
         let mut proc =
-            SmtProcessor::new(&self.smt_stores, current_blue_score, bounds.selected_parent_read_bounds(), parent_lanes_root);
+            SmtProcessor::new(&self.smt_stores, current_blue_score, bounds.selected_parent_read_bounds(), parent.lanes_root);
 
         // 2. Expire stale lanes (scans [parent-F, current-F) for lanes with no newer version)
         let expired_count = self.expire_stale_lanes(&mut proc, bounds, selected_parent);
@@ -591,8 +601,8 @@ impl VirtualStateProcessor {
         // 3. Apply lane updates.
         // A lane at the boundary (bs = current-F-1) gets both expired (step 2) and re-added
         // here as is_new=true. This is not wasteful: BlockLaneChanges uses a BTreeMap keyed
-        // by lane_key, so update_lane overwrites the expire_lane entry — the walk sees only
-        // the final leaf. The two count operations cancel: expired+1, new+1 → net zero.
+        // by lane_key, so update_lane overwrites the expire_lane entry: the walk sees only
+        // the final leaf. The two count operations cancel: expired+1, new+1 net zero.
         let mut new_lane_count = 0;
         for lu in lane_updates {
             if lu.is_new {
@@ -601,18 +611,24 @@ impl VirtualStateProcessor {
             proc.update_lane(lu.lane_key, lu.new_tip);
         }
 
-        // 4. Build SMT (skips entirely when no pending leaves — no expirations, no touches)
+        // 4. Build SMT (skips entirely when no pending leaves: no expirations, no touches)
         let mut build = proc.build(|bh| self.is_smt_canonical(bh, selected_parent)).unwrap();
 
-        // 5. Compute final hash: payload_and_ctx_digest → state_root → seq_commit
+        // 5. Compute final hash: activity_root -> state_root -> seq_commit.
+        // Pre-hardening: identity (activity_root = lanes_root). Post-hardening: wrap.
         let payload_root = miner_payload_root(miner_payload_leaves.into_iter());
         let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&context_hash, &payload_root);
-        let state_root = seq_state_root(&SeqState { lanes_root: &build.root, payload_and_ctx_digest: &pd });
-        let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent_seq_commit, state_root: &state_root });
+        let activity_root = match inactivity_shortcut {
+            Some(s) => activity_root_hash(&s, &build.root),
+            None => build.root,
+        };
+        let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
+        let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent.seq_commit, state_root: &state_root });
 
         // 6. Store metadata on the build for persistence
         build.payload_and_ctx_digest = pd;
-        build.active_lanes_count = parent_active_lanes + new_lane_count - expired_count;
+        build.active_lanes_count = parent.active_lanes_count + new_lane_count - expired_count;
+        build.inactivity_shortcut_block = inactivity_shortcut_block;
 
         (commit, build)
     }
@@ -625,18 +641,21 @@ impl VirtualStateProcessor {
         ctx: &UtxoProcessingContext,
         header: &Header,
     ) -> BlockProcessResult<(Hash, kaspa_smt_store::processor::SmtBuild)> {
-        use kaspa_seq_commit::hashing::{mergeset_context_hash, seq_commit_timestamp};
+        use kaspa_seq_commit::hashing::mergeset_context_hash;
         use kaspa_seq_commit::types::MergesetContext;
 
         let selected_parent = ctx.selected_parent();
         let parent_header = self.headers_store.get_header(selected_parent).unwrap();
         let current_blue_score = ctx.ghostdag_data.blue_score;
 
+        let inactivity_shortcut_block = self.compute_inactivity_shortcut_block(&ctx.ghostdag_data);
         let context_hash = mergeset_context_hash(&MergesetContext {
-            timestamp: seq_commit_timestamp(parent_header.timestamp),
+            timestamp: parent_header.timestamp,
             daa_score: header.daa_score,
             blue_score: current_blue_score,
         });
+        let inactivity_shortcut =
+            self.zk_hardening_activation.is_active(header.daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);
@@ -648,18 +667,23 @@ impl VirtualStateProcessor {
             selected_parent,
             parent_seq_commit,
         );
-        let (parent_lanes_root, parent_active_lanes) = self.get_parent_smt_metadata(selected_parent, parent_header.blue_score);
+        let (parent_lanes_root, parent_active_lanes) = self.get_parent_lanes_root_and_count(selected_parent, parent_header.blue_score);
+        let parent_state = ParentBlockSeqState {
+            seq_commit: parent_seq_commit,
+            blue_score: parent_header.blue_score,
+            lanes_root: parent_lanes_root,
+            active_lanes_count: parent_active_lanes,
+        };
 
         let (hash, build) = self.build_seq_commit(
-            parent_seq_commit,
+            &parent_state,
             context_hash,
             current_blue_score,
-            parent_header.blue_score,
-            parent_lanes_root,
-            parent_active_lanes,
             &lane_updates,
             data.miner_payload_leaves,
             selected_parent,
+            inactivity_shortcut_block,
+            inactivity_shortcut,
         );
 
         Ok((hash, build))

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -573,8 +573,7 @@ impl VirtualStateProcessor {
     /// Works with an immutable view of DB state. Returns the commit hash and an `SmtBuild`
     /// containing the diff (updated branches, lane versions, score index) for later persistence.
     ///
-    /// `inactivity_shortcut`: `Some(hash)` post-hardening (wraps `lanes_root` into
-    /// `activity_root` via `H_activity_root`); `None` pre-hardening (identity).
+    /// `inactivity_shortcut` is folded into `activity_root` next to the active-lanes root.
     pub(super) fn build_seq_commit(
         &self,
         parent: &ParentBlockSeqState,
@@ -584,7 +583,7 @@ impl VirtualStateProcessor {
         miner_payload_leaves: Vec<Hash>,
         selected_parent: Hash,
         inactivity_shortcut_block: Hash,
-        inactivity_shortcut: Option<Hash>,
+        inactivity_shortcut: Hash,
     ) -> (Hash, kaspa_smt_store::processor::SmtBuild) {
         use kaspa_seq_commit::hashing::{activity_root_hash, miner_payload_root, seq_commit, seq_state_root};
         use kaspa_seq_commit::types::{SeqCommitInput, SeqState};
@@ -615,13 +614,9 @@ impl VirtualStateProcessor {
         let mut build = proc.build(|bh| self.is_smt_canonical(bh, selected_parent)).unwrap();
 
         // 5. Compute final hash: activity_root -> state_root -> seq_commit.
-        // Pre-hardening: identity (activity_root = lanes_root). Post-hardening: wrap.
         let payload_root = miner_payload_root(miner_payload_leaves.into_iter());
         let pd = kaspa_seq_commit::hashing::payload_and_context_digest(&context_hash, &payload_root);
-        let activity_root = match inactivity_shortcut {
-            Some(s) => activity_root_hash(&s, &build.root),
-            None => build.root,
-        };
+        let activity_root = activity_root_hash(&inactivity_shortcut, &build.root);
         let state_root = seq_state_root(&SeqState { activity_root: &activity_root, payload_and_ctx_digest: &pd });
         let commit = seq_commit(&SeqCommitInput { parent_seq_commit: &parent.seq_commit, state_root: &state_root });
 
@@ -654,8 +649,7 @@ impl VirtualStateProcessor {
             daa_score: header.daa_score,
             blue_score: current_blue_score,
         });
-        let inactivity_shortcut =
-            self.zk_hardening_activation.is_active(header.daa_score).then(|| self.inactivity_shortcut(inactivity_shortcut_block));
+        let inactivity_shortcut = self.inactivity_shortcut(inactivity_shortcut_block);
 
         let parent_seq_commit = parent_header.accepted_id_merkle_root;
         let data = self.collect_mergeset_seq_data(ctx);

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -303,12 +303,18 @@ impl PruningProofManager {
             // Pruning point txs are validated with the pruning point selected parent as seqcommit context.
             // Conceptually, this is the context from which the threshold should be measured on all networks.
             //
-            // On non-mainnet networks, relax this and measure against the pruning point blue score, since
-            // deployed peers may already provide chain segments using the pruning point as context.
+            // We must use pp.sp.bs whenever pp is post zk_hardening: the `inactivity_shortcut` anchor lives
+            // at `bs <= pp.bs - F - 1`. With pp.sp.bs as context, the threshold predicate continues down to
+            // `pp.bs - F - 1` and covers the anchor; with pp.bs as context it stops one block higher and
+            // misses it. Post-hardening syncers always send the segment from pp.sp, so this is safe.
             //
-            // Mainnet has no release prior to this fix, so measure against the correct context: the selected
-            // parent's blue score.
-            let context_blue_score = if self.is_mainnet {
+            // Pre zk_hardening on non-mainnet stays on pp.bs to keep compatibility with already-deployed
+            // peers that emit segments using pp.bs. Mainnet had no pre-fix release.
+            //
+            // TODO(post-zk-hardening): once all networks are past the hardening activation, use pp.sp.bs
+            // unconditionally and drop the is_mainnet/zk_hardening_activation branching.
+            let use_sp_context = self.is_mainnet || self.zk_hardening_activation.is_active(pruning_point_header.daa_score);
+            let context_blue_score = if use_sp_context {
                 let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
                 trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score
             } else {
@@ -321,6 +327,11 @@ impl PruningProofManager {
                 let current_header =
                     trusted_header_map.get(&current).ok_or(PruningImportError::MissingPruningPointChainSegment(current))?;
 
+                // pp.sp.bs context: a block failing the check satisfies `current.bs + F <= pp.sp.bs`,
+                // and chain qualification gives pp.sp.bs = pp.bs - 1, so `current.bs <= pp.bs - F - 1`.
+                // `pp.inactivity_shortcut` is defined as the highest chain block with that property
+                // (see `compute_inactivity_shortcut_block`), so its bs is at least the break block's bs
+                // and is reached by the iteration before (or at) the break.
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -301,25 +301,11 @@ impl PruningProofManager {
 
         if self.toccata_activation.is_active(pruning_point_header.daa_score) {
             // Pruning point txs are validated with the pruning point selected parent as seqcommit context.
-            // Conceptually, this is the context from which the threshold should be measured on all networks.
-            //
-            // We must use pp.sp.bs whenever pp is post zk_hardening: the `inactivity_shortcut` anchor lives
-            // at `bs <= pp.bs - F - 1`. With pp.sp.bs as context, the threshold predicate continues down to
-            // `pp.bs - F - 1` and covers the anchor; with pp.bs as context it stops one block higher and
-            // misses it. Post-hardening syncers always send the segment from pp.sp, so this is safe.
-            //
-            // Pre zk_hardening on non-mainnet stays on pp.bs to keep compatibility with already-deployed
-            // peers that emit segments using pp.bs. Mainnet had no pre-fix release.
-            //
-            // TODO(post-zk-hardening): once all networks are past the hardening activation, use pp.sp.bs
-            // unconditionally and drop the is_mainnet/zk_hardening_activation branching.
-            let use_sp_context = self.is_mainnet || self.zk_hardening_activation.is_active(pruning_point_header.daa_score);
-            let context_blue_score = if use_sp_context {
-                let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
-                trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score
-            } else {
-                pruning_point_header.blue_score
-            };
+            // The selected-parent context carries the full threshold range needed for both
+            // seqcommit access and the inactivity shortcut anchor.
+            let sp = pruning_point_header.direct_parents().first().copied().unwrap_or(pruning_point); // In case of genesis, we fall back to genesis itself
+            let context_blue_score =
+                trusted_header_map.get(&sp).ok_or(PruningImportError::MissingPruningPointChainSegment(sp))?.blue_score;
 
             let threshold = self.finality_depth;
             let mut current = pruning_point;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -120,6 +120,7 @@ pub struct PruningProofManager {
     ghostdag_k: KType,
     skip_proof_of_work: bool,
     toccata_activation: ForkActivation,
+    zk_hardening_activation: ForkActivation,
     is_mainnet: bool,
 
     is_consensus_exiting: Arc<AtomicBool>,
@@ -143,6 +144,7 @@ impl PruningProofManager {
         ghostdag_k: KType,
         skip_proof_of_work: bool,
         toccata_activation: ForkActivation,
+        zk_hardening_activation: ForkActivation,
         is_mainnet: bool,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
@@ -180,6 +182,7 @@ impl PruningProofManager {
             ghostdag_k,
             skip_proof_of_work,
             toccata_activation,
+            zk_hardening_activation,
             is_mainnet,
 
             is_consensus_exiting,
@@ -361,6 +364,13 @@ impl PruningProofManager {
                 }
 
                 let current_header = self.headers_store.get_compact_header_data(current).unwrap();
+                // This cutoff also covers the inactivity-shortcut anchor.
+                // Chain qualification gives pp.bs >= pp.sp.bs + 1, so a block failing the check
+                // satisfies `current.bs + F <= pp.sp.bs <= pp.bs - 1`, i.e. `current.bs <= pp.bs - F - 1`.
+                // pp.inactivity_shortcut is by definition the highest chain block with
+                // `bs <= pp.bs - F - 1` (see `compute_inactivity_shortcut_block`), so its bs is at
+                // least the break block's bs. The iteration walks the chain in decreasing bs and
+                // pushes before checking, so pp.inactivity_shortcut is always included in the segment.
                 if !seq_commit_within_threshold(context_blue_score, current_header.blue_score, threshold) {
                     break;
                 }

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -120,8 +120,6 @@ pub struct PruningProofManager {
     ghostdag_k: KType,
     skip_proof_of_work: bool,
     toccata_activation: ForkActivation,
-    zk_hardening_activation: ForkActivation,
-    is_mainnet: bool,
 
     is_consensus_exiting: Arc<AtomicBool>,
 }
@@ -144,8 +142,6 @@ impl PruningProofManager {
         ghostdag_k: KType,
         skip_proof_of_work: bool,
         toccata_activation: ForkActivation,
-        zk_hardening_activation: ForkActivation,
-        is_mainnet: bool,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -182,8 +178,6 @@ impl PruningProofManager {
             ghostdag_k,
             skip_proof_of_work,
             toccata_activation,
-            zk_hardening_activation,
-            is_mainnet,
 
             is_consensus_exiting,
         }

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -26,6 +26,7 @@ pub struct TransactionValidator {
     ghostdag_k: KType,
     sig_cache: Cache<SigCacheKey, bool>,
     toccata_activation: ForkActivation,
+    zk_hardening_activation: ForkActivation,
     mass_per_sig_op: u64,
 
     pub(crate) mass_calculator: MassCalculator,
@@ -44,6 +45,7 @@ impl TransactionValidator {
         counters: Arc<TxScriptCacheCounters>,
         mass_calculator: MassCalculator,
         toccata_activation: ForkActivation,
+        zk_hardening_activation: ForkActivation,
         mass_per_sig_op: u64,
     ) -> Self {
         Self {
@@ -57,6 +59,7 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator,
             toccata_activation,
+            zk_hardening_activation,
             mass_per_sig_op,
         }
     }
@@ -82,6 +85,7 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator: MassCalculator::new(0, 0, 0),
             toccata_activation: ForkActivation::never(),
+            zk_hardening_activation: ForkActivation::never(),
             mass_per_sig_op: 0,
         }
     }

--- a/consensus/src/processes/transaction_validator/mod.rs
+++ b/consensus/src/processes/transaction_validator/mod.rs
@@ -26,7 +26,6 @@ pub struct TransactionValidator {
     ghostdag_k: KType,
     sig_cache: Cache<SigCacheKey, bool>,
     toccata_activation: ForkActivation,
-    zk_hardening_activation: ForkActivation,
     mass_per_sig_op: u64,
 
     pub(crate) mass_calculator: MassCalculator,
@@ -45,7 +44,6 @@ impl TransactionValidator {
         counters: Arc<TxScriptCacheCounters>,
         mass_calculator: MassCalculator,
         toccata_activation: ForkActivation,
-        zk_hardening_activation: ForkActivation,
         mass_per_sig_op: u64,
     ) -> Self {
         Self {
@@ -59,7 +57,6 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator,
             toccata_activation,
-            zk_hardening_activation,
             mass_per_sig_op,
         }
     }
@@ -85,7 +82,6 @@ impl TransactionValidator {
             sig_cache: Cache::with_counters(10_000, counters),
             mass_calculator: MassCalculator::new(0, 0, 0),
             toccata_activation: ForkActivation::never(),
-            zk_hardening_activation: ForkActivation::never(),
             mass_per_sig_op: 0,
         }
     }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -169,9 +169,7 @@ impl TransactionValidator {
     ) -> TxResult<()> {
         let ctx = EngineCtx::new(&self.sig_cache).with_covenants_ctx(&covenants_ctx).with_seq_commit_accessor_opt(seq_commit_accessor);
         let covenants_enabled = self.toccata_activation.is_active(block_daa_score);
-        let zk_hardening_enabled = self.zk_hardening_activation.is_active(block_daa_score);
-        let flags: EngineFlags =
-            EngineFlags { covenants_enabled, zk_hardening_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
+        let flags: EngineFlags = EngineFlags { covenants_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
 
         check_scripts(tx, ctx, flags)
     }
@@ -361,7 +359,6 @@ mod tests {
             Default::default(),
             MassCalculator::new(0, 0, 0),
             ForkActivation::always(),
-            ForkActivation::always(),
             params.mass_per_sig_op,
         );
 
@@ -498,7 +495,7 @@ mod tests {
             check_scripts(
                 &verifiable_tx,
                 EngineCtx::new(&sig_cache),
-                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 5_000.into() }
+                EngineFlags { covenants_enabled: true, sigop_script_units: 5_000.into() }
             ),
             Ok(())
         );

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -169,7 +169,9 @@ impl TransactionValidator {
     ) -> TxResult<()> {
         let ctx = EngineCtx::new(&self.sig_cache).with_covenants_ctx(&covenants_ctx).with_seq_commit_accessor_opt(seq_commit_accessor);
         let covenants_enabled = self.toccata_activation.is_active(block_daa_score);
-        let flags: EngineFlags = EngineFlags { covenants_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
+        let zk_hardening_enabled = self.zk_hardening_activation.is_active(block_daa_score);
+        let flags: EngineFlags =
+            EngineFlags { covenants_enabled, zk_hardening_enabled, sigop_script_units: Gram(self.mass_per_sig_op).into() };
 
         check_scripts(tx, ctx, flags)
     }
@@ -359,6 +361,7 @@ mod tests {
             Default::default(),
             MassCalculator::new(0, 0, 0),
             ForkActivation::always(),
+            ForkActivation::always(),
             params.mass_per_sig_op,
         );
 
@@ -495,7 +498,7 @@ mod tests {
             check_scripts(
                 &verifiable_tx,
                 EngineCtx::new(&sig_cache),
-                EngineFlags { covenants_enabled: true, sigop_script_units: 5_000.into() }
+                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 5_000.into() }
             ),
             Ok(())
         );

--- a/crypto/hashes/src/hashers.rs
+++ b/crypto/hashes/src/hashers.rs
@@ -46,6 +46,7 @@ blake3_hasher! {
     struct SeqCommitActivityLeaf => b"SeqCommitActivityLeaf",
     struct SeqCommitMergesetContext => b"SeqCommitMergesetContext",
     struct SeqCommitMinerPayloadLeaf => b"SeqCommitMinerPayloadLeaf",
+    struct SeqCommitActivityRoot => b"SeqCommitActivityRoot",
 
     struct SeqCommitActiveLeaf => b"SeqCommitActiveLeaf",
     struct SeqCommitActiveNode => b"SeqCommitActiveNode",

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -108,7 +108,7 @@ type RoundTxBuilder = fn(u32, usize) -> (Transaction, Vec<UtxoEntry>);
 type ResultCheck = fn(Result<(), TxScriptError>) -> Result<(), String>;
 
 fn pricing_flags(covenants_enabled: bool) -> EngineFlags {
-    EngineFlags { covenants_enabled, zk_hardening_enabled: covenants_enabled, sigop_script_units: Gram(1000).into() }
+    EngineFlags { covenants_enabled, sigop_script_units: Gram(1000).into() }
 }
 
 fn new_script_builder() -> ScriptBuilder {

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -1,9 +1,11 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use ark_bn254::Bn254;
-use ark_groth16::VerifyingKey;
+use ark_bn254::{Bn254, Fr};
+use ark_groth16::{Groth16, VerifyingKey};
+use ark_relations::gr1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_snark::SNARK;
 use criterion::{BenchmarkId, Criterion, SamplingMode, black_box, criterion_group, criterion_main};
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::config::params::MAINNET_PARAMS;
@@ -24,10 +26,11 @@ use kaspa_txscript::{
     pay_to_script_hash_signature_script_with_flags,
     zk_precompiles::{
         tags::ZkTag,
-        tests::helpers::{build_groth_script, build_stark_script, load_groth_fields},
+        tests::helpers::{build_groth_script, load_groth_fields, load_stark_fields},
     },
 };
 use kaspa_txscript_errors::TxScriptError;
+use rand::{SeedableRng, rngs::StdRng};
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
 use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
@@ -47,10 +50,44 @@ const LARGE_PUSH_DUP_CAT_CAT_COUNT: usize = 3;
 const LARGE_PUSH_DUP_CAT_EXPANSION_FACTOR: usize = 1 << LARGE_PUSH_DUP_CAT_CAT_COUNT;
 const LARGE_PUSH_DUP_CAT_DATA_LEN_UPPER_BOUND: usize = max_script_element_size(true) / LARGE_PUSH_DUP_CAT_EXPANSION_FACTOR;
 const LARGE_PUSH_DUP_CAT_DUP_COUNT: usize = MAX_STACK_SIZE - 1;
+const STARK_LONG_CONTROL_PROOF_DOUBLINGS: usize = 11;
 const GROTH16_LARGE_VK_PADDING_CAT_COUNT: usize = 19;
+const GROTH16_2X_COUNT: usize = 2;
+const GROTH16_3X_COUNT: usize = 3;
 const OP_DUP_BASE_DUP_COUNT: usize = 243;
 const OP_DUP_FREE_BUDGET_DUP_COUNT: usize = 1107;
 const OP_DUP_ONE_TX_PAIR_SEARCH_STEP: usize = 20;
+
+struct Groth16PublicInputCircuit {
+    public_input_count: usize,
+    public_input: Fr,
+}
+
+impl ConstraintSynthesizer<Fr> for Groth16PublicInputCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let public_input = self.public_input;
+        let mut running_sum = Fr::from(0u64);
+        let mut sum_var = cs.new_witness_variable(|| Ok(Fr::from(0u64)))?;
+        for _ in 0..self.public_input_count {
+            let input = cs.new_input_variable(|| Ok(public_input))?;
+            running_sum += public_input;
+            let new_sum_var = cs.new_witness_variable(|| Ok(running_sum))?;
+            cs.enforce_r1cs_constraint(
+                || ark_relations::lc!() + sum_var + input,
+                || ark_relations::lc!() + ark_relations::gr1cs::Variable::One,
+                || ark_relations::lc!() + new_sum_var,
+            )?;
+            sum_var = new_sum_var;
+        }
+        Ok(())
+    }
+}
+
+struct Groth16SerializedFixture {
+    vk_bytes: Vec<u8>,
+    proof_bytes: Vec<u8>,
+    public_input_bytes: Vec<u8>,
+}
 
 struct BenchTx {
     tx: MutableTransaction<Transaction>,
@@ -63,14 +100,15 @@ struct BenchBlock {
     input_count: usize,
     compute_mass: u64,
     transient_mass: u64,
-    allow_zk_failure: bool,
+    expect_zk_failure: bool,
 }
 
 type TxBuilder = fn(u32) -> (Transaction, Vec<UtxoEntry>);
 type RoundTxBuilder = fn(u32, usize) -> (Transaction, Vec<UtxoEntry>);
+type ResultCheck = fn(Result<(), TxScriptError>) -> Result<(), String>;
 
 fn pricing_flags(covenants_enabled: bool) -> EngineFlags {
-    EngineFlags { covenants_enabled, sigop_script_units: Gram(1000).into() }
+    EngineFlags { covenants_enabled, zk_hardening_enabled: covenants_enabled, sigop_script_units: Gram(1000).into() }
 }
 
 fn new_script_builder() -> ScriptBuilder {
@@ -528,18 +566,15 @@ fn try_build_budgeted_single_input_tx(
     input_spk: ScriptPublicKey,
     signature_script: Vec<u8>,
 ) -> Result<(Transaction, Vec<UtxoEntry>), String> {
-    try_build_budgeted_single_input_tx_with_error_filter(nonce, input_spk, signature_script, |_| false)
+    try_build_budgeted_single_input_tx_with_result_check(nonce, input_spk, signature_script, expect_success)
 }
 
-fn try_build_budgeted_single_input_tx_with_error_filter<F>(
+fn try_build_budgeted_single_input_tx_with_result_check(
     nonce: u32,
     input_spk: ScriptPublicKey,
     signature_script: Vec<u8>,
-    accept_error: F,
-) -> Result<(Transaction, Vec<UtxoEntry>), String>
-where
-    F: Fn(&TxScriptError) -> bool,
-{
+    result_check: ResultCheck,
+) -> Result<(Transaction, Vec<UtxoEntry>), String> {
     let outpoint = input_outpoint(0, nonce);
     let utxos = vec![UtxoEntry::new(20_000, input_spk, 0, false, None)];
     let mut tx = Transaction::new(
@@ -569,11 +604,7 @@ where
         pricing_flags(true),
         ScriptUnits(u64::MAX),
     );
-    match vm.execute() {
-        Ok(()) => {}
-        Err(err) if accept_error(&err) => {}
-        Err(err) => return Err(format!("failed to measure input #0: {err}")),
-    }
+    result_check(vm.execute())?;
     let compute_budget = ComputeBudget::checked_covering_script_units(vm.used_script_units())
         .ok_or_else(|| "required compute budget does not fit for input #0".to_string())?;
     tx.inputs[0].mass = compute_budget.into();
@@ -581,14 +612,49 @@ where
     Ok((tx, utxos))
 }
 
-fn try_build_budgeted_single_input_tx_allowing_zk_failure(
+fn expect_success(result: Result<(), TxScriptError>) -> Result<(), String> {
+    result.map_err(|err| format!("failed to measure input #0: {err}"))
+}
+
+fn expect_zk_failure(result: Result<(), TxScriptError>) -> Result<(), String> {
+    match result {
+        Ok(()) => Err("expected ZK integrity failure while measuring input #0".to_string()),
+        Err(TxScriptError::ZkIntegrity(_)) => Ok(()),
+        Err(err) => Err(format!("failed to measure input #0: {err}")),
+    }
+}
+
+fn try_build_budgeted_single_input_tx_expecting_zk_failure(
     nonce: u32,
     input_spk: ScriptPublicKey,
     signature_script: Vec<u8>,
 ) -> Result<(Transaction, Vec<UtxoEntry>), String> {
-    try_build_budgeted_single_input_tx_with_error_filter(nonce, input_spk, signature_script, |err| {
-        matches!(err, TxScriptError::ZkIntegrity(_))
-    })
+    try_build_budgeted_single_input_tx_with_result_check(nonce, input_spk, signature_script, expect_zk_failure)
+}
+
+fn build_single_input_tx_with_compute_budget(
+    nonce: u32,
+    input_spk: ScriptPublicKey,
+    signature_script: Vec<u8>,
+    compute_budget: ComputeBudget,
+) -> (Transaction, Vec<UtxoEntry>) {
+    let outpoint = input_outpoint(0, nonce);
+    let utxos = vec![UtxoEntry::new(20_000, input_spk, 0, false, None)];
+    let tx = Transaction::new(
+        1,
+        vec![TransactionInput {
+            previous_outpoint: outpoint,
+            signature_script,
+            sequence: 0,
+            mass: TxInputMass::ComputeBudget(compute_budget),
+        }],
+        vec![],
+        0,
+        Default::default(),
+        0,
+        vec![],
+    );
+    (tx, utxos)
 }
 
 fn build_budgeted_single_input_tx(nonce: u32, input_spk: ScriptPublicKey, signature_script: Vec<u8>) -> (Transaction, Vec<UtxoEntry>) {
@@ -746,17 +812,260 @@ fn build_hash_storm_single_tx(nonce: u32, builder: RoundTxBuilder) -> (Transacti
     best
 }
 
-fn build_single_stark_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
-    build_budgeted_single_input_tx(nonce, ScriptPublicKey::new(0, build_stark_script(false).into()), vec![])
+fn build_stark_single_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+    let redeem_script = build_stark_p2sh_redeem_script();
+    let script_public_key = pay_to_script_hash_script(&redeem_script);
+    let signature_script = build_stark_p2sh_signature_script(redeem_script);
+    build_budgeted_single_input_tx(nonce, script_public_key, signature_script)
 }
 
-fn build_groth16_script_with_tags(tag_count: usize) -> Vec<u8> {
-    assert!(tag_count > 0, "groth16 script should contain at least one tag");
+fn build_stark_p2sh_signature_script(redeem_script: Vec<u8>) -> Vec<u8> {
+    let (_, seal, claim, _, control_index, control_digests, journal, _) = load_stark_fields();
+    let mut signature_prefix = new_script_builder();
+    signature_prefix
+        .add_data(&claim)
+        .unwrap()
+        .add_data(&control_index)
+        .unwrap()
+        .add_data(&control_digests)
+        .unwrap()
+        .add_data(&seal)
+        .unwrap()
+        .add_data(&journal)
+        .unwrap();
+    new_p2sh_signature_script(redeem_script, signature_prefix.drain())
+}
+
+fn build_stark_p2sh_redeem_script() -> Vec<u8> {
+    let (control_id, _, _, hashfn, _, _, _, image_id) = load_stark_fields();
+    let stark_tag = ZkTag::R0Succinct as u8;
+    let mut builder = new_script_builder();
+    builder
+        .add_data(&image_id)
+        .unwrap()
+        .add_data(&control_id)
+        .unwrap()
+        .add_data(&hashfn)
+        .unwrap()
+        .add_data(&[stark_tag])
+        .unwrap()
+        .add_op(codes::OpZkPrecompile)
+        .unwrap();
+    builder.drain()
+}
+
+fn build_stark_long_control_proof_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+    build_stark_long_control_proof_tx_with_seed_count(nonce, stark_long_control_proof_seed_digest_count())
+}
+
+fn build_stark_max_trailing_seal_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+    build_stark_trailing_seal_tx_with_target_len(nonce, stark_max_trailing_seal_len())
+}
+
+fn build_stark_trailing_seal_tx_with_target_len(nonce: u32, target_seal_len: usize) -> (Transaction, Vec<UtxoEntry>) {
+    let redeem_script = build_stark_trailing_seal_p2sh_redeem_script(target_seal_len);
+    let script_public_key = pay_to_script_hash_script(&redeem_script);
+    let signature_script = build_stark_trailing_seal_p2sh_signature_script(redeem_script);
+    try_build_budgeted_single_input_tx_expecting_zk_failure(nonce, script_public_key, signature_script)
+        .expect("stark trailing-seal script should build")
+}
+
+fn build_stark_trailing_seal_p2sh_signature_script(redeem_script: Vec<u8>) -> Vec<u8> {
+    let (_, seal, claim, _, control_index, control_digests, _, _) = load_stark_fields();
+    let mut signature_prefix = new_script_builder();
+    signature_prefix
+        .add_data(&claim)
+        .unwrap()
+        .add_data(&control_index)
+        .unwrap()
+        .add_data(&control_digests)
+        .unwrap()
+        .add_data(&seal)
+        .unwrap();
+    new_p2sh_signature_script(redeem_script, signature_prefix.drain())
+}
+
+fn build_stark_long_control_proof_tx_with_seed_count(nonce: u32, seed_digest_count: usize) -> (Transaction, Vec<UtxoEntry>) {
+    let redeem_script = build_stark_long_control_proof_p2sh_redeem_script();
+    let script_public_key = pay_to_script_hash_script(&redeem_script);
+    let signature_script = build_stark_long_control_proof_p2sh_signature_script(redeem_script, seed_digest_count);
+    try_build_budgeted_single_input_tx_expecting_zk_failure(nonce, script_public_key, signature_script)
+        .expect("stark long-control-proof script should build")
+}
+
+fn build_stark_long_control_proof_p2sh_signature_script(redeem_script: Vec<u8>, seed_digest_count: usize) -> Vec<u8> {
+    let (_, _, claim, _, control_index, control_digests, _, _) = load_stark_fields();
+    let control_digest_seed = repeated_control_digest_seed(&control_digests, seed_digest_count);
+    let final_control_digest_len = control_digest_seed.len() << STARK_LONG_CONTROL_PROOF_DOUBLINGS;
+
+    assert!(
+        final_control_digest_len <= max_script_element_size(true),
+        "long control proof should stay within the script element size limit"
+    );
+
+    let mut signature_prefix = new_script_builder();
+    signature_prefix.add_data(&claim).unwrap().add_data(&control_index).unwrap().add_data(&control_digest_seed).unwrap();
+    new_p2sh_signature_script(redeem_script, signature_prefix.drain())
+}
+
+fn stark_long_control_proof_seed_digest_count() -> usize {
+    static COUNT: OnceLock<usize> = OnceLock::new();
+    *COUNT.get_or_init(|| {
+        let max_seed_digest_count = max_script_element_size(true) / (32 << STARK_LONG_CONTROL_PROOF_DOUBLINGS);
+        let mut best = None;
+        for seed_digest_count in 1..=max_seed_digest_count {
+            let candidate = build_stark_long_control_proof_tx_with_seed_count(0, seed_digest_count);
+            if fits_block_mass(&candidate.0) {
+                best = Some(seed_digest_count);
+            } else {
+                break;
+            }
+        }
+        best.expect("at least one long-control-proof seed should fit in block mass")
+    })
+}
+
+fn stark_max_trailing_seal_len() -> usize {
+    static LEN: OnceLock<usize> = OnceLock::new();
+    *LEN.get_or_init(|| {
+        let (_, seal, _, _, _, _, _, _) = load_stark_fields();
+        assert_eq!(seal.len() % 4, 0, "seal length should be word-aligned");
+
+        let max_len = max_script_element_size(true);
+        if let Ok(candidate) = try_build_stark_trailing_seal_tx_with_target_len(0, max_len)
+            && fits_block_mass(&candidate.0)
+        {
+            return max_len;
+        }
+
+        let mut low_words = seal.len() / 4;
+        let mut high_words = max_len / 4 + 1;
+        let mut best = seal.len();
+
+        while low_words + 1 < high_words {
+            let mid_words = low_words + (high_words - low_words) / 2;
+            let candidate_len = mid_words * 4;
+            let Ok(candidate) = try_build_stark_trailing_seal_tx_with_target_len(0, candidate_len) else {
+                high_words = mid_words;
+                continue;
+            };
+            if fits_block_mass(&candidate.0) {
+                low_words = mid_words;
+                best = candidate_len;
+            } else {
+                high_words = mid_words;
+            }
+        }
+
+        best
+    })
+}
+
+fn try_build_stark_trailing_seal_tx_with_target_len(
+    nonce: u32,
+    target_seal_len: usize,
+) -> Result<(Transaction, Vec<UtxoEntry>), String> {
+    let redeem_script = build_stark_trailing_seal_p2sh_redeem_script(target_seal_len);
+    let script_public_key = pay_to_script_hash_script(&redeem_script);
+    let signature_script = build_stark_trailing_seal_p2sh_signature_script(redeem_script);
+    try_build_budgeted_single_input_tx_expecting_zk_failure(nonce, script_public_key, signature_script)
+}
+
+fn append_seal_prefix(builder: &mut ScriptBuilder, chunk_len: usize) {
+    builder
+        .add_op(OpDup)
+        .unwrap()
+        .add_i64(0)
+        .unwrap()
+        .add_i64(chunk_len as i64)
+        .unwrap()
+        .add_op(codes::OpSubstr)
+        .unwrap()
+        .add_op(codes::OpCat)
+        .unwrap();
+}
+
+fn build_stark_trailing_seal_p2sh_redeem_script(target_seal_len: usize) -> Vec<u8> {
+    let (control_id, seal, _, hashfn, _, _, journal, image_id) = load_stark_fields();
+    let stark_tag = ZkTag::R0Succinct as u8;
+    assert!(target_seal_len >= seal.len(), "target seal length should not shrink the fixture seal");
+    assert_eq!(target_seal_len % 4, 0, "target seal length should stay word-aligned");
+    assert!(target_seal_len <= max_script_element_size(true), "target seal length should stay within the script element size limit");
+
+    let mut builder = new_script_builder();
+    // Keep the valid proof prefix and append seal slices so verification fails at the trailing-data check.
+    let mut remaining = target_seal_len - seal.len();
+    while remaining >= seal.len() {
+        append_seal_prefix(&mut builder, seal.len());
+        remaining -= seal.len();
+    }
+    if remaining > 0 {
+        append_seal_prefix(&mut builder, remaining);
+    }
+
+    builder
+        .add_data(&journal)
+        .unwrap()
+        .add_data(&image_id)
+        .unwrap()
+        .add_data(&control_id)
+        .unwrap()
+        .add_data(&hashfn)
+        .unwrap()
+        .add_data(&[stark_tag])
+        .unwrap()
+        .add_op(codes::OpZkPrecompile)
+        .unwrap();
+    builder.drain()
+}
+
+fn build_stark_long_control_proof_p2sh_redeem_script() -> Vec<u8> {
+    let (control_id, seal, _, hashfn, _, _, journal, image_id) = load_stark_fields();
+    let stark_tag = ZkTag::R0Succinct as u8;
+    let mut builder = new_script_builder();
+
+    for _ in 0..STARK_LONG_CONTROL_PROOF_DOUBLINGS {
+        builder.add_op(OpDup).unwrap().add_op(codes::OpCat).unwrap();
+    }
+
+    builder
+        .add_data(&seal)
+        .unwrap()
+        .add_data(&journal)
+        .unwrap()
+        .add_data(&image_id)
+        .unwrap()
+        .add_data(&control_id)
+        .unwrap()
+        .add_data(&hashfn)
+        .unwrap()
+        .add_data(&[stark_tag])
+        .unwrap()
+        .add_op(codes::OpZkPrecompile)
+        .unwrap();
+    builder.drain()
+}
+
+fn repeated_control_digest_seed(control_digests: &[u8], digest_count: usize) -> Vec<u8> {
+    assert_eq!(control_digests.len() % 32, 0, "control digests should be digest-aligned");
+    let source_digest_count = control_digests.len() / 32;
+    assert!(source_digest_count > 0, "control digests should not be empty");
+
+    let mut seed = Vec::with_capacity(digest_count * 32);
+    for digest_idx in 0..digest_count {
+        let source_idx = (digest_idx % source_digest_count) * 32;
+        seed.extend_from_slice(&control_digests[source_idx..source_idx + 32]);
+    }
+    seed
+}
+
+fn build_groth16_repeated_script(call_count: usize) -> Vec<u8> {
+    assert!(call_count > 0, "groth16 script should contain at least one call");
 
     let groth16_script = build_groth_script();
-    let mut script = Vec::with_capacity(groth16_script.len() * tag_count + tag_count.saturating_sub(1));
-    for tag_idx in 0..tag_count {
-        if tag_idx > 0 {
+    let mut script = Vec::with_capacity(groth16_script.len() * call_count + call_count.saturating_sub(1));
+    for call_idx in 0..call_count {
+        if call_idx > 0 {
             script.push(OpDrop);
         }
         script.extend_from_slice(&groth16_script);
@@ -764,20 +1073,32 @@ fn build_groth16_script_with_tags(tag_count: usize) -> Vec<u8> {
     script
 }
 
-fn build_groth16_tx_with_tags(nonce: u32, tag_count: usize) -> (Transaction, Vec<UtxoEntry>) {
-    build_budgeted_single_input_tx(nonce, ScriptPublicKey::new(0, build_groth16_script_with_tags(tag_count).into()), vec![])
+fn build_groth16_repeated_tx(nonce: u32, call_count: usize) -> (Transaction, Vec<UtxoEntry>) {
+    build_budgeted_single_input_tx(nonce, ScriptPublicKey::new(0, build_groth16_repeated_script(call_count).into()), vec![])
 }
 
 fn build_groth16_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
-    build_groth16_tx_with_tags(nonce, 1)
+    build_groth16_repeated_tx(nonce, 1)
 }
 
-fn build_groth16_3tags_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
-    build_groth16_tx_with_tags(nonce, 3)
+fn build_groth16_3x_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+    static SCRIPT: OnceLock<Vec<u8>> = OnceLock::new();
+    let script = SCRIPT
+        .get_or_init(|| {
+            let public_input_count = groth16_3x_pub_input_count();
+            build_groth16_repeated_valid_script(public_input_count, GROTH16_3X_COUNT)
+                .expect("cached groth16 3x public input count should be valid")
+        })
+        .clone();
+    let candidate = try_build_budgeted_single_input_tx(nonce, ScriptPublicKey::new(0, script.into()), vec![])
+        .expect("cached groth16 3x script should be valid");
+    assert!(fits_block_mass(&candidate.0), "cached groth16 3x public input count should stay within block mass limits");
+    candidate
 }
 
-// Duplicates one public input and extends gamma_abc_g1 to stress Groth16 input preparation,
-// while allowing the final proof verification to fail after the prepared-input work.
+// Duplicates a high-Hamming public input and extends gamma_abc_g1 to stress
+// Ark's Groth16 prepare_inputs path. The proof may fail after the prepared-input
+// work; this bench is pricing the input-preparation cost.
 fn build_groth16_prepare_inputs_script(public_input_count: usize, vk_gamma_abc_count: usize) -> Result<Vec<u8>, String> {
     assert!(public_input_count > 0, "groth16 prepare-inputs script should contain public inputs");
     assert!(
@@ -785,9 +1106,23 @@ fn build_groth16_prepare_inputs_script(public_input_count: usize, vk_gamma_abc_c
         "groth16 verifying key should contain one gamma_abc_g1 base point plus all public inputs"
     );
 
-    let (vk_bytes, proof_bytes, inputs) = load_groth_fields();
-    let input = inputs.first().ok_or_else(|| "groth16 fixture should contain at least one public input".to_string())?;
+    let (vk_bytes, proof_bytes, _) = load_groth_fields();
+    let mut input = Vec::new();
+    groth16_high_hamming_public_input()
+        .serialize_uncompressed(&mut input)
+        .map_err(|err| format!("failed to serialize groth16 public input: {err}"))?;
     let (extended_vk_bytes, _) = groth16_extended_vk_bytes(vk_bytes.as_slice(), vk_gamma_abc_count)?;
+
+    build_groth16_repeated_input_script(public_input_count, &extended_vk_bytes, &proof_bytes, &input)
+}
+
+fn build_groth16_repeated_input_script(
+    public_input_count: usize,
+    vk_bytes: &[u8],
+    proof_bytes: &[u8],
+    input: &[u8],
+) -> Result<Vec<u8>, String> {
+    assert!(public_input_count > 0, "groth16 repeated-input script should contain public inputs");
 
     let mut builder = new_script_builder();
     builder.add_data(input).map_err(|err| format!("failed to add groth16 public input: {err}"))?;
@@ -797,9 +1132,9 @@ fn build_groth16_prepare_inputs_script(public_input_count: usize, vk_gamma_abc_c
     builder
         .add_i64(public_input_count as i64)
         .map_err(|err| format!("failed to add groth16 public input count: {err}"))?
-        .add_data(&proof_bytes)
+        .add_data(proof_bytes)
         .map_err(|err| format!("failed to add groth16 proof: {err}"))?
-        .add_data(&extended_vk_bytes)
+        .add_data(vk_bytes)
         .map_err(|err| format!("failed to add groth16 verifying key: {err}"))?
         .add_data(&[ZkTag::Groth16 as u8])
         .map_err(|err| format!("failed to add groth16 tag: {err}"))?
@@ -807,6 +1142,68 @@ fn build_groth16_prepare_inputs_script(public_input_count: usize, vk_gamma_abc_c
         .map_err(|err| format!("failed to add groth16 opcode: {err}"))?;
 
     Ok(builder.drain())
+}
+
+fn build_repeated_groth16_script(groth16_script: &[u8], count: usize) -> Vec<u8> {
+    assert!(count > 0, "repeated groth16 script should contain at least one call");
+
+    let mut script = Vec::with_capacity(groth16_script.len() * count + count.saturating_sub(1));
+    for call_idx in 0..count {
+        if call_idx > 0 {
+            script.push(OpDrop);
+        }
+        script.extend_from_slice(groth16_script);
+    }
+    script
+}
+
+fn build_groth16_prepare_inputs_repeated_script(public_input_count: usize, call_count: usize) -> Result<Vec<u8>, String> {
+    let groth16_script = build_groth16_prepare_inputs_script(public_input_count, public_input_count + 1)?;
+    Ok(build_repeated_groth16_script(&groth16_script, call_count))
+}
+
+fn groth16_high_hamming_public_input() -> Fr {
+    // Ark Groth16 prepares each public input with affine scalar multiplication.
+    // Its current BN254 path uses double-and-add, so the scalar bit length and
+    // Hamming weight affect the cost. Use 2^253 - 1 to cover the worst case of that path.
+    let mut bytes = [0xffu8; 32];
+    bytes[31] = 0x1f;
+    Fr::deserialize_uncompressed(bytes.as_slice()).expect("2^253 - 1 should fit in BN254 Fr")
+}
+
+fn build_groth16_valid_fixture(public_input_count: usize) -> Result<Groth16SerializedFixture, String> {
+    let public_input = groth16_high_hamming_public_input();
+
+    let mut rng = StdRng::seed_from_u64(public_input_count as u64);
+    let circuit = Groth16PublicInputCircuit { public_input_count, public_input };
+    let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(circuit, &mut rng)
+        .map_err(|err| format!("failed to setup groth16 public-input fixture: {err}"))?;
+
+    let circuit = Groth16PublicInputCircuit { public_input_count, public_input };
+    let proof = Groth16::<Bn254>::prove(&pk, circuit, &mut rng)
+        .map_err(|err| format!("failed to prove groth16 public-input fixture: {err}"))?;
+
+    let mut vk_bytes = Vec::new();
+    vk.serialize_compressed(&mut vk_bytes).map_err(|err| format!("failed to serialize groth16 public-input fixture vk: {err}"))?;
+
+    let mut proof_bytes = Vec::new();
+    proof
+        .serialize_compressed(&mut proof_bytes)
+        .map_err(|err| format!("failed to serialize groth16 public-input fixture proof: {err}"))?;
+
+    let mut public_input_bytes = Vec::new();
+    public_input
+        .serialize_uncompressed(&mut public_input_bytes)
+        .map_err(|err| format!("failed to serialize groth16 public input: {err}"))?;
+
+    Ok(Groth16SerializedFixture { vk_bytes, proof_bytes, public_input_bytes })
+}
+
+fn build_groth16_repeated_valid_script(public_input_count: usize, call_count: usize) -> Result<Vec<u8>, String> {
+    let fixture = build_groth16_valid_fixture(public_input_count)?;
+    let groth16_script =
+        build_groth16_repeated_input_script(public_input_count, &fixture.vk_bytes, &fixture.proof_bytes, &fixture.public_input_bytes)?;
+    Ok(build_repeated_groth16_script(&groth16_script, call_count))
 }
 
 fn groth16_extended_vk_bytes(vk_bytes: &[u8], vk_gamma_abc_count: usize) -> Result<(Vec<u8>, Vec<u8>), String> {
@@ -942,7 +1339,7 @@ fn try_build_groth16_prepare_inputs_tx_with_input_count(
     public_input_count: usize,
 ) -> Result<(Transaction, Vec<UtxoEntry>), String> {
     let script = build_groth16_prepare_inputs_script(public_input_count, public_input_count + 1)?;
-    try_build_budgeted_single_input_tx_allowing_zk_failure(nonce, ScriptPublicKey::new(0, script.into()), vec![])
+    try_build_budgeted_single_input_tx_expecting_zk_failure(nonce, ScriptPublicKey::new(0, script.into()), vec![])
 }
 
 fn try_build_groth16_prepare_inputs_large_vk_tx_with_gamma_count(
@@ -961,7 +1358,7 @@ fn try_build_groth16_large_vk_tx_with_params(
     let redeem_script = build_groth16_prepare_inputs_large_vk_script(vk_gamma_abc_count, padding_chunks, padding_bytes)?;
     let signature_script = pay_to_script_hash_signature_script_with_flags(redeem_script.clone(), vec![], pricing_flags(true))
         .map_err(|err| format!("failed to build groth16 large-vk p2sh signature script: {err}"))?;
-    try_build_budgeted_single_input_tx_allowing_zk_failure(nonce, pay_to_script_hash_script(&redeem_script), signature_script)
+    try_build_budgeted_single_input_tx_expecting_zk_failure(nonce, pay_to_script_hash_script(&redeem_script), signature_script)
 }
 
 fn groth16_max_pub_input_count() -> usize {
@@ -1003,11 +1400,102 @@ fn groth16_max_pub_input_count() -> usize {
     })
 }
 
-fn build_groth16_max_pub_inputs_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+fn build_groth16_1x_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
     let public_input_count = groth16_max_pub_input_count();
     let candidate = try_build_groth16_prepare_inputs_tx_with_input_count(nonce, public_input_count)
         .expect("cached groth16 public input count should be valid");
     assert!(fits_block_mass(&candidate.0), "cached groth16 public input count should stay within block mass limits");
+    candidate
+}
+
+fn estimate_groth16_repeated_tx_with_input_count(
+    nonce: u32,
+    public_input_count: usize,
+    call_count: usize,
+) -> Option<(Transaction, Vec<UtxoEntry>)> {
+    let single_candidate = try_build_groth16_prepare_inputs_tx_with_input_count(nonce, public_input_count).ok()?;
+    let TxInputMass::ComputeBudget(single_budget) = single_candidate.0.inputs.first()?.mass else {
+        return None;
+    };
+    let repeated_budget = single_budget.value().checked_mul(u16::try_from(call_count).ok()?)?.checked_add(1).map(ComputeBudget)?;
+    let script = build_groth16_prepare_inputs_repeated_script(public_input_count, call_count).ok()?;
+    Some(build_single_input_tx_with_compute_budget(nonce, ScriptPublicKey::new(0, script.into()), vec![], repeated_budget))
+}
+
+fn groth16_repeated_pub_input_count(call_count: usize) -> usize {
+    fn search(call_count: usize) -> usize {
+        fn valid_input_count_with_call_count(call_count: usize, public_input_count: usize) -> bool {
+            let Some(candidate) = estimate_groth16_repeated_tx_with_input_count(0, public_input_count, call_count) else {
+                return false;
+            };
+            fits_block_mass(&candidate.0)
+        }
+
+        let mut low_input_count = 1usize;
+        let mut high_input_count = 2usize;
+        assert!(
+            valid_input_count_with_call_count(call_count, low_input_count),
+            "single groth16 repeated public input should be valid"
+        );
+
+        loop {
+            if !valid_input_count_with_call_count(call_count, high_input_count) {
+                break;
+            }
+            low_input_count = high_input_count;
+            let next_high_input_count = high_input_count.saturating_mul(2);
+            if next_high_input_count == high_input_count {
+                break;
+            }
+            high_input_count = next_high_input_count;
+        }
+
+        high_input_count = high_input_count.min(groth16_max_pub_input_count().saturating_add(1));
+        while low_input_count + 1 < high_input_count {
+            let mid_input_count = low_input_count + (high_input_count - low_input_count) / 2;
+            if valid_input_count_with_call_count(call_count, mid_input_count) {
+                low_input_count = mid_input_count;
+            } else {
+                high_input_count = mid_input_count;
+            }
+        }
+
+        low_input_count
+    }
+
+    match call_count {
+        GROTH16_2X_COUNT => {
+            static INPUT_COUNT: OnceLock<usize> = OnceLock::new();
+            *INPUT_COUNT.get_or_init(|| search(call_count))
+        }
+        GROTH16_3X_COUNT => {
+            static INPUT_COUNT: OnceLock<usize> = OnceLock::new();
+            *INPUT_COUNT.get_or_init(|| search(call_count))
+        }
+        _ => search(call_count),
+    }
+}
+
+fn groth16_2x_pub_input_count() -> usize {
+    groth16_repeated_pub_input_count(GROTH16_2X_COUNT)
+}
+
+fn groth16_3x_pub_input_count() -> usize {
+    groth16_repeated_pub_input_count(GROTH16_3X_COUNT)
+}
+
+fn build_groth16_2x_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
+    static SCRIPT: OnceLock<Vec<u8>> = OnceLock::new();
+    let script = SCRIPT
+        .get_or_init(|| {
+            let public_input_count = groth16_2x_pub_input_count();
+            build_groth16_repeated_valid_script(public_input_count, GROTH16_2X_COUNT)
+                .expect("cached groth16 2x public input count should be valid")
+        })
+        .clone();
+    let candidate = try_build_budgeted_single_input_tx(nonce, ScriptPublicKey::new(0, script.into()), vec![])
+        .expect("cached groth16 2x script should be valid");
+    assert!(fits_block_mass(&candidate.0), "cached groth16 2x public input count should stay within block mass limits");
     candidate
 }
 
@@ -1264,10 +1752,10 @@ fn build_budgeted_charged_tx(label: &str, tx: &Transaction, entries: &[UtxoEntry
 }
 
 fn pack_repeated_txs(name: &'static str, builder: TxBuilder) -> BenchBlock {
-    pack_repeated_txs_with_zk_failure(name, builder, false)
+    pack_repeated_txs_with_expected_zk_failure(name, builder, false)
 }
 
-fn pack_repeated_txs_with_zk_failure(name: &'static str, builder: TxBuilder, allow_zk_failure: bool) -> BenchBlock {
+fn pack_repeated_txs_with_expected_zk_failure(name: &'static str, builder: TxBuilder, expect_zk_failure: bool) -> BenchBlock {
     let mut txs = Vec::new();
     let mut total_mass = 0u64;
     let mut total_transient_mass = 0u64;
@@ -1294,20 +1782,20 @@ fn pack_repeated_txs_with_zk_failure(name: &'static str, builder: TxBuilder, all
         input_count: total_inputs,
         compute_mass: total_mass,
         transient_mass: total_transient_mass,
-        allow_zk_failure,
+        expect_zk_failure,
         txs,
     }
 }
 
 fn single_tx_block(name: &'static str, tx: Transaction, entries: Vec<UtxoEntry>) -> BenchBlock {
-    single_tx_block_with_zk_failure(name, tx, entries, false)
+    single_tx_block_with_expected_zk_failure(name, tx, entries, false)
 }
 
-fn single_tx_block_with_zk_failure(
+fn single_tx_block_with_expected_zk_failure(
     name: &'static str,
     tx: Transaction,
     entries: Vec<UtxoEntry>,
-    allow_zk_failure: bool,
+    expect_zk_failure: bool,
 ) -> BenchBlock {
     BenchBlock {
         name,
@@ -1315,7 +1803,7 @@ fn single_tx_block_with_zk_failure(
         input_count: tx.inputs.len(),
         compute_mass: compute_mass(&tx),
         transient_mass: transient_mass(&tx),
-        allow_zk_failure,
+        expect_zk_failure,
         txs: vec![prepare_bench_tx(tx, entries)],
     }
 }
@@ -1327,7 +1815,7 @@ fn fixed_txs_block(name: &'static str, tx_entries: Vec<(Transaction, Vec<UtxoEnt
     let transient_mass = tx_entries.iter().map(|(tx, _)| transient_mass(tx)).sum();
     let txs = tx_entries.into_iter().map(|(tx, entries)| prepare_bench_tx(tx, entries)).collect();
 
-    BenchBlock { name, txs, tx_count, input_count, compute_mass, transient_mass, allow_zk_failure: false }
+    BenchBlock { name, txs, tx_count, input_count, compute_mass, transient_mass, expect_zk_failure: false }
 }
 
 fn build_schnorr_block() -> BenchBlock {
@@ -1418,26 +1906,40 @@ fn build_max_opcodes_block() -> BenchBlock {
     single_tx_block("max_opcodes", tx, entries)
 }
 
-fn build_single_stark_block() -> BenchBlock {
-    let (tx, entries) = build_single_stark_tx(0);
-    single_tx_block("single_stark", tx, entries)
+fn build_stark_single_block() -> BenchBlock {
+    let (tx, entries) = build_stark_single_tx(0);
+    single_tx_block("stark_single", tx, entries)
+}
+
+fn build_stark_long_control_proof_block() -> BenchBlock {
+    let (tx, entries) = build_stark_long_control_proof_tx(0);
+    single_tx_block_with_expected_zk_failure("stark_long_control_proof", tx, entries, true)
+}
+
+fn build_stark_max_trailing_seal_block() -> BenchBlock {
+    let (tx, entries) = build_stark_max_trailing_seal_tx(0);
+    single_tx_block_with_expected_zk_failure("stark_max_trailing_seal", tx, entries, true)
 }
 
 fn build_groth16_3tx_block() -> BenchBlock {
     fixed_txs_block("groth16_3tx", vec![build_groth16_tx(0), build_groth16_tx(1), build_groth16_tx(2)])
 }
 
-fn build_groth16_3tags_single_tx_block() -> BenchBlock {
-    let (tx, entries) = build_groth16_3tags_tx(0);
-    single_tx_block("groth16_3tags_single_tx", tx, entries)
+fn build_groth16_3x_block() -> BenchBlock {
+    let (tx, entries) = build_groth16_3x_tx(0);
+    single_tx_block("groth16_3x", tx, entries)
 }
 
-fn build_groth16_max_pub_inputs_block() -> BenchBlock {
-    pack_repeated_txs_with_zk_failure("groth16_max_pub_inputs", build_groth16_max_pub_inputs_tx, true)
+fn build_groth16_1x_block() -> BenchBlock {
+    pack_repeated_txs_with_expected_zk_failure("groth16_1x", build_groth16_1x_tx, true)
+}
+
+fn build_groth16_2x_block() -> BenchBlock {
+    pack_repeated_txs("groth16_2x", build_groth16_2x_tx)
 }
 
 fn build_groth16_large_vk_block() -> BenchBlock {
-    pack_repeated_txs_with_zk_failure("groth16_large_vk", build_groth16_large_vk_tx, true)
+    pack_repeated_txs_with_expected_zk_failure("groth16_large_vk", build_groth16_large_vk_tx, true)
 }
 
 fn bench_blocks() -> &'static [BenchBlock] {
@@ -1471,10 +1973,13 @@ fn bench_blocks() -> &'static [BenchBlock] {
             build_op_dup_p2sh_block(),
             build_op_dup_one_tx_block(),
             build_max_opcodes_block(),
-            build_single_stark_block(),
+            build_stark_single_block(),
+            build_stark_long_control_proof_block(),
+            build_stark_max_trailing_seal_block(),
             build_groth16_3tx_block(),
-            build_groth16_3tags_single_tx_block(),
-            build_groth16_max_pub_inputs_block(),
+            build_groth16_3x_block(),
+            build_groth16_2x_block(),
+            build_groth16_1x_block(),
             build_groth16_large_vk_block(),
         ];
 
@@ -1493,11 +1998,11 @@ fn bench_blocks() -> &'static [BenchBlock] {
     })
 }
 
-fn accept_validation_result(result: Result<(), TxScriptError>, allow_zk_failure: bool) -> Result<(), TxScriptError> {
-    match result {
-        Ok(()) => Ok(()),
-        Err(TxScriptError::ZkIntegrity(_)) if allow_zk_failure => Ok(()),
-        Err(err) => Err(err),
+fn check_validation_result(result: Result<(), TxScriptError>, expect_zk_failure: bool) -> Result<(), TxScriptError> {
+    match (result, expect_zk_failure) {
+        (Ok(()), true) => panic!("expected ZK integrity failure, validation succeeded"),
+        (Ok(()), false) | (Err(TxScriptError::ZkIntegrity(_)), true) => Ok(()),
+        (Err(err), _) => Err(err),
     }
 }
 
@@ -1521,7 +2026,7 @@ fn validate_block_sequential(block: &BenchBlock) {
                 flags,
                 script_units_limit,
             );
-            accept_validation_result(vm.execute(), block.allow_zk_failure).unwrap();
+            check_validation_result(vm.execute(), block.expect_zk_failure).unwrap();
         }
     }
 }
@@ -1548,7 +2053,7 @@ fn validate_block_parallel(block: &BenchBlock, pool: &rayon::ThreadPool) {
                     flags,
                     script_units_limit,
                 );
-                accept_validation_result(vm.execute(), block.allow_zk_failure)
+                check_validation_result(vm.execute(), block.expect_zk_failure)
             })
         })
     })

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -125,13 +125,12 @@ enum ScriptSource<'a, T: VerifiableTransaction> {
 #[derive(Copy, Clone)]
 pub struct EngineFlags {
     pub covenants_enabled: bool,
-    pub zk_hardening_enabled: bool,
     pub sigop_script_units: ScriptUnits,
 }
 
 impl Default for EngineFlags {
     fn default() -> Self {
-        Self { covenants_enabled: false, zk_hardening_enabled: false, sigop_script_units: Gram(1000).into() }
+        Self { covenants_enabled: false, sigop_script_units: Gram(1000).into() }
     }
 }
 
@@ -1183,7 +1182,7 @@ mod tests {
     fn test_used_script_units_can_drive_compute_budget_selection() {
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let flags = EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() };
+        let flags = EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() };
         let script = ScriptBuilder::with_flags(flags)
             .add_data(&vec![42u8; SCRIPT_UNITS_PER_COMPUTE_BUDGET_UNIT as usize])
             .unwrap()
@@ -1340,7 +1339,7 @@ mod tests {
                 0,
                 &utxo_entry,
                 EngineCtx::new(&sig_cache).with_reused(&reused_values),
-                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+                EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
             );
 
             assert_eq!(vm.execute(), Ok(()), "execution failed for SPK_LEN={expected_script_len}");
@@ -1460,7 +1459,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, sigop_script_units },
             budget_allows_one_sigop_only,
         );
         assert_match!(
@@ -1475,7 +1474,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, sigop_script_units },
             (budget_allows_one_sigop_only.0 * 2).into(),
         );
         assert_eq!(vm_with_doubled_budget.execute(), Ok(()), "expected tx to pass when budget is doubled");
@@ -2150,7 +2149,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));
@@ -2216,7 +2215,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -125,12 +125,13 @@ enum ScriptSource<'a, T: VerifiableTransaction> {
 #[derive(Copy, Clone)]
 pub struct EngineFlags {
     pub covenants_enabled: bool,
+    pub zk_hardening_enabled: bool,
     pub sigop_script_units: ScriptUnits,
 }
 
 impl Default for EngineFlags {
     fn default() -> Self {
-        Self { covenants_enabled: false, sigop_script_units: Gram(1000).into() }
+        Self { covenants_enabled: false, zk_hardening_enabled: false, sigop_script_units: Gram(1000).into() }
     }
 }
 
@@ -1182,7 +1183,7 @@ mod tests {
     fn test_used_script_units_can_drive_compute_budget_selection() {
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let flags = EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() };
+        let flags = EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() };
         let script = ScriptBuilder::with_flags(flags)
             .add_data(&vec![42u8; SCRIPT_UNITS_PER_COMPUTE_BUDGET_UNIT as usize])
             .unwrap()
@@ -1339,7 +1340,7 @@ mod tests {
                 0,
                 &utxo_entry,
                 EngineCtx::new(&sig_cache).with_reused(&reused_values),
-                EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
+                EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
             );
 
             assert_eq!(vm.execute(), Ok(()), "execution failed for SPK_LEN={expected_script_len}");
@@ -1459,7 +1460,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
             budget_allows_one_sigop_only,
         );
         assert_match!(
@@ -1474,7 +1475,7 @@ mod tests {
             0,
             verifiable_tx.utxo(0).unwrap(),
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, sigop_script_units },
+            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units },
             (budget_allows_one_sigop_only.0 * 2).into(),
         );
         assert_eq!(vm_with_doubled_budget.execute(), Ok(()), "expected tx to pass when budget is doubled");
@@ -2149,7 +2150,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));
@@ -2215,7 +2216,7 @@ mod tests {
             0,
             &utxo_entry,
             EngineCtx::new(&sig_cache).with_reused(&reused_values),
-            EngineFlags { covenants_enabled: true, sigop_script_units: 0.into() },
+            EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, sigop_script_units: 0.into() },
         )
         .execute();
         assert_eq!(result, Ok(()));

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -897,7 +897,7 @@ opcode_list! {
             vm.consume_script_units(tag.cost())?;
 
             // Verify the ZK proof
-            verify_zk(tag, &mut vm.dstack)?;
+            verify_zk(tag, &mut vm.dstack, &mut vm.runtime_resource_meter, vm.flags)?;
 
             // If no errors, push true to the stack
             vm.dstack.push_item(true)?;

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -897,7 +897,7 @@ opcode_list! {
             vm.consume_script_units(tag.cost())?;
 
             // Verify the ZK proof
-            verify_zk(tag, &mut vm.dstack, &mut vm.runtime_resource_meter, vm.flags)?;
+            verify_zk(tag, &mut vm.dstack, &mut vm.runtime_resource_meter)?;
 
             // If no errors, push true to the stack
             vm.dstack.push_item(true)?;

--- a/crypto/txscript/src/runtime_resource_meter.rs
+++ b/crypto/txscript/src/runtime_resource_meter.rs
@@ -103,9 +103,9 @@ impl RuntimeScriptUnitMeter {
                 Ok(())
             }
             None => {
-                let overflow = units - self.remaining_script_units;
-                let used_units = self.script_units_limit + overflow;
-                Err(TxScriptError::ExceededCommittedScriptUnits { used: used_units.0, limit: self.script_units_limit.0 })
+                let overflow = units.0 - self.remaining_script_units.0;
+                let used_units = self.script_units_limit.0.saturating_add(overflow);
+                Err(TxScriptError::ExceededCommittedScriptUnits { used: used_units, limit: self.script_units_limit.0 })
             }
         }
     }
@@ -207,6 +207,29 @@ mod tests {
         assert_eq!(meter.consume_sig_op_cost(1), Err(TxScriptError::ExceededCommittedScriptUnits { used: 300, limit: 250 }));
         assert_eq!(meter.used_sig_ops(), 2);
         assert_eq!(meter.used_script_units(), ScriptUnits(200));
+    }
+
+    #[test]
+    fn script_units_meter_saturates_exceeded_used_units() {
+        let mut meter = RuntimeScriptUnitMeter::new(ScriptUnits(0), ScriptUnits(100));
+
+        assert_eq!(meter.consume_script_units(ScriptUnits(60)), Ok(()));
+        assert_eq!(
+            meter.consume_script_units(ScriptUnits(u64::MAX)),
+            Err(TxScriptError::ExceededCommittedScriptUnits { used: u64::MAX, limit: 100 })
+        );
+        assert_eq!(meter.used_script_units(), ScriptUnits(60));
+    }
+
+    #[test]
+    fn script_units_meter_rejects_u64_max_charge_without_panicking() {
+        let mut meter = RuntimeScriptUnitMeter::new(ScriptUnits(0), ScriptUnits(100));
+
+        assert_eq!(
+            meter.consume_script_units(ScriptUnits(u64::MAX)),
+            Err(TxScriptError::ExceededCommittedScriptUnits { used: u64::MAX, limit: 100 })
+        );
+        assert_eq!(meter.used_script_units(), ScriptUnits(0));
     }
 
     #[test]

--- a/crypto/txscript/src/zk_precompiles/fields/error.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum FieldsError {
+    #[error("Invalid Fr length: expected 32 bytes, got {0}")]
+    InvalidLength(usize),
     #[error("ARK serialization error: {0}")]
     ArkSerialization(#[from] ark_serialize::SerializationError),
 }

--- a/crypto/txscript/src/zk_precompiles/fields/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/mod.rs
@@ -14,15 +14,20 @@ use crate::{
 pub struct Fr(ark_bn254::Fr);
 
 impl Fr {
-    pub fn field(&self) -> &ark_bn254::Fr {
-        &self.0
+    pub fn into_field(self) -> ark_bn254::Fr {
+        self.0
     }
 }
+
+pub const FR_BYTES: usize = 32;
 
 impl TryFrom<&[u8]> for Fr {
     type Error = FieldsError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != FR_BYTES {
+            return Err(FieldsError::InvalidLength(bytes.len()));
+        }
         Ok(Fr(ark_bn254::Fr::deserialize_uncompressed(bytes)?))
     }
 }
@@ -44,5 +49,81 @@ impl OpcodeData<Fr> for StackEntry {
         let mut bytes = Vec::new();
         from.0.serialize_uncompressed(&mut bytes).map_err(|_| SerializationError::ArkSerialization)?;
         Ok(SmallVec::from_vec(bytes))
+    }
+}
+
+#[derive(Clone, Debug)]
+/// Legacy that truncates to the first 32 bytes and accepts trailing bytes.
+pub struct TruncFr(ark_bn254::Fr);
+
+impl From<TruncFr> for Fr {
+    fn from(prev: TruncFr) -> Self {
+        Fr(prev.0)
+    }
+}
+
+impl TryFrom<&[u8]> for TruncFr {
+    type Error = FieldsError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Ok(TruncFr(ark_bn254::Fr::deserialize_uncompressed(bytes)?))
+    }
+}
+
+impl OpcodeData<TruncFr> for StackEntry {
+    fn deserialize(&self, _: bool) -> Result<TruncFr, TxScriptError> {
+        TruncFr::try_from(self.as_slice()).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))
+    }
+
+    fn serialize(from: &TruncFr) -> Result<Self, SerializationError> {
+        let mut bytes = Vec::new();
+        from.0.serialize_uncompressed(&mut bytes).map_err(|_| SerializationError::ArkSerialization)?;
+        Ok(SmallVec::from_vec(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FR_BYTES, Fr, TruncFr};
+    use crate::zk_precompiles::fields::error::FieldsError;
+
+    #[test]
+    fn fr_accepts_exactly_32_bytes() {
+        let mut bytes = [0u8; FR_BYTES];
+        bytes[0] = 0x01;
+        Fr::try_from(bytes.as_slice()).expect("32-byte in-range Fr must parse");
+    }
+
+    #[test]
+    fn fr_rejects_oversized_buffer() {
+        let oversized = vec![0u8; 64];
+        match Fr::try_from(oversized.as_slice()) {
+            Err(FieldsError::InvalidLength(64)) => {}
+            other => panic!("expected InvalidLength(64), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fr_rejects_undersized_buffer() {
+        let short = vec![0u8; 16];
+        match Fr::try_from(short.as_slice()) {
+            Err(FieldsError::InvalidLength(16)) => {}
+            other => panic!("expected InvalidLength(16), got {other:?}"),
+        }
+    }
+
+    /// TruncFr (legacy)
+    #[test]
+    fn prev_fr_accepts_oversized_buffer() {
+        let mut bytes = vec![0u8; 64];
+        bytes[0] = 0x01;
+        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 64-byte buffer");
+    }
+
+    #[test]
+    fn prev_fr_accepts_exactly_32_bytes() {
+        let mut bytes = [0u8; FR_BYTES];
+        bytes[0] = 0x01;
+        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 32-byte buffer");
     }
 }

--- a/crypto/txscript/src/zk_precompiles/fields/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/mod.rs
@@ -52,39 +52,9 @@ impl OpcodeData<Fr> for StackEntry {
     }
 }
 
-#[derive(Clone, Debug)]
-/// Legacy that truncates to the first 32 bytes and accepts trailing bytes.
-pub struct TruncFr(ark_bn254::Fr);
-
-impl From<TruncFr> for Fr {
-    fn from(prev: TruncFr) -> Self {
-        Fr(prev.0)
-    }
-}
-
-impl TryFrom<&[u8]> for TruncFr {
-    type Error = FieldsError;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Ok(TruncFr(ark_bn254::Fr::deserialize_uncompressed(bytes)?))
-    }
-}
-
-impl OpcodeData<TruncFr> for StackEntry {
-    fn deserialize(&self, _: bool) -> Result<TruncFr, TxScriptError> {
-        TruncFr::try_from(self.as_slice()).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))
-    }
-
-    fn serialize(from: &TruncFr) -> Result<Self, SerializationError> {
-        let mut bytes = Vec::new();
-        from.0.serialize_uncompressed(&mut bytes).map_err(|_| SerializationError::ArkSerialization)?;
-        Ok(SmallVec::from_vec(bytes))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{FR_BYTES, Fr, TruncFr};
+    use super::{FR_BYTES, Fr};
     use crate::zk_precompiles::fields::error::FieldsError;
 
     #[test]
@@ -110,20 +80,5 @@ mod tests {
             Err(FieldsError::InvalidLength(16)) => {}
             other => panic!("expected InvalidLength(16), got {other:?}"),
         }
-    }
-
-    /// TruncFr (legacy)
-    #[test]
-    fn prev_fr_accepts_oversized_buffer() {
-        let mut bytes = vec![0u8; 64];
-        bytes[0] = 0x01;
-        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 64-byte buffer");
-    }
-
-    #[test]
-    fn prev_fr_accepts_exactly_32_bytes() {
-        let mut bytes = [0u8; FR_BYTES];
-        bytes[0] = 0x01;
-        TruncFr::try_from(bytes.as_slice()).expect("legacy TruncFr accepts 32-byte buffer");
     }
 }

--- a/crypto/txscript/src/zk_precompiles/groth16/error.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/error.rs
@@ -8,6 +8,12 @@ pub enum Groth16Error {
     VerificationFailed,
     #[error("Groth16 verifying key has empty gamma_abc_g1")]
     EmptyGammaAbc,
+    #[error("Groth16 verifying key bytes are too short to read gamma_abc_g1 length")]
+    MalformedVerifyingKey,
+    #[error("Groth16 verifying key has trailing bytes")]
+    TrailingVerifyingKeyBytes,
+    #[error("Groth16 proof has trailing bytes")]
+    TrailingProofBytes,
     #[error("Kaspa txscript error: {0}")]
     FromTxScript(#[from] kaspa_txscript_errors::TxScriptError),
     #[error("ARK serialization error: {0}")]

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -1,15 +1,69 @@
 mod error;
-use ark_bn254::Bn254;
+use ark_bn254::{Bn254, G1Affine, G2Affine};
 use ark_groth16::{Groth16, Proof, VerifyingKey};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{CanonicalDeserialize, Compress, Valid, Validate};
+use kaspa_consensus_core::mass::ScriptUnits;
 
 pub use error::Groth16Error;
 
 use crate::{
+    EngineFlags,
     data_stack::Stack,
     opcodes::i32s_to_usizes,
-    zk_precompiles::{ZkPrecompile, fields::Fr},
+    runtime_resource_meter::RuntimeResourceMeter,
+    zk_precompiles::{
+        ZkPrecompile,
+        fields::{Fr, TruncFr},
+    },
 };
+
+/// Empirically determined script unit cost per gamma_abc_g1 element in the VK
+/// such that the total verification cost is within ~10ms.
+pub const GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS: u64 = 250_000;
+
+fn deserialize_verifying_key_with_metering(
+    bytes: &[u8],
+    public_input_count: usize,
+    meter: &mut RuntimeResourceMeter,
+) -> Result<VerifyingKey<Bn254>, Groth16Error> {
+    let mut reader = bytes;
+
+    // Mirror ark-groth16's VerifyingKey serialization order, but stop after
+    // gamma_abc_g1 length so we can check arity and charge before reading it.
+    let alpha_g1 = G1Affine::deserialize_with_mode(&mut reader, Compress::Yes, Validate::Yes)?;
+    let beta_g2 = G2Affine::deserialize_with_mode(&mut reader, Compress::Yes, Validate::Yes)?;
+    let gamma_g2 = G2Affine::deserialize_with_mode(&mut reader, Compress::Yes, Validate::Yes)?;
+    let delta_g2 = G2Affine::deserialize_with_mode(&mut reader, Compress::Yes, Validate::Yes)?;
+
+    let gamma_abc_element_count = u64::deserialize_with_mode(&mut reader, Compress::Yes, Validate::Yes)?;
+
+    // Covered by the following count check but kept for clearer error
+    if gamma_abc_element_count == 0 {
+        return Err(Groth16Error::EmptyGammaAbc);
+    }
+
+    // Public inputs are stack-depth bounded, so +1 cannot overflow.
+    if public_input_count as u64 + 1 != gamma_abc_element_count {
+        return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
+    }
+
+    let gamma_abc_cost = ScriptUnits(gamma_abc_element_count.saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
+
+    // Try consuming the vk cost and err if we are over the limit
+    meter.consume_script_units(gamma_abc_cost)?;
+
+    let gamma_abc_len = public_input_count + 1;
+    let gamma_abc_g1 = (0..gamma_abc_len)
+        .map(|_| G1Affine::deserialize_with_mode(&mut reader, Compress::Yes, Validate::No))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if !reader.is_empty() {
+        return Err(Groth16Error::TrailingVerifyingKeyBytes);
+    }
+    <G1Affine as Valid>::batch_check(gamma_abc_g1.iter())?;
+
+    Ok(VerifyingKey { alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc_g1 })
+}
 
 pub struct Groth16Precompile;
 impl ZkPrecompile for Groth16Precompile {
@@ -17,8 +71,9 @@ impl ZkPrecompile for Groth16Precompile {
     /// Verifies the integrity of a Groth16 proof.
     ///
     /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error> {
-        // Retrieve the uncompressed VK
+    ///
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
+        // Retrieve the compressed VK
         let [unprepared_compressed_key] = dstack.pop_raw()?;
 
         // Retrieve compressed proof
@@ -28,34 +83,55 @@ impl ZkPrecompile for Groth16Precompile {
         let [n_inputs] = i32s_to_usizes(dstack.pop_items::<1, i32>()?)?;
 
         // Retrieve public inputs
-        let mut unprepared_public_inputs = Vec::new();
+        // Do not change the capacity argument to allow arbitrary input, as
+        // this would allow an adversary to cause OOM. The actual remaining stack
+        // length is an upper bound on how many inputs can be read.
+        let mut unprepared_public_inputs = Vec::with_capacity(n_inputs.min(dstack.len()));
 
-        // For each public input, pop from the stack and convert to Fr
+        // For each public input, pop from the stack and convert to Fr.
+        //
+        // Note: public input count is bounded by the script stack depth limit.
         for _ in 0..n_inputs {
-            let [fr] = dstack.pop_items::<1, Fr>()?;
-            // Convert bytes to Fr and add to public inputs
-            unprepared_public_inputs.push(fr);
+            // convert bytes to Fr according to whether we're in hardened mode or not
+            let fr = if flags.zk_hardening_enabled {
+                let [fr] = dstack.pop_items::<1, Fr>()?;
+                fr
+            } else {
+                let [trunc_fr] = dstack.pop_items::<1, TruncFr>()?;
+                Fr::from(trunc_fr)
+            };
+            unprepared_public_inputs.push(fr.into_field());
         }
-        // Deserialize verifying key
-        let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
-        if vk.gamma_abc_g1.is_empty() {
-            return Err(Groth16Error::EmptyGammaAbc);
-        }
+
+        // Deserialize the verifying key. Post-activation: streamed deserialize
+        // that arity-checks and meters per gamma_abc_g1 element inline. Pre-
+        // activation: plain ark deserialize plus the historical empty-gamma_abc
+        // check, no per-element charge.
+        let vk = if flags.zk_hardening_enabled {
+            deserialize_verifying_key_with_metering(&unprepared_compressed_key, unprepared_public_inputs.len(), meter)?
+        } else {
+            let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
+            if vk.gamma_abc_g1.is_empty() {
+                return Err(Groth16Error::EmptyGammaAbc);
+            }
+            vk
+        };
+
         // Prepare verifying key
         let pvk = ark_groth16::prepare_verifying_key(&vk);
 
         // Deserialize proof
-        let proof: &Proof<ark_ec::bn::Bn<ark_bn254::Config>> = &Proof::deserialize_compressed(&*proof_bytes)?;
-
-        let mut encoded_prepared_inputs = Vec::new();
+        let mut proof_reader = proof_bytes.as_slice();
+        let proof = Proof::<Bn254>::deserialize_compressed(&mut proof_reader)?;
+        if flags.zk_hardening_enabled && !proof_reader.is_empty() {
+            return Err(Groth16Error::TrailingProofBytes);
+        }
 
         // Prepare public inputs with the prepared verifying key
-        let prepared_inputs =
-            Groth16::<Bn254>::prepare_inputs(&pvk, &unprepared_public_inputs.iter().map(|x| *x.field()).collect::<Vec<_>>())?;
-        prepared_inputs.serialize_compressed(&mut encoded_prepared_inputs)?;
+        let prepared_inputs = Groth16::<Bn254>::prepare_inputs(&pvk, &unprepared_public_inputs)?;
 
         // Verify the proof with the prepared inputs
-        if Groth16::<Bn254>::verify_proof_with_prepared_inputs(&pvk, proof, &prepared_inputs)? {
+        if Groth16::<Bn254>::verify_proof_with_prepared_inputs(&pvk, &proof, &prepared_inputs)? {
             Ok(())
         } else {
             Err(Groth16Error::VerificationFailed)
@@ -65,33 +141,227 @@ impl ZkPrecompile for Groth16Precompile {
 
 #[cfg(test)]
 mod tests {
+    use super::{GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS, Groth16Error};
     use crate::{
+        EngineFlags,
         data_stack::Stack,
-        hex,
-        zk_precompiles::{ZkPrecompile, groth16::Groth16Precompile},
+        runtime_resource_meter::RuntimeResourceMeter,
+        zk_precompiles::{ZkPrecompile, groth16::Groth16Precompile, tests::helpers::load_groth_fields},
     };
+    use ark_bn254::{Bn254, G1Affine, G2Affine};
+    use ark_groth16::VerifyingKey;
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress};
+    use kaspa_consensus_core::mass::ScriptUnits;
+    use kaspa_txscript_errors::TxScriptError;
+
+    fn hardened_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
+    }
+
+    fn legacy_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
+    }
+
+    fn stack_with_groth_fields(vk: Vec<u8>, proof: Vec<u8>, inputs: Vec<Vec<u8>>) -> Stack {
+        let mut stack = Stack::new(Vec::new(), true);
+        for input in inputs.iter().rev() {
+            stack.push(input.clone().into()).unwrap();
+        }
+        stack.push_item(inputs.len() as i32).unwrap();
+        stack.push(proof.into()).unwrap();
+        stack.push(vk.into()).unwrap();
+        stack
+    }
 
     #[test]
-    fn try_verify_stack() {
-        let unprepared_compressed_vk=hex::decode("e2f26dbea299f5223b646cb1fb33eadb059d9407559d7441dfd902e3a79a4d2dabb73dc17fbc13021e2471e0c08bd67d8401f52b73d6d07483794cad4778180e0c06f33bbc4c79a9cadef253a68084d382f17788f885c9afd176f7cb2f036789edf692d95cbdde46ddda5ef7d422436779445c5e66006a42761e1f12efde0018c212f3aeb785e49712e7a9353349aaf1255dfb31b7bf60723a480d9293938e1933033e7fea1f40604eaacf699d4be9aacc577054a0db22d9129a1728ff85a01a1c3af829b62bf4914c0bcf2c81a4bd577190eff5f194ee9bac95faefd53cb0030600000000000000e43bdc655d0f9d730535554d9caa611ddd152c081a06a932a8e1d5dc259aac123f42a188f683d869873ccc4c119442e57b056e03e2fa92f2028c97bc20b9078747c30f85444697fdf436e348711c011115963f855197243e4b39e6cbe236ca8ba7f2042e11f9255afbb6c6e2c3accb88e401f2aac21c097c92b3fbdb99f98a9b0dcd6c075ada6ed0ddfece1d4a2d005f61a7d5df0b75c18a5b2374d64e495fab93d4c4b1200394d5253cce2f25a59b862ee8e4cd43686603faa09d5d0d3c1c8f").unwrap();
-        let proof=hex::decode("570253c0c483a1b16460118e63c155f3684e784ae7d97e8fc3f544128b37fe15075eab5ac31150c8a44253d8525971241bbd7227fcefbae2db4ae71675c56a2e0eb9235136b15ab72f16e707832f3d6ae5b0ba7cca53ae17cb52b3201919eb9d908c16297abd90aa7e00267bc21a9a78116e717d4d76edd44e21cca17e3d592d").unwrap();
-        let input0 = hex::decode("a54dc85ac99f851c92d7c96d7318af4100000000000000000000000000000000").unwrap();
-        let input1 = hex::decode("dbe7c0194edfcc37eb4d422a998c1f5600000000000000000000000000000000").unwrap();
-        let input2 = hex::decode("a95ac0b37bfedcd8136e6c1143086bf500000000000000000000000000000000").unwrap();
-        let input3 = hex::decode("d223ffcb21c6ffcb7c8f60392ca49dde00000000000000000000000000000000").unwrap();
-        let input4 = hex::decode("c07a65145c3cb48b6101962ea607a4dd93c753bb26975cb47feb00d3666e4404").unwrap();
+    fn check_sizes() {
+        assert_eq!(G1Affine::default().serialized_size(Compress::Yes), 32);
+        assert_eq!(G2Affine::default().serialized_size(Compress::Yes), 64);
+    }
 
-        println!("unprepared key len: {}, proof len: {}", unprepared_compressed_vk.len(), proof.len());
+    #[test]
+    fn check_vec_prefix() {
+        let v: Vec<u8> = vec![];
+        let mut buf = Vec::new();
+        v.serialize_compressed(&mut buf).unwrap();
+        assert_eq!(buf.len(), 8); // empty Vec serializes to just the length prefix
+        assert_eq!(buf, [0u8; 8]); // length 0 as LE u64
+
+        let v: Vec<u8> = vec![0xAA];
+        let mut buf = Vec::new();
+        v.serialize_compressed(&mut buf).unwrap();
+        assert_eq!(&buf[..8], &[1, 0, 0, 0, 0, 0, 0, 0]); // length 1 LE u64
+        assert_eq!(buf[8], 0xAA);
+    }
+
+    fn vk_with_gamma_abc_count(count: usize) -> Vec<u8> {
+        let vk = VerifyingKey::<Bn254> {
+            alpha_g1: G1Affine::default(),
+            beta_g2: G2Affine::default(),
+            gamma_g2: G2Affine::default(),
+            delta_g2: G2Affine::default(),
+            gamma_abc_g1: vec![G1Affine::default(); count],
+        };
+        let mut bytes = Vec::new();
+        vk.serialize_compressed(&mut bytes).expect("serialize VK");
+        bytes
+    }
+
+    #[test]
+    fn custom_vk_deserialize_matches_ark() {
+        for &gamma_abc_count in &[1usize, 2, 6, 42] {
+            let vk_bytes = vk_with_gamma_abc_count(gamma_abc_count);
+            let ark_vk = VerifyingKey::<Bn254>::deserialize_compressed(&*vk_bytes).expect("Ark should deserialize VK");
+
+            let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+            let custom_vk = super::deserialize_verifying_key_with_metering(&vk_bytes, gamma_abc_count - 1, &mut meter)
+                .expect("custom VK deserializer should match Ark");
+
+            assert_eq!(
+                meter.used_script_units(),
+                ScriptUnits((gamma_abc_count as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS))
+            );
+            assert_eq!(custom_vk, ark_vk);
+        }
+    }
+
+    #[test]
+    fn verify_zk_rejects_arity_mismatch_before_meter_charge() {
+        let vk_bytes = vk_with_gamma_abc_count(5);
 
         let mut stack = Stack::new(Vec::new(), true);
-        stack.push(input4.into()).unwrap();
-        stack.push(input3.into()).unwrap();
-        stack.push(input2.into()).unwrap();
-        stack.push(input1.into()).unwrap();
-        stack.push(input0.into()).unwrap();
-        stack.push_item(5i32).unwrap(); // Number of public inputs
-        stack.push(proof.into()).unwrap();
-        stack.push(unprepared_compressed_vk.into()).unwrap();
-        Groth16Precompile::verify_zk(&mut stack).unwrap();
+        stack.push_item(0i32).unwrap();
+        stack.push(vec![0u8; 128].into()).unwrap();
+        stack.push(vk_bytes.into()).unwrap();
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("arity mismatch must be rejected");
+        match err {
+            Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch) => {}
+            other => panic!("expected ArityMismatch before meter charge, got: {other:?}"),
+        }
+        assert_eq!(meter.used_script_units(), ScriptUnits(0));
+    }
+
+    #[test]
+    fn verify_zk_rejects_over_budget_vk_via_meter() {
+        const PER_INPUT_BUDGET: ScriptUnits = ScriptUnits(200_000);
+        const COUNT: usize = 5;
+        let vk_bytes = vk_with_gamma_abc_count(COUNT);
+
+        let mut stack = Stack::new(Vec::new(), true);
+        for _ in 0..COUNT - 1 {
+            stack.push(vec![0u8; 32].into()).unwrap();
+        }
+        stack.push_item((COUNT - 1) as i32).unwrap();
+        stack.push(vec![0u8; 128].into()).unwrap();
+        stack.push(vk_bytes.into()).unwrap();
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), PER_INPUT_BUDGET);
+
+        let expected_charge = (COUNT as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
+        assert!(expected_charge > PER_INPUT_BUDGET.0, "gamma_abc charge {expected_charge} must exceed budget {}", PER_INPUT_BUDGET.0);
+
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("over-budget VK must be rejected");
+        match err {
+            Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
+                assert_eq!(limit, PER_INPUT_BUDGET.0);
+                assert_eq!(used, expected_charge);
+            }
+            other => panic!("expected ExceededCommittedScriptUnits for gamma_abc_g1 element count = {COUNT}, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hardened_verify_path_accepts_canonical_proof() {
+        let (vk, proof, inputs) = load_groth_fields();
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).unwrap();
+    }
+
+    #[test]
+    fn legacy_verify_path_accepts_canonical_proof_without_metering() {
+        let (vk, proof, inputs) = load_groth_fields();
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept canonical proof");
+        assert_eq!(meter.used_script_units(), ScriptUnits(0), "legacy path must not consume meter units");
+    }
+
+    #[test]
+    fn legacy_verify_path_tolerates_oversized_fr_push() {
+        let (vk, proof, mut inputs) = load_groth_fields();
+        inputs[0].extend_from_slice(&[0xAB; 32]);
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags())
+            .expect("legacy path must accept 64-byte Fr push (silent truncation)");
+    }
+
+    #[test]
+    fn legacy_verify_path_tolerates_trailing_vk_and_proof_bytes() {
+        let (mut vk, mut proof, inputs) = load_groth_fields();
+        vk.push(0xAB);
+        proof.push(0xCD);
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept trailing VK/proof bytes");
+    }
+
+    #[test]
+    fn hardened_verify_path_rejects_oversized_fr_push() {
+        let vk_bytes = vk_with_gamma_abc_count(6); // 5 pub inputs + 1
+        let oversized_input = vec![0u8; 64];
+
+        let mut stack = Stack::new(Vec::new(), true);
+        for _ in 0..4 {
+            stack.push(vec![0u8; 32].into()).unwrap();
+        }
+        stack.push(oversized_input.into()).unwrap(); // 64-byte push, must be rejected
+        stack.push_item(5i32).unwrap();
+        stack.push(vec![0u8; 128].into()).unwrap();
+        stack.push(vk_bytes.into()).unwrap();
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
+            .expect_err("hardened path must reject oversized Fr push");
+        match err {
+            Groth16Error::FromTxScript(TxScriptError::ZkIntegrity(msg)) if msg.contains("Invalid Fr length") => {}
+            other => panic!("expected Invalid Fr length error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hardened_verify_path_rejects_trailing_vk_bytes() {
+        let (mut vk, proof, inputs) = load_groth_fields();
+        vk.push(0xAB);
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
+            .expect_err("hardened path must reject trailing VK bytes");
+        match err {
+            Groth16Error::TrailingVerifyingKeyBytes => {}
+            other => panic!("expected trailing VK error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hardened_verify_path_rejects_trailing_proof_bytes() {
+        let (vk, mut proof, inputs) = load_groth_fields();
+        proof.push(0xCD);
+        let mut stack = stack_with_groth_fields(vk, proof, inputs);
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
+            .expect_err("hardened path must reject trailing proof bytes");
+        match err {
+            Groth16Error::TrailingProofBytes => {}
+            other => panic!("expected trailing proof error, got: {other:?}"),
+        }
     }
 }

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -7,7 +7,6 @@ use kaspa_consensus_core::mass::ScriptUnits;
 pub use error::Groth16Error;
 
 use crate::{
-    EngineFlags,
     data_stack::Stack,
     opcodes::i32s_to_usizes,
     runtime_resource_meter::RuntimeResourceMeter,
@@ -67,9 +66,12 @@ impl ZkPrecompile for Groth16Precompile {
     type Error = Groth16Error;
     /// Verifies the integrity of a Groth16 proof.
     ///
-    /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
-    ///
-    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
+    /// Expects the following items on the stack (from top to bottom):
+    /// - verifying key (bytes, compressed)
+    /// - proof (bytes, compressed)
+    /// - public input count (i32)
+    /// - public inputs (Fr bytes, count items)
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error> {
         // Retrieve the compressed VK
         let [unprepared_compressed_key] = dstack.pop_raw()?;
 
@@ -122,7 +124,6 @@ impl ZkPrecompile for Groth16Precompile {
 mod tests {
     use super::{GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS, Groth16Error};
     use crate::{
-        EngineFlags,
         data_stack::Stack,
         runtime_resource_meter::RuntimeResourceMeter,
         zk_precompiles::{ZkPrecompile, groth16::Groth16Precompile, tests::helpers::load_groth_fields},
@@ -132,10 +133,6 @@ mod tests {
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress};
     use kaspa_consensus_core::mass::ScriptUnits;
     use kaspa_txscript_errors::TxScriptError;
-
-    fn test_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, ..Default::default() }
-    }
 
     fn stack_with_groth_fields(vk: Vec<u8>, proof: Vec<u8>, inputs: Vec<Vec<u8>>) -> Stack {
         let mut stack = Stack::new(Vec::new(), true);
@@ -210,7 +207,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("arity mismatch must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("arity mismatch must be rejected");
         match err {
             Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch) => {}
             other => panic!("expected ArityMismatch before meter charge, got: {other:?}"),
@@ -237,7 +234,7 @@ mod tests {
         let expected_charge = (COUNT as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
         assert!(expected_charge > PER_INPUT_BUDGET.0, "gamma_abc charge {expected_charge} must exceed budget {}", PER_INPUT_BUDGET.0);
 
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("over-budget VK must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("over-budget VK must be rejected");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
                 assert_eq!(limit, PER_INPUT_BUDGET.0);
@@ -252,7 +249,7 @@ mod tests {
         let (vk, proof, inputs) = load_groth_fields();
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).unwrap();
+        Groth16Precompile::verify_zk(&mut stack, &mut meter).unwrap();
     }
 
     #[test]
@@ -270,7 +267,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject oversized Fr push");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("must reject oversized Fr push");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ZkIntegrity(msg)) if msg.contains("Invalid Fr length") => {}
             other => panic!("expected Invalid Fr length error, got: {other:?}"),
@@ -284,7 +281,7 @@ mod tests {
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing VK bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("must reject trailing VK bytes");
         match err {
             Groth16Error::TrailingVerifyingKeyBytes => {}
             other => panic!("expected trailing VK error, got: {other:?}"),
@@ -298,7 +295,7 @@ mod tests {
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing proof bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("must reject trailing proof bytes");
         match err {
             Groth16Error::TrailingProofBytes => {}
             other => panic!("expected trailing proof error, got: {other:?}"),

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -11,10 +11,7 @@ use crate::{
     data_stack::Stack,
     opcodes::i32s_to_usizes,
     runtime_resource_meter::RuntimeResourceMeter,
-    zk_precompiles::{
-        ZkPrecompile,
-        fields::{Fr, TruncFr},
-    },
+    zk_precompiles::{ZkPrecompile, fields::Fr},
 };
 
 /// Empirically determined script unit cost per gamma_abc_g1 element in the VK
@@ -72,7 +69,7 @@ impl ZkPrecompile for Groth16Precompile {
     ///
     /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
     ///
-    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
         // Retrieve the compressed VK
         let [unprepared_compressed_key] = dstack.pop_raw()?;
 
@@ -92,30 +89,12 @@ impl ZkPrecompile for Groth16Precompile {
         //
         // Note: public input count is bounded by the script stack depth limit.
         for _ in 0..n_inputs {
-            // convert bytes to Fr according to whether we're in hardened mode or not
-            let fr = if flags.zk_hardening_enabled {
-                let [fr] = dstack.pop_items::<1, Fr>()?;
-                fr
-            } else {
-                let [trunc_fr] = dstack.pop_items::<1, TruncFr>()?;
-                Fr::from(trunc_fr)
-            };
+            let [fr] = dstack.pop_items::<1, Fr>()?;
             unprepared_public_inputs.push(fr.into_field());
         }
 
-        // Deserialize the verifying key. Post-activation: streamed deserialize
-        // that arity-checks and meters per gamma_abc_g1 element inline. Pre-
-        // activation: plain ark deserialize plus the historical empty-gamma_abc
-        // check, no per-element charge.
-        let vk = if flags.zk_hardening_enabled {
-            deserialize_verifying_key_with_metering(&unprepared_compressed_key, unprepared_public_inputs.len(), meter)?
-        } else {
-            let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
-            if vk.gamma_abc_g1.is_empty() {
-                return Err(Groth16Error::EmptyGammaAbc);
-            }
-            vk
-        };
+        // Deserialize the verifying key with arity checking and per-public-input pricing.
+        let vk = deserialize_verifying_key_with_metering(&unprepared_compressed_key, unprepared_public_inputs.len(), meter)?;
 
         // Prepare verifying key
         let pvk = ark_groth16::prepare_verifying_key(&vk);
@@ -123,7 +102,7 @@ impl ZkPrecompile for Groth16Precompile {
         // Deserialize proof
         let mut proof_reader = proof_bytes.as_slice();
         let proof = Proof::<Bn254>::deserialize_compressed(&mut proof_reader)?;
-        if flags.zk_hardening_enabled && !proof_reader.is_empty() {
+        if !proof_reader.is_empty() {
             return Err(Groth16Error::TrailingProofBytes);
         }
 
@@ -154,12 +133,8 @@ mod tests {
     use kaspa_consensus_core::mass::ScriptUnits;
     use kaspa_txscript_errors::TxScriptError;
 
-    fn hardened_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
-    }
-
-    fn legacy_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
+    fn test_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, ..Default::default() }
     }
 
     fn stack_with_groth_fields(vk: Vec<u8>, proof: Vec<u8>, inputs: Vec<Vec<u8>>) -> Stack {
@@ -235,7 +210,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("arity mismatch must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("arity mismatch must be rejected");
         match err {
             Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch) => {}
             other => panic!("expected ArityMismatch before meter charge, got: {other:?}"),
@@ -262,7 +237,7 @@ mod tests {
         let expected_charge = (COUNT as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
         assert!(expected_charge > PER_INPUT_BUDGET.0, "gamma_abc charge {expected_charge} must exceed budget {}", PER_INPUT_BUDGET.0);
 
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).expect_err("over-budget VK must be rejected");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("over-budget VK must be rejected");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
                 assert_eq!(limit, PER_INPUT_BUDGET.0);
@@ -273,47 +248,15 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_accepts_canonical_proof() {
+    fn verify_path_accepts_canonical_proof() {
         let (vk, proof, inputs) = load_groth_fields();
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags()).unwrap();
+        Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).unwrap();
     }
 
     #[test]
-    fn legacy_verify_path_accepts_canonical_proof_without_metering() {
-        let (vk, proof, inputs) = load_groth_fields();
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept canonical proof");
-        assert_eq!(meter.used_script_units(), ScriptUnits(0), "legacy path must not consume meter units");
-    }
-
-    #[test]
-    fn legacy_verify_path_tolerates_oversized_fr_push() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs[0].extend_from_slice(&[0xAB; 32]);
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags())
-            .expect("legacy path must accept 64-byte Fr push (silent truncation)");
-    }
-
-    #[test]
-    fn legacy_verify_path_tolerates_trailing_vk_and_proof_bytes() {
-        let (mut vk, mut proof, inputs) = load_groth_fields();
-        vk.push(0xAB);
-        proof.push(0xCD);
-        let mut stack = stack_with_groth_fields(vk, proof, inputs);
-
-        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        Groth16Precompile::verify_zk(&mut stack, &mut meter, legacy_flags()).expect("legacy path must accept trailing VK/proof bytes");
-    }
-
-    #[test]
-    fn hardened_verify_path_rejects_oversized_fr_push() {
+    fn verify_path_rejects_oversized_fr_push() {
         let vk_bytes = vk_with_gamma_abc_count(6); // 5 pub inputs + 1
         let oversized_input = vec![0u8; 64];
 
@@ -327,8 +270,7 @@ mod tests {
         stack.push(vk_bytes.into()).unwrap();
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject oversized Fr push");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject oversized Fr push");
         match err {
             Groth16Error::FromTxScript(TxScriptError::ZkIntegrity(msg)) if msg.contains("Invalid Fr length") => {}
             other => panic!("expected Invalid Fr length error, got: {other:?}"),
@@ -336,14 +278,13 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_rejects_trailing_vk_bytes() {
+    fn verify_path_rejects_trailing_vk_bytes() {
         let (mut vk, proof, inputs) = load_groth_fields();
         vk.push(0xAB);
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject trailing VK bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing VK bytes");
         match err {
             Groth16Error::TrailingVerifyingKeyBytes => {}
             other => panic!("expected trailing VK error, got: {other:?}"),
@@ -351,14 +292,13 @@ mod tests {
     }
 
     #[test]
-    fn hardened_verify_path_rejects_trailing_proof_bytes() {
+    fn verify_path_rejects_trailing_proof_bytes() {
         let (vk, mut proof, inputs) = load_groth_fields();
         proof.push(0xCD);
         let mut stack = stack_with_groth_fields(vk, proof, inputs);
 
         let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
-        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, hardened_flags())
-            .expect_err("hardened path must reject trailing proof bytes");
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter, test_flags()).expect_err("must reject trailing proof bytes");
         match err {
             Groth16Error::TrailingProofBytes => {}
             other => panic!("expected trailing proof error, got: {other:?}"),

--- a/crypto/txscript/src/zk_precompiles/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/mod.rs
@@ -5,7 +5,6 @@ pub mod risc0;
 pub mod tags;
 pub mod tests;
 use crate::{
-    EngineFlags,
     data_stack::Stack,
     runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{error::ZkIntegrityError, groth16::Groth16Precompile, risc0::R0SuccinctPrecompile, tags::ZkTag},
@@ -15,7 +14,7 @@ use kaspa_txscript_errors::TxScriptError;
 
 trait ZkPrecompile {
     type Error: Into<ZkIntegrityError> + std::fmt::Display;
-    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error>;
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error>;
 }
 
 pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
@@ -31,18 +30,11 @@ pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
  * Verifies a ZK proof from the data stack.
  * The first byte on the stack indicates the ZK tag (proof type).
  */
-pub(crate) fn verify_zk(
-    tag: ZkTag,
-    dstack: &mut Stack,
-    meter: &mut RuntimeResourceMeter,
-    flags: EngineFlags,
-) -> Result<(), TxScriptError> {
+pub(crate) fn verify_zk(tag: ZkTag, dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), TxScriptError> {
     // Match the tag and verify the proof accordingly
     match tag {
-        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack, meter, flags).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
-        ZkTag::R0Succinct => {
-            R0SuccinctPrecompile::verify_zk(dstack, meter, flags).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))
-        }
+        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack, meter).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
+        ZkTag::R0Succinct => R0SuccinctPrecompile::verify_zk(dstack, meter).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
     }
 }
 

--- a/crypto/txscript/src/zk_precompiles/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/mod.rs
@@ -5,7 +5,9 @@ pub mod risc0;
 pub mod tags;
 pub mod tests;
 use crate::{
+    EngineFlags,
     data_stack::Stack,
+    runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{error::ZkIntegrityError, groth16::Groth16Precompile, risc0::R0SuccinctPrecompile, tags::ZkTag},
 };
 use kaspa_consensus_core::mass::ScriptUnits;
@@ -13,7 +15,7 @@ use kaspa_txscript_errors::TxScriptError;
 
 trait ZkPrecompile {
     type Error: Into<ZkIntegrityError> + std::fmt::Display;
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error>;
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error>;
 }
 
 pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
@@ -29,11 +31,18 @@ pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
  * Verifies a ZK proof from the data stack.
  * The first byte on the stack indicates the ZK tag (proof type).
  */
-pub(crate) fn verify_zk(tag: ZkTag, dstack: &mut Stack) -> Result<(), TxScriptError> {
+pub(crate) fn verify_zk(
+    tag: ZkTag,
+    dstack: &mut Stack,
+    meter: &mut RuntimeResourceMeter,
+    flags: EngineFlags,
+) -> Result<(), TxScriptError> {
     // Match the tag and verify the proof accordingly
     match tag {
-        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
-        ZkTag::R0Succinct => R0SuccinctPrecompile::verify_zk(dstack).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
+        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack, meter, flags).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
+        ZkTag::R0Succinct => {
+            R0SuccinctPrecompile::verify_zk(dstack, meter, flags).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))
+        }
     }
 }
 

--- a/crypto/txscript/src/zk_precompiles/risc0/error.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/error.rs
@@ -2,6 +2,8 @@ use kaspa_txscript_errors::TxScriptError;
 use risc0_zkp::verify::VerificationError;
 use thiserror::Error;
 
+use crate::zk_precompiles::risc0::rcpt::HashFnId;
+
 #[derive(Debug, Error)]
 pub enum R0Error {
     #[error("Std io error: {0}")]
@@ -16,12 +18,16 @@ pub enum R0Error {
     InvalidSealLength(usize),
     #[error("Invalid digest list length: {0}")]
     InvalidDigestListLength(usize),
+    #[error("Control inclusion proof length {actual} exceeds maximum {max}")]
+    ControlInclusionProofTooLong { actual: usize, max: usize },
     #[error("Invalid merkle index length: {0}")]
     InvalidMerkleIndexLength(usize),
     #[error("Invalid hash function encoding length: {0}")]
     InvalidHashFnEncoding(usize),
     #[error("Invalid hash function id: {0}")]
     InvalidHashFnId(u8),
+    #[error("Unsupported hash function: {0:?}")]
+    UnsupportedHashFn(HashFnId),
     #[error("Verification failed")]
     VerificationFailed,
     #[error("Merkle proof verification failed")]

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -92,7 +92,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     /// - control inclusion proof digests (bytes)
     /// - control index (bytes, u32 le)
     /// - claim (bytes)
-    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
         let [claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn] = dstack.pop_raw()?;
 
         let control_id = parse_digest(control_id)?;
@@ -110,7 +110,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
         let control_digests = parse_digest_list(control_digests)?;
 
         let max_control_proof_len = control_merkle_depth_for(hashfn);
-        if flags.zk_hardening_enabled && control_digests.len() > max_control_proof_len {
+        if control_digests.len() > max_control_proof_len {
             return Err(R0Error::ControlInclusionProofTooLong { actual: control_digests.len(), max: max_control_proof_len });
         }
 

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
+    EngineFlags,
     data_stack::Stack,
+    runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{
         ZkPrecompile,
         risc0::{
@@ -9,7 +11,6 @@ use crate::{
         },
     },
 };
-use kaspa_txscript_errors::TxScriptError;
 use risc0_zkp::core::digest::DIGEST_BYTES;
 pub use risc0_zkp::core::digest::Digest;
 mod error;
@@ -19,6 +20,17 @@ pub mod receipt_claim;
 
 pub struct R0SuccinctPrecompile;
 pub use error::R0Error;
+
+// Matches risc0-zkvm's ALLOWED_CODE_MERKLE_DEPTH for the Poseidon2 control root.
+const POSEIDON2_CONTROL_MERKLE_DEPTH: usize = 8;
+
+/// Returns the control Merkle tree depth for the supported RISC0 hash function.
+fn control_merkle_depth_for(hashfn: HashFnId) -> usize {
+    match hashfn {
+        HashFnId::Poseidon2 => POSEIDON2_CONTROL_MERKLE_DEPTH,
+        HashFnId::Blake2b | HashFnId::Sha256 => unreachable!("unsupported hashfn was checked above"),
+    }
+}
 
 fn parse_digest(bytes: impl AsRef<[u8]>) -> Result<Digest, R0Error> {
     let bytes = bytes.as_ref();
@@ -80,15 +92,28 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     /// - control inclusion proof digests (bytes)
     /// - control index (bytes, u32 le)
     /// - claim (bytes)
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, flags: EngineFlags) -> Result<(), Self::Error> {
         let [claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn] = dstack.pop_raw()?;
 
         let control_id = parse_digest(control_id)?;
         let seal = parse_seal(seal)?;
         let claim = parse_digest(claim)?;
         let hashfn = parse_hashfn(hashfn)?;
+
+        // For now we only support the poseidon2 hashfn.
+        // See usage of poseidon2's ALLOWED_CONTROL_ROOT within verify_integrity::check_code
+        if hashfn != HashFnId::Poseidon2 {
+            return Err(R0Error::UnsupportedHashFn(hashfn));
+        }
+
         let control_index = parse_merkle_index(control_index)?;
         let control_digests = parse_digest_list(control_digests)?;
+
+        let max_control_proof_len = control_merkle_depth_for(hashfn);
+        if flags.zk_hardening_enabled && control_digests.len() > max_control_proof_len {
+            return Err(R0Error::ControlInclusionProofTooLong { actual: control_digests.len(), max: max_control_proof_len });
+        }
+
         let control_inclusion_proof = MerkleProof { index: control_index, digests: control_digests };
         let rcpt = SuccinctReceipt::new(seal, control_id, claim, hashfn, control_inclusion_proof);
 
@@ -109,7 +134,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
         // If we were to bypass the compute_assert_claim step, then an attacker could modify the claim in the receipt
         // to match whatever they want and just providing some arbitrary proof. This is why this step is crucial.
         // As this step binds that the provided image id and journal are indeed the ones that were used to generate the proof.
-        compute_assert_claim(rcpt.claim(), image_id, journal).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))?;
+        compute_assert_claim(rcpt.claim(), image_id, journal)?;
 
         Ok(())
     }

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    EngineFlags,
     data_stack::Stack,
     runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{
@@ -81,8 +80,6 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     type Error = R0Error;
     /// Verifies the integrity of a RISC0 succinct proof receipt.
     ///
-    /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
-    ///
     /// Expects the following items on the stack (from top to bottom):
     /// - hash function id (bytes, u8)
     /// - control id (bytes, digest length)
@@ -92,7 +89,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     /// - control inclusion proof digests (bytes)
     /// - control index (bytes, u32 le)
     /// - claim (bytes)
-    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter, _flags: EngineFlags) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error> {
         let [claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn] = dstack.pop_raw()?;
 
         let control_id = parse_digest(control_id)?;

--- a/crypto/txscript/src/zk_precompiles/tests/helpers.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/helpers.rs
@@ -1,14 +1,22 @@
-use kaspa_consensus_core::{hashing::sighash::SigHashReusedValuesUnsync, tx::PopulatedTransaction};
+use kaspa_consensus_core::{
+    hashing::sighash::SigHashReusedValuesUnsync,
+    tx::{PopulatedTransaction, Transaction, TransactionId, TransactionInput, TransactionOutpoint, UtxoEntry},
+};
 use kaspa_txscript_errors::TxScriptError;
 
 use crate::{
-    EngineFlags, SigCacheKey, TxScriptEngine,
+    EngineCtx, EngineFlags, SigCacheKey, TxScriptEngine,
     caches::Cache,
     hex,
     opcodes::codes::OpZkPrecompile,
+    pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags,
     script_builder::{ScriptBuilder, ScriptBuilderResult},
     zk_precompiles::tags::ZkTag,
 };
+
+pub fn zk_test_flags() -> EngineFlags {
+    EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
+}
 
 pub fn build_zk_script(elements: &[&[u8]]) -> ScriptBuilderResult<Vec<u8>> {
     let mut builder = ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
@@ -24,12 +32,45 @@ pub fn execute_zk_script(
     sig_cache: &Cache<SigCacheKey, bool>,
     reused_values: &SigHashReusedValuesUnsync,
 ) -> Result<(), TxScriptError> {
-    let mut vm = TxScriptEngine::<PopulatedTransaction, SigHashReusedValuesUnsync>::from_script(
+    execute_zk_script_with_flags(
         script,
-        reused_values,
         sig_cache,
-        EngineFlags { covenants_enabled: true, ..Default::default() },
+        reused_values,
+        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() },
+    )
+}
+
+pub fn execute_zk_script_with_flags(
+    script: &[u8],
+    sig_cache: &Cache<SigCacheKey, bool>,
+    reused_values: &SigHashReusedValuesUnsync,
+    flags: EngineFlags,
+) -> Result<(), TxScriptError> {
+    let mut vm =
+        TxScriptEngine::<PopulatedTransaction, SigHashReusedValuesUnsync>::from_script(script, reused_values, sig_cache, flags);
+    vm.execute()
+}
+
+pub fn execute_p2sh_script(
+    signature_script: Vec<u8>,
+    redeem_script: &[u8],
+    sig_cache: &Cache<SigCacheKey, bool>,
+    reused_values: &SigHashReusedValuesUnsync,
+) -> Result<(), TxScriptError> {
+    let outpoint = TransactionOutpoint::new(TransactionId::default(), 0);
+    let input = TransactionInput::new_with_compute_budget(outpoint, signature_script, 0, 0);
+    let utxo = UtxoEntry::new(20_000, pay_to_script_hash_script(redeem_script), 0, false, None);
+    let tx = Transaction::new(1, vec![input], vec![], 0, Default::default(), 0, vec![]);
+    let populated_tx = PopulatedTransaction::new(&tx, vec![utxo.clone()]);
+    let mut vm = TxScriptEngine::from_transaction_input(
+        &populated_tx,
+        &populated_tx.tx.inputs[0],
+        0,
+        &utxo,
+        EngineCtx::new(sig_cache).with_reused(reused_values),
+        zk_test_flags(),
     );
+
     vm.execute()
 }
 
@@ -65,32 +106,135 @@ pub fn load_stark_fields() -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<
     )
 }
 
-pub fn build_stark_script(break_control_id: bool) -> Vec<u8> {
-    let (control_id, seal, claim, hashfn, control_index, control_digests, journal, image_id) = load_stark_fields();
-    let stark_tag = ZkTag::R0Succinct as u8;
-    if break_control_id {
-        let mut broken_control_id = control_id.clone();
-        broken_control_id[0] ^= 0xFF;
-        return build_zk_script(&[
-            &claim,
-            &control_index,
-            &control_digests,
-            &seal,
-            &journal,
-            &image_id,
-            &broken_control_id,
-            &hashfn,
-            &[stark_tag],
-        ])
-        .unwrap();
+#[derive(Clone, Debug)]
+pub struct R0Fields {
+    pub claim: Vec<u8>,
+    pub control_index: Vec<u8>,
+    pub control_digests: Vec<u8>,
+    pub seal: Vec<u8>,
+    pub journal: Vec<u8>,
+    pub image_id: Vec<u8>,
+    pub control_id: Vec<u8>,
+    pub hashfn: Vec<u8>,
+}
+
+impl R0Fields {
+    pub fn from_fixture() -> Self {
+        let (control_id, seal, claim, hashfn, control_index, control_digests, journal, image_id) = load_stark_fields();
+        Self { claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn }
     }
-    build_zk_script(&[&claim, &control_index, &control_digests, &seal, &journal, &image_id, &control_id, &hashfn, &[stark_tag]])
+
+    pub fn script(&self) -> Vec<u8> {
+        build_zk_script(&[
+            &self.claim,
+            &self.control_index,
+            &self.control_digests,
+            &self.seal,
+            &self.journal,
+            &self.image_id,
+            &self.control_id,
+            &self.hashfn,
+            &[ZkTag::R0Succinct as u8],
+        ])
         .unwrap()
+    }
+
+    pub fn p2sh_redeem_script(&self) -> Vec<u8> {
+        let mut builder = ScriptBuilder::with_flags(zk_test_flags());
+        builder
+            .add_data(&self.image_id)
+            .unwrap()
+            .add_data(&self.control_id)
+            .unwrap()
+            .add_data(&self.hashfn)
+            .unwrap()
+            .add_data(&[ZkTag::R0Succinct as u8])
+            .unwrap()
+            .add_op(OpZkPrecompile)
+            .unwrap()
+            .drain()
+    }
+
+    pub fn p2sh_signature_script(&self, redeem_script: Vec<u8>) -> Vec<u8> {
+        let mut signature = ScriptBuilder::with_flags(zk_test_flags());
+        signature
+            .add_data(&self.claim)
+            .unwrap()
+            .add_data(&self.control_index)
+            .unwrap()
+            .add_data(&self.control_digests)
+            .unwrap()
+            .add_data(&self.seal)
+            .unwrap()
+            .add_data(&self.journal)
+            .unwrap();
+
+        pay_to_script_hash_signature_script_with_flags(redeem_script, signature.drain(), zk_test_flags()).unwrap()
+    }
+
+    pub fn p2sh_scripts(&self) -> (Vec<u8>, Vec<u8>) {
+        let redeem_script = self.p2sh_redeem_script();
+        let signature_script = self.p2sh_signature_script(redeem_script.clone());
+        (signature_script, redeem_script)
+    }
+}
+
+pub fn build_stark_script(break_control_id: bool) -> Vec<u8> {
+    let mut fields = R0Fields::from_fixture();
+    if break_control_id {
+        fields.control_id[0] ^= 0xFF;
+    }
+    fields.script()
 }
 
 pub fn build_groth_script() -> Vec<u8> {
     let (unprepared_compressed_vk, groth16_proof_bytes, inputs) = load_groth_fields();
     build_groth_script_from_fields(&unprepared_compressed_vk, &groth16_proof_bytes, &inputs)
+}
+
+#[derive(Clone, Debug)]
+pub struct Groth16Fields {
+    pub vk: Vec<u8>,
+    pub proof: Vec<u8>,
+    pub inputs: Vec<Vec<u8>>,
+}
+
+impl Groth16Fields {
+    pub fn from_fixture() -> Self {
+        let (vk, proof, inputs) = load_groth_fields();
+        Self { vk, proof, inputs }
+    }
+
+    pub fn script(&self) -> Vec<u8> {
+        build_groth_script_from_fields(&self.vk, &self.proof, &self.inputs)
+    }
+
+    pub fn p2sh_redeem_script(&self) -> Vec<u8> {
+        ScriptBuilder::with_flags(zk_test_flags())
+            .add_data(&self.vk)
+            .unwrap()
+            .add_data(&[ZkTag::Groth16 as u8])
+            .unwrap()
+            .add_op(OpZkPrecompile)
+            .unwrap()
+            .drain()
+    }
+
+    pub fn p2sh_signature_script(&self, redeem_script: Vec<u8>) -> Vec<u8> {
+        let mut signature = ScriptBuilder::with_flags(zk_test_flags());
+        for input in self.inputs.iter().rev() {
+            signature.add_data(input).unwrap();
+        }
+        signature.add_i64(self.inputs.len() as i64).unwrap().add_data(&self.proof).unwrap();
+
+        pay_to_script_hash_signature_script_with_flags(redeem_script, signature.drain(), zk_test_flags()).unwrap()
+    }
+
+    pub fn p2sh_scripts(&self) -> (Vec<u8>, Vec<u8>) {
+        let redeem_script = self.p2sh_redeem_script();
+        let signature_script = self.p2sh_signature_script(redeem_script.clone());
+        (signature_script, redeem_script)
+    }
 }
 
 pub fn build_groth_script_from_fields(unprepared_compressed_vk: &[u8], groth16_proof_bytes: &[u8], inputs: &[Vec<u8>]) -> Vec<u8> {

--- a/crypto/txscript/src/zk_precompiles/tests/helpers.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/helpers.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub fn zk_test_flags() -> EngineFlags {
-    EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
+    EngineFlags { covenants_enabled: true, ..Default::default() }
 }
 
 pub fn build_zk_script(elements: &[&[u8]]) -> ScriptBuilderResult<Vec<u8>> {
@@ -32,12 +32,7 @@ pub fn execute_zk_script(
     sig_cache: &Cache<SigCacheKey, bool>,
     reused_values: &SigHashReusedValuesUnsync,
 ) -> Result<(), TxScriptError> {
-    execute_zk_script_with_flags(
-        script,
-        sig_cache,
-        reused_values,
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() },
-    )
+    execute_zk_script_with_flags(script, sig_cache, reused_values, EngineFlags { covenants_enabled: true, ..Default::default() })
 }
 
 pub fn execute_zk_script_with_flags(

--- a/crypto/txscript/src/zk_precompiles/tests/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/mod.rs
@@ -4,10 +4,9 @@ pub mod helpers;
 mod fast_zk_tests {
     use super::helpers::{
         Groth16Fields, R0Fields, build_groth_script, build_groth_script_from_fields, build_stark_script, execute_p2sh_script,
-        execute_zk_script, execute_zk_script_with_flags, load_groth_fields, load_stark_fields,
+        execute_zk_script, load_groth_fields, load_stark_fields,
     };
     use crate::{
-        EngineFlags,
         caches::Cache,
         get_zk_script_units_upper_bound,
         zk_precompiles::{groth16::Groth16Error, tags::ZkTag},
@@ -694,7 +693,7 @@ mod fast_zk_tests {
     }
 
     #[test]
-    fn verify_r0_succinct_long_control_proof_gated() {
+    fn verify_r0_succinct_long_control_proof_rejected() {
         let mut fields = R0Fields::from_fixture();
         fields.control_digests.extend_from_slice(&[0; risc0_zkp::core::digest::DIGEST_BYTES]);
         let script = fields.script();
@@ -702,72 +701,9 @@ mod fast_zk_tests {
         let reused_values = SigHashReusedValuesUnsync::new();
 
         expect_zk_err(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()),
-            "legacy long control proof",
-            ExpectedZkError::StartsWith("R0: control_id mismatch:"),
-        );
-        expect_zk_err(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened long control proof",
+            execute_zk_script(&script, &cache, &reused_values),
+            "long control proof",
             ExpectedZkError::Exact("Control inclusion proof length 9 exceeds maximum 8"),
         );
-    }
-
-    fn legacy_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
-    }
-
-    fn hardened_flags() -> EngineFlags {
-        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
-    }
-
-    #[test]
-    fn groth16_extra_public_input_silently_accepted_pre_activation_rejected_post() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs.push(inputs[0].clone()); // extra public input that ark will silently drop
-
-        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-
-        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
-            .expect("legacy path silently accepts the extra public input (the bug)");
-
-        expect_groth16_arity_mismatch(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened arity",
-        );
-    }
-
-    #[test]
-    fn groth16_missing_public_input_gated_error_kind() {
-        let (vk, proof, mut inputs) = load_groth_fields();
-        inputs.pop();
-
-        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-
-        match execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()) {
-            Err(TxScriptError::ZkIntegrity(msg)) => {
-                let arity = Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string();
-                assert_ne!(msg, arity, "legacy path must not surface ArityMismatch (no upfront check)");
-            }
-            other => panic!("legacy: expected ZkIntegrity error from verify failure, got {other:?}"),
-        }
-
-        expect_groth16_arity_mismatch(
-            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
-            "hardened missing input",
-        );
-    }
-
-    #[test]
-    fn groth16_canonical_proof_verifies_under_legacy_flags() {
-        let script = build_groth_script();
-        let cache = Cache::new(0);
-        let reused_values = SigHashReusedValuesUnsync::new();
-        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
-            .expect("legacy Groth16 path must accept canonical proof");
     }
 }

--- a/crypto/txscript/src/zk_precompiles/tests/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/mod.rs
@@ -3,15 +3,17 @@ pub mod helpers;
 #[cfg(test)]
 mod fast_zk_tests {
     use super::helpers::{
-        build_groth_script, build_groth_script_from_fields, build_stark_script, build_zk_script, execute_zk_script, load_groth_fields,
-        load_stark_fields,
+        Groth16Fields, R0Fields, build_groth_script, build_groth_script_from_fields, build_stark_script, execute_p2sh_script,
+        execute_zk_script, execute_zk_script_with_flags, load_groth_fields, load_stark_fields,
     };
     use crate::{
+        EngineFlags,
         caches::Cache,
         get_zk_script_units_upper_bound,
         zk_precompiles::{groth16::Groth16Error, tags::ZkTag},
     };
-    use ark_groth16::VerifyingKey;
+    use ark_bn254::{Bn254, G1Affine};
+    use ark_groth16::{Proof, VerifyingKey};
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
     use kaspa_consensus_core::{
         hashing::sighash::SigHashReusedValuesUnsync,
@@ -22,24 +24,21 @@ mod fast_zk_tests {
     use risc0_zkp::adapter::CircuitInfo;
 
     fn r0_script_with_seal(seal: &[u8]) -> Vec<u8> {
-        let (control_id, _, claim, hashfn, control_index, control_digests, journal, image_id) = load_stark_fields();
-        let stark_tag = ZkTag::R0Succinct as u8;
-        build_zk_script(&[&claim, &control_index, &control_digests, seal, &journal, &image_id, &control_id, &hashfn, &[stark_tag]])
-            .unwrap()
+        let mut fields = R0Fields::from_fixture();
+        fields.seal = seal.to_vec();
+        fields.script()
     }
 
     fn r0_script_with_control_digests(control_digests: &[u8]) -> Vec<u8> {
-        let (control_id, seal, claim, hashfn, control_index, _, journal, image_id) = load_stark_fields();
-        let stark_tag = ZkTag::R0Succinct as u8;
-        build_zk_script(&[&claim, &control_index, control_digests, &seal, &journal, &image_id, &control_id, &hashfn, &[stark_tag]])
-            .unwrap()
+        let mut fields = R0Fields::from_fixture();
+        fields.control_digests = control_digests.to_vec();
+        fields.script()
     }
 
     fn r0_script_with_control_id(control_id: &[u8]) -> Vec<u8> {
-        let (_, seal, claim, hashfn, control_index, control_digests, journal, image_id) = load_stark_fields();
-        let stark_tag = ZkTag::R0Succinct as u8;
-        build_zk_script(&[&claim, &control_index, &control_digests, &seal, &journal, &image_id, control_id, &hashfn, &[stark_tag]])
-            .unwrap()
+        let mut fields = R0Fields::from_fixture();
+        fields.control_id = control_id.to_vec();
+        fields.script()
     }
 
     fn words_to_le_bytes(words: &[u32]) -> Vec<u8> {
@@ -52,6 +51,79 @@ mod fast_zk_tests {
             Err(e) => panic!("{case}: expected R0 receipt format error, got {e:?}"),
             Ok(_) => panic!("{case}: expected R0 receipt format error, got success"),
         }
+    }
+
+    #[derive(Copy, Clone)]
+    enum ExpectedZkError {
+        Exact(&'static str),
+        StartsWith(&'static str),
+        Groth16ArityMismatch,
+    }
+
+    type R0FailureCase = (&'static str, fn(&mut R0Fields), ExpectedZkError);
+    type Groth16FailureCase = (&'static str, fn(&mut Groth16Fields), ExpectedZkError);
+
+    fn expect_zk_err(result: Result<(), TxScriptError>, case: &str, expected: ExpectedZkError) {
+        match (result, expected) {
+            (Err(TxScriptError::ZkIntegrity(e)), ExpectedZkError::Exact(expected)) if e == expected => {}
+            (Err(TxScriptError::ZkIntegrity(e)), ExpectedZkError::StartsWith(expected)) if e.starts_with(expected) => {}
+            (Err(TxScriptError::ZkIntegrity(e)), ExpectedZkError::Groth16ArityMismatch)
+                if e == Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string() => {}
+            (Err(e), ExpectedZkError::Exact(expected)) => panic!("{case}: expected ZkIntegrity({expected:?}), got {e:?}"),
+            (Err(e), ExpectedZkError::StartsWith(expected)) => {
+                panic!("{case}: expected ZkIntegrity prefix {expected:?}, got {e:?}")
+            }
+            (Err(e), ExpectedZkError::Groth16ArityMismatch) => panic!("{case}: expected Groth16 arity mismatch, got {e:?}"),
+            (Ok(()), _) => panic!("{case}: expected ZkIntegrity error, got success"),
+        }
+    }
+
+    fn set_seal_word(seal: &mut [u8], index: usize, word: u32) {
+        let start = index * core::mem::size_of::<u32>();
+        seal[start..start + core::mem::size_of::<u32>()].copy_from_slice(&word.to_le_bytes());
+    }
+
+    fn truncate_one_digest(bytes: &mut Vec<u8>) {
+        bytes.truncate(bytes.len() - risc0_zkp::core::digest::DIGEST_BYTES);
+    }
+
+    fn expect_groth16_arity_mismatch(result: Result<(), TxScriptError>, case: &str) {
+        let expected = Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string();
+        match result {
+            Err(TxScriptError::ZkIntegrity(e)) if e == expected => {}
+            Err(e) => panic!("{case}: expected Groth16 arity mismatch, got {e:?}"),
+            Ok(_) => panic!("{case}: expected Groth16 arity mismatch, got success"),
+        }
+    }
+
+    fn serialize_vk(vk: &VerifyingKey<Bn254>) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        vk.serialize_compressed(&mut bytes).expect("serialize VK");
+        bytes
+    }
+
+    fn serialize_proof(proof: &Proof<Bn254>) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        proof.serialize_compressed(&mut bytes).expect("serialize proof");
+        bytes
+    }
+
+    fn set_empty_gamma_abc(fields: &mut Groth16Fields) {
+        let mut vk = VerifyingKey::<Bn254>::deserialize_compressed(&*fields.vk).expect("fixture VK must deserialize");
+        vk.gamma_abc_g1.clear();
+        fields.vk = serialize_vk(&vk);
+    }
+
+    fn set_parseable_wrong_vk(fields: &mut Groth16Fields) {
+        let mut vk = VerifyingKey::<Bn254>::deserialize_compressed(&*fields.vk).expect("fixture VK must deserialize");
+        vk.alpha_g1 = G1Affine::default();
+        fields.vk = serialize_vk(&vk);
+    }
+
+    fn set_parseable_wrong_proof(fields: &mut Groth16Fields) {
+        let mut proof = Proof::<Bn254>::deserialize_compressed(&*fields.proof).expect("fixture proof must deserialize");
+        proof.a = G1Affine::default();
+        fields.proof = serialize_proof(&proof);
     }
 
     #[test]
@@ -86,29 +158,149 @@ mod fast_zk_tests {
     }
 
     #[test]
-    fn verify_groth16_missing_public_input_fails_verification() {
+    fn verify_groth16_missing_public_input_rejected() {
         let (vk, proof, mut inputs) = load_groth_fields();
         inputs.pop();
         let script = build_groth_script_from_fields(&vk, &proof, &inputs);
         let cache = Cache::new(0);
         let reused_values = SigHashReusedValuesUnsync::new();
 
-        match execute_zk_script(&script, &cache, &reused_values) {
-            Err(TxScriptError::ZkIntegrity(e)) if e == Groth16Error::VerificationFailed.to_string() => {}
-            Err(e) => panic!("expected Groth16 verification failure, got {e:?}"),
-            Ok(_) => panic!("missing public input should fail verification"),
-        }
+        expect_groth16_arity_mismatch(execute_zk_script(&script, &cache, &reused_values), "missing public input");
     }
 
     #[test]
-    fn verify_groth16_extra_public_input_currently_accepted() {
+    fn verify_groth16_extra_public_input_rejected() {
         let (vk, proof, mut inputs) = load_groth_fields();
         inputs.push(inputs[0].clone());
         let script = build_groth_script_from_fields(&vk, &proof, &inputs);
         let cache = Cache::new(0);
         let reused_values = SigHashReusedValuesUnsync::new();
 
-        execute_zk_script(&script, &cache, &reused_values).unwrap();
+        expect_groth16_arity_mismatch(execute_zk_script(&script, &cache, &reused_values), "extra public input");
+    }
+
+    #[test]
+    fn verify_groth16_failure_matrix() {
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+        let cases: &[Groth16FailureCase] = &[
+            (
+                "missing public input",
+                |fields| {
+                    fields.inputs.pop();
+                },
+                ExpectedZkError::Groth16ArityMismatch,
+            ),
+            (
+                "extra public input",
+                |fields| {
+                    fields.inputs.push(fields.inputs[0].clone());
+                },
+                ExpectedZkError::Groth16ArityMismatch,
+            ),
+            (
+                "short public input",
+                |fields| {
+                    fields.inputs[0].pop();
+                },
+                ExpectedZkError::StartsWith("Kaspa txscript error: ZK Integrity: Invalid Fr length:"),
+            ),
+            (
+                "long public input",
+                |fields| {
+                    fields.inputs[0].push(0);
+                },
+                ExpectedZkError::StartsWith("Kaspa txscript error: ZK Integrity: Invalid Fr length:"),
+            ),
+            (
+                "out of field public input",
+                |fields| {
+                    fields.inputs[0] = vec![0xff; 32];
+                },
+                ExpectedZkError::StartsWith("Kaspa txscript error: ZK Integrity: ARK serialization error:"),
+            ),
+            (
+                "truncated vk",
+                |fields| {
+                    fields.vk.pop();
+                },
+                ExpectedZkError::StartsWith("ARK serialization error:"),
+            ),
+            (
+                "trailing vk bytes",
+                |fields| {
+                    fields.vk.push(0);
+                },
+                ExpectedZkError::Exact("Groth16 verifying key has trailing bytes"),
+            ),
+            ("empty gamma_abc_g1", set_empty_gamma_abc, ExpectedZkError::Exact("Groth16 verifying key has empty gamma_abc_g1")),
+            ("wrong vk", set_parseable_wrong_vk, ExpectedZkError::Exact("Groth16 verification failed")),
+            (
+                "truncated proof",
+                |fields| {
+                    fields.proof.pop();
+                },
+                ExpectedZkError::StartsWith("ARK serialization error:"),
+            ),
+            (
+                "trailing proof bytes",
+                |fields| {
+                    fields.proof.push(0);
+                },
+                ExpectedZkError::Exact("Groth16 proof has trailing bytes"),
+            ),
+            ("wrong proof", set_parseable_wrong_proof, ExpectedZkError::Exact("Groth16 verification failed")),
+            (
+                "public input binding",
+                |fields| {
+                    fields.inputs[0][0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Groth16 verification failed"),
+            ),
+        ];
+
+        let fixture = Groth16Fields::from_fixture();
+        for (case, mutate, expected) in cases {
+            let mut fields = fixture.clone();
+            mutate(&mut fields);
+            expect_zk_err(execute_zk_script(&fields.script(), &cache, &reused_values), case, *expected);
+        }
+    }
+
+    #[test]
+    fn verify_groth16_p2sh_vk_in_redeem_script_verifies() {
+        let fields = Groth16Fields::from_fixture();
+        let (signature_script, redeem_script) = fields.p2sh_scripts();
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+
+        execute_p2sh_script(signature_script, &redeem_script, &cache, &reused_values)
+            .expect("P2SH Groth16 proof should verify with VK in redeem script");
+    }
+
+    #[test]
+    fn verify_groth16_p2sh_binding_matrix() {
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+        let cases: &[Groth16FailureCase] = &[
+            ("vk binding", set_parseable_wrong_vk, ExpectedZkError::Exact("Groth16 verification failed")),
+            ("proof binding", set_parseable_wrong_proof, ExpectedZkError::Exact("Groth16 verification failed")),
+            (
+                "public input binding",
+                |fields| {
+                    fields.inputs[0][0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Groth16 verification failed"),
+            ),
+        ];
+
+        let fixture = Groth16Fields::from_fixture();
+        for (case, mutate, expected) in cases {
+            let mut fields = fixture.clone();
+            mutate(&mut fields);
+            let (signature_script, redeem_script) = fields.p2sh_scripts();
+            expect_zk_err(execute_p2sh_script(signature_script, &redeem_script, &cache, &reused_values), case, *expected);
+        }
     }
 
     #[test]
@@ -144,6 +336,258 @@ mod fast_zk_tests {
             },
         }
     }
+
+    #[test]
+    fn verify_r0_succinct_direct_failure_matrix() {
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+        let cases: &[R0FailureCase] = &[
+            (
+                "claim length",
+                |fields| {
+                    fields.claim.pop();
+                },
+                ExpectedZkError::Exact("Invalid digest length: 31"),
+            ),
+            (
+                "journal length",
+                |fields| {
+                    fields.journal.pop();
+                },
+                ExpectedZkError::Exact("Invalid digest length: 31"),
+            ),
+            (
+                "image id length",
+                |fields| {
+                    fields.image_id.pop();
+                },
+                ExpectedZkError::Exact("Invalid digest length: 31"),
+            ),
+            (
+                "control id length",
+                |fields| {
+                    fields.control_id.pop();
+                },
+                ExpectedZkError::Exact("Invalid digest length: 31"),
+            ),
+            (
+                "empty hashfn",
+                |fields| {
+                    fields.hashfn.clear();
+                },
+                ExpectedZkError::Exact("Invalid hash function encoding length: 0"),
+            ),
+            (
+                "long hashfn",
+                |fields| {
+                    fields.hashfn.push(0);
+                },
+                ExpectedZkError::Exact("Invalid hash function encoding length: 2"),
+            ),
+            (
+                "unknown hashfn",
+                |fields| {
+                    fields.hashfn[0] = 3;
+                },
+                ExpectedZkError::Exact("Invalid hash function id: 3"),
+            ),
+            (
+                "blake2b hashfn",
+                |fields| {
+                    fields.hashfn[0] = 0;
+                },
+                ExpectedZkError::Exact("Unsupported hash function: Blake2b"),
+            ),
+            (
+                "sha256 hashfn",
+                |fields| {
+                    fields.hashfn[0] = 2;
+                },
+                ExpectedZkError::Exact("Unsupported hash function: Sha256"),
+            ),
+            (
+                "unaligned seal",
+                |fields| {
+                    fields.seal.push(0);
+                },
+                ExpectedZkError::StartsWith("Invalid seal length:"),
+            ),
+            (
+                "control index length",
+                |fields| {
+                    fields.control_index.pop();
+                },
+                ExpectedZkError::Exact("Invalid merkle index length: 3"),
+            ),
+            (
+                "control digests length",
+                |fields| {
+                    fields.control_digests.push(0);
+                },
+                ExpectedZkError::StartsWith("Invalid digest list length:"),
+            ),
+            (
+                "claim binding",
+                |fields| {
+                    fields.claim[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("R0: journal digest mismatch detected"),
+            ),
+            (
+                "image id binding",
+                |fields| {
+                    fields.image_id[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Verification failed"),
+            ),
+            (
+                "journal binding",
+                |fields| {
+                    fields.journal[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Verification failed"),
+            ),
+            (
+                "control id binding",
+                |fields| {
+                    fields.control_id[0] ^= 0x01;
+                },
+                ExpectedZkError::StartsWith("R0: control_id mismatch:"),
+            ),
+            (
+                "control index binding",
+                |fields| {
+                    fields.control_index[0] ^= 0x01;
+                },
+                ExpectedZkError::StartsWith("R0: control_id mismatch:"),
+            ),
+            (
+                "control proof missing sibling",
+                |fields| {
+                    truncate_one_digest(&mut fields.control_digests);
+                },
+                ExpectedZkError::StartsWith("R0: control_id mismatch:"),
+            ),
+            (
+                "control proof extra sibling",
+                |fields| {
+                    fields.control_digests.extend_from_slice(&[0; risc0_zkp::core::digest::DIGEST_BYTES]);
+                },
+                ExpectedZkError::Exact("Control inclusion proof length 9 exceeds maximum 8"),
+            ),
+            (
+                "empty seal",
+                |fields| {
+                    fields.seal.clear();
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "short seal",
+                |fields| {
+                    fields.seal = words_to_le_bytes(&[0; CircuitImpl::OUTPUT_SIZE]);
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "first output elem at modulus",
+                |fields| {
+                    set_seal_word(&mut fields.seal, 0, risc0_zkp::field::baby_bear::P);
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "po2 elem above max",
+                |fields| {
+                    set_seal_word(&mut fields.seal, CircuitImpl::OUTPUT_SIZE, (risc0_zkp::MAX_CYCLES_PO2 + 1) as u32);
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "truncated proof after header",
+                |fields| {
+                    fields.seal.truncate((CircuitImpl::OUTPUT_SIZE + 1) * core::mem::size_of::<u32>());
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "trailing seal word",
+                |fields| {
+                    fields.seal.extend_from_slice(&0u32.to_le_bytes());
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+            (
+                "invalid seal merkle digest",
+                |fields| {
+                    set_seal_word(&mut fields.seal, CircuitImpl::OUTPUT_SIZE + 1, risc0_zkp::field::baby_bear::P);
+                },
+                ExpectedZkError::Exact("R0: invalid receipt format"),
+            ),
+        ];
+
+        let fixture = R0Fields::from_fixture();
+        for (case, mutate, expected) in cases {
+            let mut fields = fixture.clone();
+            mutate(&mut fields);
+            expect_zk_err(execute_zk_script(&fields.script(), &cache, &reused_values), case, *expected);
+        }
+    }
+
+    #[test]
+    fn verify_r0_succinct_p2sh_split_stack_verifies() {
+        let fields = R0Fields::from_fixture();
+        let (signature_script, redeem_script) = fields.p2sh_scripts();
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+
+        execute_p2sh_script(signature_script, &redeem_script, &cache, &reused_values).expect("split P2SH R0 proof should verify");
+    }
+
+    #[test]
+    fn verify_r0_succinct_p2sh_binding_matrix() {
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+        let cases: &[R0FailureCase] = &[
+            (
+                "claim binding",
+                |fields| {
+                    fields.claim[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("R0: journal digest mismatch detected"),
+            ),
+            (
+                "journal binding",
+                |fields| {
+                    fields.journal[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Verification failed"),
+            ),
+            (
+                "image id binding",
+                |fields| {
+                    fields.image_id[0] ^= 0x01;
+                },
+                ExpectedZkError::Exact("Verification failed"),
+            ),
+            (
+                "control id binding",
+                |fields| {
+                    fields.control_id[0] ^= 0x01;
+                },
+                ExpectedZkError::StartsWith("R0: control_id mismatch:"),
+            ),
+        ];
+
+        let fixture = R0Fields::from_fixture();
+        for (case, mutate, expected) in cases {
+            let mut fields = fixture.clone();
+            mutate(&mut fields);
+            let (signature_script, redeem_script) = fields.p2sh_scripts();
+            expect_zk_err(execute_p2sh_script(signature_script, &redeem_script, &cache, &reused_values), case, *expected);
+        }
+    }
+
     #[test]
     fn test_r0_succinct_not_field_elem() {
         let (_, seal, _, _, _, _, _, _) = load_stark_fields();
@@ -247,5 +691,83 @@ mod fast_zk_tests {
         let reused_values = SigHashReusedValuesUnsync::new();
 
         expect_r0_receipt_format_err(execute_zk_script(&script, &cache, &reused_values), "invalid seal Merkle digest");
+    }
+
+    #[test]
+    fn verify_r0_succinct_long_control_proof_gated() {
+        let mut fields = R0Fields::from_fixture();
+        fields.control_digests.extend_from_slice(&[0; risc0_zkp::core::digest::DIGEST_BYTES]);
+        let script = fields.script();
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+
+        expect_zk_err(
+            execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()),
+            "legacy long control proof",
+            ExpectedZkError::StartsWith("R0: control_id mismatch:"),
+        );
+        expect_zk_err(
+            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
+            "hardened long control proof",
+            ExpectedZkError::Exact("Control inclusion proof length 9 exceeds maximum 8"),
+        );
+    }
+
+    fn legacy_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, zk_hardening_enabled: false, ..Default::default() }
+    }
+
+    fn hardened_flags() -> EngineFlags {
+        EngineFlags { covenants_enabled: true, zk_hardening_enabled: true, ..Default::default() }
+    }
+
+    #[test]
+    fn groth16_extra_public_input_silently_accepted_pre_activation_rejected_post() {
+        let (vk, proof, mut inputs) = load_groth_fields();
+        inputs.push(inputs[0].clone()); // extra public input that ark will silently drop
+
+        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+
+        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
+            .expect("legacy path silently accepts the extra public input (the bug)");
+
+        expect_groth16_arity_mismatch(
+            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
+            "hardened arity",
+        );
+    }
+
+    #[test]
+    fn groth16_missing_public_input_gated_error_kind() {
+        let (vk, proof, mut inputs) = load_groth_fields();
+        inputs.pop();
+
+        let script = build_groth_script_from_fields(&vk, &proof, &inputs);
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+
+        match execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags()) {
+            Err(TxScriptError::ZkIntegrity(msg)) => {
+                let arity = Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string();
+                assert_ne!(msg, arity, "legacy path must not surface ArityMismatch (no upfront check)");
+            }
+            other => panic!("legacy: expected ZkIntegrity error from verify failure, got {other:?}"),
+        }
+
+        expect_groth16_arity_mismatch(
+            execute_zk_script_with_flags(&script, &cache, &reused_values, hardened_flags()),
+            "hardened missing input",
+        );
+    }
+
+    #[test]
+    fn groth16_canonical_proof_verifies_under_legacy_flags() {
+        let script = build_groth_script();
+        let cache = Cache::new(0);
+        let reused_values = SigHashReusedValuesUnsync::new();
+        execute_zk_script_with_flags(&script, &cache, &reused_values, legacy_flags())
+            .expect("legacy Groth16 path must accept canonical proof");
     }
 }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -16,7 +16,7 @@ faster-hex.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 kaspa-hashes.workspace = true
-kaspa-utils = { workspace = true, features = ["mem_size"]}
+kaspa-utils = { workspace = true, features = ["mem_size", "fd_budget"]}
 num_cpus.workspace = true
 num-traits.workspace = true
 parking_lot.workspace = true

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -98,15 +98,8 @@ struct CountdownActivation {
 }
 
 impl CountdownActivation {
-    fn latest(toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) -> Self {
-        [
-            Self { name: "Toccata", activation: toccata_activation },
-            Self { name: "Toccata ZK hardening", activation: zk_hardening_activation },
-        ]
-        .into_iter()
-        .filter(|candidate| candidate.activation != ForkActivation::never())
-        .max_by_key(|candidate| candidate.activation.daa_score())
-        .unwrap_or(Self { name: "Toccata", activation: ForkActivation::never() })
+    fn toccata(toccata_activation: ForkActivation) -> Self {
+        Self { name: "Toccata", activation: toccata_activation }
     }
 }
 
@@ -395,10 +388,7 @@ impl FlowContext {
                 tick_service,
                 notification_root,
                 user_agent_rules,
-                block_event_logger: Some(BlockEventLogger::new(
-                    bps,
-                    CountdownActivation::latest(config.toccata_activation, config.zk_hardening_activation),
-                )),
+                block_event_logger: Some(BlockEventLogger::new(bps, CountdownActivation::toccata(config.toccata_activation))),
                 bps,
                 orphan_resolution_range,
                 max_orphans,
@@ -840,7 +830,7 @@ impl ConnectionInitializer for FlowContext {
         let connect_only_new_versions = self.config.toccata_activation.is_active(virtual_daa_score.saturating_add(daa_threshold));
 
         // Until the one-day pre-activation threshold is reached, older protocol versions remain accepted.
-        // Once it is reached, peers must advertise protocol 10 (TN12 launch peers were normalized above).
+        // Once it is reached, peers must advertise protocol 10.
         //
         // Note: post-activation fresh nodes with virtual DAA score near genesis are not covered here and
         // are guarded later during IBD by `validate_pruning_point_freshness_for_toccata`.

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -13,7 +13,6 @@ use kaspa_consensus_core::api::{BlockValidationFuture, BlockValidationFutures};
 use kaspa_consensus_core::block::Block;
 use kaspa_consensus_core::config::{Config, params::ForkActivation};
 use kaspa_consensus_core::errors::block::RuleError;
-use kaspa_consensus_core::network::{NetworkId, NetworkType};
 use kaspa_consensus_core::tx::{Transaction, TransactionId};
 use kaspa_consensus_notify::{
     notification::{Notification, PruningPointUtxoSetOverrideNotification},
@@ -63,10 +62,6 @@ use uuid::Uuid;
 /// The P2P protocol version.
 const PROTOCOL_VERSION: u32 = 10;
 
-/// Testnet 12 was launched with the Toccata flow set under protocol version 9.
-const TN12_LAUNCH_PROTOCOL_VERSION: u32 = 9;
-const TN12_NETWORK: NetworkId = NetworkId::with_suffix(NetworkType::Testnet, 12);
-
 /// See `check_orphan_resolution_range`
 const BASELINE_ORPHAN_RESOLUTION_RANGE: u32 = 5;
 
@@ -91,15 +86,34 @@ pub enum BlockLogEvent {
 
 pub struct BlockEventLogger {
     bps: usize,
-    toccata_activation: ForkActivation,
+    countdown_activation: CountdownActivation,
     sender: UnboundedSender<BlockLogEvent>,
     receiver: Mutex<Option<UnboundedReceiver<BlockLogEvent>>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CountdownActivation {
+    name: &'static str,
+    activation: ForkActivation,
+}
+
+impl CountdownActivation {
+    fn latest(toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) -> Self {
+        [
+            Self { name: "Toccata", activation: toccata_activation },
+            Self { name: "Toccata ZK hardening", activation: zk_hardening_activation },
+        ]
+        .into_iter()
+        .filter(|candidate| candidate.activation != ForkActivation::never())
+        .max_by_key(|candidate| candidate.activation.daa_score())
+        .unwrap_or(Self { name: "Toccata", activation: ForkActivation::never() })
+    }
+}
+
 impl BlockEventLogger {
-    pub fn new(bps: usize, toccata_activation: ForkActivation) -> Self {
+    fn new(bps: usize, countdown_activation: CountdownActivation) -> Self {
         let (sender, receiver) = unbounded_channel();
-        Self { bps, toccata_activation, sender, receiver: Mutex::new(Some(receiver)) }
+        Self { bps, countdown_activation, sender, receiver: Mutex::new(Some(receiver)) }
     }
 
     pub fn log(&self, event: BlockLogEvent) {
@@ -110,7 +124,7 @@ impl BlockEventLogger {
     fn start(&self) {
         let chunk_limit = self.bps * 10; // We prefer that the 1 sec timeout forces the log, but nonetheless still want a reasonable bound on each chunk
         let receiver = self.receiver.lock().take().expect("expected to be called once");
-        let toccata_activation = self.toccata_activation;
+        let countdown_activation = self.countdown_activation;
         tokio::spawn(async move {
             let chunk_stream = UnboundedReceiverStream::new(receiver).chunks_timeout(chunk_limit, Duration::from_secs(1));
             tokio::pin!(chunk_stream);
@@ -146,10 +160,10 @@ impl BlockEventLogger {
                     }
                 }
 
-                fn toccata_countdown_suffix(toccata_activation: ForkActivation, daa_score: Option<u64>) -> String {
+                fn activation_countdown_suffix(countdown: CountdownActivation, daa_score: Option<u64>) -> String {
                     daa_score
-                        .and_then(|daa_score| toccata_activation.is_within_range_before_activation(daa_score, 36_000))
-                        .map(|dist| format!(" \t [Toccata countdown: -{}]", dist))
+                        .and_then(|daa_score| countdown.activation.is_within_range_before_activation(daa_score, 36_000))
+                        .map(|dist| format!(" \t [{} countdown: -{}]", countdown.name, dist))
                         .unwrap_or_default()
                 }
 
@@ -207,24 +221,24 @@ impl BlockEventLogger {
                     (1, 0) => info!(
                         "Accepted block {} via submit block{}",
                         summary.submit(),
-                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                     ),
                     (n, 0) => info!(
                         "Accepted {} blocks ...{} via submit block{}",
                         n,
                         summary.submit(),
-                        toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                     ),
                     (0, 1) => info!(
                         "Accepted block {} via relay{}",
                         summary.relay(),
-                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.relay_rep_daa_score())
                     ),
                     (0, m) => info!(
                         "Accepted {} blocks ...{} via relay{}",
                         m,
                         summary.relay(),
-                        toccata_countdown_suffix(toccata_activation, summary.relay_rep_daa_score())
+                        activation_countdown_suffix(countdown_activation, summary.relay_rep_daa_score())
                     ),
                     (n, m) => {
                         info!(
@@ -233,7 +247,7 @@ impl BlockEventLogger {
                             summary.submit(),
                             m,
                             n,
-                            toccata_countdown_suffix(toccata_activation, summary.submit_rep_daa_score())
+                            activation_countdown_suffix(countdown_activation, summary.submit_rep_daa_score())
                         )
                     }
                 }
@@ -381,7 +395,10 @@ impl FlowContext {
                 tick_service,
                 notification_root,
                 user_agent_rules,
-                block_event_logger: Some(BlockEventLogger::new(bps, config.toccata_activation)),
+                block_event_logger: Some(BlockEventLogger::new(
+                    bps,
+                    CountdownActivation::latest(config.toccata_activation, config.zk_hardening_activation),
+                )),
                 bps,
                 orphan_resolution_range,
                 max_orphans,
@@ -814,14 +831,7 @@ impl ConnectionInitializer for FlowContext {
 
         debug!("protocol versions - self: {}, peer: {}", PROTOCOL_VERSION, peer_version.protocol_version);
 
-        // TN12 launched Toccata flows under protocol 9. Normalize those peers to the current
-        // protocol locally while preserving the originally advertised version in peer properties.
-        let peer_protocol_version = if self.config.net == TN12_NETWORK && peer_version.protocol_version == TN12_LAUNCH_PROTOCOL_VERSION
-        {
-            PROTOCOL_VERSION
-        } else {
-            peer_version.protocol_version
-        };
+        let peer_protocol_version = peer_version.protocol_version;
 
         // One day before activation, upgraded nodes start disconnecting outdated peers from the P2P network.
         const ONE_DAY_SECONDS: u64 = 24 * 60 * 60;

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -760,8 +760,8 @@ impl ConnectionInitializer for FlowContext {
 
         let local_address = self.address_manager.lock().best_local_address();
 
-        // Networks with a scheduled Toccata activation advertise protocol 10. Other networks
-        // still support v10 locally, but advertise v9 so future Toccata-activated peers reject them.
+        // Networks with a scheduled Toccata activation advertise the current protocol version.
+        // Other networks still support v10 locally, but advertise v9 so future Toccata-activated peers reject them.
         let advertise_toccata_p2p = self.config.toccata_activation != ForkActivation::never();
         let advertised_protocol_version = if advertise_toccata_p2p { PROTOCOL_VERSION } else { 9 };
 

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -709,33 +709,22 @@ impl IbdFlow {
         // Phase 0: receive and verify metadata. Single 96-byte wire.
         let md = stream.recv_metadata().await?;
         let parent_header = consensus.async_get_header(pp_header.direct_parents()[0]).await.unwrap();
-        let pp_is_post_hardening = self.ctx.config.zk_hardening_activation.is_active(pp_header.daa_score);
 
-        // Post-hardening: derive the shortcut block via consensus (uses reachability + headers
-        // only; safe at the PP boundary before the SMT is imported). Then resolve to the
-        // seq_commit hash with the same fold-to-zero rule used by `inactivity_shortcut(block)`.
-        // The block hash is also passed to `import_pruning_point_smt` for the V1 metadata row.
-        let (shortcut_block, inactivity_shortcut) = if pp_is_post_hardening {
-            let block = consensus
-                .async_inactivity_shortcut_block_for_pov(pruning_point)
-                .await
-                .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
-            let shortcut = if block == self.ctx.config.genesis.hash {
-                kaspa_hashes::ZERO_HASH
-            } else {
-                let shortcut_header = consensus
-                    .async_get_header(block)
-                    .await
-                    .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
-                if !self.ctx.config.zk_hardening_activation.is_active(shortcut_header.daa_score) {
-                    kaspa_hashes::ZERO_HASH
-                } else {
-                    shortcut_header.accepted_id_merkle_root
-                }
-            };
-            (Some(block), Some(shortcut))
+        // Derive the shortcut block via consensus (uses reachability + headers only; safe at the PP
+        // boundary before the SMT is imported). Then resolve to the seqcommit hash with the same
+        // fold-to-zero rule used by `inactivity_shortcut(block)`.
+        let shortcut_block = consensus
+            .async_inactivity_shortcut_block_for_pov(pruning_point)
+            .await
+            .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
+        let shortcut_header = consensus
+            .async_get_header(shortcut_block)
+            .await
+            .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
+        let inactivity_shortcut = if !self.ctx.config.toccata_activation.is_active(shortcut_header.daa_score) {
+            kaspa_hashes::ZERO_HASH
         } else {
-            (None, None)
+            shortcut_header.accepted_id_merkle_root
         };
 
         verify_smt_metadata(

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -706,32 +706,57 @@ impl IbdFlow {
 
         let mut stream = SmtStream::new(&self.router, &mut self.incoming_route);
 
-        // Phase 0: receive and verify metadata
+        // Phase 0: receive and verify metadata. Single 96-byte wire.
         let md = stream.recv_metadata().await?;
         let parent_header = consensus.async_get_header(pp_header.direct_parents()[0]).await.unwrap();
+        let pp_is_post_hardening = self.ctx.config.zk_hardening_activation.is_active(pp_header.daa_score);
+
+        // Post-hardening: derive the shortcut block via consensus (uses reachability + headers
+        // only; safe at the PP boundary before the SMT is imported). Then resolve to the
+        // seq_commit hash with the same fold-to-zero rule used by `inactivity_shortcut(block)`.
+        // The block hash is also passed to `import_pruning_point_smt` for the V1 metadata row.
+        let (shortcut_block, inactivity_shortcut) = if pp_is_post_hardening {
+            let block = consensus
+                .async_inactivity_shortcut_block_for_pov(pruning_point)
+                .await
+                .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block resolution failed: {e}")))?;
+            let shortcut = if block == self.ctx.config.genesis.hash {
+                kaspa_hashes::ZERO_HASH
+            } else {
+                let shortcut_header = consensus
+                    .async_get_header(block)
+                    .await
+                    .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
+                if !self.ctx.config.zk_hardening_activation.is_active(shortcut_header.daa_score) {
+                    kaspa_hashes::ZERO_HASH
+                } else {
+                    shortcut_header.accepted_id_merkle_root
+                }
+            };
+            (Some(block), Some(shortcut))
+        } else {
+            (None, None)
+        };
+
         verify_smt_metadata(
             &SmtMetadata {
                 lanes_root: &md.lanes_root,
                 payload_and_ctx_digest: &md.payload_and_ctx_digest,
                 parent_seq_commit: &md.parent_seq_commit,
             },
+            inactivity_shortcut,
             pp_header.accepted_id_merkle_root,
             parent_header.accepted_id_merkle_root,
         )
         .map_err(|e| ProtocolError::OtherOwned(format!("SMT metadata verification failed: {e}")))?;
-
-        let lanes_root = md.lanes_root;
-        let payload_and_ctx_digest = md.payload_and_ctx_digest;
-        let expected_count = md.active_lanes_count;
 
         // Small queue of already-chunked batches: one in flight + one being processed
         // by the importer is enough headroom; each chunk holds up to SMT_CHUNK_SIZE lanes.
         let (tx, rx) = tokio::sync::mpsc::channel::<Vec<kaspa_consensus_core::api::ImportLane>>(2);
 
         let consensus_for_import = consensus.clone();
-        let builder_handle = tokio::task::spawn_blocking(move || {
-            consensus_for_import.import_pruning_point_smt(pruning_point, lanes_root, payload_and_ctx_digest, expected_count, rx)
-        });
+        let builder_handle =
+            tokio::task::spawn_blocking(move || consensus_for_import.import_pruning_point_smt(pruning_point, md, shortcut_block, rx));
 
         while let Some(chunk) = stream.next_chunk().await? {
             tx.send(chunk).await.map_err(|_| ProtocolError::Other("streaming SMT builder stopped unexpectedly"))?;

--- a/protocol/flows/src/ibd/streams.rs
+++ b/protocol/flows/src/ibd/streams.rs
@@ -239,22 +239,27 @@ impl<'a, 'b> SmtStream<'a, 'b> {
         match timeout(DEFAULT_TIMEOUT, self.incoming_route.recv()).await {
             Ok(Some(msg)) => match msg.payload {
                 Some(Payload::SmtMetadata(payload)) => {
+                    use kaspa_consensus_core::api::SmtExportMetadata;
+                    // Wire: 96 bytes = lanes_root || payload_and_ctx_digest || parent_seq_commit.
                     let (chunks, rem) = payload.data.as_chunks::<32>();
-                    let &[lanes_root, payload_and_ctx_digest, parent_seq_commit] = chunks else {
-                        return Err(ProtocolError::Other("SmtMetadata data must be exactly 96 bytes"));
-                    };
                     if !rem.is_empty() {
-                        return Err(ProtocolError::Other("SmtMetadata data must be exactly 96 bytes"));
+                        return Err(ProtocolError::Other("SmtMetadata data length not a multiple of 32 bytes"));
                     }
-                    let [lanes_root, payload_and_ctx_digest, parent_seq_commit] =
-                        [lanes_root, payload_and_ctx_digest, parent_seq_commit].map(Hash::from_bytes);
                     self.expected_count = payload.active_lanes_count;
-                    Ok(kaspa_consensus_core::api::SmtExportMetadata {
-                        lanes_root,
-                        payload_and_ctx_digest,
-                        parent_seq_commit,
-                        active_lanes_count: payload.active_lanes_count,
-                    })
+                    let md = match *chunks {
+                        [lanes_root, payload_and_ctx_digest, parent_seq_commit] => {
+                            let [lanes_root, payload_and_ctx_digest, parent_seq_commit] =
+                                [lanes_root, payload_and_ctx_digest, parent_seq_commit].map(Hash::from_bytes);
+                            SmtExportMetadata {
+                                lanes_root,
+                                payload_and_ctx_digest,
+                                parent_seq_commit,
+                                active_lanes_count: payload.active_lanes_count,
+                            }
+                        }
+                        _ => return Err(ProtocolError::Other("SmtMetadata data must be 96 bytes")),
+                    };
+                    Ok(md)
                 }
                 Some(Payload::UnexpectedPruningPoint(_)) => Err(ProtocolError::ConsensusError(ConsensusError::UnexpectedPruningPoint)),
                 _ => Err(ProtocolError::UnexpectedMessage(stringify!(Payload::SmtMetadata), msg.payload.as_ref().map(|v| v.into()))),

--- a/protocol/flows/src/v10/request_pruning_point_smt_state.rs
+++ b/protocol/flows/src/v10/request_pruning_point_smt_state.rs
@@ -97,7 +97,9 @@ impl RequestPruningPointSmtStateFlow {
             }
             if !batch.is_empty() {
                 count += batch.len() as u64;
-                let _ = tx.blocking_send(batch);
+                if tx.blocking_send(batch).is_err() {
+                    return Err(ConsensusError::General("receiver went away"));
+                }
             }
             Ok(count)
         });

--- a/protocol/flows/src/v10/request_pruning_point_smt_state.rs
+++ b/protocol/flows/src/v10/request_pruning_point_smt_state.rs
@@ -3,7 +3,10 @@ use crate::{
     flow_trait::Flow,
     ibd::{SMT_CHUNK_SIZE, SMT_FLOW_CONTROL_WINDOW},
 };
-use kaspa_consensus_core::{api::ImportLane, errors::consensus::ConsensusError};
+use kaspa_consensus_core::{
+    api::{ImportLane, SmtExportMetadata},
+    errors::consensus::ConsensusError,
+};
 use kaspa_core::{debug, info};
 use kaspa_hashes::Hash;
 use kaspa_p2p_lib::{
@@ -56,10 +59,12 @@ impl RequestPruningPointSmtStateFlow {
 
         let expected_count = metadata.active_lanes_count;
 
+        // Wire: 96 bytes = lanes_root || payload_and_ctx_digest || parent_seq_commit.
+        let SmtExportMetadata { lanes_root, payload_and_ctx_digest, parent_seq_commit, .. } = metadata;
         let mut md_bytes = Vec::with_capacity(96);
-        md_bytes.extend_from_slice(&metadata.lanes_root.as_bytes());
-        md_bytes.extend_from_slice(&metadata.payload_and_ctx_digest.as_bytes());
-        md_bytes.extend_from_slice(&metadata.parent_seq_commit.as_bytes());
+        md_bytes.extend_from_slice(&lanes_root.as_bytes());
+        md_bytes.extend_from_slice(&payload_and_ctx_digest.as_bytes());
+        md_bytes.extend_from_slice(&parent_seq_commit.as_bytes());
         self.router
             .enqueue(make_message!(Payload::SmtMetadata, SmtMetadataMessage { data: md_bytes, active_lanes_count: expected_count }))
             .await?;
@@ -85,8 +90,7 @@ impl RequestPruningPointSmtStateFlow {
                 if batch.len() == SMT_CHUNK_SIZE {
                     count += batch.len() as u64;
                     if tx.blocking_send(std::mem::take(&mut batch)).is_err() {
-                        // Receiver went away — let the async side surface the error.
-                        return Ok(count);
+                        return Err(ConsensusError::General("receiver went away"));
                     }
                     batch.reserve(SMT_CHUNK_SIZE);
                 }

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Arg, ArgAction, Command};
 use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
-    config::params::{TESTNET_PARAMS, TESTNET12_PARAMS},
+    config::params::TESTNET_PARAMS,
     constants::{SOMPI_PER_KASPA, TX_VERSION, TX_VERSION_TOCCATA},
     hashing::covenant_id::covenant_id,
     network::NetworkType,
@@ -289,11 +289,7 @@ async fn main() {
 
     let info = rpc_client.get_block_dag_info().await.expect("Failed to get block dag info.");
 
-    let coinbase_maturity = match info.network.suffix {
-        Some(11) => panic!("TN11 is not supported on this version"),
-        Some(12) => TESTNET12_PARAMS.coinbase_maturity(),
-        None | Some(_) => TESTNET_PARAMS.coinbase_maturity(),
-    };
+    let coinbase_maturity = TESTNET_PARAMS.coinbase_maturity();
     info!(
         "Node block-DAG info: \n\tNetwork: {}, \n\tBlock count: {}, \n\tHeader count: {}, \n\tDifficulty: {},
 \tMedian time: {}, \n\tDAA score: {}, \n\tPruning point: {}, \n\tTips: {}, \n\t{} virtual parents: ...{}, \n\tCoinbase maturity: {}",

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -400,7 +400,6 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         params.pruning_depth = 100 * 2 * 2 + 50;
 
         params.toccata_activation = ForkActivation::new(1000);
-        params.zk_hardening_activation = ForkActivation::new(2000);
 
         info!("Setting pruning depth to {:?}", params.pruning_depth());
     }

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -400,6 +400,7 @@ fn apply_args_to_consensus_params(args: &Args, params: &mut Params) {
         params.pruning_depth = 100 * 2 * 2 + 50;
 
         params.toccata_activation = ForkActivation::new(1000);
+        params.zk_hardening_activation = ForkActivation::new(2000);
 
         info!("Setting pruning depth to {:?}", params.pruning_depth());
     }

--- a/simpa/tests/smt_repro.rs
+++ b/simpa/tests/smt_repro.rs
@@ -47,44 +47,26 @@ static REPRO_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_2() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(2);
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_4() {
-    assert_pruning_point_smt_roundtrip(4, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(4);
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_5() {
-    assert_pruning_point_smt_roundtrip(5, ForkActivation::always(), ForkActivation::always());
+    assert_pruning_point_smt_roundtrip(5);
 }
 
-/// Hardening activates mid-chain (DAA 400): chain crosses the hardening boundary
-/// while toccata stays always-active. Toccata cannot be gated here because the
-/// simulator's ChurningLaneProducer relies on toccata-era subnetwork txs from
-/// block 1; pre-toccata they would be rejected and panic OnetimeTxSelector.
-/// Pre-toccata crossing is covered by daemon_zk_hardening_activation_test.
-#[test]
-fn pruning_point_smt_export_import_repro_seed_2_hardening_mid_chain() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(400));
-}
-
-/// Hardening at DAA 1: chain is post-hardening from block 1 onward.
-/// Sanity-checks the "hardening fires almost immediately" boundary case.
-#[test]
-fn pruning_point_smt_export_import_repro_seed_2_hardening_at_1() {
-    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(1));
-}
-
-fn assert_pruning_point_smt_roundtrip(seed: u64, toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) {
+fn assert_pruning_point_smt_roundtrip(seed: u64) {
     let _guard = REPRO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     kaspa_core::log::try_init_logger("warn");
 
     let mut params = DEVNET_PARAMS;
     apply_pruning_repro_params(&mut params);
-    params.toccata_activation = toccata_activation;
-    params.zk_hardening_activation = zk_hardening_activation;
+    params.toccata_activation = ForkActivation::always();
     let config = Arc::new(
         ConfigBuilder::new(params)
             .apply_args(|config| apply_perf_params(&mut config.perf))
@@ -186,8 +168,7 @@ fn apply_pruning_repro_params(params: &mut Params) {
     params.mergeset_size_limit = 32 * 2;
     params.pruning_depth = PRUNING_DEPTH;
 
-    // toccata + hardening activations are set by the caller.
-    // (see assert_pruning_point_smt_roundtrip).
+    // Toccata activation is set by the caller.
     params.storage_mass_parameter = 10_000;
 }
 

--- a/simpa/tests/smt_repro.rs
+++ b/simpa/tests/smt_repro.rs
@@ -47,25 +47,44 @@ static REPRO_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_2() {
-    assert_pruning_point_smt_roundtrip(2);
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::always());
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_4() {
-    assert_pruning_point_smt_roundtrip(4);
+    assert_pruning_point_smt_roundtrip(4, ForkActivation::always(), ForkActivation::always());
 }
 
 #[test]
 fn pruning_point_smt_export_import_repro_seed_5() {
-    assert_pruning_point_smt_roundtrip(5);
+    assert_pruning_point_smt_roundtrip(5, ForkActivation::always(), ForkActivation::always());
 }
 
-fn assert_pruning_point_smt_roundtrip(seed: u64) {
+/// Hardening activates mid-chain (DAA 400): chain crosses the hardening boundary
+/// while toccata stays always-active. Toccata cannot be gated here because the
+/// simulator's ChurningLaneProducer relies on toccata-era subnetwork txs from
+/// block 1; pre-toccata they would be rejected and panic OnetimeTxSelector.
+/// Pre-toccata crossing is covered by daemon_zk_hardening_activation_test.
+#[test]
+fn pruning_point_smt_export_import_repro_seed_2_hardening_mid_chain() {
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(400));
+}
+
+/// Hardening at DAA 1: chain is post-hardening from block 1 onward.
+/// Sanity-checks the "hardening fires almost immediately" boundary case.
+#[test]
+fn pruning_point_smt_export_import_repro_seed_2_hardening_at_1() {
+    assert_pruning_point_smt_roundtrip(2, ForkActivation::always(), ForkActivation::new(1));
+}
+
+fn assert_pruning_point_smt_roundtrip(seed: u64, toccata_activation: ForkActivation, zk_hardening_activation: ForkActivation) {
     let _guard = REPRO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     kaspa_core::log::try_init_logger("warn");
 
     let mut params = DEVNET_PARAMS;
     apply_pruning_repro_params(&mut params);
+    params.toccata_activation = toccata_activation;
+    params.zk_hardening_activation = zk_hardening_activation;
     let config = Arc::new(
         ConfigBuilder::new(params)
             .apply_args(|config| apply_perf_params(&mut config.perf))
@@ -87,6 +106,7 @@ fn assert_pruning_point_smt_roundtrip(seed: u64) {
 
     let pp = consensus.pruning_point();
     let pp_blue_score = consensus.get_header(pp).unwrap().blue_score;
+    // KIP-21: pruning cutoff uses finality_depth.
     let smt_cutoff = pp_blue_score.saturating_sub(FINALITY_DEPTH).saturating_sub(1);
     let metadata = consensus.get_pruning_point_smt_metadata(pp).unwrap();
     let (imported_root, imported_lanes) =
@@ -166,7 +186,8 @@ fn apply_pruning_repro_params(params: &mut Params) {
     params.mergeset_size_limit = 32 * 2;
     params.pruning_depth = PRUNING_DEPTH;
 
-    params.toccata_activation = ForkActivation::always();
+    // toccata + hardening activations are set by the caller.
+    // (see assert_pruning_point_smt_roundtrip).
     params.storage_mass_parameter = 10_000;
 }
 

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -48,9 +48,7 @@ use kaspa_core::time::unix_now;
 use kaspa_database::utils::get_kaspa_tempdir;
 use kaspa_hashes::{Hash, SeqCommitActiveNode};
 use kaspa_rpc_core::RpcHeader;
-use kaspa_seq_commit::hashing::{
-    activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, seq_commit_timestamp, smt_leaf_hash,
-};
+use kaspa_seq_commit::hashing::{activity_digest_lane, activity_leaf, lane_key, lane_tip_next, mergeset_context_hash, smt_leaf_hash};
 use kaspa_seq_commit::types::{LaneTipInput, MergesetContext, SmtLeafInput};
 use kaspa_seq_commit::verify::{SmtMetadata, verify_smt_metadata};
 use kaspa_txscript::{MAX_SCRIPT_ELEMENT_SIZE_POST_TOCCATA, pay_to_script_hash_script};
@@ -1481,7 +1479,7 @@ fn chain_seq_commit_context_hash(consensus: &TestConsensus, accepting_block: Has
     let header = consensus.get_header(accepting_block).unwrap();
     let parent_header = consensus.get_header(header.direct_parents()[0]).unwrap();
     mergeset_context_hash(&MergesetContext {
-        timestamp: seq_commit_timestamp(parent_header.timestamp),
+        timestamp: parent_header.timestamp,
         daa_score: header.daa_score,
         blue_score: header.blue_score,
     })
@@ -1495,6 +1493,7 @@ fn assert_chain_seq_commit_lane(consensus: &TestConsensus, accepting_block: Hash
             payload_and_ctx_digest: &proof.payload_and_ctx_digest,
             parent_seq_commit: &proof.parent_seq_commit,
         },
+        proof.inactivity_shortcut,
         proof.expected_seq_commit,
         proof.parent_seq_commit,
     )
@@ -1589,6 +1588,8 @@ async fn seqcommit_sp_context_threshold_edge_test() {
             p.genesis.hash = genesis_header.hash;
 
             // Keep the threshold minimal so the selected-parent edge is reached by the next block.
+            // KIP-21: the seqcommit look-back equals `finality_depth`; set it to 1 so a
+            // single follow-up block is still within the threshold during template validation.
             p.finality_depth = 1;
             p.toccata_activation = ForkActivation::always();
         })

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -1653,7 +1653,7 @@ async fn seqcommit_sp_context_threshold_edge_test() {
 }
 
 #[tokio::test]
-async fn staging_consensus_test() {
+async fn staging_consensus_lifecycle_test() {
     init_allocator_with_default_settings();
     let config = ConfigBuilder::new(MAINNET_PARAMS).build();
 
@@ -1690,8 +1690,26 @@ async fn staging_consensus_test() {
     let joins = core.start();
 
     let staging = consensus_manager.new_staging_consensus();
-    staging.commit();
+    let staging_session = staging.session().await;
+    let genesis_hash = config.genesis.hash;
 
+    // A fresh staging consensus skips normal genesis processing, so genesis is
+    // absent from both the headers store and the status store before import.
+    assert!(staging_session.async_get_header(genesis_hash).await.is_err());
+    assert_eq!(staging_session.async_get_block_status(genesis_hash).await, None);
+
+    let mut genesis_header: Header = (&config.genesis).into();
+    genesis_header.hash = genesis_hash;
+    let genesis_header = Arc::new(genesis_header);
+    staging_session.clone().spawn_blocking(move |c| c.import_pruning_points(vec![genesis_header])).await.unwrap();
+
+    // Importing pruning points stores headers without assigning block statuses.
+    // Header access must keep working for headers-proof IBD in this state.
+    assert_eq!(staging_session.async_get_header(genesis_hash).await.unwrap().hash, genesis_hash);
+    assert_eq!(staging_session.async_get_block_status(genesis_hash).await, None);
+
+    drop(staging_session);
+    staging.commit();
     core.shutdown();
     core.join(joins);
 }
@@ -2354,7 +2372,6 @@ fn init_toccata_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<(
     let mut params = TESTNET_PARAMS;
     params.crescendo_activation = ForkActivation::always();
     params.toccata_activation = ForkActivation::always();
-    params.zk_hardening_activation = ForkActivation::always();
 
     let config = ConfigBuilder::new(params)
         .skip_proof_of_work()

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -16,7 +16,7 @@ use kaspa_consensus::model::stores::headers::HeaderStoreReader;
 use kaspa_consensus::model::stores::reachability::DbReachabilityStore;
 use kaspa_consensus::model::stores::relations::DbRelationsStore;
 use kaspa_consensus::model::stores::selected_chain::SelectedChainStoreReader;
-use kaspa_consensus::params::{DEVNET_PARAMS, ForkActivation, MAINNET_PARAMS, OverrideParams, TESTNET12_PARAMS};
+use kaspa_consensus::params::{DEVNET_PARAMS, ForkActivation, MAINNET_PARAMS, OverrideParams, TESTNET_PARAMS};
 use kaspa_consensus::pipeline::ProcessingCounters;
 use kaspa_consensus::pipeline::monitor::ConsensusMonitor;
 use kaspa_consensus::processes::reachability::tests::{DagBlock, DagBuilder, StoreValidationExtensions};
@@ -2280,7 +2280,7 @@ fn build_p2pk_block(
     (consensus, wait_handles, transactions, block.to_immutable())
 }
 
-fn init_testnet12_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<()>>, Hash, Vec<Transaction>) {
+fn init_toccata_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle<()>>, Hash, Vec<Transaction>) {
     let redeem_script = ScriptBuilder::new().add_op(OpZkPrecompile).unwrap().drain();
     let stark_spk = pay_to_script_hash_script(&redeem_script);
     let output_spk = ScriptPublicKey::from_vec(0, vec![OpTrue]);
@@ -2351,7 +2351,12 @@ fn init_testnet12_stark_fixture() -> (TestConsensus, Vec<std::thread::JoinHandle
         })
         .collect::<Vec<_>>();
 
-    let config = ConfigBuilder::new(TESTNET12_PARAMS)
+    let mut params = TESTNET_PARAMS;
+    params.crescendo_activation = ForkActivation::always();
+    params.toccata_activation = ForkActivation::always();
+    params.zk_hardening_activation = ForkActivation::always();
+
+    let config = ConfigBuilder::new(params)
         .skip_proof_of_work()
         .edit_consensus_params(|p| {
             let mut genesis_multiset = MuHash::new();
@@ -2430,10 +2435,10 @@ async fn mass_per_sig_op_does_not_change_block_capacity() {
 }
 
 #[tokio::test]
-async fn testnet12_accepts_one_valid_stark_proof_but_rejects_two() {
+async fn toccata_accepts_one_valid_stark_proof_but_rejects_two() {
     init_allocator_with_default_settings();
 
-    let (consensus, wait_handles, genesis_hash, transactions) = init_testnet12_stark_fixture();
+    let (consensus, wait_handles, genesis_hash, transactions) = init_toccata_stark_fixture();
     let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
     let one_stark_block = consensus
         .build_utxo_valid_block_with_parents(new_unique(), vec![genesis_hash], miner_data.clone(), vec![transactions[0].clone()])
@@ -2450,7 +2455,7 @@ async fn testnet12_accepts_one_valid_stark_proof_but_rejects_two() {
         .to_immutable();
     assert_match!(
         consensus.validate_and_insert_block(two_stark_block).virtual_state_task.await,
-        Err(RuleError::ExceedsComputeMassLimit(_, limit)) if limit == TESTNET12_PARAMS.block_mass_limits().after().compute
+        Err(RuleError::ExceedsComputeMassLimit(_, limit)) if limit == consensus.params().block_mass_limits().after().compute
     );
     consensus.shutdown(wait_handles);
 }

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -131,63 +131,6 @@ async fn daemon_toccata_activation_log_file_test() {
     );
 }
 
-/// KIP-21 zk_hardening_activation crossing: pre-activation blocks commit
-/// `seq_commit` with `inactivity_shortcut: None` (omitted from the mergeset
-/// context hash); post-activation blocks fold the shortcut in. Both layouts
-/// of `SmtBlockMetadata` (always-stored shortcut block) must roundtrip and
-/// the chain must continue to advance across the boundary.
-///
-/// If the activation gate were wired wrong on either side, `build_seq_commit`
-/// and `recompute_seq_commit` would diverge and the daemon would disqualify
-/// its own mined blocks; the assert on virtual_daa_score is the smoke test.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn daemon_zk_hardening_activation_test() {
-    init_allocator_with_default_settings();
-
-    let test_dir = tempfile::tempdir().unwrap();
-    let params_path = test_dir.path().join("params.json");
-    // Activate at DAA score 3; mine across it.
-    fs::write(&params_path, r#"{"skip_proof_of_work":true,"zk_hardening_activation":3}"#).unwrap();
-
-    let args = Args {
-        simnet: true,
-        unsafe_rpc: true,
-        enable_unsynced_mining: true,
-        disable_upnp: true,
-        disable_dns_seeding: true,
-        outbound_target: 0,
-        override_params_file: Some(params_path.to_string_lossy().to_string()),
-        ..Default::default()
-    };
-
-    let _runtime = KaspadRuntime::from_args(&args);
-    let mut kaspad = Daemon::new_random_with_args(args, 10);
-    let rpc_client = kaspad.start().await;
-
-    let miner_address = Address::new(kaspad.network.into(), kaspa_addresses::Version::PubKey, &[0; 32]);
-    let target_daa_score: u64 = 6;
-    for _ in 1..=target_daa_score {
-        let template = rpc_client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
-        rpc_client.submit_block(template.block, false).await.unwrap();
-    }
-
-    let check_client = rpc_client.clone();
-    wait_for(
-        50,
-        100,
-        move || {
-            let client = check_client.clone();
-            Box::pin(async move { client.get_server_info().await.unwrap().virtual_daa_score >= target_daa_score })
-        },
-        "daemon did not cross zk_hardening_activation boundary",
-    )
-    .await;
-
-    rpc_client.disconnect().await.unwrap();
-    drop(rpc_client);
-    kaspad.shutdown();
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_sanity_test() {
     init_allocator_with_default_settings();

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -131,6 +131,63 @@ async fn daemon_toccata_activation_log_file_test() {
     );
 }
 
+/// KIP-21 zk_hardening_activation crossing: pre-activation blocks commit
+/// `seq_commit` with `inactivity_shortcut: None` (omitted from the mergeset
+/// context hash); post-activation blocks fold the shortcut in. Both layouts
+/// of `SmtBlockMetadata` (always-stored shortcut block) must roundtrip and
+/// the chain must continue to advance across the boundary.
+///
+/// If the activation gate were wired wrong on either side, `build_seq_commit`
+/// and `recompute_seq_commit` would diverge and the daemon would disqualify
+/// its own mined blocks; the assert on virtual_daa_score is the smoke test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn daemon_zk_hardening_activation_test() {
+    init_allocator_with_default_settings();
+
+    let test_dir = tempfile::tempdir().unwrap();
+    let params_path = test_dir.path().join("params.json");
+    // Activate at DAA score 3; mine across it.
+    fs::write(&params_path, r#"{"skip_proof_of_work":true,"zk_hardening_activation":3}"#).unwrap();
+
+    let args = Args {
+        simnet: true,
+        unsafe_rpc: true,
+        enable_unsynced_mining: true,
+        disable_upnp: true,
+        disable_dns_seeding: true,
+        outbound_target: 0,
+        override_params_file: Some(params_path.to_string_lossy().to_string()),
+        ..Default::default()
+    };
+
+    let _runtime = KaspadRuntime::from_args(&args);
+    let mut kaspad = Daemon::new_random_with_args(args, 10);
+    let rpc_client = kaspad.start().await;
+
+    let miner_address = Address::new(kaspad.network.into(), kaspa_addresses::Version::PubKey, &[0; 32]);
+    let target_daa_score: u64 = 6;
+    for _ in 1..=target_daa_score {
+        let template = rpc_client.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        rpc_client.submit_block(template.block, false).await.unwrap();
+    }
+
+    let check_client = rpc_client.clone();
+    wait_for(
+        50,
+        100,
+        move || {
+            let client = check_client.clone();
+            Box::pin(async move { client.get_server_info().await.unwrap().virtual_daa_score >= target_daa_score })
+        },
+        "daemon did not cross zk_hardening_activation boundary",
+    )
+    .await;
+
+    rpc_client.disconnect().await.unwrap();
+    drop(rpc_client);
+    kaspad.shutdown();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn daemon_sanity_test() {
     init_allocator_with_default_settings();
@@ -856,7 +913,8 @@ async fn daemon_pruning_seqcommit_sync_test() {
 
     // Step 1: advance the chain to ~1.5 * finality depth from genesis.
     // We will create a seqcommit transaction at that height, referencing a block
-    // almost a full finality depth below the tip.
+    // almost a full finality_depth below the tip (KIP-21 seqcommit look-back is
+    // bounded by `finality_depth`).
     let finality_depth = params.finality_depth();
     let initial_blocks = finality_depth.saturating_mul(3).saturating_div(2) as usize;
     for _ in 0..initial_blocks {
@@ -876,7 +934,7 @@ async fn daemon_pruning_seqcommit_sync_test() {
     )
     .await;
 
-    // Choose a target almost a full finality depth below the current tip, leaving
+    // Choose a target almost a full finality_depth below the current tip, leaving
     // a small buffer for the confirmation and spend blocks.
     let dag_info = rpc_client1.get_block_dag_info().await.unwrap();
     let remaining = finality_depth.saturating_sub(3);
@@ -943,9 +1001,13 @@ async fn daemon_pruning_seqcommit_sync_test() {
 
     // Step 2: advance the pruning point so it moves off genesis and ends up above the
     // target block that the seqcommit script references.
+    //
+    // KIP-21: the seqcommit look-back is `finality_depth`, so the target sits at
+    // depth ≈ F below the initial tip. Pruning samples space by F in blue_score, so
+    // PP may need to advance to climb past the target.
     let mut dag_info = rpc_client1.get_block_dag_info().await.unwrap();
     let mut extra_blocks = 0usize;
-    let extra_blocks_limit = params.pruning_depth().saturating_add(30) as usize;
+    let extra_blocks_limit = params.pruning_depth().saturating_add(params.finality_depth()).saturating_add(30) as usize;
     while (dag_info.pruning_point_hash == SIMNET_GENESIS.hash
         || !is_ancestor_in_selected_parent_chain(&rpc_client1, dag_info.pruning_point_hash, target_block).await)
         && extra_blocks < extra_blocks_limit
@@ -1198,6 +1260,36 @@ async fn daemon_ibd_smt_state_sync_test() {
             })
         },
         "syncee did not complete SMT-era IBD within timeout (suspected sync_new_smt_state stall)",
+    )
+    .await;
+
+    // Phase 6: mine finality_depth + buffer blocks on the syncer and assert
+    // the syncee catches up. Verifies syncer/syncee shortcut agreement for live
+    // blocks whose target_bs lands in the IBD-imported lane range.
+    let finality_depth = params.finality_depth() as usize;
+    let post_ibd_blocks = finality_depth + 30;
+    for _ in 0..post_ibd_blocks {
+        let template = rpc_client1.get_block_template(miner_address.clone(), vec![]).await.unwrap();
+        rpc_client1.submit_block(template.block, false).await.unwrap();
+    }
+
+    let post_ibd_target_score = rpc_client1.get_server_info().await.unwrap().virtual_daa_score;
+    let post_ibd_target_pp = rpc_client1.get_block_dag_info().await.unwrap().pruning_point_hash;
+    let post_ibd_check = rpc_client2.clone();
+    wait_for(
+        100,
+        600,
+        move || {
+            let client = post_ibd_check.clone();
+            Box::pin(async move {
+                let server_info = client.get_server_info().await.unwrap();
+                if server_info.virtual_daa_score < post_ibd_target_score {
+                    return false;
+                }
+                client.get_block_dag_info().await.unwrap().pruning_point_hash == post_ibd_target_pp
+            })
+        },
+        "syncee did not accept post-IBD blocks",
     )
     .await;
 

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -577,8 +577,7 @@ async fn daemon_compute_budget_relay_test() {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/params/compute_budget_relay_test_params.json");
 
     let args = Args {
-        testnet: true,
-        testnet_suffix: 12,
+        simnet: true,
         unsafe_rpc: true,
         enable_unsynced_mining: true,
         disable_upnp: true,
@@ -814,8 +813,7 @@ async fn daemon_rejects_transactions_with_inconsistent_input_mass_and_version() 
     let compute_budget_relay_test_params =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/params/compute_budget_relay_test_params.json");
     let args = Args {
-        testnet: true,
-        testnet_suffix: 12,
+        simnet: true,
         unsafe_rpc: true,
         enable_unsynced_mining: true,
         disable_upnp: true,

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -4,6 +4,7 @@ use crate::{
         args::ArgsBuilder,
         client_notify::ChannelNotify,
         daemon::{ClientManager, Daemon},
+        fee::FEE_RATE,
         utils::CONTRACT_FACTOR,
     },
     tasks::{Stopper, TasksRunner, block::group::MinerGroupTask, daemon::DaemonTask, tx::group::TxSenderGroupTask},
@@ -680,7 +681,7 @@ fn generate_stark_tx_dag(
                     );
                     logged_first_provisional_tx = true;
                 }
-                let fee = provisional_tx_mass_normalized;
+                let fee = FEE_RATE * provisional_tx_mass_normalized;
                 let total_out = total_in.saturating_sub(fee);
                 let outputs = (0..num_outputs)
                     .map(|_| TransactionOutput {


### PR DESCRIPTION
## Summary

Ports the finalized TN10-tested Toccata ZK hardening changes back into `toccata`.

On mainnet, Toccata has not activated yet, so the post-Toccata consensus logic can still be finalized directly. On TN10, both Toccata and the hardening activation are already active, and the pruning point is post-hardening, so new TN10 nodes can sync using this finalized logic without the temporary activation split.

This PR therefore does not include the TN10-only `zk_hardening_activation` scaffolding. The finalized behavior is integrated as ordinary Toccata consensus logic.

## Changes

- Finalizes ZK verifier hardening:
  - Groth16:
    - stricter public-input, verifying-key, and proof validation
    - per-public-input pricing
  - Risc0:
    - bounds Merkle witness size

- Adds the KIP-21 seqcommit inactivity shortcut:
  - commits `inactivity_shortcut` next to `lanes_root` under `ActivityRoot`
  - lets inactivity proofs hop by the shortcut instead of walking long linear selected-parent-chain spans and avoids requiring zk guests to know the exact inactivity threshold
  - finalizes SMT metadata and pruning-point/IBD sync behavior
