### PR TITLE
fix: park on spawn_blocking cancellation during shutdown, systematically (#1031)

### DIFF
--- a/components/connectionmanager/src/lib.rs
+++ b/components/connectionmanager/src/lib.rs
@@ -10,7 +10,11 @@ use duration_string::DurationString;
 use futures_util::future::{join_all, try_join_all};
 use itertools::Itertools;
 use kaspa_addressmanager::{AddressManager, NetAddress};
-use kaspa_core::{debug, info, warn};
+use kaspa_core::{
+    debug, info,
+    task::blocking::{join_blocking_or_park, join_result_or_park},
+    warn,
+};
 use kaspa_p2p_lib::{ConnectionError, Peer, common::ProtocolError};
 use kaspa_utils::triggers::SingleTrigger;
 use parking_lot::Mutex as ParkingLotMutex;
@@ -254,7 +258,8 @@ impl ConnectionManager {
     /// Queries DNS seeders in random order, one after the other, until obtaining `min_addresses_to_fetch` addresses
     async fn dns_seed_with_address_target(self: &Arc<Self>, min_addresses_to_fetch: usize) {
         let cmgr = self.clone();
-        tokio::task::spawn_blocking(move || cmgr.dns_seed_with_address_target_blocking(min_addresses_to_fetch)).await.unwrap();
+        join_blocking_or_park(tokio::task::spawn_blocking(move || cmgr.dns_seed_with_address_target_blocking(min_addresses_to_fetch)))
+            .await;
     }
 
     fn dns_seed_with_address_target_blocking(self: &Arc<Self>, mut min_addresses_to_fetch: usize) {
@@ -278,7 +283,7 @@ impl ConnectionManager {
             let cmgr = self.clone();
             tokio::task::spawn_blocking(move || cmgr.dns_seed_single(seeder))
         });
-        try_join_all(jobs).await.unwrap().into_iter().sum()
+        join_result_or_park(try_join_all(jobs).await).await.into_iter().sum()
     }
 
     /// Query a single DNS seeder and add the obtained addresses to the address manager.

--- a/core/src/task/blocking.rs
+++ b/core/src/task/blocking.rs
@@ -1,0 +1,75 @@
+//! Helpers for awaiting `tokio` blocking-task joins during normal operation and shutdown.
+
+use tokio::task::{JoinError, JoinHandle};
+
+/// Resolves the outcome of awaiting a `spawn_blocking` join (or a combinator such as
+/// `try_join_all` over such joins), handling the two [`JoinError`] cases:
+///
+/// - **Cancellation** only happens while the Tokio runtime is shutting down, where there is no
+///   result to return. Rather than panicking (which crashes a worker thread mid-teardown), park
+///   until this task is dropped as part of runtime teardown.
+/// - **Panic** inside the spawned closure is propagated to the caller, preserving the behavior of
+///   the previous `.unwrap()` while re-raising the original panic payload.
+pub async fn join_result_or_park<T>(joined: Result<T, JoinError>) -> T {
+    match joined {
+        Ok(value) => value,
+        // A cancelled blocking task only occurs on runtime shutdown; there is nothing to return,
+        // so park until teardown drops this task instead of panicking.
+        Err(err) if err.is_cancelled() => std::future::pending().await,
+        // Propagate a genuine panic from the spawned closure.
+        Err(err) => std::panic::resume_unwind(err.into_panic()),
+    }
+}
+
+/// Awaits a `spawn_blocking` join handle, parking on shutdown cancellation and propagating a
+/// closure panic. See [`join_result_or_park`].
+pub async fn join_blocking_or_park<R>(handle: JoinHandle<R>) -> R {
+    join_result_or_park(handle.await).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).build().unwrap()
+    }
+
+    #[test]
+    fn returns_closure_result() {
+        let rt = runtime();
+        let value = rt.block_on(async { join_blocking_or_park(tokio::task::spawn_blocking(|| 42u32)).await });
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn parks_on_cancellation() {
+        // A cancelled join handle (the runtime-shutdown case) must park rather than panic or resolve,
+        // since there is no result to return. We emulate the cancellation by aborting a task.
+        let rt = runtime();
+        rt.block_on(async {
+            let cancelled = tokio::spawn(std::future::pending::<u32>());
+            cancelled.abort();
+
+            let parked = tokio::spawn(join_blocking_or_park(cancelled));
+            for _ in 0..1000 {
+                tokio::task::yield_now().await;
+            }
+            assert!(!parked.is_finished(), "helper should park on cancellation rather than resolve");
+            parked.abort();
+        });
+    }
+
+    #[test]
+    fn propagates_closure_panic() {
+        // A genuine panic inside the closure must propagate to the caller (not be swallowed).
+        let rt = runtime();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(async { join_blocking_or_park(tokio::task::spawn_blocking(|| -> u32 { panic!("boom-{}", 42) })).await })
+        }));
+        let payload = result.expect_err("closure panic should propagate through join_blocking_or_park");
+        let message =
+            payload.downcast_ref::<String>().map(String::as_str).or_else(|| payload.downcast_ref::<&str>().copied()).unwrap_or("");
+        assert!(message.contains("boom-42"), "panic payload should be preserved, got: {message:?}");
+    }
+}

