### PR TITLE
fix(bridge/web): keep dashboard available under load & bound /metrics cardinality

### DIFF
--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -8,6 +8,7 @@ use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
+use tokio::time::timeout;
 
 use crate::app_config::BridgeConfig;
 use crate::net_utils::bind_addr_from_port;
@@ -345,16 +346,25 @@ async fn write_response(
     if let Some(body) = body_bytes {
         stream.write_all(&body).await?;
     }
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+async fn send_response(
+    mut stream: tokio::net::TcpStream,
+    response: impl AsRef<[u8]>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use tokio::io::AsyncWriteExt;
+    stream.write_all(response.as_ref()).await?;
+    let _ = stream.shutdown().await;
     Ok(())
 }
 
 async fn handle_http_request(
-    mut stream: tokio::net::TcpStream,
+    stream: tokio::net::TcpStream,
     request: &str,
     mode: &HttpMode,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::io::AsyncWriteExt;
-
     let path = request.lines().next().and_then(|line| line.split_whitespace().nth(1)).unwrap_or("/");
 
     if request.starts_with("GET /metrics") {
@@ -368,11 +378,11 @@ async fn handle_http_request(
         encoder.encode(&metric_families, &mut buf)?;
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
             buf.len(),
             String::from_utf8_lossy(&buf)
         );
-        stream.write_all(response.as_bytes()).await?;
+        send_response(stream, response).await?;
         return Ok(());
     }
 
@@ -388,11 +398,11 @@ async fn handle_http_request(
             WebStatusResponse { kaspad_address: status_cfg.kaspad_address, kaspad_version, instances: status_cfg.instances, web_bind };
         let json = serde_json::to_string(&status).unwrap_or_else(|_| "{}".to_string());
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
             json.len(),
             json
         );
-        stream.write_all(response.as_bytes()).await?;
+        send_response(stream, response).await?;
         return Ok(());
     }
 
@@ -403,22 +413,22 @@ async fn handle_http_request(
         };
         let json = serde_json::to_string(&stats).unwrap_or_else(|_| "{}".to_string());
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
             json.len(),
             json
         );
-        stream.write_all(response.as_bytes()).await?;
+        send_response(stream, response).await?;
         return Ok(());
     }
 
     if matches!(mode, HttpMode::Instance { .. }) && request.starts_with("GET /api/config") {
         let config_json = get_config_json().await;
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
             config_json.len(),
             config_json
         );
-        stream.write_all(response.as_bytes()).await?;
+        send_response(stream, response).await?;
         return Ok(());
     }
 
@@ -427,11 +437,11 @@ async fn handle_http_request(
             let json_response =
                 r#"{"success": false, "message": "Config write disabled. Set RKSTRATUM_ALLOW_CONFIG_WRITE=1 to enable."}"#;
             let response = format!(
-                "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
                 json_response.len(),
                 json_response
             );
-            stream.write_all(response.as_bytes()).await?;
+            send_response(stream, response).await?;
             return Ok(());
         }
 
@@ -444,40 +454,66 @@ async fn handle_http_request(
             r#"{"success": false, "message": "Failed to update config"}"#
         };
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
             json_response.len(),
             json_response
         );
