### PR TITLE
SPM calculation Fix

### DIFF
--- a/bridge/src/share_handler.rs
+++ b/bridge/src/share_handler.rs
@@ -101,6 +101,10 @@ fn vardiff_compute_next_diff(current: f64, shares: f64, elapsed_secs: f64, expec
     if (next - current).abs() > f64::EPSILON { Some(next) } else { None }
 }
 
+pub fn average_worker_spm(sum_spm: f64, worker_count: usize) -> f64 {
+    if worker_count == 0 { 0.0 } else { sum_spm / worker_count as f64 }
+}
+
 struct StatsPrinterEntry {
     instance_id: String,
     inst_short: String,
@@ -1313,6 +1317,8 @@ impl ShareHandler {
 
                 let mut rows: Vec<(String, String)> = Vec::new();
                 let mut total_rate = 0.0;
+                let mut total_worker_spm = 0.0;
+                let mut total_worker_count: usize = 0;
                 let mut total_shares: i64 = 0;
                 let mut total_stales: i64 = 0;
                 let mut total_invalids: i64 = 0;
@@ -1321,8 +1327,6 @@ impl ShareHandler {
 
                 let now = Instant::now();
                 let start = entries.iter().map(|(_, _, start, _, _)| *start).max_by_key(|t| t.elapsed()).unwrap_or_else(Instant::now);
-                let total_uptime_mins = now.duration_since(start).as_secs_f64() / 60.0;
-
                 let mut total_target: Option<f64> = Some(entries[0].1);
                 for (inst_short, target_spm, _, stats, overall) in entries.iter() {
                     if let Some(t) = total_target
@@ -1359,6 +1363,8 @@ impl ShareHandler {
                         total_blocks += blocks;
 
                         let spm = if elapsed > 0.0 { (shares as f64) / (elapsed / 60.0) } else { 0.0 };
+                        total_worker_spm += spm;
+                        total_worker_count += 1;
                         let trend = if spm > *target_spm * 1.2 {
                             "up"
                         } else if spm < *target_spm * 0.8 {
@@ -1517,7 +1523,7 @@ impl ShareHandler {
                     total_blocks_all_time += blocks; // Also add to all-time total for the "Total" column
                 }
 
-                let overall_spm = if total_uptime_mins > 0.0 { (total_shares as f64) / total_uptime_mins } else { 0.0 };
+                let overall_spm = average_worker_spm(total_worker_spm, total_worker_count);
                 let total_spm_tgt = match total_target {
                     Some(t) => format!("{:>4.1}/{:<4.1}", overall_spm, t),
                     None => format!("{:>4.1}/-", overall_spm),

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -532,6 +532,15 @@ fn test_append_line_data_accepts_exactly_at_limit() {
     assert!(!append_line_data(&mut buf, "y"));
 }
 
+#[cfg(test)]
+#[test]
+fn test_total_row_spm_uses_worker_average() {
+    use kaspa_stratum_bridge::average_worker_spm;
+    assert_eq!(average_worker_spm(0.0, 0), 0.0);
+    assert!((average_worker_spm(30.0, 2) - 15.0).abs() < f64::EPSILON);
+    assert!((average_worker_spm(12.5, 1) - 12.5).abs() < f64::EPSILON);
+}
+
 // JSON-RPC event tests
 #[cfg(test)]
 #[test]


### PR DESCRIPTION
Fixed TOTAL-row SPM calculation to use the average worker SPM instead of an aggregate pool-wide SPM. Previously, the terminal TOTAL row computed SPM as total accepted shares divided by elapsed runtime, which inflated the value when multiple workers were active. The fix now accumulates each worker’s individual SPM and reports the arithmetic average across active workers, so the TOTAL SPM reflects per-worker performance rather than summed throughput.

Implementation details:

Added average_worker_spm(sum_spm, worker_count) in bridge/src/share_handler.rs. Updated TOTAL-row stats computation in the shared stats printer to: sum per-worker SPM values,
track active worker count,
compute TOTAL SPM via average_worker_spm(...).
Removed the old uptime-based aggregate SPM formula for TOTAL row. Validation:

Added test_total_row_spm_uses_worker_average to bridge/src/tests.rs. Ran cargo fmt --all -- --check.
Ran cargo test -p kaspa-stratum-bridge --bin stratum-bridge test_total_row_spm_uses_worker_average.