### PR TITLE
Rename tx.mass -> tx.storage_mass

### DIFF
--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -292,7 +292,7 @@ pub struct SerializableTransaction {
     pub lock_time: u64,
     pub gas: u64,
     #[serde(default)]
-    pub mass: u64,
+    pub storage_mass: u64,
     pub subnetwork_id: SubnetworkId,
     #[serde(with = "hex::serde")]
     pub payload: Vec<u8>,
@@ -335,7 +335,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time,
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas,
-            mass: transaction.storage_mass(),
+            storage_mass: transaction.storage_mass(),
             payload: transaction.payload.clone(),
             id: transaction.id(),
         })
@@ -355,7 +355,7 @@ impl SerializableTransaction {
             subnetwork_id: inner.subnetwork_id,
             gas: inner.gas,
             payload: inner.payload.clone(),
-            mass: inner.mass,
+            storage_mass: inner.storage_mass,
             id: inner.id,
         })
     }
@@ -383,7 +383,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time,
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas,
-            mass: transaction.storage_mass(),
+            storage_mass: transaction.storage_mass(),
             payload: transaction.payload.clone(),
         })
     }
@@ -411,7 +411,7 @@ impl TryFrom<SerializableTransaction> for cctx::SignableTransaction {
             serializable.gas,
             serializable.payload,
         )
-        .with_storage_mass(serializable.mass);
+        .with_storage_mass(serializable.storage_mass);
 
         Ok(Self::with_entries(tx, entries))
     }
@@ -424,6 +424,6 @@ impl TryFrom<SerializableTransaction> for Transaction {
         let inputs: Vec<TransactionInput> = tx.inputs.iter().map(TryInto::try_into).collect::<Result<Vec<_>>>()?;
         let outputs: Vec<TransactionOutput> = tx.outputs.iter().map(TryInto::try_into).collect::<Result<Vec<_>>>()?;
 
-        Transaction::new(Some(id), tx.version, inputs, outputs, tx.lock_time, tx.subnetwork_id, tx.gas, tx.payload, tx.mass)
+        Transaction::new(Some(id), tx.version, inputs, outputs, tx.lock_time, tx.subnetwork_id, tx.gas, tx.payload, tx.storage_mass)
     }
 }

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -335,7 +335,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time,
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas,
-            mass: transaction.mass(),
+            mass: transaction.storage_mass(),
             payload: transaction.payload.clone(),
             id: transaction.id(),
         })
@@ -383,7 +383,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time,
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas,
-            mass: transaction.mass(),
+            mass: transaction.storage_mass(),
             payload: transaction.payload.clone(),
         })
     }
@@ -411,7 +411,7 @@ impl TryFrom<SerializableTransaction> for cctx::SignableTransaction {
             serializable.gas,
             serializable.payload,
         )
-        .with_mass(serializable.mass);
+        .with_storage_mass(serializable.mass);
 
         Ok(Self::with_entries(tx, entries))
     }

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -286,7 +286,7 @@ pub struct SerializableTransaction {
     pub lock_time: String,
     pub gas: String,
     #[serde(default)]
-    pub mass: String,
+    pub storage_mass: String,
     #[serde(with = "hex::serde")]
     pub payload: Vec<u8>,
 }
@@ -328,7 +328,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time.to_string(),
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas.to_string(),
-            mass: transaction.storage_mass().to_string(),
+            storage_mass: transaction.storage_mass().to_string(),
             payload: transaction.payload.clone(),
         })
     }
@@ -346,7 +346,7 @@ impl SerializableTransaction {
             lock_time: inner.lock_time.to_string(),
             subnetwork_id: inner.subnetwork_id,
             gas: inner.gas.to_string(),
-            mass: inner.mass.to_string(),
+            storage_mass: inner.storage_mass.to_string(),
             payload: inner.payload.clone(),
             id: inner.id,
         })
@@ -375,7 +375,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time.to_string(),
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas.to_string(),
-            mass: transaction.storage_mass().to_string(),
+            storage_mass: transaction.storage_mass().to_string(),
             payload: transaction.payload.clone(),
         })
     }
@@ -403,7 +403,7 @@ impl TryFrom<SerializableTransaction> for cctx::SignableTransaction {
             signable.gas.parse()?,
             signable.payload,
         )
-        .with_storage_mass(signable.mass.parse().unwrap_or_default());
+        .with_storage_mass(signable.storage_mass.parse().unwrap_or_default());
 
         Ok(Self::with_entries(tx, entries))
     }
@@ -425,7 +425,7 @@ impl TryFrom<SerializableTransaction> for crate::Transaction {
             tx.subnetwork_id,
             tx.gas.parse()?,
             tx.payload,
-            tx.mass.parse().unwrap_or_default(),
+            tx.storage_mass.parse().unwrap_or_default(),
         )
     }
 }

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -328,7 +328,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time.to_string(),
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas.to_string(),
-            mass: transaction.mass().to_string(),
+            mass: transaction.storage_mass().to_string(),
             payload: transaction.payload.clone(),
         })
     }
@@ -375,7 +375,7 @@ impl SerializableTransaction {
             lock_time: transaction.lock_time.to_string(),
             subnetwork_id: transaction.subnetwork_id,
             gas: transaction.gas.to_string(),
-            mass: transaction.mass().to_string(),
+            mass: transaction.storage_mass().to_string(),
             payload: transaction.payload.clone(),
         })
     }
@@ -403,7 +403,7 @@ impl TryFrom<SerializableTransaction> for cctx::SignableTransaction {
             signable.gas.parse()?,
             signable.payload,
         )