-        stream.write_all(response.as_bytes()).await?;
+        send_response(stream, response).await?;
         return Ok(());
     }
 
     if request.starts_with("GET /") {
         if let Some((rel, bytes)) = try_read_static_file(path) {
             let ct = content_type_for_path(&rel);
-            let response = format!("HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\n\r\n", ct, bytes.len());
+            let response =
+                format!("HTTP/1.1 200 OK\r\nContent-Type: {}\r\nConnection: close\r\nContent-Length: {}\r\n\r\n", ct, bytes.len());
             write_response(stream, response, Some(bytes)).await?;
         } else {
-            stream.write_all("HTTP/1.1 404 Not Found\r\n\r\n".as_bytes()).await?;
+            send_response(stream, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n").await?;
         }
         return Ok(());
     }
 
-    stream.write_all("HTTP/1.1 404 Not Found\r\n\r\n".as_bytes()).await?;
+    send_response(stream, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n").await?;
     Ok(())
 }
 
-async fn serve_http_loop(listener: tokio::net::TcpListener, mode: HttpMode) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn handle_one_connection(
+    mut stream: tokio::net::TcpStream,
+    mode: HttpMode,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use tokio::io::AsyncReadExt;
 
-    loop {
-        let (mut stream, _) = listener.accept().await?;
-        let mut buffer = [0; 8192];
+    let mut buffer = [0u8; 8192];
 
-        if let Ok(n) = stream.read(&mut buffer).await {
+    match timeout(READ_TIMEOUT, stream.read(&mut buffer)).await {
+        Ok(Ok(0)) => Ok(()),
+        Ok(Ok(n)) => {
             let request = String::from_utf8_lossy(&buffer[..n]);
-            let _ = handle_http_request(stream, &request, &mode).await;
+            handle_http_request(stream, &request, &mode).await
         }
+        Ok(Err(_)) => Ok(()),
+        Err(_) => Ok(()),
+    }
+}
+
+async fn serve_http_loop(listener: tokio::net::TcpListener, mode: HttpMode) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::warn!("TCP accept error on web dashboard: {}", e);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+        };
+
+        let mode = mode.clone();
+        tokio::spawn(async move {
+            let _ = handle_one_connection(stream, mode).await;
+        });
     }
 }
 
@@ -1590,6 +1626,7 @@ min_share_diff: 8192
 
         let status_resp = send_request(mode.clone(), "GET /api/status HTTP/1.1\r\n\r\n").await;
         assert!(status_resp.contains("200 OK"));
+        assert!(status_resp.contains("Connection: close"));
         assert!(status_resp.contains("\"kaspad_address\""));
         assert!(status_resp.contains("\"instances\":2"));
 

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -546,6 +546,18 @@ pub struct WorkerContext {
     pub ip: String,
 }
 
+/// Resolve the `miner` (mining-software) label for a worker.
+///
+/// The value is sourced from the live connection (`ctx.remote_app`, captured at `mining.subscribe`,
+/// which always precedes any share/job) so it is identical across every recording path for a
+/// session. Callers historically passed the real app string from some sites and `""` from others,
+/// which split each worker across an empty and a populated series — unbounded label churn. The
+/// caller-provided `hint` is used only as a fallback when the connection has not reported an app.
+fn resolve_miner_label(ctx: &crate::stratum_context::StratumContext, hint: &str) -> String {
+    let app = ctx.remote_app.lock().clone();
+    if app.is_empty() { hint.to_string() } else { app }
+}
+
 impl WorkerContext {
     pub fn labels(&self) -> Vec<&str> {
         vec![&self.instance_id, &self.worker_name, &self.miner, &self.wallet, &self.ip]
@@ -566,21 +578,25 @@ impl WorkerContext {
         Self {
             instance_id: instance_id.to_string(),
             worker_name: worker_name.to_string(),
-            miner: miner.to_string(),
+            miner: resolve_miner_label(ctx, miner),
             wallet: ctx.wallet_addr.lock().clone(),
-            ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
+            // Host only — the ephemeral remote *port* changes on every reconnect, minting a fresh
+            // time series per connection and growing the metrics endpoint without bound. The host
+            // alone is bounded by the real client fleet.
+            ip: ctx.remote_addr().to_string(),
         }
     }
 }
 
 /// Build Prometheus worker labels from a Stratum session (stable name, no empty `worker` label).
 pub fn worker_context(instance_id: &str, ctx: &crate::stratum_context::StratumContext, miner: impl Into<String>) -> WorkerContext {
+    let miner = miner.into();
     WorkerContext {
         instance_id: instance_id.to_string(),
         worker_name: ctx.effective_worker_name(),
-        miner: miner.into(),
+        miner: resolve_miner_label(ctx, &miner),
         wallet: ctx.wallet_addr.lock().clone(),
-        ip: format!("{}:{}", ctx.remote_addr(), ctx.remote_port()),
+        ip: ctx.remote_addr().to_string(),
     }
 }
 

--- a/bridge/src/prom.rs
+++ b/bridge/src/prom.rs
@@ -3,9 +3,7 @@ use prometheus::proto::MetricFamily;
 use prometheus::{Counter, register_counter};
 use prometheus::{CounterVec, Gauge, GaugeVec, register_counter_vec, register_gauge, register_gauge_vec};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "rkstratum_cpu_miner")]
