### PR TITLE
chore: 1.3.0 pre-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-build-info"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "duct",
  "faster-hex 0.9.0",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "ahash",
  "borsh",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "duration-string",
  "futures",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "criterion",
@@ -3363,14 +3363,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-system-info"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "kaspa-utils",
  "mac_address",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "aes",
  "ahash",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "clap",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6506,7 +6506,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.2.2-toc.4"
+version = "1.3.0-toc.5"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -88,67 +88,67 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.2.2-toc.4", path = "testing/integration" }
-kaspa-addresses = { version = "1.2.2-toc.4", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.2.2-toc.4", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.2.2-toc.4", path = "wallet/bip32" }
-kaspa-cli = { version = "1.2.2-toc.4", path = "cli" }
-kaspa-connectionmanager = { version = "1.2.2-toc.4", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.2.2-toc.4", path = "consensus" }
-kaspa-consensus-core = { version = "1.2.2-toc.4", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.2.2-toc.4", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.2.2-toc.4", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.2.2-toc.4", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.2.2-toc.4", path = "components/consensusmanager" }
-kaspa-core = { version = "1.2.2-toc.4", path = "core" }
-kaspa-daemon = { version = "1.2.2-toc.4", path = "daemon" }
-kaspa-database = { version = "1.2.2-toc.4", path = "database" }
-kaspa-grpc-client = { version = "1.2.2-toc.4", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.2.2-toc.4", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.2.2-toc.4", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.2.2-toc.4", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.2.2-toc.4", path = "indexes/core" }
-kaspa-index-processor = { version = "1.2.2-toc.4", path = "indexes/processor" }
-kaspa-math = { version = "1.2.2-toc.4", path = "math" }
-kaspa-merkle = { version = "1.2.2-toc.4", path = "crypto/merkle" }
-kaspa-smt = { version = "1.2.2-toc.4", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.2.2-toc.4", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.2.2-toc.4", path = "metrics/core" }
-kaspa-mining = { version = "1.2.2-toc.4", path = "mining" }
-kaspa-mining-errors = { version = "1.2.2-toc.4", path = "mining/errors" }
-kaspa-muhash = { version = "1.2.2-toc.4", path = "crypto/muhash" }
-kaspa-notify = { version = "1.2.2-toc.4", path = "notify" }
-kaspa-p2p-flows = { version = "1.2.2-toc.4", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.2.2-toc.4", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.2.2-toc.4", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.2.2-toc.4", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.2.2-toc.4", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.2.2-toc.4", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.2.2-toc.4", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.2.2-toc.4", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.2.2-toc.4", path = "rpc/service" }
-kaspa-txscript = { version = "1.2.2-toc.4", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.2.2-toc.4", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.2.2-toc.4", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.2.2-toc.4", path = "utils/tower" }
-kaspa-system-info = { version = "1.2.2-toc.4", path = "system-info" }
-kaspa-build-info = { version = "1.2.2-toc.4", path = "build-info" }
-kaspa-utxoindex = { version = "1.2.2-toc.4", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.2.2-toc.4", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.2.2-toc.4", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.2.2-toc.4", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.2.2-toc.4", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.2.2-toc.4", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.2.2-toc.4", path = "wallet/macros" }
-kaspa-wasm = { version = "1.2.2-toc.4", path = "wasm" }
-kaspa-wasm-core = { version = "1.2.2-toc.4", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.2.2-toc.4", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.2.2-toc.4", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.2.2-toc.4", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.2.2-toc.4", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.2.2-toc.4", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.2.2-toc.4", path = "kaspad" }
-kaspa-alloc = { version = "1.2.2-toc.4", path = "utils/alloc" }
+kaspa-testing-integration = { version = "1.3.0-toc.5", path = "testing/integration" }
+kaspa-addresses = { version = "1.3.0-toc.5", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "1.3.0-toc.5", path = "components/addressmanager" }
+kaspa-bip32 = { version = "1.3.0-toc.5", path = "wallet/bip32" }
+kaspa-cli = { version = "1.3.0-toc.5", path = "cli" }
+kaspa-connectionmanager = { version = "1.3.0-toc.5", path = "components/connectionmanager" }
+kaspa-consensus = { version = "1.3.0-toc.5", path = "consensus" }
+kaspa-consensus-core = { version = "1.3.0-toc.5", path = "consensus/core" }
+kaspa-consensus-client = { version = "1.3.0-toc.5", path = "consensus/client" }
+kaspa-consensus-notify = { version = "1.3.0-toc.5", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "1.3.0-toc.5", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "1.3.0-toc.5", path = "components/consensusmanager" }
+kaspa-core = { version = "1.3.0-toc.5", path = "core" }
+kaspa-daemon = { version = "1.3.0-toc.5", path = "daemon" }
+kaspa-database = { version = "1.3.0-toc.5", path = "database" }
+kaspa-grpc-client = { version = "1.3.0-toc.5", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "1.3.0-toc.5", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "1.3.0-toc.5", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "1.3.0-toc.5", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "1.3.0-toc.5", path = "indexes/core" }
+kaspa-index-processor = { version = "1.3.0-toc.5", path = "indexes/processor" }
+kaspa-math = { version = "1.3.0-toc.5", path = "math" }
+kaspa-merkle = { version = "1.3.0-toc.5", path = "crypto/merkle" }
+kaspa-smt = { version = "1.3.0-toc.5", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "1.3.0-toc.5", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "1.3.0-toc.5", path = "metrics/core" }
+kaspa-mining = { version = "1.3.0-toc.5", path = "mining" }
+kaspa-mining-errors = { version = "1.3.0-toc.5", path = "mining/errors" }
+kaspa-muhash = { version = "1.3.0-toc.5", path = "crypto/muhash" }
+kaspa-notify = { version = "1.3.0-toc.5", path = "notify" }
+kaspa-p2p-flows = { version = "1.3.0-toc.5", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "1.3.0-toc.5", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "1.3.0-toc.5", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "1.3.0-toc.5", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "1.3.0-toc.5", path = "consensus/pow" }
+kaspa-rpc-core = { version = "1.3.0-toc.5", path = "rpc/core" }
+kaspa-seq-commit = { version = "1.3.0-toc.5", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "1.3.0-toc.5", path = "rpc/macros" }
+kaspa-rpc-service = { version = "1.3.0-toc.5", path = "rpc/service" }
+kaspa-txscript = { version = "1.3.0-toc.5", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "1.3.0-toc.5", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "1.3.0-toc.5", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "1.3.0-toc.5", path = "utils/tower" }
+kaspa-system-info = { version = "1.3.0-toc.5", path = "system-info" }
+kaspa-build-info = { version = "1.3.0-toc.5", path = "build-info" }
+kaspa-utxoindex = { version = "1.3.0-toc.5", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "1.3.0-toc.5", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "1.3.0-toc.5", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "1.3.0-toc.5", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "1.3.0-toc.5", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "1.3.0-toc.5", path = "wallet/core" }
+kaspa-wallet-macros = { version = "1.3.0-toc.5", path = "wallet/macros" }
+kaspa-wasm = { version = "1.3.0-toc.5", path = "wasm" }
+kaspa-wasm-core = { version = "1.3.0-toc.5", path = "wasm/core" }
+kaspa-wrpc-client = { version = "1.3.0-toc.5", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "1.3.0-toc.5", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "1.3.0-toc.5", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "1.3.0-toc.5", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "1.3.0-toc.5", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "1.3.0-toc.5", path = "kaspad" }
+kaspa-alloc = { version = "1.3.0-toc.5", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -720,7 +720,7 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
 
-    toccata_activation: ForkActivation::never(),
+    toccata_activation: ForkActivation::new(u64::MAX / 10),
 };
 
 pub const TESTNET_PARAMS: Params = Params {

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -720,7 +720,7 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
 
-    toccata_activation: ForkActivation::new(u64::MAX / 10),
+    toccata_activation: ForkActivation::never(),
 };
 
 pub const TESTNET_PARAMS: Params = Params {

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -18,9 +18,52 @@ use kaspa_txscript::{post_toccata_p2sh_sig_scanner, script_class::ScriptClass};
 /// standardness limit encourages parallelism across inputs rather than concentrating work in one input.
 const MAX_STANDARD_P2SH_SIG_OPS: u16 = 15;
 
+/// MAXIMUM_STANDARD_TRANSACTION_MASS is the maximum per-dimension transaction mass considered
+/// standard prior to Toccata. Until the network is about to activate Toccata (see
+/// STANDARD_MASS_RELAXATION_WINDOW_SECONDS), the mempool keeps rejecting higher-mass transactions
+/// as non-standard, so that updated nodes don't admit and relay transactions that not-yet-updated
+/// peers would drop, leaving them stuck unmined.
+pub(crate) const MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA: u64 = 100_000;
+
+/// Window, in seconds, before Toccata activation at which the standard mass cap is relaxed. By this
+/// point the network is expected to be fully updated, so high-mass transactions can be admitted and
+/// primed in mempools ahead of activation.
+const STANDARD_MASS_RELAXATION_WINDOW_SECONDS: u64 = 30 * 60;
+
 impl Mempool {
-    pub(crate) fn check_transaction_standard_in_isolation(&self, transaction: &MutableTransaction) -> NonStandardResult<()> {
+    /// Returns the per-dimension standard mass cap currently in effect, or `None` once the cap has
+    /// been relaxed (within [`STANDARD_MASS_RELAXATION_WINDOW_SECONDS`] before Toccata activation,
+    /// and ever after). `early_by` keeps `never`/`always` activations untouched, so networks without
+    /// a scheduled Toccata keep the cap and `always`-active ones never apply it.
+    ///
+    /// TODO(post-toccata): once Toccata is active on all networks, delete this helper together with
+    /// MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA, STANDARD_MASS_RELAXATION_WINDOW_SECONDS and the
+    /// cap checks in `check_transaction_standard_in_isolation`/`_in_context`. The block-fit limits in
+    /// check_transaction_limits then remain the only per-tx mass ceiling.
+    fn standard_transaction_mass_cap(&self, virtual_daa_score: u64) -> Option<u64> {
+        let window = STANDARD_MASS_RELAXATION_WINDOW_SECONDS.saturating_mul(self.config.network_blocks_per_second);
+        let relaxation = self.toccata_activation.early_by(window);
+        (!relaxation.is_active(virtual_daa_score)).then_some(MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA)
+    }
+
+    pub(crate) fn check_transaction_standard_in_isolation(
+        &self,
+        transaction: &MutableTransaction,
+        virtual_daa_score: u64,
+    ) -> NonStandardResult<()> {
         let transaction_id = transaction.id();
+
+        // Until shortly before Toccata activates, keep the legacy per-tx standard mass cap on the
+        // non-contextual dimensions so updated nodes don't relay transactions that peers still reject.
+        if let Some(cap) = self.standard_transaction_mass_cap(virtual_daa_score) {
+            let masses = transaction.calculated_non_contextual_masses.unwrap();
+            if masses.compute_mass > cap {
+                return Err(NonStandardError::RejectComputeMass(transaction_id, masses.compute_mass, cap));
+            }
+            if masses.transient_mass > cap {
+                return Err(NonStandardError::RejectTransientMass(transaction_id, masses.transient_mass, cap));
+            }
+        }
 
         // None of the output public key scripts can be a non-standard script.
         for (i, output) in transaction.tx.outputs.iter().enumerate() {
@@ -50,6 +93,15 @@ impl Mempool {
         virtual_daa_score: u64,
     ) -> NonStandardResult<()> {
         let transaction_id = transaction.id();
+
+        // Storage mass is only known after contextual population, so the standard mass cap is applied to it here.
+        if let Some(cap) = self.standard_transaction_mass_cap(virtual_daa_score) {
+            let storage_mass = transaction.tx.mass();
+            if storage_mass > cap {
+                return Err(NonStandardError::RejectStorageMass(transaction_id, storage_mass, cap));
+            }
+        }
+
         for i in 0..transaction.tx.inputs.len() {
             // It is safe to elide existence and index checks here since
             // they have already been checked prior to calling this
@@ -333,7 +385,7 @@ mod tests {
 
                 // Ensure standard-ness is as expected.
                 println!("test_check_transaction_standard_in_isolation test '{}' ", test.name);
-                let res = mempool.check_transaction_standard_in_isolation(&test.mtx);
+                let res = mempool.check_transaction_standard_in_isolation(&test.mtx, 0);
                 if res.is_ok() && test.is_standard {
                     // Test passes since function returned standard for a
                     // transaction which is intended to be standard.
@@ -536,5 +588,96 @@ mod tests {
             ))
         );
         // end-TODO
+    }
+
+    #[test]
+    fn test_standard_transaction_mass_cap() {
+        // Toccata score far enough out that the relaxation window (30 min * bps) starts at a positive score.
+        let toccata_activation = ForkActivation::new(1_000_000);
+        let params: Params = NetworkType::Mainnet.into();
+        let config =
+            Config::build_default(params.target_time_per_block(), false, params.mempool_block_mass_limits(), params.block_lane_limits);
+        let mempool = Mempool::new(Arc::new(config), toccata_activation, Arc::new(MiningCounters::default()));
+
+        let addr = Address::new(Prefix::Mainnet, Version::PubKey, &[1u8; 32]);
+        let spk = kaspa_txscript::pay_to_address_script(&addr);
+
+        // 0 is before the relaxation window opens; one score below activation is inside it.
+        let before_window = 0;
+        let in_window = toccata_activation.daa_score() - 1;
+        let over = MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA + 1;
+
+        // Non-contextual (compute/transient) dimensions, checked in isolation.
+        let isolation_mtx = |compute, transient| {
+            let input = TransactionInput::new(
+                TransactionOutpoint::new(kaspa_hashes::Hash::from_u64_word(1), 0),
+                vec![],
+                MAX_TX_IN_SEQUENCE_NUM,
+                0,
+            );
+            let tx = Transaction::new(
+                TX_VERSION,
+                vec![input],
+                vec![TransactionOutput::new(SOMPI_PER_KASPA, spk.clone())],
+                0,
+                SUBNETWORK_ID_NATIVE,
+                0,
+                vec![],
+            );
+            let mut mtx = MutableTransaction::from_tx(tx);
+            mtx.calculated_non_contextual_masses = Some(NonContextualMasses::new(compute, transient));
+            mtx
+        };
+
+        let high_compute = isolation_mtx(over, 1_000);
+        assert_eq!(
+            mempool.check_transaction_standard_in_isolation(&high_compute, before_window),
+            Err(NonStandardError::RejectComputeMass(high_compute.id(), over, MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA))
+        );
+        assert_eq!(mempool.check_transaction_standard_in_isolation(&high_compute, in_window), Ok(()));
+
+        let high_transient = isolation_mtx(1_000, over);
+        assert_eq!(
+            mempool.check_transaction_standard_in_isolation(&high_transient, before_window),
+            Err(NonStandardError::RejectTransientMass(high_transient.id(), over, MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA))
+        );
+        assert_eq!(mempool.check_transaction_standard_in_isolation(&high_transient, in_window), Ok(()));
+
+        // A transaction at the cap is standard even before the window.
+        let within_cap = isolation_mtx(MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA, MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA);
+        assert_eq!(mempool.check_transaction_standard_in_isolation(&within_cap, before_window), Ok(()));
+
+        // Contextual storage dimension, checked in context.
+        let context_mtx = |storage: u64, fee: u64| {
+            let input = TransactionInput::new(
+                TransactionOutpoint::new(kaspa_hashes::Hash::from_u64_word(1), 0),
+                vec![],
+                MAX_TX_IN_SEQUENCE_NUM,
+                0,
+            );
+            let tx = Transaction::new(
+                TX_VERSION,
+                vec![input],
+                vec![TransactionOutput::new(SOMPI_PER_KASPA, spk.clone())],
+                0,
+                SUBNETWORK_ID_NATIVE,
+                0,
+                vec![],
+            );
+            tx.set_mass(storage);
+            let mut mtx =
+                MutableTransaction::with_entries(tx.into(), vec![UtxoEntry::new(2 * SOMPI_PER_KASPA, spk.clone(), 0, false, None)]);
+            mtx.calculated_non_contextual_masses = Some(NonContextualMasses::new(1_000, 1_000));
+            mtx.calculated_fee = Some(fee);
+            mtx
+        };
+
+        let high_storage = context_mtx(over, SOMPI_PER_KASPA);
+        assert_eq!(
+            mempool.check_transaction_standard_in_context(&high_storage, Priority::High, before_window),
+            Err(NonStandardError::RejectStorageMass(high_storage.id(), over, MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA))
+        );
+        // Within the window the storage cap is lifted; the well-funded, standard tx is accepted.
+        assert_eq!(mempool.check_transaction_standard_in_context(&high_storage, Priority::High, in_window), Ok(()));
     }
 }

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -30,7 +30,7 @@ impl Mempool {
         transaction.calculated_non_contextual_masses = Some(consensus.calculate_transaction_non_contextual_masses(&transaction.tx)?);
         let virtual_daa_score = consensus.get_virtual_daa_score();
         self.validate_transaction_limits_in_isolation(&transaction, virtual_daa_score)?;
-        self.validate_transaction_std_in_isolation(&transaction)?;
+        self.validate_transaction_std_in_isolation(&transaction, virtual_daa_score)?;
         let feerate_threshold = self.get_replace_by_fee_constraint(&transaction, rbf_policy, virtual_daa_score)?;
         self.populate_mempool_entries(&mut transaction);
         Ok(TransactionPreValidation { transaction, feerate_threshold })
@@ -146,9 +146,9 @@ impl Mempool {
         Ok(())
     }
 
-    fn validate_transaction_std_in_isolation(&self, transaction: &MutableTransaction) -> RuleResult<()> {
+    fn validate_transaction_std_in_isolation(&self, transaction: &MutableTransaction, virtual_daa_score: u64) -> RuleResult<()> {
         if !self.config.accept_non_standard {
-            self.check_transaction_standard_in_isolation(transaction)?;
+            self.check_transaction_standard_in_isolation(transaction, virtual_daa_score)?;
         }
         Ok(())
     }

--- a/mining/src/toccata_transient_mass_activation_tests.rs
+++ b/mining/src/toccata_transient_mass_activation_tests.rs
@@ -24,11 +24,14 @@ use crate::{
     errors::MiningManagerError,
     manager::MiningManager,
     mempool::{
+        check_transaction_standard::MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA,
         config::Config,
         errors::RuleError,
         tx::{Orphan, Priority, RbfPolicy},
     },
+    model::tx_query::TransactionQuery,
 };
+use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::{
     api::{
         ConsensusApi,
@@ -57,6 +60,7 @@ use kaspa_consensus_core::{
 };
 use kaspa_core::time::unix_now;
 use kaspa_hashes::{Hash, ZERO_HASH};
+use kaspa_txscript::pay_to_address_script;
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, HashSet},
@@ -408,12 +412,110 @@ fn template_limits_reject_gas_even_when_non_standard_transactions_are_allowed() 
     assert_eq!(consensus.validation_attempts(), 0, "gas limit rejection should happen before consensus in-context validation");
 }
 
+// TODO(post-toccata): remove once Toccata is active everywhere; it covers the temporary pre-Toccata
+// standard mass cap, which is deleted then.
+//
+// A transaction whose mass exceeds the pre-Toccata standard cap (here via transient mass) is rejected
+// by mempool standardness until shortly before activation, and admitted (and mineable) from the
+// relaxation window onward. The pre-window rejection is the fix: it stops updated nodes from admitting
+// and relaying high-mass transactions that not-yet-updated peers would drop, leaving them stuck unmined.
+//
+// Note: a node never admits a transaction it cannot also fit into a block (mempool admission limits
+// mirror the consensus block limits), so "accepted but unmineable" is a network-level outcome that
+// the rejection prevents rather than a single-node state we can assert here.
+#[test]
+fn high_mass_tx_rejected_by_standardness_until_pre_activation_window() {
+    let params = standardness_activation_params();
+    let window = standardness_relaxation_window_daa_score();
+    // Transient mass over the standard cap (100k); two of them stay within the block limit (500k).
+    const HIGH_TRANSIENT: u64 = 150_000;
+    const { assert!(HIGH_TRANSIENT > MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA && 2 * HIGH_TRANSIENT < PRIOR_BLOCK_MASS_LIMIT) };
+
+    // Before the relaxation window opens: rejected as non-standard, never enters the mempool.
+    let consensus = Arc::new(MassPolicyTestConsensus::new(&params));
+    let mining_manager = standard_mining_manager(&params);
+    consensus.set_virtual_daa_score(STANDARDNESS_ACTIVATION_DAA_SCORE - window - 1);
+    let tx = standard_high_mass_transaction(0, HIGH_TRANSIENT);
+    let err = insert_transaction(&mining_manager, consensus.as_ref(), tx.clone(), RbfPolicy::Forbidden)
+        .expect_err("high-mass tx must be rejected before the relaxation window");
+    assert!(
+        matches!(err, MiningManagerError::MempoolError(RuleError::RejectNonStandard(id, ref msg))
+            if id == tx.id()
+                && msg.contains(&HIGH_TRANSIENT.to_string())
+                && msg.contains(&MAXIMUM_STANDARD_TRANSACTION_MASS_PRE_TOCCATA.to_string())),
+        "expected pre-window standard mass-cap rejection, got {err:?}"
+    );
+    assert!(!mining_manager.has_transaction(&tx.id(), TransactionQuery::All));
+
+    // Inside the window (still before activation) and after activation: admitted and selected into the
+    // block template, so the mempool drains such transactions into blocks.
+    for (name, virtual_daa_score) in
+        [("in window", STANDARDNESS_ACTIVATION_DAA_SCORE - 1), ("after activation", STANDARDNESS_ACTIVATION_DAA_SCORE)]
+    {
+        let consensus = Arc::new(MassPolicyTestConsensus::new(&params));
+        let mining_manager = standard_mining_manager(&params);
+        consensus.set_virtual_daa_score(virtual_daa_score);
+        let txs = [standard_high_mass_transaction(0, HIGH_TRANSIENT), standard_high_mass_transaction(1, HIGH_TRANSIENT)];
+        for tx in txs.iter().cloned() {
+            insert_transaction(&mining_manager, consensus.as_ref(), tx, RbfPolicy::Forbidden)
+                .unwrap_or_else(|err| panic!("{name}: high-mass tx must be admitted, got {err:?}"));
+        }
+        let selected = selected_template_transactions(&mining_manager, consensus.as_ref());
+        let selected_ids = selected.iter().map(Transaction::id).collect::<HashSet<_>>();
+        for tx in txs {
+            assert!(selected_ids.contains(&tx.id()), "{name}: admitted high-mass tx should be selected into the template");
+        }
+        assert_eq!(total_transient_mass(&selected), 2 * HIGH_TRANSIENT, "{name}: both high-mass txs should be mined");
+    }
+}
+
 fn transient_activation_params() -> Params {
     let mut params = SIMNET_PARAMS.clone();
     params.prior_block_mass_limits = BlockMassLimits::with_shared_limit(PRIOR_BLOCK_MASS_LIMIT);
     params.new_transient_mass_limit = NEW_TRANSIENT_LIMIT;
     params.toccata_activation = ForkActivation::new(ACTIVATION_DAA_SCORE);
     params
+}
+
+// TODO(post-toccata): remove together with the pre-Toccata standard mass cap it covers
+// (high_mass_tx_rejected_by_standardness_until_pre_activation_window and these two helpers).
+
+// Activation score for the standardness-cap test. It must exceed the relaxation window so that a
+// pre-window score (where the cap is still enforced) exists at a non-negative DAA score.
+const STANDARDNESS_ACTIVATION_DAA_SCORE: u64 = 1_000_000;
+
+fn standardness_activation_params() -> Params {
+    let mut params = transient_activation_params();
+    params.toccata_activation = ForkActivation::new(STANDARDNESS_ACTIVATION_DAA_SCORE);
+    params
+}
+
+// Mirrors STANDARD_MASS_RELAXATION_WINDOW_SECONDS (30 min) scaled by the mempool's blocks-per-second,
+// which Config derives from TARGET_TIME_PER_BLOCK.
+fn standardness_relaxation_window_daa_score() -> u64 {
+    30 * 60 * (1000 / TARGET_TIME_PER_BLOCK)
+}
+
+// Mining manager with standardness enforced (accept_non_standard = false), unlike `mining_manager`
+// which relays non-standard transactions and thus skips the standard mass cap.
+fn standard_mining_manager(params: &Params) -> MiningManager {
+    let config = Config::build_default(TARGET_TIME_PER_BLOCK, false, params.mempool_block_mass_limits(), BLOCK_LANE_LIMITS);
+    MiningManager::with_config(config, params.toccata_activation, None, Arc::new(MiningCounters::default()))
+}
+
+// A transaction with standard P2PK scripts (so it passes script-class standardness) whose transient
+// mass is driven by the payload byte count. Fees and input amount are large enough to clear the relay
+// fee floor both before and after activation, isolating the standard mass cap under test.
+fn standard_high_mass_transaction(n: u64, transient_bytes: u64) -> MutableTransaction {
+    let spk = pay_to_address_script(&Address::new(Prefix::Simnet, Version::PubKey, &[1u8; 32]));
+    let input_amount = 10_000 * SOMPI_PER_KASPA;
+    let fee = 1_000 * SOMPI_PER_KASPA;
+    let input = TransactionInput::new(outpoint(n), vec![], MAX_TX_IN_SEQUENCE_NUM, 0);
+    let output = TransactionOutput::new(input_amount - fee, spk.clone());
+    let tx =
+        Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, 0, vec![n as u8; transient_bytes as usize]);
+    let entry = UtxoEntry::new(input_amount, spk, 0, false, None);
+    MutableTransaction::with_entries(tx.into(), vec![entry])
 }
 
 fn mempool_delay_daa_score(params: &Params) -> u64 {


### PR DESCRIPTION
- (by @biryukovmaxim) enforce legacy tx std mass limits until toccata activation (minus a ~60s delta), then enforce toccata std mass limits
- bump to 1.3.0-toc.5