### PR TITLE
Rename input.mass -> input.compute_commit, TxInputMass -> ComputeCommit

### DIFF
--- a/cli/src/extensions/transaction.rs
+++ b/cli/src/extensions/transaction.rs
@@ -178,7 +178,7 @@ impl TransactionExtension for TransactionRecord {
                     for input in transaction.inputs.iter() {
                         let TransactionInput { previous_outpoint, signature_script: _, sequence, .. } = input;
                         let TransactionOutpoint { transaction_id, index } = previous_outpoint;
-                        let sig_op_count = input.mass.sig_op_count().unwrap_or(0);
+                        let sig_op_count = input.compute_commit.sig_op_count().unwrap_or(0);
 
                         lines.push(format!("{:>4}{sequence:>2}: {transaction_id}:{index} SigOps: {sig_op_count}", ""));
                     }

--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -6,7 +6,7 @@ use kaspa_consensus::processes::transaction_validator::tx_validation_in_utxo_con
 use kaspa_consensus_core::hashing::sighash::{SigHashReusedValuesSync, SigHashReusedValuesUnsync, calc_schnorr_signature_hash};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::subnets::SubnetworkId;
-use kaspa_consensus_core::tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, ComputeCommit, UtxoEntry};
+use kaspa_consensus_core::tx::{ComputeCommit, MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, UtxoEntry};
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::{EngineCtx, pay_to_address_script};
 use kaspa_utils::iter::parallelism_in_power_steps;

--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -6,7 +6,7 @@ use kaspa_consensus::processes::transaction_validator::tx_validation_in_utxo_con
 use kaspa_consensus_core::hashing::sighash::{SigHashReusedValuesSync, SigHashReusedValuesUnsync, calc_schnorr_signature_hash};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::subnets::SubnetworkId;
-use kaspa_consensus_core::tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, TxInputMass, UtxoEntry};
+use kaspa_consensus_core::tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, ComputeCommit, UtxoEntry};
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::{EngineCtx, pay_to_address_script};
 use kaspa_utils::iter::parallelism_in_power_steps;
@@ -37,7 +37,7 @@ fn mock_tx_with_payload(inputs_count: usize, non_uniq_signatures: usize, payload
             previous_outpoint: dummy_prev_out,
             signature_script: vec![],
             sequence: 0,
-            mass: TxInputMass::SigopCount(1.into()),
+            compute_commit: ComputeCommit::SigopCount(1.into()),
         });
         let address = Address::new(Prefix::Mainnet, Version::PubKey, &kp.x_only_public_key().0.serialize());
         utxos.push(UtxoEntry {
@@ -56,7 +56,7 @@ fn mock_tx_with_payload(inputs_count: usize, non_uniq_signatures: usize, payload
             previous_outpoint: dummy_prev_out,
             signature_script: vec![],
             sequence: 0,
-            mass: TxInputMass::SigopCount(1.into()),
+            compute_commit: ComputeCommit::SigopCount(1.into()),
         });
         let address = Address::new(Prefix::Mainnet, Version::PubKey, &kp.x_only_public_key().0.serialize());
         utxos.push(UtxoEntry {

--- a/consensus/client/src/input.rs
+++ b/consensus/client/src/input.rs
@@ -241,8 +241,8 @@ impl From<cctx::TransactionInput> for TransactionInput {
             previous_outpoint: tx_input.previous_outpoint.into(),
             signature_script: Some(tx_input.signature_script),
             sequence: tx_input.sequence,
-            sig_op_count: tx_input.mass.sig_op_count().unwrap_or(0),
-            compute_budget: tx_input.mass.compute_budget().unwrap_or(0),
+            sig_op_count: tx_input.compute_commit.sig_op_count().unwrap_or(0),
+            compute_budget: tx_input.compute_commit.compute_budget().unwrap_or(0),
             utxo: None,
         };
         TransactionInput::new_with_inner(inner)
@@ -267,10 +267,10 @@ impl From<TransactionInputWithVersion<'_>> for cctx::TransactionInput {
             previous_outpoint: inner.previous_outpoint.clone().into(),
             signature_script: inner.signature_script.clone().unwrap_or_default(), // TODO - discuss: should this unwrap_or_default or return an error?
             sequence: inner.sequence,
-            mass: if cctx::TxInputMass::version_expects_compute_budget_field(value.version) {
-                cctx::TxInputMass::ComputeBudget(inner.compute_budget.into())
+            compute_commit: if cctx::ComputeCommit::version_expects_compute_budget_field(value.version) {
+                cctx::ComputeCommit::ComputeBudget(inner.compute_budget.into())
             } else {
-                cctx::TxInputMass::SigopCount(inner.sig_op_count.into())
+                cctx::ComputeCommit::SigopCount(inner.sig_op_count.into())
             },
         }
     }

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -109,8 +109,8 @@ impl SerializableTransactionInput {
             // signature_script: (!input.signature_script.is_empty()).then_some(input.signature_script.clone()),
             signature_script: input.signature_script.clone(),
             sequence: input.sequence,
-            sig_op_count: input.mass.sig_op_count().unwrap_or(0),
-            compute_budget: input.mass.compute_budget().unwrap_or(0),
+            sig_op_count: input.compute_commit.sig_op_count().unwrap_or(0),
+            compute_budget: input.compute_commit.compute_budget().unwrap_or(0),
             utxo: utxo.clone(),
         }
     }
@@ -149,16 +149,16 @@ impl TryFrom<SerializableInputWithVersion> for cctx::TransactionInput {
             previous_outpoint: cctx::TransactionOutpoint { transaction_id: input.transaction_id, index: input.index },
             signature_script: input.signature_script,
             sequence: input.sequence,
-            mass: if cctx::TxInputMass::version_expects_compute_budget_field(value.version) {
+            compute_commit: if cctx::ComputeCommit::version_expects_compute_budget_field(value.version) {
                 if input.sig_op_count != 0 {
                     return Err(invalid_input_mass_variant("sig_op_count", value.version));
                 }
-                cctx::TxInputMass::ComputeBudget(input.compute_budget.into())
+                cctx::ComputeCommit::ComputeBudget(input.compute_budget.into())
             } else {
                 if input.compute_budget != 0 {
                     return Err(invalid_input_mass_variant("compute_budget", value.version));
                 }
-                cctx::TxInputMass::SigopCount(input.sig_op_count.into())
+                cctx::ComputeCommit::SigopCount(input.sig_op_count.into())
             },
         })
     }

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -103,8 +103,8 @@ impl SerializableTransactionInput {
             index: input.previous_outpoint.index,
             signature_script: input.signature_script.clone(),
             sequence: input.sequence.to_string(),
-            sig_op_count: input.mass.sig_op_count().unwrap_or(0),
-            compute_budget: input.mass.compute_budget().unwrap_or(0),
+            sig_op_count: input.compute_commit.sig_op_count().unwrap_or(0),
+            compute_budget: input.compute_commit.compute_budget().unwrap_or(0),
             utxo: utxo.clone(),
         }
     }
@@ -143,16 +143,16 @@ impl TryFrom<SerializableInputWithVersion> for cctx::TransactionInput {
             previous_outpoint: cctx::TransactionOutpoint { transaction_id: input.transaction_id, index: input.index },
             signature_script: input.signature_script,
             sequence: input.sequence.parse()?,
-            mass: if cctx::TxInputMass::version_expects_compute_budget_field(value.version) {
+            compute_commit: if cctx::ComputeCommit::version_expects_compute_budget_field(value.version) {
                 if input.sig_op_count != 0 {
                     return Err(invalid_input_mass_variant("sig_op_count", value.version));
                 }
-                cctx::TxInputMass::ComputeBudget(input.compute_budget.into())
+                cctx::ComputeCommit::ComputeBudget(input.compute_budget.into())
             } else {
                 if input.compute_budget != 0 {
                     return Err(invalid_input_mass_variant("compute_budget", value.version));
                 }
-                cctx::TxInputMass::SigopCount(input.sig_op_count.into())
+                cctx::ComputeCommit::SigopCount(input.sig_op_count.into())
             },
         })
     }

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -403,8 +403,8 @@ impl Transaction {
                     previous_outpoint,
                     Some(input.signature_script.clone()),
                     input.sequence,
-                    input.mass.sig_op_count().unwrap_or(0),
-                    input.mass.compute_budget().unwrap_or(0),
+                    input.compute_commit.sig_op_count().unwrap_or(0),
+                    input.compute_commit.compute_budget().unwrap_or(0),
                     utxo,
                 )
             })

--- a/consensus/core/benches/serde_benchmark.rs
+++ b/consensus/core/benches/serde_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use kaspa_consensus_core::subnets::SUBNETWORK_ID_COINBASE;
 use kaspa_consensus_core::tx::{
-    ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+    ComputeCommit, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
 };
 use smallvec::smallvec;
 use std::time::{Duration, Instant};

--- a/consensus/core/benches/serde_benchmark.rs
+++ b/consensus/core/benches/serde_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use kaspa_consensus_core::subnets::SUBNETWORK_ID_COINBASE;
 use kaspa_consensus_core::tx::{
-    ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+    ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
 };
 use smallvec::smallvec;
 use std::time::{Duration, Instant};