-use std::collections::VecDeque;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
@@ -22,6 +20,14 @@ const INVALID_LABELS: &[&str] = &["instance", "worker", "miner", "wallet", "ip",
 
 /// Block labels
 const BLOCK_LABELS: &[&str] = &["instance", "worker", "miner", "wallet", "ip", "nonce", "bluescore", "timestamp", "hash"];
+
+/// Maximum number of recent mined-block series retained in `ks_mined_blocks_gauge`.
+///
+/// Each mined block carries unique `hash`/`nonce`/`timestamp` labels, so without a cap the gauge
+/// grows one permanent series per block for the process lifetime — the only throughput-sensitive
+/// unbounded metric. Older series are evicted past this bound (see `remember_block_gauge_labels`);
+/// the monotonic `ks_blocks_mined` counter preserves the true lifetime block total.
+pub const BLOCK_GAUGE_HISTORY_LIMIT: usize = 512;
 
 /// Error labels
 const ERROR_LABELS: &[&str] = &["instance", "wallet", "error"];
@@ -47,6 +53,10 @@ static BLOCK_NOT_CONFIRMED_BLUE_COUNTER: OnceLock<CounterVec> = OnceLock::new();
 
 /// Block gauge - unique instances per block mined
 static BLOCK_GAUGE: OnceLock<GaugeVec> = OnceLock::new();
+
+/// Insertion-ordered history of `ks_mined_blocks_gauge` label sets (newest first), used to evict
+/// the oldest series once `BLOCK_GAUGE_HISTORY_LIMIT` is exceeded.
+static BLOCK_GAUGE_LABEL_HISTORY: OnceLock<parking_lot::Mutex<VecDeque<Vec<String>>>> = OnceLock::new();
 
 /// Disconnect counter - number of disconnects by worker
 static DISCONNECT_COUNTER: OnceLock<CounterVec> = OnceLock::new();
@@ -675,22 +685,44 @@ fn update_worker_activity(worker: &WorkerContext) {
     activity_map.lock().insert(key, Instant::now());
 }
 
+/// Record a `ks_mined_blocks_gauge` label set and evict the oldest series once the history limit
+/// is exceeded. Keeps the gauge bounded even on a high-hashrate bridge that finds many blocks.
+fn remember_block_gauge_labels(gauge: &GaugeVec, labels: Vec<String>) {
+    let history =
+        BLOCK_GAUGE_LABEL_HISTORY.get_or_init(|| parking_lot::Mutex::new(VecDeque::with_capacity(BLOCK_GAUGE_HISTORY_LIMIT)));
+    let mut history = history.lock();
+
+    // Move an already-tracked label set back to the front rather than tracking it twice.
+    if let Some(existing_idx) = history.iter().position(|existing| existing == &labels) {
+        history.remove(existing_idx);
+    }
+    history.push_front(labels);
+
+    while history.len() > BLOCK_GAUGE_HISTORY_LIMIT {
+        let Some(old_labels) = history.pop_back() else {
+            break;
+        };
+        let old_refs = old_labels.iter().map(String::as_str).collect::<Vec<_>>();
+        let _ = gauge.remove_label_values(&old_refs);
+    }
+}
+
 /// Record a block found
 pub fn record_block_found(worker: &WorkerContext, nonce: u64, bluescore: u64, hash: String) {
     if let Some(counter) = BLOCK_COUNTER.get() {
         counter.with_label_values(&worker.labels()).inc();
     }
     if let Some(gauge) = BLOCK_GAUGE.get() {
-        let mut labels = worker.labels();
-        let nonce_str = nonce.to_string();
-        let bluescore_str = bluescore.to_string();
-        let timestamp_str =
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs().to_string();
-        labels.push(&nonce_str);
-        labels.push(&bluescore_str);
-        labels.push(&timestamp_str);
-        labels.push(&hash);
-        gauge.with_label_values(&labels).set(1.0);
+        // Build owned labels in BLOCK_LABELS order (worker labels, then the per-block fields) so the
+        // set can be retained for later eviction.
+        let mut labels = worker.labels().iter().map(|s| s.to_string()).collect::<Vec<String>>();
+        labels.push(nonce.to_string());
+        labels.push(bluescore.to_string());
+        labels.push(std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs().to_string());
+        labels.push(hash);
+        let label_refs = labels.iter().map(String::as_str).collect::<Vec<_>>();
+        gauge.with_label_values(&label_refs).set(1.0);
+        remember_block_gauge_labels(gauge, labels);
     }
 }
 
@@ -1020,6 +1052,10 @@ async fn get_stats_json_filtered(instance_id: Option<&str>) -> StatsResponse {
     let mut worker_start_times: HashMap<String, f64> = HashMap::new(); // Store start times for hashrate calculation
     let mut worker_difficulties: HashMap<String, f64> = HashMap::new(); // Store current difficulty for each worker
     let mut block_set: HashSet<String> = HashSet::new();
+    // The block gauge is capped (see BLOCK_GAUGE_HISTORY_LIMIT), so its unique-hash count can
+    // undercount lifetime blocks once older series are evicted; the monotonic ks_blocks_mined
+    // counter is the source of truth for the total.
+    let mut total_blocks_from_counters = 0u64;
 
     // Parse global network gauges from the unfiltered set.
     // Also pick up internal CPU miner metrics (if present).
@@ -1162,6 +1198,7 @@ async fn get_stats_json_filtered(instance_id: Option<&str>) -> StatsResponse {
                 if !worker_key.is_empty() {
                     let key = format!("{}:{}:{}", instance, worker_key, wallet);
                     let count = metric.get_counter().value() as u64;
+                    total_blocks_from_counters = total_blocks_from_counters.saturating_add(count);
                     let entry = worker_stats.entry(key.clone()).or_insert_with(|| new_worker_info(instance, worker_key, wallet));
                     // Aggregate across multiple time series for the same (instance,worker,wallet)
                     entry.blocks = entry.blocks.saturating_add(count);
@@ -1383,6 +1420,10 @@ async fn get_stats_json_filtered(instance_id: Option<&str>) -> StatsResponse {
     stats.workers = active_workers;
     // Active workers are the number of Stratum workers, plus the internal CPU miner if present.
     stats.activeWorkers = stats.workers.len() + stats.internalCpu.as_ref().map(|_| 1).unwrap_or(0);
+
+    // The block gauge may have evicted older blocks; fall back to the monotonic counter total so the
+    // "Total Blocks" card still reflects the full lifetime count.
+    stats.totalBlocks = stats.totalBlocks.max(total_blocks_from_counters);
 
     // Fold internal CPU miner counts into summary totals so the dashboard top-cards reflect
     // internal mining even when no ASICs are connected.

--- a/bridge/static/js/dashboard.js
+++ b/bridge/static/js/dashboard.js
@@ -740,11 +740,13 @@ function initCollapsibles() {
   }
 }
 
-function updateBlocksChartFromBlocks(blocks, totalAllBlocks, walletFilter) {
+function updateBlocksChartFromWorkers(workers, walletFilter, allWorkers) {
   const blockBuckets = new Map();
-  for (const b of (blocks || [])) {
-    const label = `${b.instance || '-'} / ${displayWorkerName(b.worker)}`;
-    blockBuckets.set(label, (blockBuckets.get(label) || 0) + 1);
+  for (const w of (workers || [])) {
+    const count = Number(w.blocks) || 0;
+    if (count <= 0) continue;
+    const label = `${w.instance || '-'} / ${displayWorkerName(w.worker)}`;
+    blockBuckets.set(label, (blockBuckets.get(label) || 0) + count);
   }
 
   const items = Array.from(blockBuckets.entries())
@@ -757,8 +759,8 @@ function updateBlocksChartFromBlocks(blocks, totalAllBlocks, walletFilter) {
   if (restTotal > 0) top.push({ label: 'Other', value: restTotal });
 
   const filter = normalizeWalletFilter(walletFilter);
-  const allCount = Number(totalAllBlocks) || 0;
-  const emptyMessage = filter && allCount > 0
+  const anyBlocks = (allWorkers || []).some(w => (Number(w.blocks) || 0) > 0);
+  const emptyMessage = filter && anyBlocks
     ? 'No blocks match the current wallet filter. Clear the filter to see all blocks.'
     : 'No blocks mined data to chart yet.';
 
@@ -972,7 +974,7 @@ async function refresh() {
       workersBody.appendChild(tr);
     });
 
-    updateBlocksChartFromBlocks(blocks, (mergedStats.blocks || []).length, filter);
+    updateBlocksChartFromWorkers(workers, filter, allWorkers);
 
     // raw view is on /raw.html
   } catch (e) {
@@ -1147,7 +1149,7 @@ async function refresh() {
         workersBody.appendChild(tr);
       });
 
-      updateBlocksChartFromBlocks(blocks, (cached.stats.blocks || []).length, filter);
+      updateBlocksChartFromWorkers(workers, filter, allWorkers);
 
       return;
     }
@@ -1491,7 +1493,7 @@ setInterval(() => {
     workersBody.appendChild(tr);
   });
 
-  updateBlocksChartFromBlocks(blocks, (cached.stats.blocks || []).length, filter);
+  updateBlocksChartFromWorkers(workers, filter, allWorkers);
 })();
 initCollapsibles();
 refresh();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>fix(bridge/web): keep dashboard available under load &amp; bound /metrics cardinality</h1>
<h2>Summary</h2>
<p>Operators reported the bridge overview/dashboard becomes unavailable over time (the web UI & <code>/metrics</code> stop responding while mining continues unaffected). Fixing the connection issue surfaced a second, slower-building problem: the Prometheus <code>/metrics</code> endpoint grew without bound. This PR addresses both, plus one UI follow-on caused by the metrics fix.</p>

This has been reported in public & private chats, and experienced first-hand.

Commit | Area | Change
-- | -- | --
f224f1c | Web server | tokio dedicated tasks, Force Connection: close, & 10s (READ_TIMEOUT) 
1e1780f | Metrics | Bound per-worker label churn (ip host-only, consistent miner label)
1c90bee | Metrics | Bound ks_mined_blocks_gauge with a 512-entry eviction ring
7ecec4a | Dashboard | Base the Blocks Mined chart on monotonic counters, not the capped list


<h2>Problem</h2>
<p><strong>Dashboard unavailability (reported).</strong>
One slow or half-open connection could block the entire web UI: serve_http_loop accepted a socket and awaited handle_http_request to completion before calling accept() again, so a single
  stalled client queued every other request and the overview page appeared unresponsive.

Additionally, stale connections piled up and exhausted the webserver's ability to serve new requests. Mining was unaffected, so the failure was silent until someone opened the dashboard or experienced a timeout on <code>/metrics</code>.

<p><strong>Unbounded <code>/metrics</code> growth (surfaced by long-run testing).</strong>
With the connection fix deployed and left running ~30 days, a slower problem (the short-lived pre-fix sessions had masked) became visible: scrapes that started fast degraded into large, slow polls (~18k series / ~3.5 MB) that eventually timed out external scrapers.</p>
<p>Root cause: <code>*Vec</code> series in <code>bridge/src/prom.rs</code> are never evicted, so any label with an unbounded value domain grows for the entire process lifetime. Two offenders:</p>
<ul>
<li><strong>Per-worker label churn</strong> - the <code>ip</code> label carried the ephemeral port (duplicated hundreds of lines per worker, per port for every reconnection), and the <code>miner</code> label was inconsistent (blank vs. the real app string), splitting each worker across multiple series.</li>
<li><strong><code>ks_mined_blocks_gauge</code></strong> - the only throughput-sensitive unbounded metric: one permanent series per block found (keyed on unique block hash). A high-hashrate bridge accumulates tens of thousands of these.</li>
</ul>
<h2>Solution</h2>
<p><strong><code>f224f1c</code> - Dashboard unavailability.</strong> fixed this by spawning a dedicated tokio task per accepted socket via the new handle_one_connection and by forcing <code>Connection: close</code> so sockets no longer linger, 10s (READ_TIMEOUT).</p>
<p><strong><code>1e1780f</code> - bound per-worker label churn.</strong> Strip the ephemeral port from <code>ip</code> (host only) and source <code>miner</code> consistently via <code>resolve_miner_label</code>. Label-value only - no schema or call-site changes, dashboard stats unchanged. All per-entity metric families are now bounded: they grow only with genuine wallet/worker/host churn, not throughput.</p>
<p><strong><code>1c90bee</code> - bound <code>ks_mined_blocks_gauge</code> with an eviction ring.</strong> A <code>VecDeque</code>-backed label-history ring (<code>BLOCK_GAUGE_HISTORY_LIMIT = 512</code>) evicts the oldest block series once the limit is exceeded. The monotonic <code>ks_blocks_mined</code> counter is preserved and folded into <code>totalBlocks</code> via <code>stats.totalBlocks.max(total_blocks_from_counters)</code>, so the Total Blocks card never undercounts after eviction.</p>
<h2>UI follow-up (caused by the eviction fix)</h2>
<p>Bounding the gauge introduced a downstream display bug: the "Blocks Mined" chart bucketed the eviction-ring <code>stats.blocks</code> list, so once the 512-block window rolled over, the chart reflected only the recent window rather than the true per-worker distribution.</p>
<p><strong><code>7ecec4a</code> - base the chart on the monotonic counters.</strong> Renamed <code>updateBlocksChartFromBlocks</code> → <code>updateBlocksChartFromWorkers</code>, now bucketing by <code>workers[].blocks</code> (per-worker <code>ks_blocks_mined</code>) instead of the capped list. Effects:</p>
<ul>
<li>The 512-cap no longer distorts the distribution; the segment sum reconciles exactly with the Total Blocks card.</li>
<li>Wallet filtering is preserved (the <code>workers</code> array is already filtered); zero-block workers are skipped.</li>
</ul>
<p>Single-file, UI-only change.</p>
<h2>Compatibility notes</h2>
<ul>
<li><code>ip</code> label changes from <code>host:port</code> to <code>host</code>. Nothing in the bridge or bundled dashboard parses the port, but external Prometheus queries matching the old format may require updating.</li>
<li><code>ks_mined_blocks_gauge</code> now exposes at most the 512 most recent blocks (shared across all instances on merged endpoints). Consumers needing lifetime totals should use the monotonic <code>ks_blocks_mined</code> and/or run a Prometheus database of their own.</li>
</ul>
<h2>Testing</h2>
<ul>
<li>~30-day soak: to confirm f224f1c webserver & <code>/metrics</code> connection stability.</li>
<li>~7-day soak: 1c90bee & 1e1780f - across 3 users public bridges to observe bounded /metrics cardinality.  <code>/metrics</code> payload flat at steady state; verified the ring holds at 512 while <code>ks_blocks_mined</code> continues climbing (oldest-out/newest-in), Total Blocks accurate throughout. </li>
<li>~1-day soak: to confirm 7ecec4a UI fix on high hash rate bridge (+520 blocks and counting).</li>
</ul></body></html><!--EndFragment-->
</body>
</html>