### PR TITLE
docs: fix minor typos in code comments

### DIFF
--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -93,7 +93,7 @@ impl Mempool {
                 // self.transaction_pool.limit_transaction_count(&transaction) returns the
                 // smallest prefix of `ready_transactions` (sorted by ascending fee-rate)
                 // that makes enough room for `transaction`, but since each call to `self.remove_transaction`
-                // also removes all transactions dependant on `x` we might already have sufficient space, so
+                // also removes all transactions dependent on `x` we might already have sufficient space, so
                 // we constantly check the break condition.
                 //
                 // Note that self.transaction_pool.len() < self.config.maximum_transaction_count means we have

--- a/wallet/core/src/wasm/utxo/context.rs
+++ b/wallet/core/src/wasm/utxo/context.rs
@@ -176,7 +176,7 @@ impl UtxoContext {
     /// (i.e. UtxoContext has received notification from the network that
     /// UtxoEntries have been spent externally).
     ///
-    /// UtxoEntries are kept in in the ascending sorted order by their amount.
+    /// UtxoEntries are kept in the ascending sorted order by their amount.
     ///
     #[wasm_bindgen(js_name = "getMatureRange")]
     pub fn mature_range(&self, mut from: usize, mut to: usize) -> Result<UtxoEntryReferenceArrayT> {

--- a/wallet/keys/src/xpub.rs
+++ b/wallet/keys/src/xpub.rs
@@ -10,7 +10,7 @@ use crate::imports::*;
 ///
 /// Extended public key (XPub).
 ///
-/// This class allows accepts another XPub and and provides
+/// This class accepts another XPub and provides
 /// functions for derivation of dependent child public keys.
 ///
 /// Please note that Kaspa extended public keys use `kpub` prefix.


### PR DESCRIPTION
Fixes a few small typos in code comments. No functional changes.

- mempool: "dependant" -> "dependent"
- wallet wasm `UtxoContext`: remove a doubled "in"
- wallet keys `XPub`: fix "allows accepts ... and and provides" wording