@@ -27,7 +27,7 @@ fn serialize_benchmark(c: &mut Criterion) {
                 },
                 signature_script: vec![1; 32],
                 sequence: u64::MAX,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             },
             TransactionInput {
                 previous_outpoint: TransactionOutpoint {
@@ -39,7 +39,7 @@ fn serialize_benchmark(c: &mut Criterion) {
                 },
                 signature_script: vec![1; 32],
                 sequence: u64::MAX,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             },
         ],
         vec![
@@ -89,7 +89,7 @@ fn deserialize_benchmark(c: &mut Criterion) {
                 },
                 signature_script: vec![1; 32],
                 sequence: u64::MAX,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             },
             TransactionInput {
                 previous_outpoint: TransactionOutpoint {
@@ -101,7 +101,7 @@ fn deserialize_benchmark(c: &mut Criterion) {
                 },
                 signature_script: vec![1; 32],
                 sequence: u64::MAX,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             },
         ],
         vec![

--- a/consensus/core/src/hashing/sighash.rs
+++ b/consensus/core/src/hashing/sighash.rs
@@ -300,7 +300,7 @@ mod tests {
     use crate::{
         hashing::sighash_type::{SIG_HASH_ALL, SIG_HASH_ANY_ONE_CAN_PAY, SIG_HASH_NONE, SIG_HASH_SINGLE},
         subnets::{SUBNETWORK_ID_NATIVE, SubnetworkId},
-        tx::{PopulatedTransaction, Transaction, TransactionId, TransactionInput, ComputeCommit, UtxoEntry},
+        tx::{ComputeCommit, PopulatedTransaction, Transaction, TransactionId, TransactionInput, UtxoEntry},
     };
 
     use super::*;

--- a/consensus/core/src/hashing/sighash.rs
+++ b/consensus/core/src/hashing/sighash.rs
@@ -174,7 +174,7 @@ pub fn sig_op_counts_hash(tx: &Transaction, hash_type: SigHashType, reused_value
     let hash = || {
         let mut hasher = TransactionSigningHash::new();
         for input in tx.inputs.iter() {
-            hasher.write_u8(input.mass.sig_op_count().unwrap_or(0));
+            hasher.write_u8(input.compute_commit.sig_op_count().unwrap_or(0));
         }
         hasher.finalize()
     };
@@ -266,7 +266,7 @@ pub fn calc_schnorr_signature_hash(
     hasher.write_u64(input.1.amount).write_u64(input.0.sequence);
 
     if tx.version < 1 {
-        hasher.write_u8(input.0.mass.sig_op_count().unwrap_or(0));
+        hasher.write_u8(input.0.compute_commit.sig_op_count().unwrap_or(0));
     }
 
     hasher
@@ -300,7 +300,7 @@ mod tests {
     use crate::{
         hashing::sighash_type::{SIG_HASH_ALL, SIG_HASH_ANY_ONE_CAN_PAY, SIG_HASH_NONE, SIG_HASH_SINGLE},
         subnets::{SUBNETWORK_ID_NATIVE, SubnetworkId},
-        tx::{PopulatedTransaction, Transaction, TransactionId, TransactionInput, TxInputMass, UtxoEntry},
+        tx::{PopulatedTransaction, Transaction, TransactionId, TransactionInput, ComputeCommit, UtxoEntry},
     };
 
     use super::*;
@@ -324,19 +324,19 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                     signature_script: vec![],
                     sequence: 1,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 2 },
                     signature_script: vec![],
                     sequence: 2,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
             ],
             vec![
@@ -383,19 +383,19 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: TxInputMass::ComputeBudget(11.into()),
+                    compute_commit: ComputeCommit::ComputeBudget(11.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                     signature_script: vec![],
                     sequence: 1,
-                    mass: TxInputMass::ComputeBudget(22.into()),
+                    compute_commit: ComputeCommit::ComputeBudget(22.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 2 },
                     signature_script: vec![],
                     sequence: 2,
-                    mass: TxInputMass::ComputeBudget(33.into()),
+                    compute_commit: ComputeCommit::ComputeBudget(33.into()),
                 },
             ],
             vec![
@@ -784,10 +784,10 @@ mod tests {
                     tx.inputs[i].previous_outpoint.index = 2;
                 }
                 ModifyAction::ComputeBudget(i) => {
-                    tx.inputs[i].mass = TxInputMass::ComputeBudget(1234.into());
+                    tx.inputs[i].compute_commit = ComputeCommit::ComputeBudget(1234.into());
                 }
                 ModifyAction::SigOpCount(i) => {
-                    tx.inputs[i].mass = TxInputMass::SigopCount(123.into());
+                    tx.inputs[i].compute_commit = ComputeCommit::SigopCount(123.into());
                 }
                 ModifyAction::AmountSpent(i) => {
                     entries[i].amount = 666;

--- a/consensus/core/src/hashing/tx.rs
+++ b/consensus/core/src/hashing/tx.rs
@@ -1,7 +1,7 @@
 use super::HasherExtensions;
 use crate::{
     mass::transaction_estimated_serialized_size,
-    tx::{Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass},
+    tx::{ComputeCommit, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput},
 };
 use kaspa_hashes::{Hash, Hasher, HasherBase, PayloadDigest};
 
@@ -101,16 +101,16 @@ fn write_input<T: HasherBase>(hasher: &mut T, input: &TransactionInput, version:
     write_outpoint(hasher, &input.previous_outpoint);
     if !encoding_flags.contains(TxEncodingFlags::EXCLUDE_SIGNATURE_SCRIPT) {
         hasher.write_var_bytes(input.signature_script.as_slice());
-        if TxInputMass::version_expects_sig_op_count_field(version) {
-            hasher.update([input.mass.sig_op_count().unwrap_or(0)]);
+        if ComputeCommit::version_expects_sig_op_count_field(version) {
+            hasher.update([input.compute_commit.sig_op_count().unwrap_or(0)]);
         }
     } else {
         hasher.write_var_bytes(&[]);
     }
     hasher.update(input.sequence.to_le_bytes());
 
-    if !encoding_flags.contains(TxEncodingFlags::EXCLUDE_MASS_COMMIT) && TxInputMass::version_expects_compute_budget_field(version) {
-        hasher.write_u16(input.mass.compute_budget().unwrap_or(0));
+    if !encoding_flags.contains(TxEncodingFlags::EXCLUDE_MASS_COMMIT) && ComputeCommit::version_expects_compute_budget_field(version) {
+        hasher.write_u16(input.compute_commit.compute_budget().unwrap_or(0));
     }
 }
 
@@ -240,7 +240,7 @@ mod tests {
     use super::*;
     use crate::{
         subnets::{self, SubnetworkId},
-        tx::{ScriptPublicKey, TxInputMass, scriptvec},
+        tx::{ComputeCommit, ScriptPublicKey, scriptvec},
     };
     use std::str::FromStr;
 
@@ -353,7 +353,7 @@ mod tests {
         // Version >= 1: tx::id excludes mass commitments while tx::hash commits to both mass and per input compute_budget
         let tx_v1_a = Transaction::new(
             1,
-            vec![TransactionInput::new_with_mass(TransactionOutpoint::default(), vec![], 0, TxInputMass::ComputeBudget(111.into()))],
+            vec![TransactionInput::new_with_mass(TransactionOutpoint::default(), vec![], 0, ComputeCommit::ComputeBudget(111.into()))],
             vec![],
             0,
             subnets::SUBNETWORK_ID_NATIVE,
@@ -363,7 +363,7 @@ mod tests {
         tx_v1_a.set_storage_mass(0);
 
         let mut tx_v1_b = tx_v1_a.clone();
-        tx_v1_b.inputs[0].mass = TxInputMass::ComputeBudget(222.into());
+        tx_v1_b.inputs[0].compute_commit = ComputeCommit::ComputeBudget(222.into());
 
         // Test #11
         tests.push(Test {

--- a/consensus/core/src/mass/mod.rs
+++ b/consensus/core/src/mass/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     constants::TRANSIENT_BYTE_TO_MASS_FACTOR,
     mass::units::GRAMS_PER_SIGOP_COUNT_UNIT,
     subnets::SUBNETWORK_ID_SIZE,
-    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutput, TxInputMass, UtxoEntry, VerifiableTransaction},
+    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutput, ComputeCommit, UtxoEntry, VerifiableTransaction},
 };
 use kaspa_hashes::HASH_SIZE;
 
@@ -346,17 +346,17 @@ impl MassCalculator {
             .sum();
         let total_script_public_key_mass = total_script_public_key_size * self.mass_per_script_pub_key_byte;
 
-        let script_mass = if TxInputMass::version_expects_compute_budget_field(tx.version) {
+        let script_mass = if ComputeCommit::version_expects_compute_budget_field(tx.version) {
             GRAMS_PER_COMPUTE_BUDGET_UNIT
                 * tx.inputs
                     .iter()
-                    .map(|input| input.mass.compute_budget().expect("v1 transactions are expected to have compute budget") as u64)
+                    .map(|input| input.compute_commit.compute_budget().expect("v1 transactions are expected to have compute budget") as u64)
                     .sum::<u64>()
         } else {
             let total_sigops: u64 = tx
                 .inputs
                 .iter()
-                .map(|input| input.mass.sig_op_count().expect("v0 transactions are expected to have sig op count") as u64)
+                .map(|input| input.compute_commit.sig_op_count().expect("v0 transactions are expected to have sig op count") as u64)
                 .sum();
             total_sigops * GRAMS_PER_SIGOP_COUNT_UNIT
         };
@@ -800,7 +800,7 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: i as u32 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 })
                 .collect(),
             outs.iter()

--- a/consensus/core/src/mass/mod.rs
+++ b/consensus/core/src/mass/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     constants::TRANSIENT_BYTE_TO_MASS_FACTOR,
     mass::units::GRAMS_PER_SIGOP_COUNT_UNIT,
     subnets::SUBNETWORK_ID_SIZE,
-    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutput, ComputeCommit, UtxoEntry, VerifiableTransaction},
+    tx::{ComputeCommit, ScriptPublicKey, Transaction, TransactionInput, TransactionOutput, UtxoEntry, VerifiableTransaction},
 };
 use kaspa_hashes::HASH_SIZE;
 
@@ -350,7 +350,9 @@ impl MassCalculator {
             GRAMS_PER_COMPUTE_BUDGET_UNIT
                 * tx.inputs
                     .iter()
-                    .map(|input| input.compute_commit.compute_budget().expect("v1 transactions are expected to have compute budget") as u64)
+                    .map(|input| {
+                        input.compute_commit.compute_budget().expect("v1 transactions are expected to have compute budget") as u64
+                    })
                     .sum::<u64>()
         } else {
             let total_sigops: u64 = tx

--- a/consensus/core/src/mass/units.rs
+++ b/consensus/core/src/mass/units.rs
@@ -204,7 +204,7 @@ impl From<ScriptUnits> for u64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::tx::TxInputMass;
+    use crate::tx::ComputeCommit;
 
     use super::{ComputeBudget, ScriptUnits};
 
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn checked_covering_script_units_returns_none_on_budget_overflow() {
-        let max_coverable = TxInputMass::from(ComputeBudget(u16::MAX)).allowed_script_units();
+        let max_coverable = ComputeCommit::from(ComputeBudget(u16::MAX)).allowed_script_units();
 
         assert_eq!(ComputeBudget::checked_covering_script_units(max_coverable), Some(ComputeBudget(u16::MAX)));
         assert_eq!(ComputeBudget::checked_covering_script_units(max_coverable.saturating_add(ScriptUnits(1))), None);

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -21,7 +21,7 @@ mod tests {
     use crate::{
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
             scriptvec,
         },
     };
@@ -62,7 +62,7 @@ mod tests {
                         },
                         signature_script: vec![],
                         sequence: u64::MAX,
-                        mass: TxInputMass::SigopCount(0.into()),
+                        compute_commit: ComputeCommit::SigopCount(0.into()),
                     },
                     TransactionInput {
                         previous_outpoint: TransactionOutpoint {
@@ -74,7 +74,7 @@ mod tests {
                         },
                         signature_script: vec![],
                         sequence: u64::MAX,
-                        mass: TxInputMass::SigopCount(0.into()),
+                        compute_commit: ComputeCommit::SigopCount(0.into()),
                     },
                 ],
                 vec![],
@@ -107,7 +107,7 @@ mod tests {
                         0x16, 0x1b, 0xc6, 0xf8, 0xa6, 0x30, 0x12, 0x1d, 0xf2, 0xb3, 0xd3, // 65-byte pubkey
                     ],
                     sequence: u64::MAX,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 }],
                 vec![
                     TransactionOutput {
@@ -169,7 +169,7 @@ mod tests {
                         0xe3, 0x95, 0x60, 0x63, 0x9d, 0xb4, 0x62, 0xe9, 0xcb, 0x85, 0x0f, // 65-byte pubkey
                     ],
                     sequence: u64::MAX,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 }],
                 vec![
                     TransactionOutput {
@@ -232,7 +232,7 @@ mod tests {
                         0x63, 0xce, 0x6a, 0xf4, 0xcf, 0xaa, 0xea, 0x4e, 0xa1, 0x4f, 0xbb, // 65-byte pubkey
                     ],
                     sequence: u64::MAX,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 }],
                 vec![TransactionOutput {
                     value: 0xf4240,

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -21,7 +21,7 @@ mod tests {
     use crate::{
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+            ComputeCommit, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
             scriptvec,
         },
     };

--- a/consensus/core/src/sign.rs
+++ b/consensus/core/src/sign.rs
@@ -4,7 +4,7 @@ use crate::{
         sighash_type::{SIG_HASH_ALL, SigHashType},
     },
     mass::{ComputeBudget, SigopCount},
-    tx::{SignableTransaction, TxInputMass, VerifiableTransaction},
+    tx::{SignableTransaction, ComputeCommit, VerifiableTransaction},
 };
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -81,14 +81,14 @@ impl Signed {
 
 /// Sign a transaction using schnorr
 pub fn sign(mut signable_tx: SignableTransaction, schnorr_key: secp256k1::Keypair) -> SignableTransaction {
-    let input_mass = if TxInputMass::version_expects_compute_budget_field(signable_tx.tx.version) {
+    let input_mass = if ComputeCommit::version_expects_compute_budget_field(signable_tx.tx.version) {
         // Assumes grams per sigop = 1000 and 1 compute budget = 100 gram
         ComputeBudget(10).into()
     } else {
         SigopCount(1).into()
     };
     for i in 0..signable_tx.tx.inputs.len() {
-        signable_tx.tx.inputs[i].mass = input_mass;
+        signable_tx.tx.inputs[i].compute_commit = input_mass;
     }
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -110,14 +110,14 @@ pub fn sign_with_multiple(mut mutable_tx: SignableTransaction, privkeys: Vec<[u8
         map.insert(schnorr_key.public_key().serialize(), schnorr_key);
     }
 
-    let input_mass = if TxInputMass::version_expects_compute_budget_field(mutable_tx.tx.version) {
+    let input_mass = if ComputeCommit::version_expects_compute_budget_field(mutable_tx.tx.version) {
         // Assumes grams per sigop = 1000 and 1 compute budget = 100 gram
         ComputeBudget(10).into()
     } else {
         SigopCount(1).into()
     };
     for i in 0..mutable_tx.tx.inputs.len() {
-        mutable_tx.tx.inputs[i].mass = input_mass;
+        mutable_tx.tx.inputs[i].compute_commit = input_mass;
     }
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -222,19 +222,19 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: SigopCount(0).into(),
+                    compute_commit: SigopCount(0).into(),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                     signature_script: vec![],
                     sequence: 1,
-                    mass: SigopCount(0).into(),
+                    compute_commit: SigopCount(0).into(),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 2 },
                     signature_script: vec![],
                     sequence: 2,
-                    mass: SigopCount(0).into(),
+                    compute_commit: SigopCount(0).into(),
                 },
             ],
             vec![
@@ -292,7 +292,7 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: SigopCount(0).into(),
+                    compute_commit: SigopCount(0).into(),
                 }],
                 vec![TransactionOutput {
                     value: 100,
@@ -317,14 +317,14 @@ mod tests {
             SignableTransaction::with_entries(build_unsigned_tx(0), vec![entry.clone()]),
             secp256k1::Keypair::from_secret_key(secp256k1::SECP256K1, &secret_key),
         );
-        assert_eq!(signed_v0.tx.inputs[0].mass, SigopCount(1).into());
+        assert_eq!(signed_v0.tx.inputs[0].compute_commit, SigopCount(1).into());
 
         let signed_v1 = sign(
             SignableTransaction::with_entries(build_unsigned_tx(1), vec![entry.clone()]),
             secp256k1::Keypair::from_secret_key(secp256k1::SECP256K1, &secret_key),
         );
         assert_eq!(
-            signed_v1.tx.inputs[0].mass,
+            signed_v1.tx.inputs[0].compute_commit,
             ComputeBudget(MAINNET_PARAMS.mass_per_sig_op.div_ceil(GRAMS_PER_COMPUTE_BUDGET_UNIT) as u16).into()
         );
 
@@ -332,12 +332,12 @@ mod tests {
             SignableTransaction::with_entries(build_unsigned_tx(0), vec![entry.clone()]),
             vec![secret_key.secret_bytes()],
         );
-        assert_eq!(signed_multi_v0.tx.inputs[0].mass, SigopCount(1).into());
+        assert_eq!(signed_multi_v0.tx.inputs[0].compute_commit, SigopCount(1).into());
 
         let signed_multi_v1 =
             sign_with_multiple(SignableTransaction::with_entries(build_unsigned_tx(1), vec![entry]), vec![secret_key.secret_bytes()]);
         assert_eq!(
-            signed_multi_v1.tx.inputs[0].mass,
+            signed_multi_v1.tx.inputs[0].compute_commit,
             ComputeBudget(MAINNET_PARAMS.mass_per_sig_op.div_ceil(GRAMS_PER_COMPUTE_BUDGET_UNIT) as u16).into()
         );
     }

--- a/consensus/core/src/sign.rs
+++ b/consensus/core/src/sign.rs
@@ -4,7 +4,7 @@ use crate::{
         sighash_type::{SIG_HASH_ALL, SigHashType},
     },
     mass::{ComputeBudget, SigopCount},
-    tx::{SignableTransaction, ComputeCommit, VerifiableTransaction},
+    tx::{ComputeCommit, SignableTransaction, VerifiableTransaction},
 };
 use itertools::Itertools;
 use std::collections::BTreeMap;

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -65,15 +65,15 @@ impl Display for TransactionOutpoint {
     }
 }
 
-/// Encodes the mass commitment for a transaction input.
+/// Encodes the compute mass commitment for a transaction input.
 /// Version 0 transactions use `SigopCount`, version >= 1 transactions use `ComputeBudget`.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Debug, Copy)]
-pub enum TxInputMass {
+pub enum ComputeCommit {
     SigopCount(SigopCount),
     ComputeBudget(ComputeBudget),
 }
 
-impl TxInputMass {
+impl ComputeCommit {
     pub fn sig_op_count(self) -> Option<u8> {
         match self {
             Self::SigopCount(n) => Some(n.into()),
@@ -103,23 +103,23 @@ impl TxInputMass {
     }
 }
 
-impl From<SigopCount> for TxInputMass {
+impl From<SigopCount> for ComputeCommit {
     fn from(value: SigopCount) -> Self {
         Self::SigopCount(value)
     }
 }
 
-impl From<ComputeBudget> for TxInputMass {
+impl From<ComputeBudget> for ComputeCommit {
     fn from(value: ComputeBudget) -> Self {
         Self::ComputeBudget(value)
     }
 }
 
-impl From<TxInputMass> for ScriptUnits {
-    fn from(value: TxInputMass) -> Self {
+impl From<ComputeCommit> for ScriptUnits {
+    fn from(value: ComputeCommit) -> Self {
         match value {
-            TxInputMass::SigopCount(count) => ScriptUnits::from(count),
-            TxInputMass::ComputeBudget(budget) => ScriptUnits::from(budget),
+            ComputeCommit::SigopCount(count) => ScriptUnits::from(count),
+            ComputeCommit::ComputeBudget(budget) => ScriptUnits::from(budget),
         }
     }
 }
@@ -130,16 +130,21 @@ pub struct TransactionInput {
     pub previous_outpoint: TransactionOutpoint,
     pub signature_script: Vec<u8>, // TODO: Consider using SmallVec
     pub sequence: u64,
-    pub mass: TxInputMass,
+    pub compute_commit: ComputeCommit,
 }
 
 impl TransactionInput {
-    pub fn new_with_mass(previous_outpoint: TransactionOutpoint, signature_script: Vec<u8>, sequence: u64, mass: TxInputMass) -> Self {
-        Self { previous_outpoint, signature_script, sequence, mass }
+    pub fn new_with_mass(
+        previous_outpoint: TransactionOutpoint,
+        signature_script: Vec<u8>,
+        sequence: u64,
+        compute_commit: ComputeCommit,
+    ) -> Self {
+        Self { previous_outpoint, signature_script, sequence, compute_commit }
     }
 
     pub fn new(previous_outpoint: TransactionOutpoint, signature_script: Vec<u8>, sequence: u64, sig_op_count: u8) -> Self {
-        Self { previous_outpoint, signature_script, sequence, mass: SigopCount(sig_op_count).into() }
+        Self { previous_outpoint, signature_script, sequence, compute_commit: SigopCount(sig_op_count).into() }
     }
 
     pub fn new_with_compute_budget(
@@ -148,7 +153,7 @@ impl TransactionInput {
         sequence: u64,
         compute_budget: u16,
     ) -> Self {
-        Self { previous_outpoint, signature_script, sequence, mass: ComputeBudget(compute_budget).into() }
+        Self { previous_outpoint, signature_script, sequence, compute_commit: ComputeBudget(compute_budget).into() }
     }
 }
 
@@ -158,8 +163,8 @@ impl std::fmt::Debug for TransactionInput {
             .field("previous_outpoint", &self.previous_outpoint)
             .field("signature_script", &self.signature_script.to_hex())
             .field("sequence", &self.sequence)
-            .field("sig_op_count", &self.mass.sig_op_count().unwrap_or_default())
-            .field("compute_budget", &self.mass.compute_budget().unwrap_or_default())
+            .field("sig_op_count", &self.compute_commit.sig_op_count().unwrap_or_default())
+            .field("compute_budget", &self.compute_commit.compute_budget().unwrap_or_default())
             .finish()
     }
 }
@@ -779,7 +784,7 @@ mod tests {
                         0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
                     ],
                     sequence: 2,
-                    mass: TxInputMass::SigopCount(3.into()),
+                    compute_commit: ComputeCommit::SigopCount(3.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint {
@@ -794,7 +799,7 @@ mod tests {
                         0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
                     ],
                     sequence: 4,
-                    mass: TxInputMass::SigopCount(5.into()),
+                    compute_commit: ComputeCommit::SigopCount(5.into()),
                 },
             ],
             vec![
@@ -820,8 +825,8 @@ mod tests {
         tx.version = 1;
         // A valid v1 transaction must carry a ComputeBudget mass on every input;
         // the serializer panics otherwise (that's its contract with the type system).
-        tx.inputs[0].mass = TxInputMass::ComputeBudget(ComputeBudget(17));
-        tx.inputs[1].mass = TxInputMass::ComputeBudget(ComputeBudget(23));
+        tx.inputs[0].compute_commit = ComputeCommit::ComputeBudget(ComputeBudget(17));
+        tx.inputs[1].compute_commit = ComputeCommit::ComputeBudget(ComputeBudget(23));
         tx.outputs[0].covenant = Some(CovenantBinding::new(1, hashing::tx::payload_digest(&[1, 2, 3])));
         tx.finalize();
         tx

--- a/consensus/core/src/tx/serde_impl.rs
+++ b/consensus/core/src/tx/serde_impl.rs
@@ -19,7 +19,7 @@
 //! `#[serde(transparent)]` over `u8` / `u16`, the two sides share the exact
 //! same wire format by construction.
 
-use super::{CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass};
+use super::{CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit};
 use crate::mass::{ComputeBudget, SigopCount};
 use kaspa_utils::serde_bytes::{self, ByteBuf, Bytes};
 use serde::{
@@ -106,7 +106,7 @@ impl From<TxInputV0Owned> for TransactionInput {
             previous_outpoint: value.previous_outpoint,
             signature_script: value.signature_script,
             sequence: value.sequence,
-            mass: TxInputMass::SigopCount(value.sig_op_count),
+            compute_commit: ComputeCommit::SigopCount(value.sig_op_count),
         }
     }
 }
@@ -117,7 +117,7 @@ impl From<TxInputV1Owned> for TransactionInput {
             previous_outpoint: value.previous_outpoint,
             signature_script: value.signature_script,
             sequence: value.sequence,
-            mass: TxInputMass::ComputeBudget(value.compute_budget),
+            compute_commit: ComputeCommit::ComputeBudget(value.compute_budget),
         }
     }
 }
@@ -155,7 +155,7 @@ impl Serialize for InputsRef<'_> {
                         previous_outpoint: &input.previous_outpoint,
                         signature_script: input.signature_script.as_slice(),
                         sequence: input.sequence,
-                        sig_op_count: input.mass.sig_op_count().expect("v0 transaction inputs must carry a SigopCount mass"),
+                        sig_op_count: input.compute_commit.sig_op_count().expect("v0 transaction inputs must carry a SigopCount mass"),
                     })?;
                 }
             }
@@ -165,7 +165,7 @@ impl Serialize for InputsRef<'_> {
                         previous_outpoint: &input.previous_outpoint,
                         signature_script: input.signature_script.as_slice(),
                         sequence: input.sequence,
-                        compute_budget: input.mass.compute_budget().expect("v1+ transaction inputs must carry a ComputeBudget mass"),
+                        compute_budget: input.compute_commit.compute_budget().expect("v1+ transaction inputs must carry a ComputeBudget mass"),
                     })?;
                 }
             }

--- a/consensus/core/src/tx/serde_impl.rs
+++ b/consensus/core/src/tx/serde_impl.rs
@@ -19,7 +19,7 @@
 //! `#[serde(transparent)]` over `u8` / `u16`, the two sides share the exact
 //! same wire format by construction.
 
-use super::{CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit};
+use super::{ComputeCommit, CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput};
 use crate::mass::{ComputeBudget, SigopCount};
 use kaspa_utils::serde_bytes::{self, ByteBuf, Bytes};
 use serde::{
@@ -165,7 +165,10 @@ impl Serialize for InputsRef<'_> {
                         previous_outpoint: &input.previous_outpoint,
                         signature_script: input.signature_script.as_slice(),
                         sequence: input.sequence,
-                        compute_budget: input.compute_commit.compute_budget().expect("v1+ transaction inputs must carry a ComputeBudget mass"),
+                        compute_budget: input
+                            .compute_commit
+                            .compute_budget()
+                            .expect("v1+ transaction inputs must carry a ComputeBudget mass"),
                     })?;
                 }
             }

--- a/consensus/core/tests/db_compat.rs
+++ b/consensus/core/tests/db_compat.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use kaspa_consensus_core::mass::ComputeBudget;
 use kaspa_consensus_core::subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE};
 use kaspa_consensus_core::tx::{
-    CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+    CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
 };
 use kaspa_hashes::Hash;
 
@@ -121,7 +121,7 @@ fn roundtrip_post_toccata_transaction_with_compute_budget_and_covenant() {
         TransactionOutpoint::new(Hash::from_bytes([0x33; 32]), 2),
         vec![0xaa, 0xbb, 0xcc],
         42,
-        TxInputMass::ComputeBudget(ComputeBudget(17)),
+        ComputeCommit::ComputeBudget(ComputeBudget(17)),
     );
     let output =
         TransactionOutput::with_covenant(999, spk(0, &[0x40, 0x41]), Some(CovenantBinding::new(0, Hash::from_bytes([0x77; 32]))));
@@ -150,7 +150,7 @@ fn roundtrip_mixed_pre_and_post_toccata_block_body() {
             TransactionOutpoint::new(Hash::from_bytes([0x55; 32]), 1),
             vec![0x02, 0x03],
             0,
-            TxInputMass::ComputeBudget(ComputeBudget(5)),
+            ComputeCommit::ComputeBudget(ComputeBudget(5)),
         )],
         vec![TransactionOutput::with_covenant(20, spk(0, &[0x60]), Some(CovenantBinding::new(0, Hash::from_bytes([0x88; 32]))))],
         0,

--- a/consensus/core/tests/db_compat.rs
+++ b/consensus/core/tests/db_compat.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use kaspa_consensus_core::mass::ComputeBudget;
 use kaspa_consensus_core::subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE};
 use kaspa_consensus_core::tx::{
-    CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+    ComputeCommit, CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
 };
 use kaspa_hashes::Hash;
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -72,8 +72,8 @@ use kaspa_consensus_core::{
     pruning::{PruningPointProof, PruningPointTrustedData, PruningPointsList, PruningProofMetadata},
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{
-        MutableTransaction, Transaction, TransactionId, TransactionIndexType, TransactionOutpoint, TransactionQueryResult,
-        TransactionType, ComputeCommit, UtxoEntry,
+        ComputeCommit, MutableTransaction, Transaction, TransactionId, TransactionIndexType, TransactionOutpoint,
+        TransactionQueryResult, TransactionType, UtxoEntry,
     },
 };
 use kaspa_consensus_notify::root::ConsensusNotificationRoot;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -73,7 +73,7 @@ use kaspa_consensus_core::{
     trusted::{ExternalGhostdagData, TrustedBlock},
     tx::{
         MutableTransaction, Transaction, TransactionId, TransactionIndexType, TransactionOutpoint, TransactionQueryResult,
-        TransactionType, TxInputMass, UtxoEntry,
+        TransactionType, ComputeCommit, UtxoEntry,
     },
 };
 use kaspa_consensus_notify::root::ConsensusNotificationRoot;
@@ -609,15 +609,15 @@ impl Consensus {
             return Err(TxRuleError::TooManyOutputs(transaction.outputs.len(), self.config.params.max_tx_outputs));
         }
 
-        if TxInputMass::version_expects_compute_budget_field(transaction.version) {
+        if ComputeCommit::version_expects_compute_budget_field(transaction.version) {
             for (i, input) in transaction.inputs.iter().enumerate() {
-                if let Some(sig_op_count) = input.mass.sig_op_count() {
+                if let Some(sig_op_count) = input.compute_commit.sig_op_count() {
                     return Err(TxRuleError::SigopCountInV1(i, sig_op_count));
                 }
             }
         } else {
             for (i, input) in transaction.inputs.iter().enumerate() {
-                if let Some(compute_budget) = input.mass.compute_budget() {
+                if let Some(compute_budget) = input.compute_commit.compute_budget() {
                     return Err(TxRuleError::ComputeBudgetInV0(i, compute_budget));
                 }
             }

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -177,7 +177,7 @@ mod tests {
         merkle::calc_hash_merkle_root,
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE, SubnetworkId},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+            ComputeCommit, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
             scriptvec,
         },
     };

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -177,7 +177,7 @@ mod tests {
         merkle::calc_hash_merkle_root,
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE, SubnetworkId},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
             scriptvec,
         },
     };
@@ -193,7 +193,7 @@ mod tests {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_slice(&[index; 32]), index: 0 },
             signature_script: vec![],
             sequence: u64::MAX,
-            mass: TxInputMass::ComputeBudget(0.into()),
+            compute_commit: ComputeCommit::ComputeBudget(0.into()),
         };
         let output = TransactionOutput { value: 1, script_public_key: ScriptPublicKey::new(0, scriptvec!(0u8)), covenant: None };
         Transaction::new(TX_VERSION_TOCCATA, vec![input], vec![output], 0, lane, gas, vec![])
@@ -267,7 +267,7 @@ mod tests {
                             },
                             signature_script: vec![],
                             sequence: u64::MAX,
-                            mass: TxInputMass::SigopCount(0.into()),
+                            compute_commit: ComputeCommit::SigopCount(0.into()),
                         },
                         TransactionInput {
                             previous_outpoint: TransactionOutpoint {
@@ -279,7 +279,7 @@ mod tests {
                             },
                             signature_script: vec![],
                             sequence: u64::MAX,
-                            mass: TxInputMass::SigopCount(0.into()),
+                            compute_commit: ComputeCommit::SigopCount(0.into()),
                         },
                     ],
                     vec![],
