### PR TITLE
fix(windows): avoid native cdylib links for bridge deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,6 +4097,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-core",
  "risc0-zkp",
+ "risc0-zkvm-platform",
  "secp256k1",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,6 +307,7 @@ risc0-binfmt = "=3.0.4"
 risc0-circuit-recursion = { version = "=4.0.4", default-features = false }
 risc0-core = "=3.0.1"
 risc0-zkp = "=3.0.4"
+risc0-zkvm-platform = { version = "=2.2.2", features = ["export-syscalls"] }
 risc0-groth16 = "=3.0.4"
 risc0-zkvm = { version="=3.0.4", default-features = false }
 # workflow dependencies that are not a part of core libraries

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -45,6 +45,7 @@ risc0-binfmt.workspace = true
 risc0-circuit-recursion.workspace = true
 risc0-core.workspace = true
 risc0-zkp.workspace = true
+risc0-zkvm-platform.workspace = true
 secp256k1.workspace = true
 serde-wasm-bindgen.workspace = true
 serde.workspace = true

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 
 [lib]
 name = "kaspad_lib"
-crate-type = ["cdylib", "lib"]
 
 [dependencies]
 kaspa-alloc.workspace = true # This changes the global allocator for all of the next dependencies so should be kept first

--- a/rpc/wrpc/server/Cargo.toml
+++ b/rpc/wrpc/server/Cargo.toml
@@ -9,9 +9,6 @@ include.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[lib]
-crate-type = ["cdylib", "lib"]
-
 [dependencies]
 async-trait.workspace = true
 borsh = { workspace = true, features = ["rc"] }


### PR DESCRIPTION
## Summary

This fixes a Windows MSVC release build failure when building `kaspa-stratum-bridge` with in-process node support.

The bridge depends on `kaspad`, which depends on `kaspa-wrpc-server`. Both `kaspad` and `kaspa-wrpc-server` were configured to build as `cdylib` in addition to normal Rust libraries. On Windows, Cargo therefore tried to link `kaspad_lib.dll` / `kaspa_wrpc_server.dll`, which pulled in `risc0_zkvm_platform` and failed with:

`error LNK2019: unresolved external symbol sys_alloc_aligned`

These crates are consumed as Rust libraries by the bridge and do not expose a native DLL/FFI interface, so this removes the unnecessary `cdylib` crate type from both manifests.

## What This Fixes

Before this change, the following command failed during release linking on Windows:

`cargo run -p kaspa-stratum-bridge --release --bin stratum-bridge -- --config bridge/config.yaml --node-mode inprocess --appdir "C:\KaspaData" --coinbase-tag-suffix dablackasplash --web-dashboard-port 3030 -- --utxoindex --rpclisten=0.0.0.0:16110 --listen=0.0.0.0:16111 --uacomment="RKStratum"`

The failure occurred while linking a generated DLL artifact, not while linking the final bridge executable.

## Validation

Verified on Windows with:

- `cargo fmt`
- `cargo build -p kaspa-wrpc-server --release`
- `cargo build -p kaspa-stratum-bridge --release --bin stratum-bridge`
- `cargo clippy -p kaspa-stratum-bridge --release --bin stratum-bridge -- -D warnings`