-        .with_mass(signable.mass.parse().unwrap_or_default());
+        .with_storage_mass(signable.mass.parse().unwrap_or_default());
 
         Ok(Self::with_entries(tx, entries))
     }

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -335,7 +335,7 @@ impl TryCastFromJs for Transaction {
 impl From<cctx::Transaction> for Transaction {
     fn from(tx: cctx::Transaction) -> Self {
         let id = tx.id();
-        let mass = tx.mass();
+        let mass = tx.storage_mass();
         let inputs: Vec<TransactionInput> = tx.inputs.into_iter().map(|input| input.into()).collect::<Vec<TransactionInput>>();
         let outputs: Vec<TransactionOutput> = tx.outputs.into_iter().map(|output| output.into()).collect::<Vec<TransactionOutput>>();
         Self::new_with_inner(TransactionInner {
@@ -364,7 +364,7 @@ impl From<&Transaction> for cctx::Transaction {
         let outputs: Vec<cctx::TransactionOutput> =
             inner.outputs.clone().into_iter().map(|output| output.as_ref().into()).collect::<Vec<cctx::TransactionOutput>>();
         cctx::Transaction::new(inner.version, inputs, outputs, inner.lock_time, inner.subnetwork_id, inner.gas, inner.payload.clone())
-            .with_mass(inner.mass)
+            .with_storage_mass(inner.mass)
     }
 }
 
@@ -396,7 +396,7 @@ impl Transaction {
             lock_time: tx.lock_time,
             gas: tx.gas,
             payload: tx.payload.clone(),
-            mass: tx.mass(),
+            mass: tx.storage_mass(),
             subnetwork_id: tx.subnetwork_id,
         })
     }
@@ -424,7 +424,7 @@ impl Transaction {
             inner.gas,
             inner.payload.clone(),
         )
-        .with_mass(inner.mass);
+        .with_storage_mass(inner.mass);
 
         Ok((tx, utxos))
     }

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -24,7 +24,7 @@ use kaspa_utils::hex::*;
 const TS_TRANSACTION: &'static str = r#"
 /**
  * Interface defining the structure of a transaction.
- * 
+ *
  * @category Consensus
  */
 export interface ITransaction {
@@ -35,8 +35,14 @@ export interface ITransaction {
     subnetworkId: HexString;
     gas: bigint;
     payload: HexString;
-    /** The mass of the transaction (the mass is undefined or zero unless explicitly set or obtained from the node) */
+
+    /**
+     * @deprecated since version 1.3.0, use `storageMass`
+    */
     mass?: bigint;
+
+    /** The mass of the transaction (the mass is undefined or zero unless explicitly set or obtained from the node) */
+    storageMass?: bigint;
 
     /** Optional verbose data provided by RPC */
     verboseData?: ITransactionVerboseData;
@@ -44,7 +50,7 @@ export interface ITransaction {
 
 /**
  * Optional transaction verbose data.
- * 
+ *
  * @category Node RPC
  */
 export interface ITransactionVerboseData {
@@ -75,7 +81,7 @@ pub struct TransactionInner {
     pub subnetwork_id: SubnetworkId,
     pub gas: u64,
     pub payload: Vec<u8>,
-    pub mass: u64,
+    pub storage_mass: u64,
 
     // A field that is used to cache the transaction ID.
     // Always use the corresponding self.id() instead of accessing this field directly
@@ -103,7 +109,7 @@ impl Transaction {
         subnetwork_id: SubnetworkId,
         gas: u64,
         payload: Vec<u8>,
-        mass: u64,
+        storage_mass: u64,
     ) -> Result<Self> {
         let finalize = id.is_none();
         let tx = Self {
@@ -116,7 +122,7 @@ impl Transaction {
                 subnetwork_id,
                 gas,
                 payload,
-                mass,
+                storage_mass,
             })),
         };
         if finalize {
@@ -268,14 +274,26 @@ impl Transaction {
         self.inner.lock().unwrap().payload = js_value.try_as_vec_u8().unwrap_or_else(|err| panic!("payload value error: {err}"));
     }
 
+    /// @deprecated Use `storageMass` instead
     #[wasm_bindgen(getter = mass)]
     pub fn get_mass(&self) -> u64 {
-        self.inner().mass
+        self.inner().storage_mass
     }
 
+    /// @deprecated Use `storageMass` instead
     #[wasm_bindgen(setter = mass)]
     pub fn set_mass(&self, v: u64) {
-        self.inner().mass = v;
+        self.inner().storage_mass = v;
+    }
+
+    #[wasm_bindgen(getter = storageMass)]
+    pub fn get_storage_mass(&self) -> u64 {
+        self.inner().storage_mass
+    }
+
+    #[wasm_bindgen(setter = storageMass)]
+    pub fn set_storage_mass(&self, v: u64) {
+        self.inner().storage_mass = v;
     }
 
     #[wasm_bindgen(js_name = populateGenesisCovenants)]
@@ -302,8 +320,12 @@ impl TryCastFromJs for Transaction {
                     let lock_time = object.get_u64("lockTime")?;
                     let gas = object.get_u64("gas")?;
                     let payload = object.get_vec_u8("payload")?;
+
                     // mass field is optional
                     let mass = object.get_u64("mass").unwrap_or_default();
+                    // storage mass is the new name for legacy `mass`, take the max between both
+                    let storage_mass = object.get_u64("storageMass").unwrap_or_default().max(mass);
+
                     let subnetwork_id = object.get_vec_u8("subnetworkId")?;
                     if subnetwork_id.len() != subnets::SUBNETWORK_ID_SIZE {
                         return Err(Error::Custom("subnetworkId must be 20 bytes long".into()));
@@ -322,7 +344,8 @@ impl TryCastFromJs for Transaction {
                         .iter()
                         .map(TryCastFromJs::try_owned_from)
                         .collect::<std::result::Result<Vec<TransactionOutput>, Error>>()?;
-                    Transaction::new(id, version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass).map(Into::into)
+                    Transaction::new(id, version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass)
+                        .map(Into::into)
                 }
             } else {
                 Err("Transaction must be an object".into())
@@ -335,7 +358,7 @@ impl TryCastFromJs for Transaction {
 impl From<cctx::Transaction> for Transaction {
     fn from(tx: cctx::Transaction) -> Self {
         let id = tx.id();
-        let mass = tx.storage_mass();
+        let storage_mass = tx.storage_mass();
         let inputs: Vec<TransactionInput> = tx.inputs.into_iter().map(|input| input.into()).collect::<Vec<TransactionInput>>();
         let outputs: Vec<TransactionOutput> = tx.outputs.into_iter().map(|output| output.into()).collect::<Vec<TransactionOutput>>();
         Self::new_with_inner(TransactionInner {
@@ -345,7 +368,7 @@ impl From<cctx::Transaction> for Transaction {
             lock_time: tx.lock_time,
             gas: tx.gas,
             payload: tx.payload,
-            mass,
+            storage_mass,
             subnetwork_id: tx.subnetwork_id,
             id,
         })
@@ -364,7 +387,7 @@ impl From<&Transaction> for cctx::Transaction {
         let outputs: Vec<cctx::TransactionOutput> =
             inner.outputs.clone().into_iter().map(|output| output.as_ref().into()).collect::<Vec<cctx::TransactionOutput>>();
         cctx::Transaction::new(inner.version, inputs, outputs, inner.lock_time, inner.subnetwork_id, inner.gas, inner.payload.clone())
-            .with_storage_mass(inner.mass)
+            .with_storage_mass(inner.storage_mass)
     }
 }
 
@@ -396,7 +419,7 @@ impl Transaction {
             lock_time: tx.lock_time,
             gas: tx.gas,
             payload: tx.payload.clone(),
-            mass: tx.storage_mass(),
+            storage_mass: tx.storage_mass(),
             subnetwork_id: tx.subnetwork_id,
         })
     }
@@ -424,7 +447,7 @@ impl Transaction {
             inner.gas,
             inner.payload.clone(),
         )
-        .with_storage_mass(inner.mass);
+        .with_storage_mass(inner.storage_mass);
 
         Ok((tx, utxos))
     }

--- a/consensus/core/src/hashing/tx.rs
+++ b/consensus/core/src/hashing/tx.rs
@@ -84,7 +84,7 @@ fn write_transaction<T: HasherBase>(hasher: &mut T, tx: &Transaction, encoding_f
     */
 
     if !encoding_flags.contains(TxEncodingFlags::EXCLUDE_MASS_COMMIT) {
-        let mass = tx.mass();
+        let mass = tx.storage_mass();
         if tx.version < 1 {
             if mass > 0 {
                 hasher.write_u64(mass);
@@ -360,7 +360,7 @@ mod tests {
             0,
             vec![],
         );
-        tx_v1_a.set_mass(0);
+        tx_v1_a.set_storage_mass(0);
 
         let mut tx_v1_b = tx_v1_a.clone();
         tx_v1_b.inputs[0].mass = TxInputMass::ComputeBudget(222.into());

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -264,7 +264,7 @@ mod tests {
         );
 
         // Test a tx with storage mass commitment > 0
-        txs[0].set_mass(7);
+        txs[0].set_storage_mass(7);
 
         assert_eq!(
             calc_hash_merkle_root(txs.iter()),

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -401,9 +401,9 @@ impl Transaction {
         self.id
     }
 
-    /// [DEPRECATED] This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.set_storage_mass(mass)` instead.
     /// Set the storage mass commitment field of this transaction. This field has been activated on mainnet as part
     /// of the Crescendo hardfork. The field has no effect on tx ID so no need to finalize following this call.
+    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.set_storage_mass(mass)` instead."]
     pub fn set_mass(&self, mass: u64) {
         self.set_storage_mass(mass);
     }
@@ -414,8 +414,8 @@ impl Transaction {
         self.storage_mass.0.store(mass, SeqCst)
     }
 
-    /// [DEPRECATED] This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.storage_mass()` instead.
     /// Read the storage mass commitment
+    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.storage_mass()` instead."]
     pub fn mass(&self) -> u64 {
         self.storage_mass()
     }

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -257,7 +257,7 @@ pub struct Transaction {
 
     /// Holds a commitment to the storage mass (KIP-0009)
     /// TODO: rename field and related methods to storage_mass
-    mass: TransactionMass,
+    storage_mass: TransactionMass,
 
     // A field that is used to cache the transaction ID.
     // Always use the corresponding self.id() instead of accessing this field directly
@@ -290,7 +290,7 @@ impl Transaction {
         mass: u64,
     ) -> Self {
         let mut tx = Self::new_non_finalized(version, inputs, outputs, lock_time, subnetwork_id, gas, payload);
-        tx.set_mass(mass);
+        tx.set_storage_mass(mass);
         tx.finalize();
         tx
     }
@@ -304,7 +304,17 @@ impl Transaction {
         gas: u64,
         payload: Vec<u8>,
     ) -> Self {
-        Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass: Default::default(), id: Default::default() }
+        Self {
+            version,
+            inputs,
+            outputs,
+            lock_time,
+            subnetwork_id,
+            gas,
+            payload,
+            storage_mass: Default::default(),
+            id: Default::default(),
+        }
     }
 
     /// Populates genesis covenant bindings for multiple output groups.
@@ -391,20 +401,33 @@ impl Transaction {
         self.id
     }
 
+    /// [DEPRECATED] This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.set_storage_mass(mass)` instead.
     /// Set the storage mass commitment field of this transaction. This field has been activated on mainnet as part
     /// of the Crescendo hardfork. The field has no effect on tx ID so no need to finalize following this call.
     pub fn set_mass(&self, mass: u64) {
-        self.mass.0.store(mass, SeqCst)
+        self.set_storage_mass(mass);
+    }
+
+    /// Set the storage mass commitment field of this transaction. This field has been activated on mainnet as part
+    /// of the Crescendo hardfork. The field has no effect on tx ID so no need to finalize following this call.
+    pub fn set_storage_mass(&self, mass: u64) {
+        self.storage_mass.0.store(mass, SeqCst)
+    }
+
+    /// [DEPRECATED] This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.storage_mass()` instead.
+    /// Read the storage mass commitment
+    pub fn mass(&self) -> u64 {
+        self.storage_mass()
     }
 
     /// Read the storage mass commitment
-    pub fn mass(&self) -> u64 {
-        self.mass.0.load(SeqCst)
+    pub fn storage_mass(&self) -> u64 {
+        self.storage_mass.0.load(SeqCst)
     }
 
     /// Set the storage mass commitment of the passed transaction
-    pub fn with_mass(self, mass: u64) -> Self {
-        self.set_mass(mass);
+    pub fn with_storage_mass(self, mass: u64) -> Self {
+        self.set_storage_mass(mass);
         self
     }
 
@@ -634,7 +657,9 @@ impl<T: AsRef<Transaction>> MutableTransaction<T> {
     /// exist, otherwise `None` is returned.
     pub fn calculated_feerate(&self, cofactors: &MassCofactors) -> Option<f64> {
         self.calculated_non_contextual_masses
-            .map(|non_contextual| Mass::new(non_contextual, ContextualMasses::new(self.tx.as_ref().mass())).normalized_max(cofactors))
+            .map(|non_contextual| {
+                Mass::new(non_contextual, ContextualMasses::new(self.tx.as_ref().storage_mass())).normalized_max(cofactors)
+            })
             .and_then(|max_mass| self.calculated_fee.map(|fee| fee as f64 / max_mass as f64))
     }
 

--- a/consensus/core/src/tx/serde_impl.rs
+++ b/consensus/core/src/tx/serde_impl.rs
@@ -213,7 +213,7 @@ impl Serialize for Transaction {
         state.serialize_field("subnetworkId", &self.subnetwork_id)?;
         state.serialize_field("gas", &self.gas)?;
         state.serialize_field("payload", &Bytes(&self.payload))?;
-        state.serialize_field("mass", &self.mass)?;
+        state.serialize_field("mass", &self.storage_mass)?;
         state.serialize_field("id", &self.id)?;
         state.end()
     }
@@ -287,7 +287,7 @@ impl<'de> Visitor<'de> for TransactionVisitor {
         let mass = seq.next_element()?.unwrap_or_default();
         let id = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(8, &self))?;
 
-        Ok(Transaction { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass, id })
+        Ok(Transaction { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass: mass, id })
     }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
@@ -397,7 +397,17 @@ impl<'de> Visitor<'de> for TransactionVisitor {
 
         // `mass` keeps its historical `#[serde(default)]` leniency; `id` is required and
         // read verbatim — serde does not recompute the txid on deserialization.
-        Ok(Transaction { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass: mass.unwrap_or_default(), id })
+        Ok(Transaction {
+            version,
+            inputs,
+            outputs,
+            lock_time,
+            subnetwork_id,
+            gas,
+            payload,
+            storage_mass: mass.unwrap_or_default(),
+            id,
+        })
     }
 }
 

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -77,7 +77,7 @@ impl BlockBodyProcessor {
             // Read the storage mass commitment. This value cannot be computed here w/o UTXO context
             // so we use the commitment. Later on, when the transaction is verified in context, we use
             // the context to calculate the expected storage mass and verify it matches this commitment
-            let storage_mass_commitment = tx.mass();
+            let storage_mass_commitment = tx.storage_mass();
 
             // Sum over the various masses separately
             total_compute_mass = total_compute_mass.saturating_add(compute_mass);

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -457,7 +457,7 @@ impl VirtualStateProcessor {
             .ok_or(TxRuleError::MassIncomputable)?;
 
         // Set the inner mass field
-        mutable_tx.tx.set_mass(contextual_mass.storage_mass);
+        mutable_tx.tx.set_storage_mass(contextual_mass.storage_mass);
 
         // At this point we know all UTXO entries are populated, so we can safely pass the tx as verifiable
         let mass_and_feerate_threshold = args.feerate_threshold.map(|threshold| {

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -46,7 +46,7 @@ impl TransactionValidator {
             return Err(TxRuleError::CoinbaseHasInputs(tx.inputs.len()));
         }
 
-        if tx.mass() > 0 {
+        if tx.storage_mass() > 0 {
             return Err(TxRuleError::CoinbaseNonZeroMassCommitment);
         }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -126,7 +126,7 @@ impl TransactionValidator {
     fn check_mass_commitment(&self, tx: &impl VerifiableTransaction) -> TxResult<()> {
         let calculated_contextual_mass =
             self.mass_calculator.calc_contextual_masses(tx).ok_or(TxRuleError::MassIncomputable)?.storage_mass;
-        let committed_contextual_mass = tx.tx().mass();
+        let committed_contextual_mass = tx.tx().storage_mass();
         if committed_contextual_mass != calculated_contextual_mass {
             return Err(TxRuleError::WrongMass(calculated_contextual_mass, committed_contextual_mass));
         }

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -1071,7 +1071,7 @@ fn feerate_stats(transactions: Vec<Transaction>, calculated_fees: Vec<u64>) -> O
             .iter()
             // skip coinbase tx
             .skip(1)
-            .map(Transaction::mass))
+            .map(Transaction::storage_mass))
         .map(|(fee, mass)| fee as f64 / mass as f64)
         .collect_vec();
     feerates.sort_unstable_by(f64::total_cmp);
@@ -1092,7 +1092,7 @@ mod tests {
     fn transactions(length: usize) -> Vec<Transaction> {
         let tx = || {
             let tx = Transaction::new(0, vec![], vec![], 0, Default::default(), 0, vec![]);
-            tx.set_mass(2);
+            tx.set_storage_mass(2);
             tx
         };
         let mut txs = repeat_n(tx(), length).collect_vec();

--- a/mining/src/mempool/check_transaction_limits.rs
+++ b/mining/src/mempool/check_transaction_limits.rs
@@ -43,7 +43,7 @@ impl Mempool {
         virtual_daa_score: u64,
     ) -> RuleResult<()> {
         let limits = self.config.mempool_block_mass_limits.get(virtual_daa_score);
-        let storage_mass = transaction.tx.mass();
+        let storage_mass = transaction.tx.storage_mass();
         if storage_mass > limits.storage {
             return Err(RuleError::RejectStorageMass(transaction.id(), storage_mass, limits.storage));
         }
@@ -102,7 +102,7 @@ mod tests {
         let input = TransactionInput::new(outpoint, vec![], MAX_TX_IN_SEQUENCE_NUM, 0);
         let output = TransactionOutput::new(SOMPI_PER_KASPA, script_public_key.clone());
         let tx = Transaction::new(TX_VERSION, vec![input], vec![output], 0, SUBNETWORK_ID_NATIVE, gas, vec![]);
-        tx.set_mass(storage_mass);
+        tx.set_storage_mass(storage_mass);
         let entry = UtxoEntry::new(SOMPI_PER_KASPA, script_public_key, 0, false, None);
         let mut tx = MutableTransaction::with_entries(tx.into(), vec![entry]);
         tx.calculated_non_contextual_masses = Some(NonContextualMasses::new(compute_mass, transient_mass));

--- a/mining/src/mempool/check_transaction_standard.rs
+++ b/mining/src/mempool/check_transaction_standard.rs
@@ -96,7 +96,7 @@ impl Mempool {
 
         // Storage mass is only known after contextual population, so the standard mass cap is applied to it here.
         if let Some(cap) = self.standard_transaction_mass_cap(virtual_daa_score) {
-            let storage_mass = transaction.tx.mass();
+            let storage_mass = transaction.tx.storage_mass();
             if storage_mass > cap {
                 return Err(NonStandardError::RejectStorageMass(transaction_id, storage_mass, cap));
             }
@@ -664,7 +664,7 @@ mod tests {
                 0,
                 vec![],
             );
-            tx.set_mass(storage);
+            tx.set_storage_mass(storage);
             let mut mtx =
                 MutableTransaction::with_entries(tx.into(), vec![UtxoEntry::new(2 * SOMPI_PER_KASPA, spk.clone(), 0, false, None)]);
             mtx.calculated_non_contextual_masses = Some(NonContextualMasses::new(1_000, 1_000));

--- a/mining/src/mempool/model/frontier/feerate_key.rs
+++ b/mining/src/mempool/model/frontier/feerate_key.rs
@@ -92,7 +92,7 @@ impl FeerateTransactionKey {
         // in order to optimize and increase block space usage.
         let mass = Mass::new(
             tx.mtx.calculated_non_contextual_masses.expect("masses are expected to be calculated"),
-            ContextualMasses::new(tx.mtx.tx.mass()),
+            ContextualMasses::new(tx.mtx.tx.storage_mass()),
         )
         .normalized_max(cofactors);
         let fee = tx.mtx.calculated_fee.expect("fee is expected to be populated");

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -139,7 +139,7 @@ impl ConsensusApi for ConsensusMock {
         // At this point we know all UTXO entries are populated, so we can safely calculate the fee
         let total_in: u64 = mutable_tx.entries.iter().map(|x| x.as_ref().unwrap().amount).sum();
         let total_out: u64 = mutable_tx.tx.outputs.iter().map(|x| x.value).sum();
-        mutable_tx.tx.set_mass(self.calculate_transaction_contextual_masses(mutable_tx).unwrap().storage_mass);
+        mutable_tx.tx.set_storage_mass(self.calculate_transaction_contextual_masses(mutable_tx).unwrap().storage_mass);
 
         if mutable_tx.calculated_fee.is_none() {
             let calculated_fee = total_in - total_out;

--- a/mining/src/toccata_transient_mass_activation_tests.rs
+++ b/mining/src/toccata_transient_mass_activation_tests.rs
@@ -163,7 +163,7 @@ impl ConsensusApi for MassPolicyTestConsensus {
         }
         let non_contextual_masses = mutable_tx.calculated_non_contextual_masses.expect("populated by mempool");
         let contextual_masses = self.calculate_transaction_contextual_masses(mutable_tx).ok_or(TxRuleError::MassIncomputable)?;
-        mutable_tx.tx.set_mass(contextual_masses.storage_mass);
+        mutable_tx.tx.set_storage_mass(contextual_masses.storage_mass);
 
         let total_in: u64 = mutable_tx.entries.iter().map(|entry| entry.as_ref().unwrap().amount).sum();
         let total_out: u64 = mutable_tx.tx.outputs.iter().map(|output| output.value).sum();

--- a/protocol/p2p/proto/p2p.proto
+++ b/protocol/p2p/proto/p2p.proto
@@ -30,7 +30,7 @@ message TransactionMessage{
   SubnetworkId subnetworkId = 5;
   uint64 gas = 6;
   bytes payload = 8;
-  uint64 mass = 9;
+  uint64 storage_mass = 9;
 }
 
 message TransactionInput{

--- a/protocol/p2p/src/convert/tx.rs
+++ b/protocol/p2p/src/convert/tx.rs
@@ -84,7 +84,7 @@ impl From<&Transaction> for protowire::TransactionMessage {
             subnetwork_id: Some((&tx.subnetwork_id).into()),
             gas: tx.gas,
             payload: tx.payload.clone(),
-            mass: tx.mass(),
+            mass: tx.storage_mass(),
         }
     }
 }
@@ -201,7 +201,7 @@ impl TryFrom<protowire::TransactionMessage> for Transaction {
             tx.gas,
             tx.payload,
         );
-        transaction.set_mass(tx.mass);
+        transaction.set_storage_mass(tx.mass);
         Ok(transaction)
     }
 }
@@ -226,7 +226,7 @@ mod tests {
             7,
             vec![1, 2, 3],
         );
-        tx.set_mass(54_321);
+        tx.set_storage_mass(54_321);
 
         let message: protowire::TransactionMessage = (&tx).into();
         assert_eq!(message.inputs[0].mass, 12_345);
@@ -234,6 +234,6 @@ mod tests {
         let received = Transaction::try_from(message).unwrap();
         assert_eq!(received.inputs.len(), 1);
         assert_eq!(received.inputs[0].mass.compute_budget(), Some(12_345));
-        assert_eq!(received.mass(), 54_321);
+        assert_eq!(received.storage_mass(), 54_321);
     }
 }

--- a/protocol/p2p/src/convert/tx.rs
+++ b/protocol/p2p/src/convert/tx.rs
@@ -84,7 +84,7 @@ impl From<&Transaction> for protowire::TransactionMessage {
             subnetwork_id: Some((&tx.subnetwork_id).into()),
             gas: tx.gas,
             payload: tx.payload.clone(),
-            mass: tx.storage_mass(),
+            storage_mass: tx.storage_mass(),
         }
     }
 }
@@ -201,7 +201,7 @@ impl TryFrom<protowire::TransactionMessage> for Transaction {
             tx.gas,
             tx.payload,
         );
-        transaction.set_storage_mass(tx.mass);
+        transaction.set_storage_mass(tx.storage_mass);
         Ok(transaction)
     }
 }

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -92,7 +92,7 @@ impl From<&Transaction> for RpcTransaction {
             subnetwork_id: item.subnetwork_id,
             gas: item.gas,
             payload: item.payload.clone(),
-            mass: item.storage_mass(),
+            storage_mass: item.storage_mass(),
             verbose_data: None,
         }
     }
@@ -145,7 +145,7 @@ impl TryFrom<RpcTransaction> for Transaction {
             item.gas,
             item.payload.clone(),
         );
-        transaction.set_storage_mass(item.mass);
+        transaction.set_storage_mass(item.storage_mass);
         Ok(transaction)
     }
 }

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -171,7 +171,7 @@ impl From<&Transaction> for RpcOptionalTransaction {
             subnetwork_id: Some(item.subnetwork_id),
             gas: Some(item.gas),
             payload: Some(item.payload.clone()),
-            mass: Some(item.storage_mass()),
+            storage_mass: Some(item.storage_mass()),
             verbose_data: None,
         }
     }
@@ -224,7 +224,9 @@ impl TryFrom<RpcOptionalTransaction> for Transaction {
             item.gas.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "gas".to_owned()))?,
             item.payload.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "payload".to_owned()))?,
         );
-        transaction.set_storage_mass(item.mass.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "mass".to_owned()))?);
+        transaction.set_storage_mass(
+            item.storage_mass.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "mass".to_owned()))?,
+        );
         Ok(transaction)
     }
 }

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -92,7 +92,7 @@ impl From<&Transaction> for RpcTransaction {
             subnetwork_id: item.subnetwork_id,
             gas: item.gas,
             payload: item.payload.clone(),
-            mass: item.mass(),
+            mass: item.storage_mass(),
             verbose_data: None,
         }
     }
@@ -145,7 +145,7 @@ impl TryFrom<RpcTransaction> for Transaction {
             item.gas,
             item.payload.clone(),
         );
-        transaction.set_mass(item.mass);
+        transaction.set_storage_mass(item.mass);
         Ok(transaction)
     }
 }
@@ -171,7 +171,7 @@ impl From<&Transaction> for RpcOptionalTransaction {
             subnetwork_id: Some(item.subnetwork_id),
             gas: Some(item.gas),
             payload: Some(item.payload.clone()),
-            mass: Some(item.mass()),
+            mass: Some(item.storage_mass()),
             verbose_data: None,
         }
     }
@@ -224,7 +224,7 @@ impl TryFrom<RpcOptionalTransaction> for Transaction {
             item.gas.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "gas".to_owned()))?,
             item.payload.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "payload".to_owned()))?,
         );