--- a/core/src/task/mod.rs
+++ b/core/src/task/mod.rs
@@ -1,3 +1,4 @@
+pub mod blocking;
 pub mod runtime;
 pub mod service;
 pub mod tick;

--- a/indexes/utxoindex/src/core/api/mod.rs
+++ b/indexes/utxoindex/src/core/api/mod.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{
     utxo::utxo_diff::UtxoDiff,
 };
 use kaspa_consensusmanager::spawn_blocking;
+use kaspa_core::task::blocking::join_blocking_or_park;
 use kaspa_database::prelude::StoreResult;
 use kaspa_hashes::Hash;
 use kaspa_index_core::indexed_utxos::BalanceByScriptPublicKey;
@@ -67,21 +68,21 @@ impl UtxoIndexProxy {
     }
 
     pub async fn get_circulating_supply(self) -> StoreResult<u64> {
-        spawn_blocking(move || self.inner.read().get_circulating_supply()).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.read().get_circulating_supply())).await
     }
 
     pub async fn get_utxos_by_script_public_keys(self, script_public_keys: ScriptPublicKeys) -> StoreResult<UtxoSetByScriptPublicKey> {
-        spawn_blocking(move || self.inner.read().get_utxos_by_script_public_keys(script_public_keys)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.read().get_utxos_by_script_public_keys(script_public_keys))).await
     }
 
     pub async fn get_balance_by_script_public_keys(
         self,
         script_public_keys: ScriptPublicKeys,
     ) -> StoreResult<BalanceByScriptPublicKey> {
-        spawn_blocking(move || self.inner.read().get_balance_by_script_public_keys(script_public_keys)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.read().get_balance_by_script_public_keys(script_public_keys))).await
     }
 
     pub async fn update(self, utxo_diff: Arc<UtxoDiff>, tips: Arc<Vec<Hash>>) -> UtxoIndexResult<UtxoChanges> {
-        spawn_blocking(move || self.inner.write().update(utxo_diff, tips)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.write().update(utxo_diff, tips))).await
     }
 }

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -32,7 +32,7 @@ use kaspa_consensus_core::{
     tx::{MutableTransaction, Transaction, TransactionId, TransactionOutput},
 };
 use kaspa_consensusmanager::{ConsensusProxy, spawn_blocking};
-use kaspa_core::{debug, error, info, time::Stopwatch, warn};
+use kaspa_core::{debug, error, info, task::blocking::join_blocking_or_park, time::Stopwatch, warn};
 use kaspa_mining_errors::{manager::MiningManagerError, mempool::RuleError};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -855,7 +855,7 @@ impl MiningManagerProxy {
 
     /// Returns realtime feerate estimations based on internal mempool state
     pub async fn get_realtime_feerate_estimations(self) -> FeerateEstimations {
-        spawn_blocking(move || self.inner.get_realtime_feerate_estimations()).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.get_realtime_feerate_estimations())).await
     }
 
     /// Returns realtime feerate estimations based on internal mempool state with additional verbose data
@@ -938,20 +938,20 @@ impl MiningManagerProxy {
     ///
     /// Note: the transaction is an orphan if tx.is_fully_populated() returns false.
     pub async fn get_transaction(self, transaction_id: TransactionId, query: TransactionQuery) -> Option<MutableTransaction> {
-        spawn_blocking(move || self.inner.get_transaction(&transaction_id, query)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.get_transaction(&transaction_id, query))).await
     }
 
     /// Returns whether the mempool holds this transaction in any form.
     pub async fn has_transaction(self, transaction_id: TransactionId, query: TransactionQuery) -> bool {
-        spawn_blocking(move || self.inner.has_transaction(&transaction_id, query)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.has_transaction(&transaction_id, query))).await
     }
 
     pub async fn transaction_count(self, query: TransactionQuery) -> usize {
-        spawn_blocking(move || self.inner.transaction_count(query)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.transaction_count(query))).await
     }
 
     pub async fn get_all_transactions(self, query: TransactionQuery) -> (Vec<MutableTransaction>, Vec<MutableTransaction>) {
-        spawn_blocking(move || self.inner.get_all_transactions(query)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.get_all_transactions(query))).await
     }
 
     /// get_transactions_by_addresses returns the sending and receiving transactions for
