### PR TITLE
Fix/windows risc0 sys alloc shim

### DIFF
--- a/bridge/src/inprocess_node.rs
+++ b/bridge/src/inprocess_node.rs
@@ -13,6 +13,9 @@ impl InProcessNode {
     pub(crate) fn start_from_args(args: kaspad_args::Args) -> Result<Self, anyhow::Error> {
         let _ = fd_budget::try_set_fd_limit(kaspad_daemon::DESIRED_DAEMON_SOFT_FD_LIMIT);
 
+        #[cfg(test)]
+        let runtime = kaspad_daemon::Runtime::default();
+        #[cfg(not(test))]
         let runtime = kaspad_daemon::Runtime::from_args(&args);
         let fd_total_budget =
             fd_budget::limit() - args.rpc_max_clients as i32 - args.inbound_limit as i32 - args.outbound_target as i32;

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -1345,26 +1345,26 @@ async fn get_stats_json_filtered(instance_id: Option<&str>) -> StatsResponse {
     // Add internal CPU recent blocks into the unified blocks list so the donut chart and
     // recent blocks table populate even in CPU-only runs.
     #[cfg(feature = "rkstratum_cpu_miner")]
-    if let Some(icpu) = stats.internalCpu.as_ref() {
-        if let Some(q) = INTERNAL_CPU_RECENT_BLOCKS.get() {
-            let wallet = icpu.wallet.clone();
-            let guard = q.lock();
-            for b in guard.iter() {
-                let hash = b.hash.clone();
-                if hash.is_empty() || block_set.contains(&hash) {
-                    continue;
-                }
-                block_set.insert(hash.clone());
-                stats.blocks.push(BlockInfo {
-                    instance: "-".to_string(),
-                    worker: "InternalCPU".to_string(),
-                    wallet: wallet.clone(),
-                    timestamp: b.timestamp_unix.to_string(),
-                    hash,
-                    nonce: b.nonce.to_string(),
-                    bluescore: b.bluescore.to_string(),
-                });
+    if let Some(icpu) = stats.internalCpu.as_ref()
+        && let Some(q) = INTERNAL_CPU_RECENT_BLOCKS.get()
+    {
+        let wallet = icpu.wallet.clone();
+        let guard = q.lock();
+        for b in guard.iter() {
+            let hash = b.hash.clone();
+            if hash.is_empty() || block_set.contains(&hash) {
+                continue;
             }
+            block_set.insert(hash.clone());
+            stats.blocks.push(BlockInfo {
+                instance: "-".to_string(),
+                worker: "InternalCPU".to_string(),
+                wallet: wallet.clone(),
+                timestamp: b.timestamp_unix.to_string(),
+                hash,
+                nonce: b.nonce.to_string(),
+                bluescore: b.bluescore.to_string(),
+            });
         }
     }
 

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -1079,9 +1079,16 @@ mod integration {
     use kaspa_stratum_bridge::{KaspaApi, StratumServerBridgeConfig as StratumBridgeConfig, listen_and_serve_with_shutdown};
     use kaspad_lib::args as kaspad_args;
     use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
     use std::time::Duration;
     use tokio::sync::watch;
     use tokio::time::timeout;
+
+    static INPROCESS_NODE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_inprocess_node_test() -> MutexGuard<'static, ()> {
+        INPROCESS_NODE_TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     // Mirrors testing/integration/src/common/daemon.rs::free_port.
     fn free_port() -> u16 {
@@ -1096,6 +1103,7 @@ mod integration {
 
     #[tokio::test]
     async fn test_bridge_startup_with_inprocess_node() {
+        let _guard = lock_inprocess_node_test();
         init_allocator_with_default_settings();
 
         // Use a temporary directory for the node data
@@ -1166,8 +1174,8 @@ mod integration {
 
     #[tokio::test]
     #[cfg(feature = "rkstratum_cpu_miner")]
-    // Note: When running both integration tests, use --test-threads=1 to avoid file descriptor limits
     async fn test_bridge_startup_with_cpu_miner_feature() {
+        let _guard = lock_inprocess_node_test();
         init_allocator_with_default_settings();
 
         // Use a temporary directory for the node data

--- a/bridge/src/tests.rs
+++ b/bridge/src/tests.rs
@@ -1079,15 +1079,14 @@ mod integration {
     use kaspa_stratum_bridge::{KaspaApi, StratumServerBridgeConfig as StratumBridgeConfig, listen_and_serve_with_shutdown};
     use kaspad_lib::args as kaspad_args;
     use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
     use std::time::Duration;
-    use tokio::sync::watch;
+    use tokio::sync::{Mutex, MutexGuard, watch};
     use tokio::time::timeout;
 
-    static INPROCESS_NODE_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static INPROCESS_NODE_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
-    fn lock_inprocess_node_test() -> MutexGuard<'static, ()> {
-        INPROCESS_NODE_TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    async fn lock_inprocess_node_test() -> MutexGuard<'static, ()> {
+        INPROCESS_NODE_TEST_LOCK.lock().await
     }
 
     // Mirrors testing/integration/src/common/daemon.rs::free_port.
@@ -1103,7 +1102,7 @@ mod integration {
 
     #[tokio::test]
     async fn test_bridge_startup_with_inprocess_node() {
-        let _guard = lock_inprocess_node_test();
+        let _guard = lock_inprocess_node_test().await;
         init_allocator_with_default_settings();
 
         // Use a temporary directory for the node data
@@ -1175,7 +1174,7 @@ mod integration {
     #[tokio::test]
     #[cfg(feature = "rkstratum_cpu_miner")]
     async fn test_bridge_startup_with_cpu_miner_feature() {
-        let _guard = lock_inprocess_node_test();
+        let _guard = lock_inprocess_node_test().await;
         init_allocator_with_default_settings();
 
         // Use a temporary directory for the node data
@@ -1218,7 +1217,7 @@ mod integration {
         };
 
         // Verify the config can be created (this tests the feature is available)
-        assert_eq!(miner_config.enabled, false);
+        assert!(!miner_config.enabled);
         assert_eq!(miner_config.threads, 1);
 
         // Create bridge config
@@ -2507,7 +2506,7 @@ mod comprehensive_tests {
 
         // Test that InternalMinerMetrics is available
         use kaspa_stratum_bridge::rkstratum_cpu_miner::InternalMinerMetrics;
-        let _metrics = InternalMinerMetrics::default();
+        let metrics = InternalMinerMetrics::default();
 
         // Test that spawn function is available (compile-time check)
         // The actual function signature: spawn_internal_cpu_miner(
@@ -2516,8 +2515,7 @@ mod comprehensive_tests {
         //     shutdown_rx: watch::Receiver<bool>,
         // ) -> Result<Arc<InternalMinerMetrics>, anyhow::Error>
 
-        // If we can compile this test, the feature is available
-        assert!(true, "CPU miner feature is available");
+        assert_eq!(metrics.blocks_accepted.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 
     // ========================================================================

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -16,6 +16,9 @@ name = "kip-10"
 [features]
 wasm32-core = ["dep:js-sys", "dep:kaspa-wasm-core"]
 wasm32-sdk = ["wasm32-core", "kaspa-consensus-core/wasm32-sdk"]
+# Disable the Windows host allocator shim when another selected crate enables
+# `risc0-zkvm-platform/export-syscalls` and RISC0 exports the symbol itself.
+risc0-platform-exports-syscalls = []
 
 [dependencies]
 ark-bn254.workspace = true

--- a/crypto/txscript/build.rs
+++ b/crypto/txscript/build.rs
@@ -1,13 +1,22 @@
 #[cfg(windows)]
 fn main() {
-    // WORKAROUND: Compile Windows stub for risc0-zkvm-platform's sys_alloc_aligned
+    // WORKAROUND: Compile Windows stub for risc0-zkvm-platform's sys_alloc_aligned.
     //
+    // Verifier-only RISC0 builds may still declare sys_alloc_aligned as an external
+    // symbol on Windows. The optional `risc0-platform-exports-syscalls` feature is
+    // enabled by kaspa-txscript-zk-sdk, where risc0-zkvm enables
+    // risc0-zkvm-platform/export-syscalls and exports sys_alloc_aligned itself.
+    // In that graph, compiling this shim would create duplicate MSVC symbols.
+    if std::env::var_os("CARGO_FEATURE_RISC0_PLATFORM_EXPORTS_SYSCALLS").is_some() {
+        return;
+    }
+
     // This build script compiles a C stub that provides the missing sys_alloc_aligned()
-    // and sys_free_aligned() symbols required by risc0-zkvm-platform on Windows.
+    // symbol required by risc0-zkvm-platform on Windows.
     //
     // The stub is only compiled on Windows platforms and links against the MSVC runtime
     // to provide aligned memory allocation functions. This allows the crate to build
-    // successfully on Windows while risc0-zkvm-platform lacks native Windows support.
+    // successfully on Windows when the RISC0 platform does not export the host symbol.
     //
     // See src/zk_precompiles/risc0/windows_stub/sys_alloc.c for implementation details.
     //

--- a/crypto/txscript/src/zk_precompiles/risc0/windows_stub/sys_alloc.c
+++ b/crypto/txscript/src/zk_precompiles/risc0/windows_stub/sys_alloc.c
@@ -1,6 +1,7 @@
 // Windows stub implementation for risc0-zkvm-platform's sys_alloc_aligned
 //
-// WORKAROUND: Temporary workaround for Windows linking errors with risc0-zkvm-platform
+// WORKAROUND: Temporary workaround for verifier-only Windows linking with
+// risc0-zkvm-platform.
 //
 // ERROR ENCOUNTERED:
 // ==================
@@ -17,9 +18,13 @@
 //
 // WHY THIS SOLUTION:
 // ==================
-// We provide a Windows-specific implementation of sys_alloc_aligned()
-// using MSVC's native _aligned_malloc() functions. This satisfies the
-// linker's requirement for these symbols while maintaining the same functionality.
+// We provide a Windows-specific implementation of sys_alloc_aligned() using
+// MSVC's native _aligned_malloc() function. This satisfies the linker's
+// requirement while maintaining the same functionality.
+//
+// This file must only be compiled when risc0-zkvm-platform is not already built
+// with its export-syscalls feature. If RISC0 exports sys_alloc_aligned itself,
+// compiling this shim as well causes MSVC LNK2005/LNK1169 duplicate symbols.
 //
 // IMPORTANT NOTES:
 // ================
@@ -27,7 +32,8 @@
 //   not during verification-only use cases (which is how Kaspa uses it).
 // - The implementation uses Windows-specific functions (_aligned_malloc) which
 //   are part of the MSVC runtime library, so no additional dependencies are required.
-// - This is a temporary workaround until risc0-zkvm-platform adds proper Windows support.
+// - This is a temporary workaround for dependency graphs where risc0-zkvm-platform
+//   declares but does not export sys_alloc_aligned.
 //
 // TESTING/VERIFICATION:
 // =====================
@@ -49,7 +55,8 @@
 // The implementation uses standard MSVC runtime functions available in all modern
 // MSVC versions, so no specific version requirements beyond standard Rust/MSVC setup.
 //
-// TODO: Remove this workaround when risc0-zkvm-platform adds proper Windows support.
+// TODO: Remove this workaround when all supported RISC0 dependency graphs export
+// sys_alloc_aligned themselves on Windows.
 // Issue tracking: https://github.com/kaspanet/rusty-kaspa/issues/<ISSUE_NUMBER>
 // Upstream risc0-zkvm-platform issue: <UPSTREAM_ISSUE_LINK> (if applicable)
 //

--- a/crypto/txscript/zk-sdk/Cargo.toml
+++ b/crypto/txscript/zk-sdk/Cargo.toml
@@ -28,7 +28,7 @@ ark-groth16.workspace = true
 ark-serialize.workspace = true
 borsh = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
-kaspa-txscript.workspace = true
+kaspa-txscript = { workspace = true, features = ["risc0-platform-exports-syscalls"] }
 kaspa-wasm-core = { workspace = true, optional = true }
 risc0-binfmt.workspace = true
 risc0-groth16.workspace = true


### PR DESCRIPTION
Fix Windows/MSVC release builds that fail with a duplicate sys_alloc_aligned symbol when rkstratum_cpu_miner or full workspace builds include both kaspa-txscript and RISC0 ZK SDK dependencies.

**Why This Is Needed**

**kaspa-txscript** has a Windows C shim that exports sys_alloc_aligned as a workaround for RISC0 verifier-only builds where the symbol is declared but not provided.

However, when **kaspa-txscript-zk-sdk** is included, it pulls in risc0-zkvm, which enables risc0-zkvm-platform/export-syscalls. In that build graph, RISC0 already exports sys_alloc_aligned.

On Windows/MSVC, both exports are treated as strong symbols, so the linker fails with:

LNK2005: sys_alloc_aligned already defined
LNK1169: one or more multiply defined symbols found

**What The Fix Does**
This change gates the local Kaspa Windows shim behind a Cargo feature:
risc0-platform-exports-syscalls

When kaspa-txscript-zk-sdk is present, it enables this feature on kaspa-txscript, telling the build script not to compile the local C shim because RISC0 already provides the symbol.

The shim still remains available for verifier-only builds where RISC0 does not export sys_alloc_aligned.
Result

This prevents duplicate symbols in full/RISC0 SDK builds while preserving compatibility for narrower txscript verifier builds that still need the shim.

Issue found and reported by @KaspaPulse