-        transaction.set_mass(item.mass.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "mass".to_owned()))?);
+        transaction.set_storage_mass(item.mass.ok_or(RpcError::MissingRpcFieldError("RpcTransaction".to_owned(), "mass".to_owned()))?);
         Ok(transaction)
     }
 }

--- a/rpc/core/src/convert/verbosity.rs
+++ b/rpc/core/src/convert/verbosity.rs
@@ -143,7 +143,7 @@ impl_verbosity_from! {
 impl_verbosity_from! {
     for RpcTransactionVerbosity, from RpcDataVerbosityLevel {
         include_payload:           (RpcDataVerbosityLevel::High),
-        include_mass:              (RpcDataVerbosityLevel::High),
+        include_storage_mass:      (RpcDataVerbosityLevel::High),
         include_version:           (RpcDataVerbosityLevel::Full),
         include_lock_time:         (RpcDataVerbosityLevel::Full),
         include_subnetwork_id:     (RpcDataVerbosityLevel::Full),

--- a/rpc/core/src/model/optional/tx.rs
+++ b/rpc/core/src/model/optional/tx.rs
@@ -473,8 +473,7 @@ impl TryFrom<RpcNullableCovenantBinding> for RpcCovenantBinding {
 }
 
 /// Represents a Kaspa transaction
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub struct RpcOptionalTransaction {
     /// Level: Full
     pub version: Option<u16>,
@@ -486,13 +485,65 @@ pub struct RpcOptionalTransaction {
     pub subnetwork_id: Option<RpcSubnetworkId>,
     /// Level: Full
     pub gas: Option<u64>,
-    #[serde(with = "serde_bytes_optional")]
     /// Level: High
     pub payload: Option<Vec<u8>>,
     /// Level: High
-    #[serde(alias = "mass")] // DEPRECATED alias for mass to avoid breaking existing clients. Should be removed in the future.
     pub storage_mass: Option<u64>,
     pub verbose_data: Option<RpcOptionalTransactionVerboseData>,
+}
+
+// This struct is used only for human-readable serialization of RpcOptionalTransaction, and is not intended to be used directly.
+// It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcOptionalTransaction,
+// while allowing us to rename the internal storage mass field to storage_mass for better clarity.
+// Once the "mass" field is removed from RpcOptionalTransaction, this struct and the related code can be removed as well.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcOptionalTransactionHumanReadable {
+    version: Option<u16>,
+    inputs: Vec<RpcOptionalTransactionInput>,
+    outputs: Vec<RpcOptionalTransactionOutput>,
+    lock_time: Option<u64>,
+    subnetwork_id: Option<RpcSubnetworkId>,
+    gas: Option<u64>,
+    #[serde(with = "serde_bytes_optional")]
+    payload: Option<Vec<u8>>,
+    storage_mass: Option<u64>,
+    mass: Option<u64>, // Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future.
+    verbose_data: Option<RpcOptionalTransactionVerboseData>,
+}
+
+impl<'de> serde::Deserialize<'de> for RpcOptionalTransaction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if !deserializer.is_human_readable() {
+            return Err(serde::de::Error::custom("RpcOptionalTransaction does not support non-human-readable deserialization"));
+        }
+
+        let value = RpcOptionalTransactionHumanReadable::deserialize(deserializer)?;
+        let storage_mass = match (value.storage_mass, value.mass) {
+            (Some(storage_mass), Some(mass)) if storage_mass != mass => {
+                return Err(serde::de::Error::custom(format!(
+                    "storageMass and mass must match when both are provided: storageMass={storage_mass}, mass={mass}"
+                )));
+            }
+            (Some(storage_mass), _) => Some(storage_mass),
+            (None, mass) => mass,
+        };
+
+        Ok(Self {
+            version: value.version,
+            inputs: value.inputs,
+            outputs: value.outputs,
+            lock_time: value.lock_time,
+            subnetwork_id: value.subnetwork_id,
+            gas: value.gas,
+            payload: value.payload,
+            storage_mass,
+            verbose_data: value.verbose_data,
+        })
+    }
 }
 
 impl Serialize for RpcOptionalTransaction {
@@ -500,32 +551,11 @@ impl Serialize for RpcOptionalTransaction {
     where
         S: serde::Serializer,
     {
-        // This struct is used only for human-readable serialization of RpcOptionalTransaction, and is not intended to be used directly.
-        // It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcOptionalTransaction,
-        // while allowing us to rename the internal storage mass field to storage_mass for better clarity.
-        // Once the "mass" field is removed from RpcOptionalTransaction, this struct and the related code can be removed as well.
-        #[derive(Clone, Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct RpcOptionalTransactionHumanReadable {
-            version: Option<u16>,
-            inputs: Vec<RpcOptionalTransactionInput>,
-            outputs: Vec<RpcOptionalTransactionOutput>,
-            lock_time: Option<u64>,
-            subnetwork_id: Option<RpcSubnetworkId>,
-            gas: Option<u64>,
-            #[serde(with = "serde_bytes_optional")]
-            payload: Option<Vec<u8>>,
-            storage_mass: Option<u64>,
-            #[deprecated = "Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future."]
-            mass: Option<u64>,
-            verbose_data: Option<RpcOptionalTransactionVerboseData>,
-        }
-
         if !serializer.is_human_readable() {
             return Err(serde::ser::Error::custom("RpcOptionalTransaction does not support non-human-readable serialization"));
         }
 
-        // We use this destructuring so any change in the fields of RpcTransaction will cause a compile error here, reminding us to update the serialization code of RpcTransactionHumanReadable accordingly.
+        // We use this destructuring so any change in the fields of RpcOptionalTransaction will cause a compile error here, reminding us to update the serialization code of RpcOptionalTransactionHumanReadable accordingly.
         let Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass, verbose_data } = self;
 
         let hr = RpcOptionalTransactionHumanReadable {
@@ -561,7 +591,7 @@ impl RpcOptionalTransaction {
 
 impl std::fmt::Debug for RpcOptionalTransaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RpcTransaction")
+        f.debug_struct("RpcOptionalTransaction")
             .field("version", &self.version)
             .field("lock_time", &self.lock_time)
             .field("subnetwork_id", &self.subnetwork_id)

--- a/rpc/core/src/model/optional/tx.rs
+++ b/rpc/core/src/model/optional/tx.rs
@@ -490,7 +490,8 @@ pub struct RpcOptionalTransaction {
     /// Level: High
     pub payload: Option<Vec<u8>>,
     /// Level: High
-    pub mass: Option<u64>,
+    #[serde(alias = "mass")] // DEPRECATED alias for mass to avoid breaking existing clients. Should be removed in the future.
+    pub storage_mass: Option<u64>,
     pub verbose_data: Option<RpcOptionalTransactionVerboseData>,
 }
 
@@ -503,7 +504,7 @@ impl RpcOptionalTransaction {
             && self.subnetwork_id.is_none()
             && self.gas.is_none()
             && self.payload.is_none()
-            && self.mass.is_none()
+            && self.storage_mass.is_none()
             && (self.verbose_data.is_none() || self.verbose_data.as_ref().is_some_and(|x| x.is_empty()))
     }
 }
@@ -516,7 +517,7 @@ impl std::fmt::Debug for RpcOptionalTransaction {
             .field("subnetwork_id", &self.subnetwork_id)
             .field("gas", &self.gas)
             .field("payload", &self.payload.as_ref().map(|v|v.to_hex()))
-            .field("mass", &self.mass)
+            .field("storage_mass", &self.storage_mass)
             .field("inputs", &self.inputs) // Inputs and outputs are placed purposely at the end for better debug visibility
             .field("outputs", &self.outputs)
             .field("verbose_data", &self.verbose_data)
@@ -534,7 +535,7 @@ impl Serializer for RpcOptionalTransaction {
         store!(Option<RpcSubnetworkId>, &self.subnetwork_id, writer)?;
         store!(Option<u64>, &self.gas, writer)?;
         store!(Option<Vec<u8>>, &self.payload, writer)?;
-        store!(Option<u64>, &self.mass, writer)?;
+        store!(Option<u64>, &self.storage_mass, writer)?;
         serialize!(Option<RpcOptionalTransactionVerboseData>, &self.verbose_data, writer)?;
 
         Ok(())
@@ -552,10 +553,10 @@ impl Deserializer for RpcOptionalTransaction {
         let subnetwork_id = load!(Option<RpcSubnetworkId>, reader)?;
         let gas = load!(Option<u64>, reader)?;
         let payload = load!(Option<Vec<u8>>, reader)?;
-        let mass = load!(Option<u64>, reader)?;
+        let storage_mass = load!(Option<u64>, reader)?;
         let verbose_data = deserialize!(Option<RpcOptionalTransactionVerboseData>, reader)?;
 
-        Ok(Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass, verbose_data })
+        Ok(Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass, verbose_data })
     }
 }
 

--- a/rpc/core/src/model/optional/tx.rs
+++ b/rpc/core/src/model/optional/tx.rs
@@ -473,7 +473,7 @@ impl TryFrom<RpcNullableCovenantBinding> for RpcCovenantBinding {
 }
 
 /// Represents a Kaspa transaction
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcOptionalTransaction {
     /// Level: Full
@@ -493,6 +493,56 @@ pub struct RpcOptionalTransaction {
     #[serde(alias = "mass")] // DEPRECATED alias for mass to avoid breaking existing clients. Should be removed in the future.
     pub storage_mass: Option<u64>,
     pub verbose_data: Option<RpcOptionalTransactionVerboseData>,
+}
+
+impl Serialize for RpcOptionalTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // This struct is used only for human-readable serialization of RpcOptionalTransaction, and is not intended to be used directly.
+        // It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcOptionalTransaction,
+        // while allowing us to rename the internal storage mass field to storage_mass for better clarity.
+        // Once the "mass" field is removed from RpcOptionalTransaction, this struct and the related code can be removed as well.
+        #[derive(Clone, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RpcOptionalTransactionHumanReadable {
+            version: Option<u16>,
+            inputs: Vec<RpcOptionalTransactionInput>,
+            outputs: Vec<RpcOptionalTransactionOutput>,
+            lock_time: Option<u64>,
+            subnetwork_id: Option<RpcSubnetworkId>,
+            gas: Option<u64>,
+            #[serde(with = "serde_bytes_optional")]
+            payload: Option<Vec<u8>>,
+            storage_mass: Option<u64>,
+            #[deprecated = "Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future."]
+            mass: Option<u64>,
+            verbose_data: Option<RpcOptionalTransactionVerboseData>,
+        }
+
+        if !serializer.is_human_readable() {
+            return Err(serde::ser::Error::custom("RpcOptionalTransaction does not support non-human-readable serialization"));
+        }
+
+        // We use this destructuring so any change in the fields of RpcTransaction will cause a compile error here, reminding us to update the serialization code of RpcTransactionHumanReadable accordingly.
+        let Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass, verbose_data } = self;
+
+        let hr = RpcOptionalTransactionHumanReadable {
+            version: *version,
+            inputs: inputs.clone(),
+            outputs: outputs.clone(),
+            lock_time: *lock_time,
+            subnetwork_id: *subnetwork_id,
+            gas: *gas,
+            payload: payload.clone(),
+            storage_mass: *storage_mass,
+            #[allow(deprecated)]
+            mass: *storage_mass,
+            verbose_data: verbose_data.clone(),
+        };
+        hr.serialize(serializer)
+    }
 }
 
 impl RpcOptionalTransaction {

--- a/rpc/core/src/model/optional/tx_serde_tests.rs
+++ b/rpc/core/src/model/optional/tx_serde_tests.rs
@@ -71,7 +71,7 @@ fn transaction_some() -> RpcOptionalTransaction {
         subnetwork_id: Some(SubnetworkId::from_byte(0)),
         gas: Some(0),
         payload: Some(vec![0xde, 0xad, 0xbe, 0xef]),
-        mass: Some(0),
+        storage_mass: Some(0),
         verbose_data: None,
     }
 }
