### PR TITLE
fix: harden gRPC request conversions

### DIFF
--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -156,7 +156,7 @@ from!(item: RpcResult<&kaspa_rpc_core::SubmitBlockResponse>, protowire::SubmitBl
 from!(item: &kaspa_rpc_core::GetBlockTemplateRequest, protowire::GetBlockTemplateRequestMessage, {
     Self {
         pay_address: (&item.pay_address).into(),
-        extra_data: String::from_utf8(item.extra_data.clone()).expect("extra data has to be valid UTF-8"),
+        extra_data: String::from_utf8_lossy(&item.extra_data).into_owned(),
     }
 });
 from!(item: RpcResult<&kaspa_rpc_core::GetBlockTemplateResponse>, protowire::GetBlockTemplateResponseMessage, {
@@ -1171,9 +1171,21 @@ fn hash_from_bytes(bytes: &[u8]) -> RpcResult<RpcHash> {
 
 #[cfg(test)]
 mod tests {
-    use kaspa_rpc_core::{RpcError, RpcResult, SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse};
+    use kaspa_addresses::{Address, Prefix, Version};
+    use kaspa_rpc_core::{
+        GetBlockTemplateRequest, RpcError, RpcResult, SubmitBlockRejectReason, SubmitBlockReport, SubmitBlockResponse,
+    };
 
     use crate::protowire::{self, SubmitBlockResponseMessage, submit_block_response_message::RejectReason};
+
+    #[test]
+    fn get_block_template_extra_data_does_not_panic_on_invalid_utf8() {
+        let request =
+            GetBlockTemplateRequest::new(Address::new(Prefix::Mainnet, Version::PubKey, &[0; 32]), vec![0xff, b'a']);
+        let wire: protowire::GetBlockTemplateRequestMessage = (&request).into();
+
+        assert_eq!(wire.extra_data, "\u{fffd}a");
+    }
 
     #[test]
     fn test_submit_block_response() {

--- a/rpc/grpc/core/src/convert/optional/header.rs
+++ b/rpc/grpc/core/src/convert/optional/header.rs
@@ -52,13 +52,13 @@ from!(item: &kaspa_rpc_core::RpcOptionalHeader, protowire::RpcOptionalHeader, {
 
 try_from!(item: &protowire::RpcOptionalHeader, kaspa_rpc_core::RpcOptionalHeader, {
     Self {
-        version: item.version.map(|x| x as u16),
+        version: item.version.map(u16::try_from).transpose()?,
         hash: item.hash.as_ref().map(|x| RpcHash::from_str(x)).transpose()?,
         parents_by_level: Some(compressed_parents_from_protowire(&item.parents_by_level)?),
         hash_merkle_root: item.hash_merkle_root.as_ref().map(|x| RpcHash::from_str(x)).transpose()?,
         accepted_id_merkle_root: item.accepted_id_merkle_root.as_ref().map(|x| RpcHash::from_str(x)).transpose()?,
         utxo_commitment: item.utxo_commitment.as_ref().map(|x| RpcHash::from_str(x)).transpose()?,
-        timestamp: item.timestamp.map(|x| x as u64),
+        timestamp: item.timestamp.map(u64::try_from).transpose()?,
         bits: item.bits,
         nonce: item.nonce,
         daa_score: item.daa_score,
@@ -67,3 +67,26 @@ try_from!(item: &protowire::RpcOptionalHeader, kaspa_rpc_core::RpcOptionalHeader
         pruning_point: item.pruning_point.as_ref().map(|x| RpcHash::from_str(x)).transpose()?,
     }
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_out_of_range_optional_header_fields() {
+        let wire = protowire::RpcOptionalHeader {
+            version: Some(u16::MAX as u32 + 1),
+            ..Default::default()
+        };
+        assert!(matches!(
+            kaspa_rpc_core::RpcOptionalHeader::try_from(&wire),
+            Err(RpcError::IntConversionError(_))
+        ));
+
+        let wire = protowire::RpcOptionalHeader { timestamp: Some(-1), ..Default::default() };
+        assert!(matches!(
+            kaspa_rpc_core::RpcOptionalHeader::try_from(&wire),
+            Err(RpcError::IntConversionError(_))
+        ));
+    }
+}

--- a/rpc/grpc/core/src/convert/optional/tx.rs
+++ b/rpc/grpc/core/src/convert/optional/tx.rs
@@ -100,7 +100,7 @@ from!(item: &kaspa_rpc_core::RpcOptionalUtxoEntryVerboseData, protowire::RpcOpti
 
 try_from!(item: &protowire::RpcOptionalTransaction, kaspa_rpc_core::RpcOptionalTransaction, {
     Self {
-        version: item.version.map(|x| x as u16),
+        version: item.version.map(u16::try_from).transpose()?,
         inputs: item.inputs.iter().map(kaspa_rpc_core::RpcOptionalTransactionInput::try_from).collect::<RpcResult<_>>()?,
         outputs: item.outputs.iter().map(kaspa_rpc_core::RpcOptionalTransactionOutput::try_from).collect::<RpcResult<_>>()?,
         lock_time: item.lock_time,
@@ -117,8 +117,8 @@ try_from!(item: &protowire::RpcOptionalTransactionInput, kaspa_rpc_core::RpcOpti
         previous_outpoint: item.previous_outpoint.as_ref().map(kaspa_rpc_core::RpcOptionalTransactionOutpoint::try_from).transpose()?,
         signature_script: item.signature_script.as_ref().map(|x| Vec::from_rpc_hex(x)).transpose()?,
         sequence: item.sequence,
-        sig_op_count: item.sig_op_count.map(|x| x as u8),
-        compute_budget: item.compute_budget.map(|x| x as u16),
+        sig_op_count: item.sig_op_count.map(u8::try_from).transpose()?,
+        compute_budget: item.compute_budget.map(u16::try_from).transpose()?,
         verbose_data: item.verbose_data.as_ref().map(kaspa_rpc_core::RpcOptionalTransactionInputVerboseData::try_from).transpose()?,
     }
 });
@@ -192,7 +192,7 @@ try_from!(item: &protowire::RpcOptionalUtxoEntryVerboseData, kaspa_rpc_core::Rpc
 mod tests {
     use crate::protowire;
     use kaspa_consensus_core::subnets::SubnetworkId;
-    use kaspa_rpc_core::RpcOptionalTransaction;
+    use kaspa_rpc_core::{RpcError, RpcOptionalTransaction};
 
     #[test]
     fn test_rpc_optional_transaction_compute_budget_roundtrip() {
@@ -224,5 +224,33 @@ mod tests {
         let decoded = RpcOptionalTransaction::try_from(&wire).unwrap();
         assert_eq!(decoded.inputs[0].compute_budget, Some(444));
         assert_eq!(decoded.storage_mass, Some(333));
+    }
+
+    #[test]
+    fn rejects_out_of_range_optional_transaction_fields() {
+        let wire = protowire::RpcOptionalTransaction {
+            version: Some(u16::MAX as u32 + 1),
+            ..Default::default()
+        };
+        assert!(matches!(
+            RpcOptionalTransaction::try_from(&wire),
+            Err(RpcError::IntConversionError(_))
+        ));
+
+        let wire_input = protowire::RpcOptionalTransactionInput {
+            sig_op_count: Some(u8::MAX as u32 + 1),
+            ..Default::default()
+        };
+        assert!(matches!(
+            kaspa_rpc_core::RpcOptionalTransactionInput::try_from(&wire_input),
+            Err(RpcError::IntConversionError(_))
+        ));
+
+        let wire_input =
+            protowire::RpcOptionalTransactionInput { compute_budget: Some(u16::MAX as u32 + 1), ..Default::default() };
+        assert!(matches!(
+            kaspa_rpc_core::RpcOptionalTransactionInput::try_from(&wire_input),
+            Err(RpcError::IntConversionError(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Harden gRPC conversions against invalid UTF8 and out of range optional integer fields.

## Root cause

The block template conversion assumed extra data was valid UTF8 and panicked otherwise. Optional transaction and header conversions used unchecked casts that silently truncated or wrapped wire values.

## Impact

Invalid extra data is converted without panicking. Oversized transaction versions, signature operation counts, compute budgets, header versions, and negative header timestamps now return `RpcError::IntConversionError` instead of being silently altered.

Addresses findings 2 through 4 in #917.

## Validation

`cargo test -p kaspa-grpc-core`

9 tests passed.
