### PR TITLE
Toccata Cleanup - Part 5

### DIFF
--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -4,14 +4,14 @@ use crate::flowcontext::{
     transactions::TransactionsSpread,
 };
 use crate::user_agent_rule::{UserAgentRuleRejectReason, UserAgentRuleSet};
-use crate::{v7, v8, v10};
+use crate::v10;
 use async_trait::async_trait;
 use futures::future::join_all;
 use kaspa_addressmanager::AddressManager;
 use kaspa_connectionmanager::ConnectionManager;
 use kaspa_consensus_core::api::{BlockValidationFuture, BlockValidationFutures};
 use kaspa_consensus_core::block::Block;
-use kaspa_consensus_core::config::{Config, params::ForkActivation};
+use kaspa_consensus_core::config::Config;
 use kaspa_consensus_core::errors::block::RuleError;
 use kaspa_consensus_core::tx::{Transaction, TransactionId};
 use kaspa_consensus_notify::{
@@ -712,15 +712,9 @@ impl ConnectionInitializer for FlowContext {
 
         let local_address = self.address_manager.lock().best_local_address();
 
-        // Networks with a scheduled Toccata activation advertise the current protocol version.
-        // Other networks still support v10 locally, but advertise v9 so future Toccata-activated peers reject them.
-        let advertise_toccata_p2p = self.config.toccata_activation != ForkActivation::never();
-        let advertised_protocol_version = if advertise_toccata_p2p { PROTOCOL_VERSION } else { 9 };
-
         // Build the local version message
         // Subnets are not currently supported
-        let mut self_version_message =
-            Version::new(local_address, self.node_id, network_name.clone(), None, advertised_protocol_version);
+        let mut self_version_message = Version::new(local_address, self.node_id, network_name.clone(), None, PROTOCOL_VERSION);
         self_version_message.add_user_agent(name(), version(), &self.config.user_agent_comments);
         // TODO: disable_relay_tx from config/cmd
 
@@ -768,29 +762,10 @@ impl ConnectionInitializer for FlowContext {
 
         let peer_protocol_version = peer_version.protocol_version;
 
-        // One day before activation, upgraded nodes start disconnecting outdated peers from the P2P network.
-        const ONE_DAY_SECONDS: u64 = 24 * 60 * 60;
-        let daa_threshold = ONE_DAY_SECONDS * self.config.bps();
-        let virtual_daa_score = self.consensus().unguarded_session().get_virtual_daa_score();
-        let connect_only_new_versions = self.config.toccata_activation.is_active(virtual_daa_score.saturating_add(daa_threshold));
-
-        // Until the one-day pre-activation threshold is reached, older protocol versions remain accepted.
-        // Once it is reached, peers must advertise protocol 10.
-        let (flows, applied_protocol_version) = if connect_only_new_versions {
-            // Register all flows according to version
-            match peer_protocol_version {
-                v if v >= PROTOCOL_VERSION => (v10::register(self.clone(), router.clone(), PROTOCOL_VERSION), PROTOCOL_VERSION),
-                v => return Err(ProtocolError::VersionMismatch(PROTOCOL_VERSION, v)),
-            }
-        } else {
-            // Register all flows according to version
-            match peer_protocol_version {
-                v if v >= PROTOCOL_VERSION => (v10::register(self.clone(), router.clone(), PROTOCOL_VERSION), PROTOCOL_VERSION),
-                9 => (v8::register(self.clone(), router.clone(), 9), 9),
-                8 => (v8::register(self.clone(), router.clone(), 8), 8),
-                7 => (v7::register(self.clone(), router.clone()), 7),
-                v => return Err(ProtocolError::VersionMismatch(PROTOCOL_VERSION, v)),
-            }
+        // Peers must advertise at least the current protocol version. Register all flows according to version.
+        let (flows, applied_protocol_version) = match peer_protocol_version {
+            v if v >= PROTOCOL_VERSION => (v10::register(self.clone(), router.clone(), PROTOCOL_VERSION), PROTOCOL_VERSION),
+            v => return Err(ProtocolError::VersionMismatch(PROTOCOL_VERSION, v)),
         };
 
         // Build and register the peer properties

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -276,15 +276,7 @@ impl IbdFlow {
 
                 let is_utxo_stable = consensus.async_is_pruning_utxoset_stable().await;
                 let is_pp_anticone_synced = consensus.async_is_pruning_point_anticone_fully_synced().await;
-                // The SMT stable flag is only meaningful once Toccata is active at the current
-                // pruning point. Before activation, `sync_new_smt_state` is a no-op and the flag
-                // is never set, so we treat it as stable to preserve pre-activation IBD behavior.
-                let pp_header = consensus.async_get_header(pruning_point).await.unwrap();
-                let is_smt_stable = if self.ctx.config.toccata_activation.is_active(pp_header.daa_score) {
-                    consensus.async_is_pruning_smt_stable().await
-                } else {
-                    true
-                };
+                let is_smt_stable = consensus.async_is_pruning_smt_stable().await;
 
                 return match (syncer_skew, is_utxo_stable && is_smt_stable && is_pp_anticone_synced) {
                     (SyncerSkew::Aligned, _) => {
@@ -392,13 +384,13 @@ impl IbdFlow {
     }
 
     async fn sync_and_validate_pruning_proof(&mut self, staging: &ConsensusProxy, relay_block: &Block) -> Result<Hash, ProtocolError> {
-        // [Toccata] Guard IBD from outdated nodes. P2P flow registration does not protect
+        // Guard IBD from outdated nodes. P2P flow registration does not protect
         // fresh IBD peers, and the relay block is usually the syncer sink, so reject an unexpected
         // block version before requesting the pruning proof.
-        let expected_relay_block_version = self.ctx.config.block_version().get(relay_block.header.daa_score);
+        let expected_relay_block_version = self.ctx.config.block_version().after();
         if relay_block.header.version != expected_relay_block_version {
             return Err(ProtocolError::OtherOwned(format!(
-                "peer relayed block {} header version mismatch: got {}, expected {} at DAA score {} (Toccata guard)",
+                "peer relayed block {} header version mismatch: got {}, expected {} at DAA score {}",
                 relay_block.hash(),
                 relay_block.header.version,
                 expected_relay_block_version,
@@ -685,10 +677,6 @@ impl IbdFlow {
         use kaspa_seq_commit::verify::{SmtMetadata, verify_smt_metadata};
 
         let pp_header = consensus.async_get_header(pruning_point).await.unwrap();
-        if !self.ctx.config.toccata_activation.is_active(pp_header.daa_score) {
-            consensus.async_set_pruning_smt_stable().await;
-            return Ok(());
-        }
 
         consensus.async_clear_pruning_smt_stores().await;
 
@@ -718,11 +706,7 @@ impl IbdFlow {
             .async_get_header(shortcut_block)
             .await
             .map_err(|_| ProtocolError::Other("inactivity_shortcut_block header not found"))?;
-        let inactivity_shortcut = if !self.ctx.config.toccata_activation.is_active(shortcut_header.daa_score) {
-            kaspa_hashes::ZERO_HASH
-        } else {
-            shortcut_header.accepted_id_merkle_root
-        };
+        let inactivity_shortcut = shortcut_header.accepted_id_merkle_root;
 
         verify_smt_metadata(
             &SmtMetadata {


### PR DESCRIPTION
Part 5 of the Toccata activation cleanup series.

| Part | PR |
|---|---|
| 1 - transition machinery | #1082 |
| 2 - consensus leaves | #1083 |
| 3 - txscript | #1084 |
| 4 - mining/mempool | #1086 |
| 5 - protocol/flows | this PR |
| 6 - params (final) | to come |

Toccata is permanently active, so the activation-conditional handling in `protocol/flows` collapses to
its post-fork behavior.

### `flow_context.rs`

* The local version message always advertises `PROTOCOL_VERSION`. Previously, networks without a
  scheduled activation advertised 9 so that future activated peers would reject them.
* Peer negotiation always requires protocol 10. This drops the one-day pre-activation DAA threshold
  and, with it, the fallback arms that registered v8 flows for peers advertising 9 or 8 and v7 flows
  for peers advertising 7.

**This changes peer negotiation**, which is why it is a separate PR from the mempool work. A node now
rejects protocol 7, 8 and 9 peers outright rather than accepting them until one day before activation.

### `ibd/flow.rs`

* `is_smt_stable` always queries `async_is_pruning_smt_stable` instead of reporting stable while the
  fork was inactive at the pruning point. This is safe for nodes that never wrote the flag:
  `pruning_smt_stable_flag()` reads `unwrap_or(true)`, so a fresh node from genesis still reports
  stable. A false flag now only blocks a lagging syncer, which is the intended behavior.
* `sync_new_smt_state` always performs the full SMT sync. Its pre-activation early return, which set
  the stable flag and returned, is gone; the call that sets the flag on the success path stays.
* The inactivity shortcut always resolves to `shortcut_header.accepted_id_merkle_root`, dropping the
  fold-to-zero branch.
* The relay block header version guard **stays** and is unchanged in behavior. It is a generic
  version check rather than fork machinery, so it only loses its Toccata-specific naming and now
  reads the expected version from `block_version().after()`.

### Not included

The v7 and v8 modules stay. Only `v7::register` and `v8::register` lose their last callers;
`v10::register` still constructs most of v7's flows and v8's block body request handler. Removing
those two entry points is version negotiation cleanup rather than fork cleanup, so it belongs in its
own PR.