@@ -312,7 +312,7 @@ mod tests {
                             0x25, 0xf8, 0x7c, 0x16, 0x1b, 0xc6, 0xf8, 0xa6, 0x30, 0x12, 0x1d, 0xf2, 0xb3, 0xd3, // 65-byte pubkey
                         ],
                         sequence: u64::MAX,
-                        mass: TxInputMass::SigopCount(0.into()),
+                        compute_commit: ComputeCommit::SigopCount(0.into()),
                     }],
                     vec![
                         TransactionOutput {
@@ -374,7 +374,7 @@ mod tests {
                             0xa4, 0x63, 0x1e, 0xe3, 0x95, 0x60, 0x63, 0x9d, 0xb4, 0x62, 0xe9, 0xcb, 0x85, 0x0f, // 65-byte pubkey
                         ],
                         sequence: u64::MAX,
-                        mass: TxInputMass::SigopCount(0.into()),
+                        compute_commit: ComputeCommit::SigopCount(0.into()),
                     }],
                     vec![
                         TransactionOutput {
@@ -437,7 +437,7 @@ mod tests {
                             0xaa, 0xd3, 0xe0, 0x63, 0xce, 0x6a, 0xf4, 0xcf, 0xaa, 0xea, 0x4e, 0xa1, 0x4f, 0xbb, // 65-byte pubkey
                         ],
                         sequence: u64::MAX,
-                        mass: TxInputMass::SigopCount(0.into()),
+                        compute_commit: ComputeCommit::SigopCount(0.into()),
                     }],
                     vec![TransactionOutput {
                         value: 0xf4240,
@@ -471,8 +471,8 @@ mod tests {
 
         let mut block = example_block.clone();
         let txs = &mut block.transactions;
-        txs[1].inputs[0].mass = TxInputMass::SigopCount(255.into());
-        txs[1].inputs[1].mass = TxInputMass::SigopCount(255.into());
+        txs[1].inputs[0].compute_commit = ComputeCommit::SigopCount(255.into());
+        txs[1].inputs[1].compute_commit = ComputeCommit::SigopCount(255.into());
         block.header.hash_merkle_root = calc_hash_merkle_root(txs.iter());
         assert_match!(body_processor.validate_body_in_isolation(&block.to_immutable()), Err(RuleError::ExceedsComputeMassLimit(_, _)));
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -222,7 +222,7 @@ mod tests {
         constants::{TX_VERSION, TX_VERSION_TOCCATA},
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE, SubnetworkId},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+            ComputeCommit, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
             scriptvec,
         },
     };

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -195,13 +195,13 @@ fn check_transaction_subnetwork(tx: &Transaction) -> TxResult<()> {
 fn check_tx_version_specific_fields(tx: &Transaction) -> TxResult<()> {
     if tx.version > 0 {
         for (i, input) in tx.inputs.iter().enumerate() {
-            if let Some(sig_op_count) = input.mass.sig_op_count() {
+            if let Some(sig_op_count) = input.compute_commit.sig_op_count() {
                 return Err(TxRuleError::SigopCountInV1(i, sig_op_count));
             }
         }
     } else {
         for (i, input) in tx.inputs.iter().enumerate() {
-            if let Some(compute_budget) = input.mass.compute_budget() {
+            if let Some(compute_budget) = input.compute_commit.compute_budget() {
                 return Err(TxRuleError::ComputeBudgetInV0(i, compute_budget));
             }
         }
@@ -222,7 +222,7 @@ mod tests {
         constants::{TX_VERSION, TX_VERSION_TOCCATA},
         subnets::{SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE, SubnetworkId},
         tx::{
-            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+            ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
             scriptvec,
         },
     };
@@ -295,7 +295,7 @@ mod tests {
                     0xf8, 0xa6, 0x30, 0x12, 0x1d, 0xf2, 0xb3, 0xd3, // 65-byte pubkey
                 ],
                 sequence: u64::MAX,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             }],
             vec![
                 TransactionOutput {
@@ -396,12 +396,12 @@ mod tests {
 
         let mut tx = valid_tx.clone();
         tx.version = 1;
-        tx.inputs[0].mass = TxInputMass::SigopCount(1.into());
+        tx.inputs[0].compute_commit = ComputeCommit::SigopCount(1.into());
         assert_match!(tv.validate_tx_in_isolation(&tx), Err(TxRuleError::SigopCountInV1(_, _)));
 
         let mut tx = valid_tx.clone();
         tx.version = 0;
-        tx.inputs[0].mass = TxInputMass::ComputeBudget(1.into());
+        tx.inputs[0].compute_commit = ComputeCommit::ComputeBudget(1.into());
         assert_match!(tv.validate_tx_in_isolation(&tx), Err(TxRuleError::ComputeBudgetInV0(_, _)));
 
         let mut tx = valid_tx.clone();
@@ -433,7 +433,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_slice(&[0u8; 32]), index: 0 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: TxInputMass::SigopCount(0.into()),
+                compute_commit: ComputeCommit::SigopCount(0.into()),
             };
             let output = TransactionOutput { value: 1, script_public_key: ScriptPublicKey::new(0, scriptvec!(0u8)), covenant: None };
             Transaction::new(version, vec![input], vec![output], 0, subnetwork_id, 0, vec![])

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -237,8 +237,8 @@ mod tests {
     use kaspa_consensus_core::sign::sign;
     use kaspa_consensus_core::subnets::SubnetworkId;
     use kaspa_consensus_core::tx::{
-        MutableTransaction, PopulatedTransaction, ScriptPublicKey, ScriptVec, Transaction, TransactionId, TransactionInput,
-        TransactionOutpoint, TransactionOutput, ComputeCommit, UtxoEntry,
+        ComputeCommit, MutableTransaction, PopulatedTransaction, ScriptPublicKey, ScriptVec, Transaction, TransactionId,
+        TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry,
     };
     use kaspa_consensus_core::{
         config::params::ForkActivation,

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -195,7 +195,7 @@ pub fn check_scripts(tx: &(impl VerifiableTransaction + Sync), ctx: EngineCtx<'_
 
 pub fn check_scripts_sequential(tx: &impl VerifiableTransaction, ctx: EngineCtxUnsync<'_>, flags: EngineFlags) -> TxResult<()> {
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
-        let script_units_limit = input.mass.allowed_script_units();
+        let script_units_limit = input.compute_commit.allowed_script_units();
         let mut vm =
             TxScriptEngine::from_transaction_input_with_script_units_limit(tx, input, i, entry, ctx, flags, script_units_limit);
         vm.execute().map_err(|err| map_script_err(err, input))?;
@@ -206,7 +206,7 @@ pub fn check_scripts_sequential(tx: &impl VerifiableTransaction, ctx: EngineCtxU
 pub fn check_scripts_par_iter(tx: &(impl VerifiableTransaction + Sync), ctx: EngineCtxSync<'_>, flags: EngineFlags) -> TxResult<()> {
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
-        let script_units_limit = input.mass.allowed_script_units();
+        let script_units_limit = input.compute_commit.allowed_script_units();
         let mut vm =
             TxScriptEngine::from_transaction_input_with_script_units_limit(tx, input, idx, utxo, ctx, flags, script_units_limit);
         vm.execute().map_err(|err| map_script_err(err, input))
@@ -238,7 +238,7 @@ mod tests {
     use kaspa_consensus_core::subnets::SubnetworkId;
     use kaspa_consensus_core::tx::{
         MutableTransaction, PopulatedTransaction, ScriptPublicKey, ScriptVec, Transaction, TransactionId, TransactionInput,
-        TransactionOutpoint, TransactionOutput, TxInputMass, UtxoEntry,
+        TransactionOutpoint, TransactionOutput, ComputeCommit, UtxoEntry,
     };
     use kaspa_consensus_core::{
         config::params::ForkActivation,
@@ -297,7 +297,7 @@ mod tests {
                 signature_script: pay_to_script_hash_signature_script(redeem_script.clone(), signature_prefix.clone())
                     .expect("the script is canonical"),
                 sequence: 0,
-                mass: TxInputMass::ComputeBudget(1.into()),
+                compute_commit: ComputeCommit::ComputeBudget(1.into()),
             })
             .collect_vec();
 
@@ -321,7 +321,7 @@ mod tests {
 
         // (a) One input alone is over budget when compute_budget=0 (allowed units per input = 9999).
         let (mut tx, entries) = build_parallel_push_budget_test_tx(2);
-        tx.inputs[0].mass = ComputeBudget(0).into();
+        tx.inputs[0].compute_commit = ComputeBudget(0).into();
         let populated_tx = PopulatedTransaction::new(&tx, entries);
         let result = check_scripts(&populated_tx, EngineCtx::new(&sig_cache), flags);
         assert_match!(
@@ -333,14 +333,14 @@ mod tests {
         // (b) A few inputs together are all independently under budget and should pass.
         let (tx, entries) = build_parallel_push_budget_test_tx(3);
         let mut tx = tx;
-        tx.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(1).into());
+        tx.inputs.iter_mut().for_each(|input| input.compute_commit = ComputeBudget(1).into());
         let populated_tx = PopulatedTransaction::new(&tx, entries);
         check_scripts(&populated_tx, EngineCtx::new(&sig_cache), flags).expect("should succceed");
 
         // (c) Everything is ok with a larger per-input budget as well.
         let (tx, entries) = build_parallel_push_budget_test_tx(3);
         let mut tx = tx;
-        tx.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(10).into());
+        tx.inputs.iter_mut().for_each(|input| input.compute_commit = ComputeBudget(10).into());
         let populated_tx = PopulatedTransaction::new(&tx, entries);
         check_scripts(&populated_tx, EngineCtx::new(&sig_cache), flags).expect("should succeed");
     }
@@ -390,10 +390,10 @@ mod tests {
                 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: if TxInputMass::version_expects_compute_budget_field(version) {
-                    TxInputMass::ComputeBudget(compute_budget.into())
+                compute_commit: if ComputeCommit::version_expects_compute_budget_field(version) {
+                    ComputeCommit::ComputeBudget(compute_budget.into())
                 } else {
-                    TxInputMass::SigopCount(sig_op_count.into())
+                    ComputeCommit::SigopCount(sig_op_count.into())
                 },
             };
             let output = TransactionOutput {
@@ -414,8 +414,8 @@ mod tests {
             let signed_tx = sign(MutableTransaction::with_entries(tx, vec![utxo_entry]), schnorr_key);
 
             // Verify that `sign` didn't change the sig_op_count and compute_budget values.
-            assert_eq!(signed_tx.tx.inputs[0].mass.sig_op_count().unwrap_or(0), sig_op_count);
-            assert_eq!(signed_tx.tx.inputs[0].mass.compute_budget().unwrap_or(0), compute_budget);
+            assert_eq!(signed_tx.tx.inputs[0].compute_commit.sig_op_count().unwrap_or(0), sig_op_count);
+            assert_eq!(signed_tx.tx.inputs[0].compute_commit.compute_budget().unwrap_or(0), compute_budget);
 
             let verifiable_tx = signed_tx.as_verifiable();
 
@@ -459,7 +459,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([11u8; 32]), index: 0 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: TxInputMass::SigopCount(1.into()),
+                compute_commit: ComputeCommit::SigopCount(1.into()),
             }],
             vec![TransactionOutput {
                 value: 1,
@@ -482,7 +482,7 @@ mod tests {
 
         let signed_tx = sign(MutableTransaction::with_entries(tx, vec![utxo_entry]), schnorr_key);
         assert_eq!(signed_tx.tx.version, 0);
-        assert_eq!(signed_tx.tx.inputs[0].mass.sig_op_count().unwrap_or(0), 1);
+        assert_eq!(signed_tx.tx.inputs[0].compute_commit.sig_op_count().unwrap_or(0), 1);
 
         let verifiable_tx = signed_tx.as_verifiable();
 
@@ -537,7 +537,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(1.into()),
+                compute_commit: ComputeCommit::SigopCount(1.into()),
             }],
             vec![
                 TransactionOutput { value: 10360487799, script_public_key: ScriptPublicKey::new(0, script_pub_key_2), covenant: None },
@@ -613,7 +613,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(1.into()),
+                compute_commit: ComputeCommit::SigopCount(1.into()),
             }],
             vec![
                 TransactionOutput {
@@ -694,7 +694,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![
                 TransactionOutput {
@@ -775,7 +775,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![
                 TransactionOutput {
@@ -858,7 +858,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![
                 TransactionOutput {
@@ -941,7 +941,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![
                 TransactionOutput {
@@ -1018,7 +1018,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script,
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![TransactionOutput {
                 value: 2792999990000,
@@ -1084,19 +1084,19 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 1 },
                     signature_script: vec![],
                     sequence: 1,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
                 TransactionInput {
                     previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 2 },
                     signature_script: vec![],
                     sequence: 2,
-                    mass: TxInputMass::SigopCount(0.into()),
+                    compute_commit: ComputeCommit::SigopCount(0.into()),
                 },
             ],
             vec![

--- a/consensus/wasm/src/utils.rs
+++ b/consensus/wasm/src/utils.rs
@@ -2,12 +2,12 @@ use crate::result::Result;
 use kaspa_consensus_core::hashing::sighash::{SigHashReusedValuesUnsync, calc_schnorr_signature_hash};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::tx;
-use kaspa_consensus_core::tx::TxInputMass;
+use kaspa_consensus_core::tx::ComputeCommit;
 
 pub fn script_hashes(mut mutable_tx: tx::SignableTransaction) -> Result<Vec<kaspa_hashes::Hash>> {
     let mut list = vec![];
     for i in 0..mutable_tx.tx.inputs.len() {
-        mutable_tx.tx.inputs[i].mass = TxInputMass::SigopCount(1.into());
+        mutable_tx.tx.inputs[i].compute_commit = ComputeCommit::SigopCount(1.into());
     }
 
     let reused_values = SigHashReusedValuesUnsync::new();

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -16,7 +16,7 @@ use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::mass::{ComputeBudget, Gram, MassCalculator, ScriptUnits};
 use kaspa_consensus_core::tx::{
     MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
-    TransactionOutput, TxInputMass, UtxoEntry, VerifiableTransaction,
+    TransactionOutput, ComputeCommit, UtxoEntry, VerifiableTransaction,
 };
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::opcodes::codes::{self, OpDrop, OpDup};
@@ -136,12 +136,12 @@ fn format_average_input_budget(block: &BenchBlock) -> String {
 
     for bench_tx in &block.txs {
         for input in &bench_tx.tx.tx.inputs {
-            match input.mass {
-                TxInputMass::ComputeBudget(budget) => {
+            match input.compute_commit {
+                ComputeCommit::ComputeBudget(budget) => {
                     total_compute_budget += u16::from(budget) as u64;
                     compute_budget_inputs += 1;
                 }
-                TxInputMass::SigopCount(count) => {
+                ComputeCommit::SigopCount(count) => {
                     total_sigops += u8::from(count) as u64;
                     sigop_inputs += 1;
                 }
@@ -249,8 +249,8 @@ fn build_schnorr_2in1_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
     let mut tx = Transaction::new(
         1,
         vec![
-            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, mass: ComputeBudget(10).into() },
-            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, mass: ComputeBudget(10).into() },
+            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
+            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
         ],
         outputs,
         0,
@@ -289,8 +289,8 @@ fn build_ecdsa_2in1_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
     let mut tx = Transaction::new(
         1,
         vec![
-            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, mass: ComputeBudget(10).into() },
-            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, mass: ComputeBudget(10).into() },
+            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
+            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
         ],
         outputs,
         0,
@@ -583,7 +583,7 @@ fn try_build_budgeted_single_input_tx_with_result_check(
             previous_outpoint: outpoint,
             signature_script,
             sequence: 0,
-            mass: TxInputMass::ComputeBudget(0.into()),
+            compute_commit: ComputeCommit::ComputeBudget(0.into()),
         }],
         vec![],
         0,
@@ -607,7 +607,7 @@ fn try_build_budgeted_single_input_tx_with_result_check(
     result_check(vm.execute())?;
     let compute_budget = ComputeBudget::checked_covering_script_units(vm.used_script_units())
         .ok_or_else(|| "required compute budget does not fit for input #0".to_string())?;
-    tx.inputs[0].mass = compute_budget.into();
+    tx.inputs[0].compute_commit = compute_budget.into();
 
     Ok((tx, utxos))
 }
@@ -646,7 +646,7 @@ fn build_single_input_tx_with_compute_budget(
             previous_outpoint: outpoint,
             signature_script,
             sequence: 0,
-            mass: TxInputMass::ComputeBudget(compute_budget),
+            compute_commit: ComputeCommit::ComputeBudget(compute_budget),
         }],
         vec![],
         0,
@@ -690,7 +690,7 @@ fn build_introspection_cat_substr_math_tx(nonce: u32) -> (Transaction, Vec<UtxoE
             previous_outpoint: outpoint,
             signature_script,
             sequence: 0,
-            mass: TxInputMass::ComputeBudget(0.into()),
+            compute_commit: ComputeCommit::ComputeBudget(0.into()),
         }],
         vec![TransactionOutput { value: 10_000, script_public_key: output_spk, covenant: None }],
         0,
@@ -748,7 +748,7 @@ fn build_hash_storm_tx_with_rounds(
             previous_outpoint: outpoint,
             signature_script,
             sequence: 0,
-            mass: TxInputMass::ComputeBudget(0.into()),
+            compute_commit: ComputeCommit::ComputeBudget(0.into()),
         }],
         vec![],
         0,
@@ -1414,7 +1414,7 @@ fn estimate_groth16_repeated_tx_with_input_count(
     call_count: usize,
 ) -> Option<(Transaction, Vec<UtxoEntry>)> {
     let single_candidate = try_build_groth16_prepare_inputs_tx_with_input_count(nonce, public_input_count).ok()?;
-    let TxInputMass::ComputeBudget(single_budget) = single_candidate.0.inputs.first()?.mass else {
+    let ComputeCommit::ComputeBudget(single_budget) = single_candidate.0.inputs.first()?.compute_commit else {
         return None;
     };
     let repeated_budget = single_budget.value().checked_mul(u16::try_from(call_count).ok()?)?.checked_add(1).map(ComputeBudget)?;
@@ -1745,7 +1745,7 @@ fn build_budgeted_charged_tx(label: &str, tx: &Transaction, entries: &[UtxoEntry
         vm.execute().unwrap_or_else(|err| panic!("failed to measure {label} input #{input_idx}: {err}"));
         let compute_budget = ComputeBudget::checked_covering_script_units(vm.used_script_units())
             .unwrap_or_else(|| panic!("required compute budget does not fit for {label} input #{input_idx}"));
-        budgeted_tx.inputs[input_idx].mass = compute_budget.into();
+        budgeted_tx.inputs[input_idx].compute_commit = compute_budget.into();
     }
 
     budgeted_tx
@@ -2016,7 +2016,7 @@ fn validate_block_sequential(block: &BenchBlock) {
         let ctx = EngineCtx::new(&cache).with_reused(&reused_values);
 
         for (input_idx, (input, utxo)) in verifiable.populated_inputs().enumerate() {
-            let script_units_limit = input.mass.allowed_script_units();
+            let script_units_limit = input.compute_commit.allowed_script_units();
             let mut vm = TxScriptEngine::from_transaction_input_with_script_units_limit(
                 &verifiable,
                 input,
@@ -2043,7 +2043,7 @@ fn validate_block_parallel(block: &BenchBlock, pool: &rayon::ThreadPool) {
 
             (0..verifiable.inputs().len()).into_par_iter().try_for_each(|input_idx| {
                 let (input, utxo) = verifiable.populated_input(input_idx);
-                let script_units_limit = input.mass.allowed_script_units();
+                let script_units_limit = input.compute_commit.allowed_script_units();
                 let mut vm = TxScriptEngine::from_transaction_input_with_script_units_limit(
                     &verifiable,
                     input,

--- a/crypto/txscript/benches/pricing.rs
+++ b/crypto/txscript/benches/pricing.rs
@@ -15,8 +15,8 @@ use kaspa_consensus_core::hashing::sighash::{
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::mass::{ComputeBudget, Gram, MassCalculator, ScriptUnits};
 use kaspa_consensus_core::tx::{
-    MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
-    TransactionOutput, ComputeCommit, UtxoEntry, VerifiableTransaction,
+    ComputeCommit, MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput,
+    TransactionOutpoint, TransactionOutput, UtxoEntry, VerifiableTransaction,
 };
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::opcodes::codes::{self, OpDrop, OpDup};
@@ -249,8 +249,18 @@ fn build_schnorr_2in1_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
     let mut tx = Transaction::new(
         1,
         vec![
-            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
-            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
+            TransactionInput {
+                previous_outpoint: dummy_out1,
+                signature_script: vec![],
+                sequence: 0,
+                compute_commit: ComputeBudget(10).into(),
+            },
+            TransactionInput {
+                previous_outpoint: dummy_out2,
+                signature_script: vec![],
+                sequence: 0,
+                compute_commit: ComputeBudget(10).into(),
+            },
         ],
         outputs,
         0,
@@ -289,8 +299,18 @@ fn build_ecdsa_2in1_tx(nonce: u32) -> (Transaction, Vec<UtxoEntry>) {
     let mut tx = Transaction::new(
         1,
         vec![
-            TransactionInput { previous_outpoint: dummy_out1, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
-            TransactionInput { previous_outpoint: dummy_out2, signature_script: vec![], sequence: 0, compute_commit: ComputeBudget(10).into() },
+            TransactionInput {
+                previous_outpoint: dummy_out1,
+                signature_script: vec![],
+                sequence: 0,
+                compute_commit: ComputeBudget(10).into(),
+            },
+            TransactionInput {
+                previous_outpoint: dummy_out2,
+                signature_script: vec![],
+                sequence: 0,
+                compute_commit: ComputeBudget(10).into(),
+            },
         ],
         outputs,
         0,

--- a/crypto/txscript/examples/kip-10.rs
+++ b/crypto/txscript/examples/kip-10.rs
@@ -102,7 +102,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         },
         signature_script: ScriptBuilder::new().add_data(&script)?.drain(),
         sequence: 4294967295,
-        mass: SigopCount(1).into(),
+        compute_commit: SigopCount(1).into(),
     };
 
     // Create a transaction with the input and output
@@ -273,7 +273,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         },
         signature_script: ScriptBuilder::new().add_data(&script)?.drain(),
         sequence: 4294967295,
-        mass: SigopCount(1).into(),
+        compute_commit: SigopCount(1).into(),
     };
 
     // Create a transaction with the input and output
@@ -428,7 +428,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         },
         signature_script: ScriptBuilder::new().add_data(&two_times_script)?.drain(),
         sequence: 4294967295,
-        mass: SigopCount(1).into(),
+        compute_commit: SigopCount(1).into(),
     };
 
     // Create a transaction with the input and output
@@ -577,7 +577,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
         },
         signature_script: ScriptBuilder::new().add_data(&script)?.drain(),
         sequence: 4294967295,
-        mass: SigopCount(1).into(),
+        compute_commit: SigopCount(1).into(),
     };
 
     // Create a transaction with the input and output

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -964,8 +964,8 @@ mod tests {
         ComputeBudget, SCRIPT_UNITS_PER_COMPUTE_BUDGET_UNIT, SCRIPT_UNITS_PER_GRAM, ScriptUnits, SigopCount,
     };
     use kaspa_consensus_core::tx::{
-        MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
-        TransactionOutput, ComputeCommit,
+        ComputeCommit, MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput,
+        TransactionOutpoint, TransactionOutput,
     };
     use kaspa_core::assert_match;
     use kaspa_utils::hex::FromHex;

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -536,7 +536,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
         let runtime_resource_meter = if flags.covenants_enabled {
             RuntimeResourceMeter::new_script_units(flags.sigop_script_units, script_units_limit)
         } else {
-            RuntimeResourceMeter::new_sigops(input.mass.sig_op_count().unwrap_or(0))
+            RuntimeResourceMeter::new_sigops(input.compute_commit.sig_op_count().unwrap_or(0))
         };
         let script_public_key = utxo_entry.script_public_key.script();
         // The script_public_key in P2SH is just validating the hash on the OpMultiSig script
@@ -965,7 +965,7 @@ mod tests {
     };
     use kaspa_consensus_core::tx::{
         MutableTransaction, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
-        TransactionOutput, TxInputMass,
+        TransactionOutput, ComputeCommit,
     };
     use kaspa_core::assert_match;
     use kaspa_utils::hex::FromHex;
@@ -1014,7 +1014,7 @@ mod tests {
                 },
                 signature_script: vec![],
                 sequence: 4294967295,
-                mass: ComputeBudget(0).into(),
+                compute_commit: ComputeBudget(0).into(),
             };
             let output = TransactionOutput {
                 value: 1000000000,
@@ -1208,7 +1208,7 @@ mod tests {
             &script,
             &reused_values,
             &sig_cache,
-            TxInputMass::from(ComputeBudget(1)).allowed_script_units(),
+            ComputeCommit::from(ComputeBudget(1)).allowed_script_units(),
             flags,
         );
         assert!(exact_vm.execute().is_ok());
@@ -1218,7 +1218,7 @@ mod tests {
                 &script,
                 &reused_values,
                 &sig_cache,
-                TxInputMass::from(ComputeBudget(0)).allowed_script_units(),
+                ComputeCommit::from(ComputeBudget(0)).allowed_script_units(),
                 flags,
             );
         assert_eq!(
@@ -1324,7 +1324,7 @@ mod tests {
                 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: SigopCount(0).into(),
+                compute_commit: SigopCount(0).into(),
             };
             let output =
                 TransactionOutput { value: 1, script_public_key: ScriptPublicKey::new(0, vec![OpTrue].into()), covenant: None };
@@ -1359,7 +1359,7 @@ mod tests {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([7u8; 32]), index: 0 },
             signature_script: vec![OpTrue, OpTrue],
             sequence: 0,
-            mass: ComputeBudget(0).into(),
+            compute_commit: ComputeBudget(0).into(),
         };
 
         let output =
@@ -1431,7 +1431,7 @@ mod tests {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([9u8; 32]), index: 0 },
             signature_script: vec![],
             sequence: 0,
-            mass: ComputeBudget(0).into(), // We set the allowed units directly in the engine, so we skip setting sig_op_count and compute_budget.
+            compute_commit: ComputeBudget(0).into(), // We set the allowed units directly in the engine, so we skip setting sig_op_count and compute_budget.
         };
 
         let output = TransactionOutput { value: 1, script_public_key: ScriptPublicKey::new(0, vec![OpTrue].into()), covenant: None };
@@ -2125,7 +2125,7 @@ mod tests {
                     previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::default(), index: 0 },
                     signature_script: vec![],
                     sequence: 0,
-                    mass: SigopCount(test.sig_op_limit).into(),
+                    compute_commit: SigopCount(test.sig_op_limit).into(),
                 }],
                 vec![],
                 0,
@@ -2202,7 +2202,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::default(), index: 0 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: SigopCount(2).into(),
+                compute_commit: SigopCount(2).into(),
             }],
             vec![],
             0,
@@ -2314,7 +2314,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::default(), index: 0 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: SigopCount(3).into(),
+                compute_commit: SigopCount(3).into(),
             }],
             vec![],
             0,

--- a/crypto/txscript/src/standard/multisig.rs
+++ b/crypto/txscript/src/standard/multisig.rs
@@ -138,7 +138,7 @@ mod tests {
                 previous_outpoint: TransactionOutpoint { transaction_id: prev_tx_id, index: 0 },
                 signature_script: vec![],
                 sequence: 0,
-                mass: TxInputMass::SigopCount(4.into()),
+                compute_commit: ComputeCommit::SigopCount(4.into()),
             }],
             vec![],
             0,

--- a/protocol/p2p/proto/p2p.proto
+++ b/protocol/p2p/proto/p2p.proto
@@ -37,7 +37,7 @@ message TransactionInput{
   Outpoint previousOutpoint = 1;
   bytes signatureScript = 2;
   uint64 sequence = 3;
-  uint32 mass = 4;
+  uint32 compute_commit = 4;
 }
 
 message Outpoint{

--- a/protocol/p2p/src/convert/tx.rs
+++ b/protocol/p2p/src/convert/tx.rs
@@ -50,7 +50,7 @@ impl From<&TransactionInput> for protowire::TransactionInput {
             previous_outpoint: Some((&input.previous_outpoint).into()),
             signature_script: input.signature_script.clone(),
             sequence: input.sequence,
-            mass: match input.compute_commit {
+            compute_commit: match input.compute_commit {
                 ComputeCommit::SigopCount(count) => u8::from(count) as u32,
                 ComputeCommit::ComputeBudget(budget) => u16::from(budget) as u32,
             },
@@ -153,9 +153,9 @@ impl TryFrom<ProtoInputWithVersion> for TransactionInput {
             signature_script: value.input.signature_script,
             sequence: value.input.sequence,
             compute_commit: if ComputeCommit::version_expects_compute_budget_field(value.version as u16) {
-                ComputeBudget(u16::try_from(value.input.mass)?).into()
+                ComputeBudget(u16::try_from(value.input.compute_commit)?).into()
             } else {
-                SigopCount(u8::try_from(value.input.mass)?).into()
+                SigopCount(u8::try_from(value.input.compute_commit)?).into()
             },
         })
     }
@@ -229,7 +229,7 @@ mod tests {
         tx.set_storage_mass(54_321);
 
         let message: protowire::TransactionMessage = (&tx).into();
-        assert_eq!(message.inputs[0].mass, 12_345);
+        assert_eq!(message.inputs[0].compute_commit, 12_345);
 
         let received = Transaction::try_from(message).unwrap();
         assert_eq!(received.inputs.len(), 1);

--- a/protocol/p2p/src/convert/tx.rs
+++ b/protocol/p2p/src/convert/tx.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
     subnets::SubnetworkId,
     tx::{
         CovenantBinding, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
-        TxInputMass, UtxoEntry,
+        ComputeCommit, UtxoEntry,
     },
 };
 use kaspa_hashes::Hash;
@@ -50,9 +50,9 @@ impl From<&TransactionInput> for protowire::TransactionInput {
             previous_outpoint: Some((&input.previous_outpoint).into()),
             signature_script: input.signature_script.clone(),
             sequence: input.sequence,
-            mass: match input.mass {
-                TxInputMass::SigopCount(count) => u8::from(count) as u32,
-                TxInputMass::ComputeBudget(budget) => u16::from(budget) as u32,
+            mass: match input.compute_commit {
+                ComputeCommit::SigopCount(count) => u8::from(count) as u32,
+                ComputeCommit::ComputeBudget(budget) => u16::from(budget) as u32,
             },
         }
     }
@@ -152,7 +152,7 @@ impl TryFrom<ProtoInputWithVersion> for TransactionInput {
             previous_outpoint: value.input.previous_outpoint.try_into_ex()?,
             signature_script: value.input.signature_script,
             sequence: value.input.sequence,
-            mass: if TxInputMass::version_expects_compute_budget_field(value.version as u16) {
+            compute_commit: if ComputeCommit::version_expects_compute_budget_field(value.version as u16) {
                 ComputeBudget(u16::try_from(value.input.mass)?).into()
             } else {
                 SigopCount(u8::try_from(value.input.mass)?).into()
@@ -233,7 +233,7 @@ mod tests {
 
         let received = Transaction::try_from(message).unwrap();
         assert_eq!(received.inputs.len(), 1);
-        assert_eq!(received.inputs[0].mass.compute_budget(), Some(12_345));
+        assert_eq!(received.inputs[0].compute_commit.compute_budget(), Some(12_345));
         assert_eq!(received.storage_mass(), 54_321);
     }
 }

--- a/protocol/p2p/src/convert/tx.rs
+++ b/protocol/p2p/src/convert/tx.rs
@@ -4,8 +4,8 @@ use kaspa_consensus_core::{
     mass::{ComputeBudget, SigopCount},
     subnets::SubnetworkId,
     tx::{
-        CovenantBinding, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
-        ComputeCommit, UtxoEntry,
+        ComputeCommit, CovenantBinding, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint,
+        TransactionOutput, UtxoEntry,
     },
 };
 use kaspa_hashes::Hash;

--- a/rothschild/benches/bench.rs
+++ b/rothschild/benches/bench.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
     Hash,
     constants::TX_VERSION,
     subnets::SUBNETWORK_ID_NATIVE,
-    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass},
+    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit},
 };
 
 fn constuct_tx() -> Transaction {
@@ -13,7 +13,7 @@ fn constuct_tx() -> Transaction {
         previous_outpoint: TransactionOutpoint { transaction_id: Hash::from_bytes([0xFF; 32]), index: 0 },
         signature_script: vec![],
         sequence: 0,
-        mass: TxInputMass::SigopCount(1.into()),
+        compute_commit: ComputeCommit::SigopCount(1.into()),
     }];
     let outputs =
         vec![TransactionOutput { value: 10000, script_public_key: ScriptPublicKey::from_vec(0, vec![0xff; 35]), covenant: None }];

--- a/rothschild/benches/bench.rs
+++ b/rothschild/benches/bench.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
     Hash,
     constants::TX_VERSION,
     subnets::SUBNETWORK_ID_NATIVE,
-    tx::{ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit},
+    tx::{ComputeCommit, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput},
 };
 
 fn constuct_tx() -> Transaction {

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -11,7 +11,7 @@ use kaspa_consensus_core::{
     sign::sign,
     subnets::SUBNETWORK_ID_NATIVE,
     tx::{
-        CovenantBinding, MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
+        ComputeCommit, CovenantBinding, MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
         UtxoEntry,
     },
 };
@@ -647,7 +647,11 @@ fn generate_tx(
             previous_outpoint: *op,
             signature_script: vec![],
             sequence: 0,
-            compute_commit: if with_covenant_id { ComputeCommit::ComputeBudget(10.into()) } else { ComputeCommit::SigopCount(1.into()) },
+            compute_commit: if with_covenant_id {
+                ComputeCommit::ComputeBudget(10.into())
+            } else {
+                ComputeCommit::SigopCount(1.into())
+            },
         })
         .collect_vec();
 

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -11,7 +11,7 @@ use kaspa_consensus_core::{
     sign::sign,
     subnets::SUBNETWORK_ID_NATIVE,
     tx::{
-        CovenantBinding, MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, TxInputMass,
+        CovenantBinding, MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, ComputeCommit,
         UtxoEntry,
     },
 };
@@ -647,7 +647,7 @@ fn generate_tx(
             previous_outpoint: *op,
             signature_script: vec![],
             sequence: 0,
-            mass: if with_covenant_id { TxInputMass::ComputeBudget(10.into()) } else { TxInputMass::SigopCount(1.into()) },
+            compute_commit: if with_covenant_id { ComputeCommit::ComputeBudget(10.into()) } else { ComputeCommit::SigopCount(1.into()) },
         })
         .collect_vec();
 

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -5,7 +5,7 @@ use crate::{
     RpcTransactionInput, RpcTransactionOutput,
 };
 use kaspa_consensus_core::mass::{ComputeBudget, SigopCount};
-use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput, TxInputMass};
+use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput, ComputeCommit};
 
 struct RpcInputWithVersion {
     version: u16,
@@ -20,7 +20,7 @@ impl TryFrom<RpcInputWithVersion> for TransactionInput {
     type Error = RpcError;
 
     fn try_from(value: RpcInputWithVersion) -> RpcResult<Self> {
-        let mass = if TxInputMass::version_expects_compute_budget_field(value.version) {
+        let mass = if ComputeCommit::version_expects_compute_budget_field(value.version) {
             if value.input.sig_op_count != 0 {
                 return Err(invalid_input_mass_variant("sig_op_count", value.version));
             }
@@ -62,7 +62,7 @@ impl TryFrom<RpcOptionalInputWithVersion> for TransactionInput {
         let sequence =
             value.input.sequence.ok_or(RpcError::MissingRpcFieldError("RpcTransactionInput".to_owned(), "sequence".to_owned()))?;
 
-        let mass = if TxInputMass::version_expects_compute_budget_field(value.version) {
+        let mass = if ComputeCommit::version_expects_compute_budget_field(value.version) {
             if value.input.sig_op_count.is_some_and(|v| v != 0) {
                 return Err(invalid_input_mass_variant("sig_op_count", value.version));
             }
@@ -115,8 +115,8 @@ impl From<&TransactionInput> for RpcTransactionInput {
             previous_outpoint: item.previous_outpoint.into(),
             signature_script: item.signature_script.clone(),
             sequence: item.sequence,
-            sig_op_count: item.mass.sig_op_count().unwrap_or(0),
-            compute_budget: item.mass.compute_budget().unwrap_or(0),
+            sig_op_count: item.compute_commit.sig_op_count().unwrap_or(0),
+            compute_budget: item.compute_commit.compute_budget().unwrap_or(0),
             verbose_data: None,
         }
     }
@@ -194,8 +194,8 @@ impl From<&TransactionInput> for RpcOptionalTransactionInput {
             previous_outpoint: Some(item.previous_outpoint.into()),
             signature_script: Some(item.signature_script.clone()),
             sequence: Some(item.sequence),
-            sig_op_count: Some(item.mass.sig_op_count().unwrap_or(0)),
-            compute_budget: Some(item.mass.compute_budget().unwrap_or(0)),
+            sig_op_count: Some(item.compute_commit.sig_op_count().unwrap_or(0)),
+            compute_budget: Some(item.compute_commit.compute_budget().unwrap_or(0)),
             verbose_data: None,
         }
     }

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -5,7 +5,7 @@ use crate::{
     RpcTransactionInput, RpcTransactionOutput,
 };
 use kaspa_consensus_core::mass::{ComputeBudget, SigopCount};
-use kaspa_consensus_core::tx::{Transaction, TransactionInput, TransactionOutput, ComputeCommit};
+use kaspa_consensus_core::tx::{ComputeCommit, Transaction, TransactionInput, TransactionOutput};
 
 struct RpcInputWithVersion {
     version: u16,

--- a/rpc/core/src/model/optional/tx.rs
+++ b/rpc/core/src/model/optional/tx.rs
@@ -249,8 +249,8 @@ impl From<TransactionInput> for RpcOptionalTransactionInput {
             previous_outpoint: Some(input.previous_outpoint.into()),
             signature_script: Some(input.signature_script),
             sequence: Some(input.sequence),
-            sig_op_count: Some(input.mass.sig_op_count().unwrap_or(0)),
-            compute_budget: Some(input.mass.compute_budget().unwrap_or(0)),
+            sig_op_count: Some(input.compute_commit.sig_op_count().unwrap_or(0)),
+            compute_budget: Some(input.compute_commit.compute_budget().unwrap_or(0)),
             verbose_data: None,
         }
     }

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -1711,8 +1711,8 @@ mod mockery {
             assert_eq!(decoded.inputs[0].compute_budget, 0);
 
             let consensus_tx: kaspa_consensus_core::tx::Transaction = decoded.try_into().unwrap();
-            assert_eq!(consensus_tx.inputs[0].mass.sig_op_count(), Some(9));
-            assert_eq!(consensus_tx.inputs[0].mass.compute_budget(), None);
+            assert_eq!(consensus_tx.inputs[0].compute_commit.sig_op_count(), Some(9));
+            assert_eq!(consensus_tx.inputs[0].compute_commit.compute_budget(), None);
         }
 
         #[test]

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -178,8 +178,8 @@ impl From<TransactionInput> for RpcTransactionInput {
             previous_outpoint: input.previous_outpoint.into(),
             signature_script: input.signature_script,
             sequence: input.sequence,
-            sig_op_count: input.mass.sig_op_count().unwrap_or(0),
-            compute_budget: input.mass.compute_budget().unwrap_or(0),
+            sig_op_count: input.compute_commit.sig_op_count().unwrap_or(0),
+            compute_budget: input.compute_commit.compute_budget().unwrap_or(0),
             verbose_data: None,
         }
     }

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -391,12 +391,12 @@ impl ConsensusConverter {
             },
             sequence: if verbosity.include_sequence.unwrap_or(false) { Some(input.sequence) } else { Default::default() },
             sig_op_count: if verbosity.include_sig_op_count.unwrap_or(false) {
-                Some(input.mass.sig_op_count().unwrap_or(0))
+                Some(input.compute_commit.sig_op_count().unwrap_or(0))
             } else {
                 Default::default()
             },
             compute_budget: if verbosity.include_sig_op_count.unwrap_or(false) {
-                Some(input.mass.compute_budget().unwrap_or(0))
+                Some(input.compute_commit.compute_budget().unwrap_or(0))
             } else {
                 Default::default()
             }, // TODO: consider having a separate flag for compute_mass

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -227,7 +227,12 @@ pub fn generate_tx(
     let script_public_key = pay_to_address_script(address);
     let inputs = utxos
         .iter()
-        .map(|(op, _)| TransactionInput { previous_outpoint: *op, signature_script: vec![], sequence: 0, compute_commit: SigopCount(1).into() })
+        .map(|(op, _)| TransactionInput {
+            previous_outpoint: *op,
+            signature_script: vec![],
+            sequence: 0,
+            compute_commit: SigopCount(1).into(),
+        })
         .collect_vec();
 
     let outputs = (0..num_outputs)

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -227,7 +227,7 @@ pub fn generate_tx(
     let script_public_key = pay_to_address_script(address);
     let inputs = utxos
         .iter()
-        .map(|(op, _)| TransactionInput { previous_outpoint: *op, signature_script: vec![], sequence: 0, mass: SigopCount(1).into() })
+        .map(|(op, _)| TransactionInput { previous_outpoint: *op, signature_script: vec![], sequence: 0, compute_commit: SigopCount(1).into() })
         .collect_vec();
 
     let outputs = (0..num_outputs)

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -2281,7 +2281,7 @@ fn build_p2pk_block(
                 vec![],
             );
             let signed_tx = sign(MutableTransaction::with_entries(unsigned_tx, vec![utxo.clone()]), keypair).tx;
-            assert_eq!(signed_tx.inputs[0].mass.sig_op_count(), Some(1));
+            assert_eq!(signed_tx.inputs[0].compute_commit.sig_op_count(), Some(1));
             signed_tx
         })
         .collect::<Vec<_>>();

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -423,7 +423,7 @@ async fn daemon_utxos_propagation_test() {
             previous_outpoint: *op,
             signature_script: vec![],
             sequence: 0,
-            mass: ComputeBudget(0).into(),
+            compute_commit: ComputeBudget(0).into(),
         })
         .collect();
     let outputs = (0..NUMBER_OUTPUTS)
@@ -441,7 +441,7 @@ async fn daemon_utxos_propagation_test() {
     .unwrap();
     let mut transaction = signed_tx.tx;
     let per_input_compute_budget_commitment: u16 = 300; // ~30k-gram per-input upper bound
-    transaction.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(per_input_compute_budget_commitment).into());
+    transaction.inputs.iter_mut().for_each(|input| input.compute_commit = ComputeBudget(per_input_compute_budget_commitment).into());
     rpc_client1.submit_transaction((&transaction).into(), false).await.unwrap();
 
     let check_client = rpc_client1.clone();
@@ -656,7 +656,7 @@ async fn daemon_compute_budget_relay_test() {
                 previous_outpoint: *op,
                 signature_script: vec![],
                 sequence: 0,
-                mass: ComputeBudget(0).into(),
+                compute_commit: ComputeBudget(0).into(),
             })
             .collect();
         let outputs = (0..NUMBER_OUTPUTS)
@@ -677,16 +677,16 @@ async fn daemon_compute_budget_relay_test() {
 
     let tx_fee = fee::calc_from_probe(|| {
         let mut tx = build_transaction(total_in);
-        tx.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
+        tx.inputs.iter_mut().for_each(|input| input.compute_commit = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
         tx
     })
     .saturating_add(EXTRA_FEE);
     let tx_amount = total_in.checked_sub(tx_fee).expect("expected enough input value for test transaction fee");
 
     let mut transaction = build_transaction(tx_amount);
-    transaction.inputs.iter_mut().for_each(|input| input.mass = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
+    transaction.inputs.iter_mut().for_each(|input| input.compute_commit = ComputeBudget(PER_INPUT_COMPUTE_BUDGET).into());
     assert!(
-        transaction.inputs.iter().any(|input| input.mass.compute_budget().unwrap() > 0),
+        transaction.inputs.iter().any(|input| input.compute_commit.compute_budget().unwrap() > 0),
         "expected non-zero compute_budget commitment for v1 transaction"
     );
     let transaction_id = transaction.id();
@@ -790,7 +790,7 @@ async fn daemon_rejects_transactions_with_inconsistent_input_mass_and_version() 
         let mass = ComputeBudget(0).into(); // set correctly by sign below
         let tx = Transaction::new(
             version,
-            vec![TransactionInput { previous_outpoint: selected_utxo.0, signature_script: vec![], sequence: 0, mass }],
+            vec![TransactionInput { previous_outpoint: selected_utxo.0, signature_script: vec![], sequence: 0, compute_commit }],
             vec![TransactionOutput { value: output_value, script_public_key: pay_spk.clone(), covenant: None }],
             0,
             SUBNETWORK_ID_NATIVE,

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -787,7 +787,7 @@ async fn daemon_rejects_transactions_with_inconsistent_input_mass_and_version() 
     let build_single_input_tx = |version: u16, selected_utxo: &(TransactionOutpoint, UtxoEntry)| {
         let fee = fee::calc_for_plain_standard_tx(1, 1);
         let output_value = selected_utxo.1.amount.checked_sub(fee).expect("expected enough input value for test fee");
-        let mass = ComputeBudget(0).into(); // set correctly by sign below
+        let compute_commit = ComputeBudget(0).into(); // set correctly by sign below
         let tx = Transaction::new(
             version,
             vec![TransactionInput { previous_outpoint: selected_utxo.0, signature_script: vec![], sequence: 0, compute_commit }],

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -552,7 +552,7 @@ async fn bench_bbt_latency_stark() {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([0u8; 32]), index: 0 },
             signature_script: stark_signature_script.clone(),
             sequence: 0,
-            mass: ComputeBudget(0).into(),
+            compute_commit: ComputeBudget(0).into(),
         };
 
         let tx = Transaction::new(1, vec![input.clone()], vec![], 0, Default::default(), 0, vec![]);
@@ -671,7 +671,7 @@ fn generate_stark_tx_dag(
                 if !logged_first_provisional_tx {
                     let provisional_tx_size = transaction_estimated_serialized_size(&provisional_tx);
                     let provisional_tx_total_budget: u64 =
-                        provisional_tx.inputs.iter().map(|input| u64::from(input.mass.compute_budget().unwrap())).sum();
+                        provisional_tx.inputs.iter().map(|input| u64::from(input.compute_commit.compute_budget().unwrap())).sum();
                     info!(
                         "First provisional tx: non_contextual=({}), normalized_non_contextual_max={}, size={}, total_budget={}",
                         provisional_tx_non_contextual_masses,

--- a/wallet/core/src/tx/mass.rs
+++ b/wallet/core/src/tx/mass.rs
@@ -269,7 +269,7 @@ impl MassCalculator {
     }
 
     pub(crate) fn calc_compute_mass_for_client_transaction_input(&self, input: &TransactionInput) -> u64 {
-        input.mass.sig_op_count().unwrap_or(0) as u64 * self.mass_per_sig_op
+        input.compute_commit.sig_op_count().unwrap_or(0) as u64 * self.mass_per_sig_op
             + transaction_input_serialized_byte_size(input) * self.mass_per_tx_byte // TODO: Add support for v1 transactions.
     }
 

--- a/wallet/pskt/src/convert.rs
+++ b/wallet/pskt/src/convert.rs
@@ -74,7 +74,7 @@ impl TryFrom<(cctx::Transaction, Vec<(&cctx::TransactionInput, &cctx::UtxoEntry)
                 InputBuilder::default()
                     .utxo_entry(utxo.to_owned().clone())
                     .previous_outpoint(input.previous_outpoint)
-                    .sig_op_count(input.mass.sig_op_count().unwrap_or(0)) // TODO: Add support for v1 transactions with TxInputMass::ComputeBudget
+                    .sig_op_count(input.compute_commit.sig_op_count().unwrap_or(0)) // TODO: Add support for v1 transactions with TxInputMass::ComputeBudget
                     .build()
                     .map_err(Error::TxToInnerConversionInputBuildingError)
                 // Handle the error

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -20,7 +20,7 @@ use kaspa_consensus_core::mass::{MassCalculator, NonContextualMasses};
 use kaspa_consensus_core::{
     hashing::sighash_type::SigHashType,
     subnets::SUBNETWORK_ID_NATIVE,
-    tx::{MutableTransaction, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput, ComputeCommit},
+    tx::{ComputeCommit, MutableTransaction, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput},
 };
 use kaspa_txscript::{TxScriptEngine, caches::Cache};
 

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -20,7 +20,7 @@ use kaspa_consensus_core::mass::{MassCalculator, NonContextualMasses};
 use kaspa_consensus_core::{
     hashing::sighash_type::SigHashType,
     subnets::SUBNETWORK_ID_NATIVE,
-    tx::{MutableTransaction, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput, TxInputMass},
+    tx::{MutableTransaction, SignableTransaction, Transaction, TransactionId, TransactionInput, TransactionOutput, ComputeCommit},
 };
 use kaspa_txscript::{TxScriptEngine, caches::Cache};
 
@@ -144,7 +144,7 @@ impl<R> PSKT<R> {
                     previous_outpoint: *previous_outpoint,
                     signature_script: vec![],
                     sequence: sequence.unwrap_or(u64::MAX),
-                    mass: TxInputMass::SigopCount(sig_op_count.unwrap_or(0).into()), // TODO: Add support for v1 transactions with TxInputMass::ComputeBudget
+                    compute_commit: ComputeCommit::SigopCount(sig_op_count.unwrap_or(0).into()), // TODO: Add support for v1 transactions with TxInputMass::ComputeBudget
                 })
                 .collect(),
             self.outputs


### PR DESCRIPTION
The rationale for this change is to emphasize the fact the this fields commits to an upper bound of the input compute mass, and not related to storage/transient mass