@@ -85,7 +85,7 @@ fn transaction_none_payload() -> RpcOptionalTransaction {
         subnetwork_id: None,
         gas: None,
         payload: None,
-        mass: None,
+        storage_mass: None,
         verbose_data: None,
     }
 }

--- a/rpc/core/src/model/optional/tx_serde_tests.rs
+++ b/rpc/core/src/model/optional/tx_serde_tests.rs
@@ -9,6 +9,7 @@ use super::tx::{
 };
 use crate::{RpcHash, RpcTransactionId};
 use kaspa_consensus_core::{subnets::SubnetworkId, tx::TransactionId};
+use serde_json::json;
 
 fn hash32(b: u8) -> RpcHash {
     RpcHash::from_bytes([b; 32])
@@ -170,4 +171,46 @@ fn transaction_json_payload_none() {
     assert!(json.contains(r#""payload":null"#), "got: {json}");
     let back: RpcOptionalTransaction = serde_json::from_str(&json).unwrap();
     assert_eq!(back.payload, None);
+}
+
+#[test]
+fn rpc_optional_transaction_json_serializes_mass_and_storage_mass() {
+    let mut transaction = transaction_some();
+    transaction.storage_mass = Some(123);
+
+    let json = serde_json::to_value(transaction).unwrap();
+
+    assert_eq!(json["mass"], json!(123));
+    assert_eq!(json["storageMass"], json!(123));
+}
+
+#[test]
+fn rpc_optional_transaction_json_deserializes_mass_or_storage_mass_to_storage_mass() {
+    let storage_mass_json = r#"{
+        "version": 1,
+        "inputs": [],
+        "outputs": [],
+        "lockTime": 0,
+        "subnetworkId": "0000000000000000000000000000000000000000",
+        "gas": 0,
+        "payload": "deadbeef",
+        "storageMass": 123,
+        "verboseData": null
+    }"#;
+    let storage_mass_tx: RpcOptionalTransaction = serde_json::from_str(storage_mass_json).unwrap();
+    assert_eq!(storage_mass_tx.storage_mass, Some(123));
+
+    let mass_json = r#"{
+        "version": 1,
+        "inputs": [],
+        "outputs": [],
+        "lockTime": 0,
+        "subnetworkId": "0000000000000000000000000000000000000000",
+        "gas": 0,
+        "payload": "deadbeef",
+        "mass": 123,
+        "verboseData": null
+    }"#;
+    let mass_tx: RpcOptionalTransaction = serde_json::from_str(mass_json).unwrap();
+    assert_eq!(mass_tx.storage_mass, Some(123));
 }

--- a/rpc/core/src/model/optional/tx_serde_tests.rs
+++ b/rpc/core/src/model/optional/tx_serde_tests.rs
@@ -214,3 +214,43 @@ fn rpc_optional_transaction_json_deserializes_mass_or_storage_mass_to_storage_ma
     let mass_tx: RpcOptionalTransaction = serde_json::from_str(mass_json).unwrap();
     assert_eq!(mass_tx.storage_mass, Some(123));
 }
