### PR TITLE
Set Toccata to activate on mainnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2807,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "bs58",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-build-info"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "duct",
  "faster-hex 0.9.0",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-cli"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "ahash",
  "borsh",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "duration-string",
  "futures",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-daemon"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-stream",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-simple-client-example"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "futures",
  "kaspa-grpc-client",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "criterion",
@@ -3363,14 +3363,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-metrics-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "futures-util",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "kaspa-hashes",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-core",
  "log",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "js-sys",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-system-info"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "kaspa-utils",
  "mac_address",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "futures",
  "kaspa-consensus",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-cli-wasm"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "aes",
  "ahash",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-keys"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-macros"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro-error",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wallet-pskt"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-example-subscriber"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "ctrlc",
  "futures",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-proxy"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-simple-client-example"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "futures",
  "kaspa-rpc-core",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-vcc-v2"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "futures",
  "kaspa-addresses",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-wasm"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "ahash",
  "async-lock",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "rothschild"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "clap",
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "simpa"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "async-channel 2.3.1",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/kaspanet/rusty-kaspa"
@@ -88,67 +88,67 @@ include = [
 ]
 
 [workspace.dependencies]
-kaspa-testing-integration = { version = "1.3.0-toc.5", path = "testing/integration" }
-kaspa-addresses = { version = "1.3.0-toc.5", path = "crypto/addresses" }
-kaspa-addressmanager = { version = "1.3.0-toc.5", path = "components/addressmanager" }
-kaspa-bip32 = { version = "1.3.0-toc.5", path = "wallet/bip32" }
-kaspa-cli = { version = "1.3.0-toc.5", path = "cli" }
-kaspa-connectionmanager = { version = "1.3.0-toc.5", path = "components/connectionmanager" }
-kaspa-consensus = { version = "1.3.0-toc.5", path = "consensus" }
-kaspa-consensus-core = { version = "1.3.0-toc.5", path = "consensus/core" }
-kaspa-consensus-client = { version = "1.3.0-toc.5", path = "consensus/client" }
-kaspa-consensus-notify = { version = "1.3.0-toc.5", path = "consensus/notify" }
-kaspa-consensus-wasm = { version = "1.3.0-toc.5", path = "consensus/wasm" }
-kaspa-consensusmanager = { version = "1.3.0-toc.5", path = "components/consensusmanager" }
-kaspa-core = { version = "1.3.0-toc.5", path = "core" }
-kaspa-daemon = { version = "1.3.0-toc.5", path = "daemon" }
-kaspa-database = { version = "1.3.0-toc.5", path = "database" }
-kaspa-grpc-client = { version = "1.3.0-toc.5", path = "rpc/grpc/client" }
-kaspa-grpc-core = { version = "1.3.0-toc.5", path = "rpc/grpc/core" }
-kaspa-grpc-server = { version = "1.3.0-toc.5", path = "rpc/grpc/server" }
-kaspa-hashes = { version = "1.3.0-toc.5", path = "crypto/hashes", default-features = false }
-kaspa-index-core = { version = "1.3.0-toc.5", path = "indexes/core" }
-kaspa-index-processor = { version = "1.3.0-toc.5", path = "indexes/processor" }
-kaspa-math = { version = "1.3.0-toc.5", path = "math" }
-kaspa-merkle = { version = "1.3.0-toc.5", path = "crypto/merkle" }
-kaspa-smt = { version = "1.3.0-toc.5", path = "crypto/smt", default-features = false }
-kaspa-smt-store = { version = "1.3.0-toc.5", path = "consensus/smt-store" }
-kaspa-metrics-core = { version = "1.3.0-toc.5", path = "metrics/core" }
-kaspa-mining = { version = "1.3.0-toc.5", path = "mining" }
-kaspa-mining-errors = { version = "1.3.0-toc.5", path = "mining/errors" }
-kaspa-muhash = { version = "1.3.0-toc.5", path = "crypto/muhash" }
-kaspa-notify = { version = "1.3.0-toc.5", path = "notify" }
-kaspa-p2p-flows = { version = "1.3.0-toc.5", path = "protocol/flows" }
-kaspa-p2p-lib = { version = "1.3.0-toc.5", path = "protocol/p2p" }
-kaspa-p2p-mining = { version = "1.3.0-toc.5", path = "protocol/mining" }
-kaspa-perf-monitor = { version = "1.3.0-toc.5", path = "metrics/perf_monitor" }
-kaspa-pow = { version = "1.3.0-toc.5", path = "consensus/pow" }
-kaspa-rpc-core = { version = "1.3.0-toc.5", path = "rpc/core" }
-kaspa-seq-commit = { version = "1.3.0-toc.5", path = "consensus/seq-commit" }
-kaspa-rpc-macros = { version = "1.3.0-toc.5", path = "rpc/macros" }
-kaspa-rpc-service = { version = "1.3.0-toc.5", path = "rpc/service" }
-kaspa-txscript = { version = "1.3.0-toc.5", path = "crypto/txscript" }
-kaspa-txscript-errors = { version = "1.3.0-toc.5", path = "crypto/txscript/errors" }
-kaspa-utils = { version = "1.3.0-toc.5", path = "utils", default-features = false }
-kaspa-utils-tower = { version = "1.3.0-toc.5", path = "utils/tower" }
-kaspa-system-info = { version = "1.3.0-toc.5", path = "system-info" }
-kaspa-build-info = { version = "1.3.0-toc.5", path = "build-info" }
-kaspa-utxoindex = { version = "1.3.0-toc.5", path = "indexes/utxoindex" }
-kaspa-wallet = { version = "1.3.0-toc.5", path = "wallet/native" }
-kaspa-wallet-cli-wasm = { version = "1.3.0-toc.5", path = "wallet/wasm" }
-kaspa-wallet-keys = { version = "1.3.0-toc.5", path = "wallet/keys" }
-kaspa-wallet-pskt = { version = "1.3.0-toc.5", path = "wallet/pskt" }
-kaspa-wallet-core = { version = "1.3.0-toc.5", path = "wallet/core" }
-kaspa-wallet-macros = { version = "1.3.0-toc.5", path = "wallet/macros" }
-kaspa-wasm = { version = "1.3.0-toc.5", path = "wasm" }
-kaspa-wasm-core = { version = "1.3.0-toc.5", path = "wasm/core" }
-kaspa-wrpc-client = { version = "1.3.0-toc.5", path = "rpc/wrpc/client" }
-kaspa-wrpc-proxy = { version = "1.3.0-toc.5", path = "rpc/wrpc/proxy" }
-kaspa-wrpc-server = { version = "1.3.0-toc.5", path = "rpc/wrpc/server" }
-kaspa-wrpc-wasm = { version = "1.3.0-toc.5", path = "rpc/wrpc/wasm" }
-kaspa-wrpc-example-subscriber = { version = "1.3.0-toc.5", path = "rpc/wrpc/examples/subscriber" }
-kaspad = { version = "1.3.0-toc.5", path = "kaspad" }
-kaspa-alloc = { version = "1.3.0-toc.5", path = "utils/alloc" }
+kaspa-testing-integration = { version = "2.0.0", path = "testing/integration" }
+kaspa-addresses = { version = "2.0.0", path = "crypto/addresses" }
+kaspa-addressmanager = { version = "2.0.0", path = "components/addressmanager" }
+kaspa-bip32 = { version = "2.0.0", path = "wallet/bip32" }
+kaspa-cli = { version = "2.0.0", path = "cli" }
+kaspa-connectionmanager = { version = "2.0.0", path = "components/connectionmanager" }
+kaspa-consensus = { version = "2.0.0", path = "consensus" }
+kaspa-consensus-core = { version = "2.0.0", path = "consensus/core" }
+kaspa-consensus-client = { version = "2.0.0", path = "consensus/client" }
+kaspa-consensus-notify = { version = "2.0.0", path = "consensus/notify" }
+kaspa-consensus-wasm = { version = "2.0.0", path = "consensus/wasm" }
+kaspa-consensusmanager = { version = "2.0.0", path = "components/consensusmanager" }
+kaspa-core = { version = "2.0.0", path = "core" }
+kaspa-daemon = { version = "2.0.0", path = "daemon" }
+kaspa-database = { version = "2.0.0", path = "database" }
+kaspa-grpc-client = { version = "2.0.0", path = "rpc/grpc/client" }
+kaspa-grpc-core = { version = "2.0.0", path = "rpc/grpc/core" }
+kaspa-grpc-server = { version = "2.0.0", path = "rpc/grpc/server" }
+kaspa-hashes = { version = "2.0.0", path = "crypto/hashes", default-features = false }
+kaspa-index-core = { version = "2.0.0", path = "indexes/core" }
+kaspa-index-processor = { version = "2.0.0", path = "indexes/processor" }
+kaspa-math = { version = "2.0.0", path = "math" }
+kaspa-merkle = { version = "2.0.0", path = "crypto/merkle" }
+kaspa-smt = { version = "2.0.0", path = "crypto/smt", default-features = false }
+kaspa-smt-store = { version = "2.0.0", path = "consensus/smt-store" }
+kaspa-metrics-core = { version = "2.0.0", path = "metrics/core" }
+kaspa-mining = { version = "2.0.0", path = "mining" }
+kaspa-mining-errors = { version = "2.0.0", path = "mining/errors" }
+kaspa-muhash = { version = "2.0.0", path = "crypto/muhash" }
+kaspa-notify = { version = "2.0.0", path = "notify" }
+kaspa-p2p-flows = { version = "2.0.0", path = "protocol/flows" }
+kaspa-p2p-lib = { version = "2.0.0", path = "protocol/p2p" }
+kaspa-p2p-mining = { version = "2.0.0", path = "protocol/mining" }
+kaspa-perf-monitor = { version = "2.0.0", path = "metrics/perf_monitor" }
+kaspa-pow = { version = "2.0.0", path = "consensus/pow" }
+kaspa-rpc-core = { version = "2.0.0", path = "rpc/core" }
+kaspa-seq-commit = { version = "2.0.0", path = "consensus/seq-commit" }
+kaspa-rpc-macros = { version = "2.0.0", path = "rpc/macros" }
+kaspa-rpc-service = { version = "2.0.0", path = "rpc/service" }
+kaspa-txscript = { version = "2.0.0", path = "crypto/txscript" }
+kaspa-txscript-errors = { version = "2.0.0", path = "crypto/txscript/errors" }
+kaspa-utils = { version = "2.0.0", path = "utils", default-features = false }
+kaspa-utils-tower = { version = "2.0.0", path = "utils/tower" }
+kaspa-system-info = { version = "2.0.0", path = "system-info" }
+kaspa-build-info = { version = "2.0.0", path = "build-info" }
+kaspa-utxoindex = { version = "2.0.0", path = "indexes/utxoindex" }
+kaspa-wallet = { version = "2.0.0", path = "wallet/native" }
+kaspa-wallet-cli-wasm = { version = "2.0.0", path = "wallet/wasm" }
+kaspa-wallet-keys = { version = "2.0.0", path = "wallet/keys" }
+kaspa-wallet-pskt = { version = "2.0.0", path = "wallet/pskt" }
+kaspa-wallet-core = { version = "2.0.0", path = "wallet/core" }
+kaspa-wallet-macros = { version = "2.0.0", path = "wallet/macros" }
+kaspa-wasm = { version = "2.0.0", path = "wasm" }
+kaspa-wasm-core = { version = "2.0.0", path = "wasm/core" }
+kaspa-wrpc-client = { version = "2.0.0", path = "rpc/wrpc/client" }
+kaspa-wrpc-proxy = { version = "2.0.0", path = "rpc/wrpc/proxy" }
+kaspa-wrpc-server = { version = "2.0.0", path = "rpc/wrpc/server" }
+kaspa-wrpc-wasm = { version = "2.0.0", path = "rpc/wrpc/wasm" }
+kaspa-wrpc-example-subscriber = { version = "2.0.0", path = "rpc/wrpc/examples/subscriber" }
+kaspad = { version = "2.0.0", path = "kaspad" }
+kaspa-alloc = { version = "2.0.0", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -720,7 +720,8 @@ pub const MAINNET_PARAMS: Params = Params {
     // Roughly 2025-05-05 1500 UTC
     crescendo_activation: ForkActivation::new(110_165_000),
 
-    toccata_activation: ForkActivation::never(),
+    // Roughly 2026-06-30 1615 UTC
+    toccata_activation: ForkActivation::new(474_165_565),
 };
 
 pub const TESTNET_PARAMS: Params = Params {

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -261,7 +261,6 @@ pub struct Transaction {
     pub payload: Vec<u8>,
 
     /// Holds a commitment to the storage mass (KIP-0009)
-    /// TODO: rename field and related methods to storage_mass
     storage_mass: TransactionMass,
 
     // A field that is used to cache the transaction ID.
@@ -408,7 +407,7 @@ impl Transaction {
 
     /// Set the storage mass commitment field of this transaction. This field has been activated on mainnet as part
     /// of the Crescendo hardfork. The field has no effect on tx ID so no need to finalize following this call.
-    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.set_storage_mass(mass)` instead."]
+    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and transient mass. Use `self.set_storage_mass(mass)` instead."]
     pub fn set_mass(&self, mass: u64) {
         self.set_storage_mass(mass);
     }
@@ -420,7 +419,7 @@ impl Transaction {
     }
 
     /// Read the storage mass commitment
-    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and trasient mass. Use `self.storage_mass()` instead."]
+    #[deprecated = "This function is deprecated to avoid ambiguity with compute mass and transient mass. Use `self.storage_mass()` instead."]
     pub fn mass(&self) -> u64 {
         self.storage_mass()
     }


### PR DESCRIPTION
Toccata is set to activate on DAA score `474,165,565` almost exactly 360M blocks after Crescendo activated, roughly at June 30, 2026 at 1615 UTC.

The additional `565` is in reference to [Toccata and Fugue in D Minor](https://en.wikipedia.org/wiki/Toccata_and_Fugue_in_D_minor,_BWV_565)