@@ -963,7 +963,7 @@ impl MiningManagerProxy {
         script_public_keys: ScriptPublicKeySet,
         query: TransactionQuery,
     ) -> GroupedOwnerTransactions {
-        spawn_blocking(move || self.inner.get_transactions_by_addresses(&script_public_keys, query)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.get_transactions_by_addresses(&script_public_keys, query))).await
     }
 
     /// Returns whether a transaction id was registered as accepted in the mempool, meaning
@@ -975,19 +975,19 @@ impl MiningManagerProxy {
     /// a false means either the transaction was never accepted or it was but beyond the expiration
     /// delay.
     pub async fn has_accepted_transaction(self, transaction_id: TransactionId) -> bool {
-        spawn_blocking(move || self.inner.has_accepted_transaction(&transaction_id)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.has_accepted_transaction(&transaction_id))).await
     }
 
     /// Returns a vector of unaccepted transactions.
     /// For more details, see [`Self::has_accepted_transaction()`].
     pub async fn unaccepted_transactions(self, transactions: Vec<TransactionId>) -> Vec<TransactionId> {
-        spawn_blocking(move || self.inner.unaccepted_transactions(transactions)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.unaccepted_transactions(transactions))).await
     }
 
     /// Returns a vector with all transaction ids that are neither in the mempool, nor in the orphan pool
     /// nor accepted.
     pub async fn unknown_transactions(self, transactions: Vec<TransactionId>) -> Vec<TransactionId> {
-        spawn_blocking(move || self.inner.unknown_transactions(transactions)).await.unwrap()
+        join_blocking_or_park(spawn_blocking(move || self.inner.unknown_transactions(transactions))).await
     }
 
     pub fn snapshot(&self) -> MempoolCountersSnapshot {

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -15,7 +15,7 @@ use kaspa_consensus_core::{
     tx::Transaction,
 };
 use kaspa_consensusmanager::{ConsensusProxy, StagingConsensus, spawn_blocking};
-use kaspa_core::{debug, info, time::unix_now, warn};
+use kaspa_core::{debug, info, task::blocking::join_blocking_or_park, time::unix_now, warn};
 use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
 use kaspa_p2p_lib::{
@@ -160,7 +160,7 @@ impl IbdFlow {
                 let staging = self.ctx.consensus_manager.new_staging_consensus();
                 match self.ibd_with_headers_proof(&staging, negotiation_output.syncer_virtual_selected_parent, &relay_block).await {
                     Ok(()) => {
-                        spawn_blocking(|| staging.commit()).await.unwrap();
+                        join_blocking_or_park(spawn_blocking(|| staging.commit())).await;
                         info!(
                             "Header download stage of IBD with headers proof completed successfully from {}. Committed staging consensus.",
                             self.router
@@ -599,7 +599,7 @@ impl IbdFlow {
         consensus.async_set_pruning_utxoset_stable().await;
         // Once a new utxoset is stored, the utxoindex needs to be resynced as well. This happens through the reset handler mechanism.
         let consensus_manager = self.ctx.consensus_manager.clone();
-        spawn_blocking(move || consensus_manager.invoke_consensus_reset_handlers()).await.unwrap();
+        join_blocking_or_park(spawn_blocking(move || consensus_manager.invoke_consensus_reset_handlers())).await;
         self.ctx.on_pruning_point_utxoset_override();
         Ok(())
     }


### PR DESCRIPTION
⚠️ Please review/merge **after #1030**. This generalizes the fix from #1030 (issue #949); landing #1030 first validates the approach and avoids churn if it changes in review.

Closes #1031.

Several `spawn_blocking(...).await.unwrap()` sites (plus one `try_join_all(...).await.unwrap()`) panic a runtime worker thread when Tokio cancels a not-yet-started blocking task during shutdown (`Err(JoinError::Cancelled)`) — the same class of bug fixed for `consensusmanager::session` in #1030.

Adds `kaspa_core::task::blocking::{join_blocking_or_park, join_result_or_park}`:
- on cancellation (runtime shutdown, no result to return) park until teardown drops the task;
- on a genuine closure panic, propagate via `resume_unwind` (preserving prior behavior).

Applied to the remaining #1031 sites:
- `mining::manager::MiningManagerProxy` mempool proxy methods (9)
- `indexes::utxoindex::UtxoIndexProxy` methods (4)
- `protocol/flows` IBD staging-commit and consensus-reset (2)
- `connectionmanager` dns_seed blocking call + `try_join_all` (2)

`ConsensusProxy::spawn_blocking` sites (handled by #1030) are intentionally untouched. `consensusmanager::session` keeps its local helper from #1030; consolidating it onto this shared helper is a small follow-up, deferred to avoid conflicting with #1030 while it's under review.

### Testing
Unit tests for the shared helper (result returned, cancellation parks, closure panic propagates). All affected crates compile; clippy + fmt clean.

_Note: touches `connectionmanager/lib.rs` (dns_seed lines), which #1029 also touches (the wakeup sends) — different regions._