+
+#[test]
+fn rpc_optional_transaction_json_deserializes_matching_mass_and_storage_mass_to_storage_mass() {
+    let json = r#"{
+        "version": 1,
+        "inputs": [],
+        "outputs": [],
+        "lockTime": 0,
+        "subnetworkId": "0000000000000000000000000000000000000000",
+        "gas": 0,
+        "payload": "deadbeef",
+        "storageMass": 123,
+        "mass": 123,
+        "verboseData": null
+    }"#;
+
+    let tx: RpcOptionalTransaction = serde_json::from_str(json).unwrap();
+
+    assert_eq!(tx.storage_mass, Some(123));
+}
+
+#[test]
+fn rpc_optional_transaction_json_rejects_conflicting_mass_and_storage_mass() {
+    let json = r#"{
+        "version": 1,
+        "inputs": [],
+        "outputs": [],
+        "lockTime": 0,
+        "subnetworkId": "0000000000000000000000000000000000000000",
+        "gas": 0,
+        "payload": "deadbeef",
+        "storageMass": 123,
+        "mass": 456,
+        "verboseData": null
+    }"#;
+
+    let err = serde_json::from_str::<RpcOptionalTransaction>(json).unwrap_err();
+
+    assert!(err.to_string().contains("storageMass and mass must match"), "got: {err}");
+}

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -403,7 +403,7 @@ mod mockery {
                 subnetwork_id: mock(),
                 gas: mock(),
                 payload: Hash::mock().as_bytes().to_vec(),
-                mass: mock(),
+                storage_mass: mock(),
                 verbose_data: mock(),
             }
         }
@@ -1649,7 +1649,7 @@ mod mockery {
                 subnetwork_id: mock(),
                 gas: 0,
                 payload: vec![],
-                mass: 0,
+                storage_mass: 0,
                 verbose_data: None,
             };
 
@@ -1674,7 +1674,7 @@ mod mockery {
             store!(RpcSubnetworkId, &tx.subnetwork_id, &mut buffer).unwrap();
             store!(u64, &tx.gas, &mut buffer).unwrap();
             store!(Vec<u8>, &tx.payload, &mut buffer).unwrap();
-            store!(u64, &tx.mass, &mut buffer).unwrap();
+            store!(u64, &tx.storage_mass, &mut buffer).unwrap();
             serialize!(Option<RpcTransactionVerboseData>, &tx.verbose_data, &mut buffer).unwrap();
 
             let decoded = RpcTransaction::deserialize(&mut buffer.as_slice()).unwrap();

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -387,7 +387,7 @@ mod mockery {
                 include_subnetwork_id: mock(),
                 include_gas: mock(),
                 include_payload: mock(),
-                include_mass: mock(),
+                include_storage_mass: mock(),
                 verbose_data_verbosity: mock(),
             }
         }
