### PR TITLE
Finalize Toccata cleanup before master merge

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -780,7 +780,6 @@ pub const TESTNET_PARAMS: Params = Params {
     // 18:30 UTC, March 6, 2025
     crescendo_activation: ForkActivation::new(88_657_000),
 
-    // TODO(pre-covpp): Before setting the activation DAA score, resolve all comments of the form TODO(pre-covpp)
     // ~16:00 UTC, May 18, 2026
     toccata_activation: ForkActivation::new(467_579_632),
 };

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -719,7 +719,7 @@ pub const MAINNET_PARAMS: Params = Params {
 
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
-    // TODO(pre-toccata): Before setting the activation DAA score, resolve all comments of the form TODO(pre-toccata)
+
     toccata_activation: ForkActivation::never(),
 };
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -298,7 +298,7 @@ impl PruningProofManager {
                     // send is `daa_window_blocks` which represents the full trusted sub-DAG in the antifuture
                     // of the pruning point which kaspad-rust nodes expect to get when synced with headers proof
                     //
-                    // TODO(pre-covpp): remove the redundant `ghostdag_blocks` field as part of restructuring trusted data sending
+                    // TODO(post-toccata): remove the redundant `ghostdag_blocks` field as part of cleaning up old P2P versions
                     if let Entry::Vacant(e) = daa_window_blocks.entry(hash) {
                         e.insert(TrustedHeader {
                             header: self.headers_store.get_header(hash).unwrap(),

--- a/crypto/txscript/test-data/script_tests_covenants.json
+++ b/crypto/txscript/test-data/script_tests_covenants.json
@@ -4043,7 +4043,7 @@
     "0 TX_INPUT_DAA_SCORE DROP",
     "",
     "OK",
-    "OpTxInputDaaScore is enabled since covpp"
+    "OpTxInputDaaScore is enabled post covenants activation"
   ],
   [
     "1",
@@ -4212,7 +4212,7 @@
     "RETURN",
     "",
     "OP_RETURN",
-    "TODO(pre-covpp): Add tests that check basic functionality for opcodes in this range"
+    "OP_RETURN remains terminal under covenant flags"
   ],
   [
     "1",

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -119,10 +119,15 @@ pub fn validate_args(args: &Args) -> ConfigResult<()> {
 
 fn request_database_deletion_approval(approve: bool) -> bool {
     let msg = "Node database is from a different Kaspad *DB* version and needs to be fully deleted, do you confirm the delete? (y/n)";
-    get_user_approval_or_exit(msg, approve);
-    info!("Deleting databases from previous Kaspad version");
-    true // if consensus not exited, always return true
+    request_database_deletion_approval_with_message(msg, approve)
 }
+
+fn request_database_deletion_approval_with_message(message: &str, approve: bool) -> bool {
+    get_user_approval_or_exit(message, approve);
+    info!("Deleting databases due to incompatible Kaspad DB version");
+    true // Approval was granted; rejection exits the process above.
+}
+
 fn get_user_approval_or_exit(message: &str, approve: bool) {
     if approve {
         return;
@@ -439,14 +444,18 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         }
     }
 
-    // Reset Condition: Need to reset if we're upgrading from kaspad DB version
-    // TEMP: upgrade from Alpha version or any version before this one
-    'db_upgrade: while !is_db_reset_needed
-        && (meta_db.get_pinned(b"multi-consensus-metadata-key").is_ok_and(|r| r.is_some())
-            || MultiConsensusManagementStore::new(meta_db.clone()).should_upgrade().unwrap())
-    {
+    // Reset/upgrade condition: Handle mismatches against the current Kaspad DB version.
+    'db_upgrade: while !is_db_reset_needed && MultiConsensusManagementStore::new(meta_db.clone()).should_upgrade().unwrap() {
         let mut mcms = MultiConsensusManagementStore::new(meta_db.clone());
         let version = mcms.version().unwrap();
+
+        if version > LATEST_DB_VERSION {
+            let msg = format!(
+                "Node database is from a newer Kaspad DB version ({version}) than this node supports ({LATEST_DB_VERSION}). Downgrading requires deleting the database, do you confirm the delete? (y/n)"
+            );
+            is_db_reset_needed = request_database_deletion_approval_with_message(&msg, args.yes);
+            continue 'db_upgrade;
+        }
 
         if version <= 3 {
             is_db_reset_needed = request_database_deletion_approval(args.yes);

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -67,8 +67,6 @@ pub struct Frontier {
     average_transaction_mass: f64,
 
     target_time_per_block_seconds: f64,
-
-    gas_cofactor: f64,
 }
 
 #[derive(Default)]
@@ -136,17 +134,12 @@ impl SampleMassTracker {
 
 impl Frontier {
     pub fn new(target_time_per_block_seconds: f64) -> Self {
-        Self::new_with_gas_cofactor(target_time_per_block_seconds, 500_000f64 / DEFAULT_BLOCK_LANE_LIMITS.gas_per_lane as f64)
-    }
-
-    pub fn new_with_gas_cofactor(target_time_per_block_seconds: f64, gas_cofactor: f64) -> Self {
         Self {
             search_tree: Default::default(),
             by_lane: Default::default(),
             total_mass: Default::default(),
             average_transaction_mass: INITIAL_AVG_MASS,
             target_time_per_block_seconds,
-            gas_cofactor,
         }
     }
 }
@@ -172,8 +165,7 @@ impl Frontier {
         let mass = key.mass;
         let lane = key.lane();
         if self.search_tree.insert(key.clone()) {
-            // Per-lane ordering should account for gas as another lane-limited resource.
-            self.by_lane.entry(lane).or_default().insert(FeerateTransactionKey::with_normalized_gas(key, self.gas_cofactor));
+            self.by_lane.entry(lane).or_default().insert(key);
             self.total_mass += mass;
             // A decaying average formula. Denote ɛ = 1 - AVG_MASS_DECAY_FACTOR. A transaction inserted N slots ago has
             // ɛ * (1 - ɛ)^N weight within the updated average. This gives some weight to the full mempool history while
@@ -192,7 +184,7 @@ impl Frontier {
             let lane = key.lane();
             let mut remove_lane = false;
             if let Some(entries) = self.by_lane.get_mut(&lane) {
-                entries.remove(&FeerateTransactionKey::with_normalized_gas(key.clone(), self.gas_cofactor));
+                entries.remove(key);
                 remove_lane = entries.is_empty();
             }
             if remove_lane {
@@ -447,7 +439,7 @@ mod tests {
     use feerate_key::tests::build_feerate_key;
     use itertools::Itertools;
     use kaspa_consensus_core::{
-        mass::{BlockLaneLimits, BlockMassLimits},
+        mass::BlockMassLimits,
         subnets::SubnetworkId,
         tx::{Transaction, TransactionInput, TransactionOutpoint},
     };
@@ -585,32 +577,6 @@ mod tests {
         let selected_lanes = sample.iter().map(|tx| tx.tx.subnetwork_id).collect::<HashSet<_>>();
 
         assert_eq!(selected_lanes.len(), policy.lanes_per_block_limit);
-    }
-
-    #[test]
-    fn test_by_lane_feerate_key_accounts_for_normalized_gas() {
-        let lane = SubnetworkId::from_namespace([1, 1, 0, 0]);
-        let block_lane_limits = BlockLaneLimits { lanes_per_block: 1, gas_per_lane: 100 };
-        let policy = Policy::new(10_000, block_lane_limits);
-        let mut frontier = Frontier::new_with_gas_cofactor(1.0, 1_000f64 / block_lane_limits.gas_per_lane as f64);
-
-        let keys = (11..=22).map(|gas| build_feerate_key_with_lane(1_000, 100, gas, lane, gas)).collect_vec();
-        for key in keys.iter().cloned() {
-            frontier.insert(key).then_some(()).unwrap();
-        }
-
-        let mut sequence = SequenceSelectorInput::default();
-        let lanes = Lanes { occupied: HashSet::from([lane]), frozen: true };
-        let mut mass = SampleMassTracker::new(&policy);
-        frontier.finish_intra_lane_selection(&mut sequence, &HashSet::new(), &lanes, &mut mass);
-
-        assert_eq!(sequence.iter().map(|item| item.tx.gas).collect_vec(), (11..=22).collect_vec());
-
-        for key in &keys {
-            frontier.remove(key).then_some(()).unwrap();
-        }
-        assert!(frontier.is_empty());
-        assert!(frontier.by_lane.is_empty());
     }
 
     /// Epsilon used for various test comparisons

--- a/mining/src/mempool/model/frontier/feerate_key.rs
+++ b/mining/src/mempool/model/frontier/feerate_key.rs
@@ -31,16 +31,6 @@ impl FeerateTransactionKey {
         Self { fee, mass, weight: (fee as f64 / mass as f64).powi(ALPHA), tx }
     }
 
-    /// Builds a lane-local feerate key which accounts for gas as another lane-limited resource.
-    ///
-    /// The global key intentionally ignores gas, but once lane selection is frozen we compare
-    /// candidates within each occupied lane using max(normalized mass, normalized gas).
-    pub fn with_normalized_gas(inner: FeerateTransactionKey, gas_cofactor: f64) -> Self {
-        let normalized_gas_mass = (inner.tx.gas as f64 * gas_cofactor).ceil() as u64;
-        let lane_normalized_mass = inner.mass.max(normalized_gas_mass);
-        Self::new(inner.fee, lane_normalized_mass, inner.tx)
-    }
-
     pub fn feerate(&self) -> f64 {
         self.fee as f64 / self.mass as f64
     }

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -83,16 +83,12 @@ pub(crate) struct TransactionsPool {
 impl TransactionsPool {
     pub(crate) fn new(config: Arc<Config>) -> Self {
         let target_time_per_block = 1.0 / (config.network_blocks_per_second as f64);
-        // Params::mempool_block_mass_cofactors asserts that the reference mass is stable across activation.
-        assert!(config.block_lane_limits.gas_per_lane > 0);
-        let gas_cofactor = config.mempool_mass_cofactors.after().reference as f64 / config.block_lane_limits.gas_per_lane as f64;
-        let ready_transactions = Frontier::new_with_gas_cofactor(target_time_per_block, gas_cofactor);
         Self {
             config,
             all_transactions: MempoolTransactionCollection::default(),
             parent_transactions: TransactionsEdges::default(),
             chained_transactions: TransactionsEdges::default(),
-            ready_transactions,
+            ready_transactions: Frontier::new(target_time_per_block),
             last_expire_scan_daa_score: 0,
             last_expire_scan_time: unix_now(),
             utxo_set: MempoolUtxoSet::new(),

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -511,8 +511,8 @@ impl IbdFlow {
             return Err(ProtocolError::Other("the proof pruning point is not equal to the expected trusted entry"));
         }
 
-        // TODO(pre-covpp): this buffering can be heavy on RAM for large chain segments, but is acceptable
-        // for now since syncee memory usage is still low at this phase.
+        // TODO(optimization): this buffering can be heavy on RAM for large chain segments, but is acceptable
+        // since syncee memory usage is still low at this phase.
         let mut entries = vec![pruning_point_entry];
         let mut header_only_chain_segment = Vec::new();
         while let Some(entry) = entry_stream.next().await? {

--- a/protocol/flows/src/v7/request_pruning_point_and_anticone.rs
+++ b/protocol/flows/src/v7/request_pruning_point_and_anticone.rs
@@ -79,7 +79,7 @@ impl PruningPointAndItsAnticoneRequestsFlow {
                 .await?;
 
             //
-            // TODO(pre-covpp): refactor GRPC to properly include the header-only chain segment and cleanup old fields
+            // TODO(relaxed): consider refactoring GRPC to properly include the header-only chain segment and cleanup old fields
             //
 
             let blocks_iter = trusted_data

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -1161,7 +1161,7 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
                 node_mass_processed_count: processing_counters
                     .storage_mass_counts
                     .max(processing_counters.compute_mass_counts)
-                    .max(processing_counters.transient_mass_counts), // TODO(pre-covpp): mass must be multidimensional
+                    .max(processing_counters.transient_mass_counts), // TODO: mass should be multidimensional
                 // ---
                 node_database_blocks_count: consensus_stats.block_counts.block_count,
                 node_database_headers_count: consensus_stats.block_counts.header_count,


### PR DESCRIPTION
This PR applies the final cleanup pass on top of the Toccata branch before merging it to master.

Changes:

- Handle newer DB versions on startup:
  - If the local database version is higher than the node’s `LATEST_DB_VERSION`, startup now prompts for database deletion instead of showing the older-version upgrade prompt and later hitting the version assert.
  - Removes the stale alpha-era raw metadata key check from the DB-version loop.

- Revert lane-local gas-normalized mempool ordering:
  - `Frontier::by_lane` is back to normal feerate ordering.
  - The previous `max(mass, normalized_gas)` key had two issues.

  First, the normalized key was not only used for ordering. `finish_intra_lane_selection` pushes the selected key’s mass into the sequence, so gas-heavy transactions were counted against the selector’s global mass budget using the normalized gas value. This could make template selection stop early and leave usable block mass unfilled, even though gas is already enforced separately by the per-lane selection state.

  Second, the ordering heuristic itself is not clearly well-founded across lanes. Gas is a lane-local limit: gas spent in lane A does not reduce the gas capacity available in lane B. Mass is different: mass spent by any transaction reduces the same global block mass budget. Once `finish_intra_lane_selection` compares heap heads from several occupied lanes, using `fee / max(mass, normalized_gas)` mixes these two kinds of scarcity into one denominator. That can demote a gas-heavy transaction in one lane against a mass-heavy transaction in another lane, even though their gas usage competes with different lane budgets. A fixed normalized-gas denominator may be useful only with more contextual information, such as remaining gas in that specific lane and remaining global block mass. Without that, it is just a heuristic, and not obviously more correct than normal feerate ordering.

  Gas remains enforced by the existing per-lane selection limits.

- Clean up stale `pre-covpp` / `pre-toccata` comments:
  - Removes resolved activation TODOs.
  - Rewords remaining TODOs according to their actual follow-up scope.