@@ -419,7 +419,7 @@ mod mockery {
                 subnetwork_id: mock(),
                 gas: mock(),
                 payload: Some(Hash::mock().as_bytes().to_vec()),
-                mass: mock(),
+                storage_mass: mock(),
                 verbose_data: mock(),
             }
         }

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -363,7 +363,7 @@ impl Deserializer for RpcTransactionOutputVerboseData {
 }
 
 /// Represents a Kaspa transaction
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransaction {
     pub version: u16,
@@ -374,8 +374,47 @@ pub struct RpcTransaction {
     pub gas: u64,
     #[serde(with = "hex::serde")]
     pub payload: Vec<u8>,
+    #[serde(alias = "mass")] // DEPRECATED alias for mass to avoid breaking existing clients. Should be removed in the future.
+    pub storage_mass: u64,
+    pub verbose_data: Option<RpcTransactionVerboseData>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTransactionJson {
+    pub version: u16,
+    pub inputs: Vec<RpcTransactionInput>,
+    pub outputs: Vec<RpcTransactionOutput>,
+    pub lock_time: u64,
+    pub subnetwork_id: RpcSubnetworkId,
+    pub gas: u64,
+    #[serde(with = "hex::serde")]
+    pub payload: Vec<u8>,
+    #[serde(alias = "mass")]
+    pub storage_mass: u64,
     pub mass: u64,
     pub verbose_data: Option<RpcTransactionVerboseData>,
+}
+
+impl Serialize for RpcTransaction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let json = RpcTransactionJson {
+            version: self.version,
+            inputs: self.inputs.clone(),
+            outputs: self.outputs.clone(),
+            lock_time: self.lock_time,
+            subnetwork_id: self.subnetwork_id,
+            gas: self.gas,
+            payload: self.payload.clone(),
+            storage_mass: self.storage_mass,
+            mass: self.storage_mass,
+            verbose_data: self.verbose_data.clone(),
+        };
+        json.serialize(serializer)
+    }
 }
 
 impl std::fmt::Debug for RpcTransaction {
@@ -386,7 +425,7 @@ impl std::fmt::Debug for RpcTransaction {
             .field("subnetwork_id", &self.subnetwork_id)
             .field("gas", &self.gas)
             .field("payload", &self.payload.to_hex())
-            .field("mass", &self.mass)
+            .field("storage_mass", &self.storage_mass)
             .field("inputs", &self.inputs) // Inputs and outputs are placed purposely at the end for better debug visibility
             .field("outputs", &self.outputs)
             .field("verbose_data", &self.verbose_data)
@@ -404,7 +443,7 @@ impl Serializer for RpcTransaction {
         store!(RpcSubnetworkId, &self.subnetwork_id, writer)?;
         store!(u64, &self.gas, writer)?;
         store!(Vec<u8>, &self.payload, writer)?;
-        store!(u64, &self.mass, writer)?;
+        store!(u64, &self.storage_mass, writer)?;
         serialize!(Option<RpcTransactionVerboseData>, &self.verbose_data, writer)?;
 
         Ok(())
@@ -424,7 +463,67 @@ impl Deserializer for RpcTransaction {
         let mass = load!(u64, reader)?;
         let verbose_data = deserialize!(Option<RpcTransactionVerboseData>, reader)?;
 
-        Ok(Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass, verbose_data })
+        Ok(Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass: mass, verbose_data })
+    }
+}
+
+#[cfg(test)]
+mod rpc_transaction_json_tests {
+    use super::*;
+    use kaspa_consensus_core::subnets::SubnetworkId;
+    use serde_json::json;
+
+    fn transaction() -> RpcTransaction {
+        RpcTransaction {
+            version: 1,
+            inputs: vec![],
+            outputs: vec![],
+            lock_time: 0,
+            subnetwork_id: SubnetworkId::from_byte(0),
+            gas: 0,
+            payload: vec![],
+            storage_mass: 123,
+            verbose_data: None,
+        }
+    }
+
+    #[test]
+    fn rpc_transaction_json_serializes_mass_and_storage_mass() {
+        let json = serde_json::to_value(transaction()).unwrap();
+
+        assert_eq!(json["mass"], json!(123));
+        assert_eq!(json["storageMass"], json!(123));
+    }
+
+    #[test]
+    fn rpc_transaction_json_deserializes_mass_or_storage_mass_to_storage_mass() {
+        let storage_mass_json = r#"{
+            "version": 1,
+            "inputs": [],
+            "outputs": [],
+            "lockTime": 0,
+            "subnetworkId": "0000000000000000000000000000000000000000",
+            "gas": 0,
+            "payload": "",
+            "storageMass": 123,
+            "verboseData": null
+        }"#;
+        let storage_mass_tx: RpcTransaction = serde_json::from_str(storage_mass_json).unwrap();
+        assert_eq!(storage_mass_tx.storage_mass, 123);
+
+        let mass_json = r#"{
+            "version": 1,
+            "inputs": [],
+            "outputs": [],
+            "lockTime": 0,
+            "subnetworkId": "0000000000000000000000000000000000000000",
+            "gas": 0,
+            "payload": "",
+            "mass": 123,
+            "verboseData": null
+        }"#;
+        let mass_tx: RpcTransaction = serde_json::from_str(mass_json).unwrap();
+        assert_eq!(mass_tx.storage_mass, 123);
     }
 }
 

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -381,7 +381,7 @@ pub struct RpcTransaction {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcTransactionJson {
+pub struct RpcTransactionHumanReadable {
     pub version: u16,
     pub inputs: Vec<RpcTransactionInput>,
     pub outputs: Vec<RpcTransactionOutput>,
@@ -390,9 +390,8 @@ pub struct RpcTransactionJson {
     pub gas: u64,
     #[serde(with = "hex::serde")]
     pub payload: Vec<u8>,
-    #[serde(alias = "mass")]
     pub storage_mass: u64,
-    pub mass: u64,
+    pub mass: u64, // DEPRECATED field for storage mass to avoid breaking existing clients. Should be removed in the future.
     pub verbose_data: Option<RpcTransactionVerboseData>,
 }
 
@@ -401,19 +400,26 @@ impl Serialize for RpcTransaction {
     where
         S: serde::Serializer,
     {
-        let json = RpcTransactionJson {
-            version: self.version,
-            inputs: self.inputs.clone(),
-            outputs: self.outputs.clone(),
-            lock_time: self.lock_time,
-            subnetwork_id: self.subnetwork_id,
-            gas: self.gas,
-            payload: self.payload.clone(),
-            storage_mass: self.storage_mass,
-            mass: self.storage_mass,
-            verbose_data: self.verbose_data.clone(),
+        if !serializer.is_human_readable() {
+            return Err(serde::ser::Error::custom("RpcTransaction does not support non-human-readable serialization"));
+        }
+
+        // We use this destructuring so any change in the fields of RpcTransaction will cause a compile error here, reminding us to update the serialization code of RpcTransactionHumanReadable accordingly.
+        let Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, storage_mass, verbose_data } = self;
+
+        let hr = RpcTransactionHumanReadable {
+            version: *version,
+            inputs: inputs.clone(),
+            outputs: outputs.clone(),
+            lock_time: *lock_time,
+            subnetwork_id: *subnetwork_id,
+            gas: *gas,
+            payload: payload.clone(),
+            storage_mass: *storage_mass,
+            mass: *storage_mass,
+            verbose_data: verbose_data.clone(),
         };
-        json.serialize(serializer)
+        hr.serialize(serializer)
     }
 }
 

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -363,8 +363,7 @@ impl Deserializer for RpcTransactionOutputVerboseData {
 }
 
 /// Represents a Kaspa transaction
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub struct RpcTransaction {
     pub version: u16,
     pub inputs: Vec<RpcTransactionInput>,
@@ -372,11 +371,65 @@ pub struct RpcTransaction {
     pub lock_time: u64,
     pub subnetwork_id: RpcSubnetworkId,
     pub gas: u64,
-    #[serde(with = "hex::serde")]
     pub payload: Vec<u8>,
-    #[serde(alias = "mass")] // DEPRECATED alias for mass to avoid breaking existing clients. Should be removed in the future.
     pub storage_mass: u64,
     pub verbose_data: Option<RpcTransactionVerboseData>,
+}
+
+// This struct is used only for human-readable serialization of RpcTransaction, and is not intended to be used directly.
+// It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcTransaction,
+// while allowing us to rename the internal storage mass field to storage_mass for better clarity.
+// Once the "mass" field is removed from RpcTransaction, this struct and the related code can be removed as well.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcTransactionHumanReadable {
+    version: u16,
+    inputs: Vec<RpcTransactionInput>,
+    outputs: Vec<RpcTransactionOutput>,
+    lock_time: u64,
+    subnetwork_id: RpcSubnetworkId,
+    gas: u64,
+    #[serde(with = "hex::serde")]
+    payload: Vec<u8>,
+    #[serde(default)]
+    storage_mass: u64,
+    #[serde(default)]
+    mass: u64, // Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future.
+    verbose_data: Option<RpcTransactionVerboseData>,
+}
+
+impl<'de> serde::Deserialize<'de> for RpcTransaction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if !deserializer.is_human_readable() {
+            return Err(serde::de::Error::custom("RpcTransaction does not support non-human-readable deserialization"));
+        }
+
+        let value = RpcTransactionHumanReadable::deserialize(deserializer)?;
+        let storage_mass = match (value.storage_mass, value.mass) {
+            (storage_mass, mass) if storage_mass > 0 && mass > 0 && storage_mass != mass => {
+                return Err(serde::de::Error::custom(format!(
+                    "storageMass and mass must match when both are positive: storageMass={storage_mass}, mass={mass}"
+                )));
+            }
+            (storage_mass, _) if storage_mass > 0 => storage_mass,
+            (_, mass) => mass,
+        };
+
+        Ok(Self {
+            version: value.version,
+            inputs: value.inputs,
+            outputs: value.outputs,
+            lock_time: value.lock_time,
+            subnetwork_id: value.subnetwork_id,
+            gas: value.gas,
+            payload: value.payload,
+            storage_mass,
+            verbose_data: value.verbose_data,
+        })
+    }
 }
 
 impl Serialize for RpcTransaction {
@@ -384,27 +437,6 @@ impl Serialize for RpcTransaction {
     where
         S: serde::Serializer,
     {
-        // This struct is used only for human-readable serialization of RpcTransaction, and is not intended to be used directly.
-        // It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcTransaction,
-        // while allowing us to rename the internal storage mass field to storage_mass for better clarity.
-        // Once the "mass" field is removed from RpcTransaction, this struct and the related code can be removed as well.
-        #[derive(Clone, Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct RpcTransactionHumanReadable {
-            pub version: u16,
-            pub inputs: Vec<RpcTransactionInput>,
-            pub outputs: Vec<RpcTransactionOutput>,
-            pub lock_time: u64,
-            pub subnetwork_id: RpcSubnetworkId,
-            pub gas: u64,
-            #[serde(with = "hex::serde")]
-            pub payload: Vec<u8>,
-            pub storage_mass: u64,
-            #[deprecated = "Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future."]
-            pub mass: u64,
-            pub verbose_data: Option<RpcTransactionVerboseData>,
-        }
-
         if !serializer.is_human_readable() {
             return Err(serde::ser::Error::custom("RpcTransaction does not support non-human-readable serialization"));
         }
@@ -421,7 +453,6 @@ impl Serialize for RpcTransaction {
             gas: *gas,
             payload: payload.clone(),
             storage_mass: *storage_mass,
-            #[allow(deprecated)]
             mass: *storage_mass,
             verbose_data: verbose_data.clone(),
         };
@@ -536,6 +567,46 @@ mod rpc_transaction_json_tests {
         }"#;
         let mass_tx: RpcTransaction = serde_json::from_str(mass_json).unwrap();
         assert_eq!(mass_tx.storage_mass, 123);
+    }
+
+    #[test]
+    fn rpc_transaction_json_deserializes_matching_mass_and_storage_mass_to_storage_mass() {
+        let json = r#"{
+            "version": 1,
+            "inputs": [],
+            "outputs": [],
+            "lockTime": 0,
+            "subnetworkId": "0000000000000000000000000000000000000000",
+            "gas": 0,
+            "payload": "",
+            "storageMass": 123,
+            "mass": 123,
+            "verboseData": null
+        }"#;
+
+        let tx: RpcTransaction = serde_json::from_str(json).unwrap();
+
+        assert_eq!(tx.storage_mass, 123);
+    }
+
+    #[test]
+    fn rpc_transaction_json_rejects_conflicting_positive_mass_and_storage_mass() {
+        let json = r#"{
+            "version": 1,
+            "inputs": [],
+            "outputs": [],
+            "lockTime": 0,
+            "subnetworkId": "0000000000000000000000000000000000000000",
+            "gas": 0,
+            "payload": "",
+            "storageMass": 123,
+            "mass": 456,
+            "verboseData": null
+        }"#;
+
+        let err = serde_json::from_str::<RpcTransaction>(json).unwrap_err();
+
+        assert!(err.to_string().contains("storageMass and mass must match when both are positive"), "got: {err}");
     }
 }
 

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -379,27 +379,32 @@ pub struct RpcTransaction {
     pub verbose_data: Option<RpcTransactionVerboseData>,
 }
 
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcTransactionHumanReadable {
-    pub version: u16,
-    pub inputs: Vec<RpcTransactionInput>,
-    pub outputs: Vec<RpcTransactionOutput>,
-    pub lock_time: u64,
-    pub subnetwork_id: RpcSubnetworkId,
-    pub gas: u64,
-    #[serde(with = "hex::serde")]
-    pub payload: Vec<u8>,
-    pub storage_mass: u64,
-    pub mass: u64, // DEPRECATED field for storage mass to avoid breaking existing clients. Should be removed in the future.
-    pub verbose_data: Option<RpcTransactionVerboseData>,
-}
-
 impl Serialize for RpcTransaction {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
+        // This struct is used only for human-readable serialization of RpcTransaction, and is not intended to be used directly.
+        // It exists to avoid breaking existing clients that rely on the "mass" field in JSON serialization of RpcTransaction,
+        // while allowing us to rename the internal storage mass field to storage_mass for better clarity.
+        // Once the "mass" field is removed from RpcTransaction, this struct and the related code can be removed as well.
+        #[derive(Clone, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RpcTransactionHumanReadable {
+            pub version: u16,
+            pub inputs: Vec<RpcTransactionInput>,
+            pub outputs: Vec<RpcTransactionOutput>,
+            pub lock_time: u64,
+            pub subnetwork_id: RpcSubnetworkId,
+            pub gas: u64,
+            #[serde(with = "hex::serde")]
+            pub payload: Vec<u8>,
+            pub storage_mass: u64,
+            #[deprecated = "Deprecated field for storage mass to avoid breaking existing clients. Should be removed in the future."]
+            pub mass: u64,
+            pub verbose_data: Option<RpcTransactionVerboseData>,
+        }
+
         if !serializer.is_human_readable() {
             return Err(serde::ser::Error::custom("RpcTransaction does not support non-human-readable serialization"));
         }
@@ -416,6 +421,7 @@ impl Serialize for RpcTransaction {
             gas: *gas,
             payload: payload.clone(),
             storage_mass: *storage_mass,
+            #[allow(deprecated)]
             mass: *storage_mass,
             verbose_data: verbose_data.clone(),
         };

--- a/rpc/core/src/model/verbosity.rs
+++ b/rpc/core/src/model/verbosity.rs
@@ -374,7 +374,7 @@ pub struct RpcTransactionVerbosity {
     pub include_subnetwork_id: Option<bool>,
     pub include_gas: Option<bool>,
     pub include_payload: Option<bool>,
-    pub include_mass: Option<bool>,
+    pub include_storage_mass: Option<bool>,
     pub verbose_data_verbosity: Option<RpcTransactionVerboseDataVerbosity>,
 }
 
@@ -387,7 +387,7 @@ impl RpcTransactionVerbosity {
         include_subnetwork_id: Option<bool>,
         include_gas: Option<bool>,
         include_payload: Option<bool>,
-        include_mass: Option<bool>,
+        include_storage_mass: Option<bool>,
         verbose_data_verbosity: Option<RpcTransactionVerboseDataVerbosity>,
     ) -> Self {
         Self {
@@ -398,7 +398,7 @@ impl RpcTransactionVerbosity {
             include_subnetwork_id,
             include_gas,
             include_payload,
-            include_mass,
+            include_storage_mass,
             verbose_data_verbosity,
         }
     }
@@ -428,7 +428,7 @@ impl Serializer for RpcTransactionVerbosity {
         store!(Option<bool>, &self.include_subnetwork_id, writer)?;
         store!(Option<bool>, &self.include_gas, writer)?;
         store!(Option<bool>, &self.include_payload, writer)?;
-        store!(Option<bool>, &self.include_mass, writer)?;
+        store!(Option<bool>, &self.include_storage_mass, writer)?;
         serialize!(Option<RpcTransactionVerboseDataVerbosity>, &self.verbose_data_verbosity, writer)?;
 
         Ok(())
@@ -446,7 +446,7 @@ impl Deserializer for RpcTransactionVerbosity {
         let include_subnetwork_id = load!(Option<bool>, reader)?;
         let include_gas = load!(Option<bool>, reader)?;
         let include_payload = load!(Option<bool>, reader)?;
-        let include_mass = load!(Option<bool>, reader)?;
+        let include_storage_mass = load!(Option<bool>, reader)?;
         let verbose_data_verbosity = deserialize!(Option<RpcTransactionVerboseDataVerbosity>, reader)?;
 
         Ok(Self {
@@ -457,7 +457,7 @@ impl Deserializer for RpcTransactionVerbosity {
             include_subnetwork_id,
             include_gas,
             include_payload,
-            include_mass,
+            include_storage_mass,
             verbose_data_verbosity,
         })
     }

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -112,7 +112,7 @@ cfg_if::cfg_if! {
                     subnetwork_id: inner.subnetwork_id,
                     gas: inner.gas,
                     payload: inner.payload.clone(),
-                    mass: inner.mass,
+                    storage_mass: inner.mass,
                     verbose_data: None,
                 }
             }

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -162,7 +162,7 @@ cfg_if::cfg_if! {
                     subnetwork_id: Some(inner.subnetwork_id),
                     gas: Some(inner.gas),
                     payload: Some(inner.payload.clone()),
-                    mass: Some(inner.storage_mass),
+                    storage_mass: Some(inner.storage_mass),
                     verbose_data: None,
                 }
             }

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -112,7 +112,7 @@ cfg_if::cfg_if! {
                     subnetwork_id: inner.subnetwork_id,
                     gas: inner.gas,
                     payload: inner.payload.clone(),
-                    storage_mass: inner.mass,
+                    storage_mass: inner.storage_mass,
                     verbose_data: None,
                 }
             }
@@ -162,7 +162,7 @@ cfg_if::cfg_if! {
                     subnetwork_id: Some(inner.subnetwork_id),
                     gas: Some(inner.gas),
                     payload: Some(inner.payload.clone()),
-                    mass: Some(inner.mass),
+                    mass: Some(inner.storage_mass),
                     verbose_data: None,
                 }
             }

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -70,7 +70,7 @@ message RpcTransaction {
   uint64 gas = 6;
   string payload = 8;
   RpcTransactionVerboseData verboseData = 9;
-  uint64 mass = 10;
+  uint64 storage_mass = 10;
 }
 
 message RpcTransactionVerboseData {

--- a/rpc/grpc/core/src/convert/optional/tx.rs
+++ b/rpc/grpc/core/src/convert/optional/tx.rs
@@ -223,6 +223,6 @@ mod tests {
 
         let decoded = RpcOptionalTransaction::try_from(&wire).unwrap();
         assert_eq!(decoded.inputs[0].compute_budget, Some(444));
-        assert_eq!(decoded.mass, Some(333));
+        assert_eq!(decoded.storage_mass, Some(333));
     }
 }

--- a/rpc/grpc/core/src/convert/optional/tx.rs
+++ b/rpc/grpc/core/src/convert/optional/tx.rs
@@ -17,7 +17,7 @@ from!(item: &kaspa_rpc_core::RpcOptionalTransaction, protowire::RpcOptionalTrans
         subnetwork_id: item.subnetwork_id.as_ref().map(|x| x.to_string()),
         gas: item.gas,
         payload: item.payload.as_ref().map(|x| x.to_rpc_hex()),
-        mass: item.mass,
+        mass: item.storage_mass,
         verbose_data: item.verbose_data.as_ref().map(|x| x.into()),
     }
 });

--- a/rpc/grpc/core/src/convert/optional/tx.rs
+++ b/rpc/grpc/core/src/convert/optional/tx.rs
@@ -107,7 +107,7 @@ try_from!(item: &protowire::RpcOptionalTransaction, kaspa_rpc_core::RpcOptionalT
         subnetwork_id: item.subnetwork_id.as_ref().map(|x| RpcSubnetworkId::from_str(x)).transpose()?,
         gas: item.gas,
         payload: item.payload.as_ref().map(|x| Vec::from_rpc_hex(x)).transpose()?,
-        mass: item.mass,
+        storage_mass: item.mass,
         verbose_data: item.verbose_data.as_ref().map(kaspa_rpc_core::RpcOptionalTransactionVerboseData::try_from).transpose()?,
     }
 });
@@ -214,7 +214,7 @@ mod tests {
             subnetwork_id: Some(SubnetworkId::from_bytes([5; 20])),
             gas: Some(0),
             payload: Some(vec![0x01, 0x02]),
-            mass: Some(333),
+            storage_mass: Some(333),
             verbose_data: None,
         };
 

--- a/rpc/grpc/core/src/convert/tx.rs
+++ b/rpc/grpc/core/src/convert/tx.rs
@@ -30,7 +30,7 @@ from!(item: &kaspa_rpc_core::RpcOptionalTransaction, protowire::RpcTransaction, 
         subnetwork_id: item.subnetwork_id.as_ref().map(|x| x.to_string()).unwrap_or_default(),
         gas: item.gas.unwrap_or_default(),
         payload: item.payload.as_ref().map(|x| x.to_rpc_hex()).unwrap_or_default(),
-        storage_mass: item.mass.unwrap_or_default(),
+        storage_mass: item.storage_mass.unwrap_or_default(),
         verbose_data: item.verbose_data.as_ref().map(|x| x.into()),
     }
 });
@@ -243,7 +243,7 @@ try_from!(item: &protowire::RpcTransaction, kaspa_rpc_core::RpcOptionalTransacti
             .subnetwork_id)?),
         gas: Some(item.gas),
         payload: Some(Vec::from_rpc_hex(&item.payload)?),
-        mass: Some(item.storage_mass),
+        storage_mass: Some(item.storage_mass),
         verbose_data: item.verbose_data.as_ref().map(kaspa_rpc_core::RpcOptionalTransactionVerboseData::try_from).transpose()?,
     }
 });

--- a/rpc/grpc/core/src/convert/tx.rs
+++ b/rpc/grpc/core/src/convert/tx.rs
@@ -16,7 +16,7 @@ from!(item: &kaspa_rpc_core::RpcTransaction, protowire::RpcTransaction, {
         subnetwork_id: item.subnetwork_id.to_string(),
         gas: item.gas,
         payload: item.payload.to_rpc_hex(),
-        mass: item.mass,
+        storage_mass: item.storage_mass,
         verbose_data: item.verbose_data.as_ref().map(|x| x.into()),
     }
 });
@@ -30,7 +30,7 @@ from!(item: &kaspa_rpc_core::RpcOptionalTransaction, protowire::RpcTransaction, 
         subnetwork_id: item.subnetwork_id.as_ref().map(|x| x.to_string()).unwrap_or_default(),
         gas: item.gas.unwrap_or_default(),
         payload: item.payload.as_ref().map(|x| x.to_rpc_hex()).unwrap_or_default(),
-        mass: item.mass.unwrap_or_default(),
+        storage_mass: item.mass.unwrap_or_default(),
         verbose_data: item.verbose_data.as_ref().map(|x| x.into()),
     }
 });
@@ -220,7 +220,7 @@ try_from!(item: &protowire::RpcTransaction, kaspa_rpc_core::RpcTransaction, {
         subnetwork_id: kaspa_rpc_core::RpcSubnetworkId::from_str(&item.subnetwork_id)?,
         gas: item.gas,
         payload: Vec::from_rpc_hex(&item.payload)?,
-        mass: item.mass,
+        storage_mass: item.storage_mass,
         verbose_data: item.verbose_data.as_ref().map(kaspa_rpc_core::RpcTransactionVerboseData::try_from).transpose()?,
     }
 });
@@ -243,7 +243,7 @@ try_from!(item: &protowire::RpcTransaction, kaspa_rpc_core::RpcOptionalTransacti
             .subnetwork_id)?),
         gas: Some(item.gas),
         payload: Some(Vec::from_rpc_hex(&item.payload)?),
-        mass: Some(item.mass),
+        mass: Some(item.storage_mass),
         verbose_data: item.verbose_data.as_ref().map(kaspa_rpc_core::RpcOptionalTransactionVerboseData::try_from).transpose()?,
     }
 });
@@ -476,7 +476,7 @@ mod tests {
             subnetwork_id: SubnetworkId::from_bytes([4; 20]),
             gas: 0,
             payload: vec![0xaa, 0xbb],
-            mass: 111,
+            storage_mass: 111,
             verbose_data: None,
         };
 
@@ -485,6 +485,6 @@ mod tests {
 
         let decoded = RpcTransaction::try_from(&wire).unwrap();
         assert_eq!(decoded.inputs[0].compute_budget, 222);
-        assert_eq!(decoded.mass, 111);
+        assert_eq!(decoded.storage_mass, 111);
     }
 }

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -153,7 +153,7 @@ impl ConsensusConverter {
                 subnetwork_id: transaction.subnetwork_id,
                 gas: transaction.gas,
                 payload: transaction.payload.clone(),
-                mass: transaction.storage_mass(),
+                storage_mass: transaction.storage_mass(),
                 verbose_data,
             })
         } else {

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -444,7 +444,11 @@ impl ConsensusConverter {
             },
             gas: if verbosity.include_gas.unwrap_or(false) { Some(transaction.gas) } else { Default::default() },
             payload: if verbosity.include_payload.unwrap_or(false) { Some(transaction.payload.clone()) } else { Default::default() },
-            mass: if verbosity.include_mass.unwrap_or(false) { Some(transaction.storage_mass()) } else { Default::default() },
+            storage_mass: if verbosity.include_storage_mass.unwrap_or(false) {
+                Some(transaction.storage_mass())
+            } else {
+                Default::default()
+            },
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
                 Some(
                     self.get_transaction_verbose_data_with_verbosity(
@@ -499,7 +503,7 @@ impl ConsensusConverter {
             subnetwork_id: Some(transaction.tx.subnetwork_id),
             gas: Some(transaction.tx.gas),
             payload: Some(transaction.tx.payload.clone()),
-            mass: Some(transaction.tx.storage_mass()),
+            storage_mass: Some(transaction.tx.storage_mass()),
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
                 Some(
                     self.get_transaction_verbose_data_with_verbosity(

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -153,7 +153,7 @@ impl ConsensusConverter {
                 subnetwork_id: transaction.subnetwork_id,
                 gas: transaction.gas,
                 payload: transaction.payload.clone(),
-                mass: transaction.mass(),
+                mass: transaction.storage_mass(),
                 verbose_data,
             })
         } else {
@@ -444,7 +444,7 @@ impl ConsensusConverter {
             },
             gas: if verbosity.include_gas.unwrap_or(false) { Some(transaction.gas) } else { Default::default() },
             payload: if verbosity.include_payload.unwrap_or(false) { Some(transaction.payload.clone()) } else { Default::default() },
-            mass: if verbosity.include_mass.unwrap_or(false) { Some(transaction.mass()) } else { Default::default() },
+            mass: if verbosity.include_mass.unwrap_or(false) { Some(transaction.storage_mass()) } else { Default::default() },
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
                 Some(
                     self.get_transaction_verbose_data_with_verbosity(
@@ -499,7 +499,7 @@ impl ConsensusConverter {
             subnetwork_id: Some(transaction.tx.subnetwork_id),
             gas: Some(transaction.tx.gas),
             payload: Some(transaction.tx.payload.clone()),
-            mass: Some(transaction.tx.mass()),
+            mass: Some(transaction.tx.storage_mass()),
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
                 Some(
                     self.get_transaction_verbose_data_with_verbosity(

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -196,7 +196,7 @@ impl Miner {
             .map(|mutable_tx| {
                 let signed_tx = sign(mutable_tx, schnorr_key);
                 let mass = self.mass_calculator.calc_contextual_masses(&signed_tx.as_verifiable()).unwrap().storage_mass;
-                signed_tx.tx.set_mass(mass);
+                signed_tx.tx.set_storage_mass(mass);
                 let mut signed_tx = signed_tx.tx;
                 signed_tx.finalize();
                 signed_tx

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -1103,7 +1103,7 @@ impl Generator {
                     // this should never occur as we should not produce transactions higher than the mass limit
                     return Err(Error::MassCalculationError);
                 }
-                tx.set_mass(transaction_mass);
+                tx.set_storage_mass(transaction_mass);
 
                 context.aggregate_mass += transaction_mass;
                 context.final_transaction_id = Some(tx.id());
@@ -1161,7 +1161,7 @@ impl Generator {
                     // this should never occur as we should not produce transactions higher than the mass limit
                     return Err(Error::MassCalculationError);
                 }
-                tx.set_mass(transaction_mass);
+                tx.set_storage_mass(transaction_mass);
 
                 context.aggregate_mass += transaction_mass;
                 context.number_of_transactions += 1;

--- a/wallet/core/src/wasm/tx/mass.rs
+++ b/wallet/core/src/wasm/tx/mass.rs
@@ -63,7 +63,7 @@ pub fn update_unsigned_transaction_mass(network_id: NetworkIdT, tx: &Transaction
     if mass > MAXIMUM_STANDARD_TRANSACTION_MASS {
         Ok(false)
     } else {
-        tx.set_mass(mass);
+        tx.set_storage_mass(mass);
         Ok(true)
     }
 }

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -477,7 +477,7 @@ impl PSKT<Extractor> {
         let storage_mass = calculator.calc_contextual_masses(&tx.as_verifiable()).map(|mass| mass.storage_mass).unwrap_or_default();
         let NonContextualMasses { compute_mass, transient_mass } = calculator.calc_non_contextual_masses(&tx.tx);
         let mass = storage_mass.max(compute_mass).max(transient_mass);
-        tx.tx.set_mass(mass);
+        tx.tx.set_storage_mass(mass);
         Ok(tx)
     }
 

--- a/wallet/pskt/src/wasm/pskt.rs
+++ b/wallet/pskt/src/wasm/pskt.rs
@@ -382,6 +382,6 @@ impl PSKT {
         let tx = extractor
             .extract_tx_unchecked(&network_id.into())
             .map_err(|e| Error::custom(format!("Failed to extract transaction: {e}")))?;
-        Ok(tx.tx.mass())
+        Ok(tx.tx.storage_mass())
     }
 }


### PR DESCRIPTION
  This PR renames the transaction storage mass field from the ambiguous mass naming to storage_mass / storageMass across consensus, RPC, wallet, mining, and wire conversion code.

  The change clarifies the distinction between storage mass, compute mass, and transient mass while preserving compatibility where needed. Deprecated mass accessors remain in place for consensus
  transactions, and JSON-RPC transaction models continue to support the legacy mass field during the transition.

  ## Changes

  - Rename transaction storage mass APIs and fields to storage_mass / storageMass
  - Update P2P and gRPC transaction wire conversions to use the renamed storage mass field
  - Update RPC transaction and optional transaction models to expose storageMass
  - Keep JSON compatibility by serializing both storageMass and deprecated mass
  - Accept legacy mass on JSON deserialization, with conflict checks when both fields are present
