### PR TITLE
reachability: hull-based common chain ancestor query

### DIFF
--- a/consensus/src/model/services/reachability.rs
+++ b/consensus/src/model/services/reachability.rs
@@ -17,8 +17,11 @@ pub trait ReachabilityService {
 
     /// Checks if `this` block is a chain ancestor all the blocks in `queried`
     fn is_chain_ancestor_of_all(&self, this: Hash, queried: &[Hash]) -> bool {
-        queried.iter().all(|&hash| self.is_chain_ancestor_of(this, hash))
+        self.try_is_chain_ancestor_of_all(this, queried).unwrap()
     }
+
+    /// Result version of [`Self::is_chain_ancestor_of_all`] (avoids unwrapping internally)
+    fn try_is_chain_ancestor_of_all(&self, this: Hash, queried: &[Hash]) -> Result<bool>;
 
     /// Result version of [`Self::is_chain_ancestor_of`] (avoids unwrapping internally)
     fn try_is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool>;
@@ -48,6 +51,14 @@ pub trait ReachabilityService {
     /// (A "tree child of X" is a block which X is its chain parent)
     fn get_next_chain_ancestor(&self, descendant: Hash, ancestor: Hash) -> Hash;
 
+    /// Finds the latest common chain ancestor of the given non-empty `members`
+    fn common_chain_ancestor<'a>(&self, members: impl IntoIterator<Item = &'a Hash>) -> Hash {
+        self.try_common_chain_ancestor(members).unwrap()
+    }
+
+    /// Result version of [`Self::common_chain_ancestor`] (avoids unwrapping internally)
+    fn try_common_chain_ancestor<'a>(&self, members: impl IntoIterator<Item = &'a Hash>) -> Result<Hash>;
+
     /// Returns the chain parent of `this`
     fn get_chain_parent(&self, this: Hash) -> Hash;
 
@@ -60,8 +71,16 @@ impl<T: ReachabilityStoreReader + ?Sized> ReachabilityService for T {
         inquirer::is_chain_ancestor_of(self, this, queried)
     }
 
+    fn try_is_chain_ancestor_of_all(&self, this: Hash, queried: &[Hash]) -> Result<bool> {
+        inquirer::is_chain_ancestor_of_all(self, this, queried)
+    }
+
     fn try_is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
         inquirer::is_dag_ancestor_of(self, this, queried)
+    }
+
+    fn try_common_chain_ancestor<'a>(&self, members: impl IntoIterator<Item = &'a Hash>) -> Result<Hash> {
+        inquirer::common_chain_ancestor(self, members)
     }
 
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool {
@@ -108,9 +127,19 @@ impl<T: ReachabilityStoreReader + ?Sized> ReachabilityService for MTReachability
         inquirer::is_chain_ancestor_of(read_guard.deref(), this, queried)
     }
 
+    fn try_is_chain_ancestor_of_all(&self, this: Hash, queried: &[Hash]) -> Result<bool> {
+        let read_guard = self.store.read();
+        inquirer::is_chain_ancestor_of_all(read_guard.deref(), this, queried)
+    }
+
     fn try_is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
         let read_guard = self.store.read();
         inquirer::is_dag_ancestor_of(read_guard.deref(), this, queried)
+    }
+
+    fn try_common_chain_ancestor<'a>(&self, members: impl IntoIterator<Item = &'a Hash>) -> Result<Hash> {
+        let read_guard = self.store.read();
+        inquirer::common_chain_ancestor(read_guard.deref(), members)
     }
 
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool {

--- a/consensus/src/model/stores/reachability.rs
+++ b/consensus/src/model/stores/reachability.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 #[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct ReachabilityData {
+pub struct ReachabilityData {
     pub parent: Hash,
     pub interval: Interval,
     pub height: u64,
@@ -40,6 +40,8 @@ impl ReachabilityData {
 pub trait ReachabilityStoreReader {
     fn has(&self, hash: Hash) -> Result<bool, StoreError>;
     fn get_interval(&self, hash: Hash) -> Result<Interval, StoreError>;
+    /// Returns the full reachability data of `hash`: tree parent, interval and height
+    fn get_reachability_data(&self, hash: Hash) -> Result<ReachabilityData, StoreError>;
     /// Returns the reachability *tree* parent of `hash`
     fn get_parent(&self, hash: Hash) -> Result<Hash, StoreError>;
     /// Returns the reachability *tree* children of `hash`
@@ -312,6 +314,10 @@ impl ReachabilityStoreReader for DbReachabilityStore {
 
     fn get_interval(&self, hash: Hash) -> Result<Interval, StoreError> {
         Ok(self.access.read(hash)?.interval)
+    }
+
+    fn get_reachability_data(&self, hash: Hash) -> Result<ReachabilityData, StoreError> {
+        self.access.read(hash)
     }
 
     fn get_parent(&self, hash: Hash) -> Result<Hash, StoreError> {
@@ -599,6 +605,11 @@ impl ReachabilityStoreReader for StagingReachabilityStore<'_> {
         }
     }
 
+    fn get_reachability_data(&self, hash: Hash) -> Result<ReachabilityData, StoreError> {
+        self.check_not_in_deletions(hash)?;
+        if let Some(data) = self.staging_writes.get(&hash) { Ok(data.clone()) } else { self.store_read.access.read(hash) }
+    }
+
     fn get_parent(&self, hash: Hash) -> Result<Hash, StoreError> {
         self.check_not_in_deletions(hash)?;
         if let Some(data) = self.staging_writes.get(&hash) { Ok(data.parent) } else { Ok(self.store_read.access.read(hash)?.parent) }
@@ -797,6 +808,13 @@ impl ReachabilityStoreReader for MemoryReachabilityStore {
         let data =
             map.get(&hash).ok_or_else(|| StoreError::KeyNotFound(DbKey::new(DatabaseStorePrefixes::Reachability.as_ref(), hash)))?;
         Ok(data.interval)
+    }
+
+    fn get_reachability_data(&self, hash: Hash) -> Result<ReachabilityData, StoreError> {
+        let map = self.map.read();
+        let data =
+            map.get(&hash).ok_or_else(|| StoreError::KeyNotFound(DbKey::new(DatabaseStorePrefixes::Reachability.as_ref(), hash)))?;
+        Ok(ReachabilityData::new(data.parent, data.interval, data.height))
     }
 
     fn get_parent(&self, hash: Hash) -> Result<Hash, StoreError> {

--- a/consensus/src/processes/dagknight/protocol.rs
+++ b/consensus/src/processes/dagknight/protocol.rs
@@ -214,23 +214,9 @@ impl<
         /*
            Notes:
                - ignore parents not agreeing on the pruning point as a chain block
-               - optimize for shortest path
-               - optimize with index
         */
 
-        let start = parents[0];
-
-        if start == self.genesis_hash {
-            return self.genesis_hash;
-        }
-
-        for cb in self.reachability_service.default_backward_chain_iterator(start).skip(1) {
-            if self.reachability_service.is_chain_ancestor_of_all(cb, &parents[1..]) {
-                return cb;
-            }
-        }
-
-        panic!("")
+        self.reachability_service.common_chain_ancestor(parents)
     }
 
     /// Baseline UMC cascade voting: naive reference impl of paper Algorithm 6 (work-weighted),

--- a/consensus/src/processes/reachability/inquirer.rs
+++ b/consensus/src/processes/reachability/inquirer.rs
@@ -1,6 +1,6 @@
 use super::interval::Interval;
 use super::{tree::*, *};
-use crate::model::stores::reachability::{ReachabilityStore, ReachabilityStoreReader};
+use crate::model::stores::reachability::{ReachabilityData, ReachabilityStore, ReachabilityStoreReader};
 use kaspa_consensus_core::blockhash;
 use kaspa_hashes::Hash;
 
@@ -168,6 +168,73 @@ pub fn is_chain_ancestor_of(store: &(impl ReachabilityStoreReader + ?Sized), thi
     Ok(store.get_interval(this)?.contains(store.get_interval(queried)?))
 }
 
+/// Checks if `this` block is a chain ancestor of all the blocks in `queried`.
+pub fn is_chain_ancestor_of_all<'a>(
+    store: &(impl ReachabilityStoreReader + ?Sized),
+    this: Hash,
+    queried: impl IntoIterator<Item = &'a Hash>,
+) -> Result<bool> {
+    let this_interval = store.get_interval(this)?;
+    let mut queried = queried.into_iter();
+    let Some(&first) = queried.next() else {
+        // An empty queried set is vacuously satisfied
+        return Ok(true);
+    };
+    let mut hull = store.get_interval(first)?;
+    if !this_interval.contains(hull) {
+        return Ok(false);
+    }
+    for &hash in queried {
+        hull = hull.hull(store.get_interval(hash)?);
+        if !this_interval.contains(hull) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Seed for a common chain ancestor query: the hull of the member intervals plus the
+/// data of the shallowest member, from which the chain walk towards the ancestor is shortest
+struct CommonAncestorSeed {
+    hull: Interval,
+    start: Hash,
+    start_data: ReachabilityData,
+}
+
+/// Finds the latest common chain ancestor of the given non-empty `members`.
+pub fn common_chain_ancestor<'a>(
+    store: &(impl ReachabilityStoreReader + ?Sized),
+    members: impl IntoIterator<Item = &'a Hash>,
+) -> Result<Hash> {
+    let seed = members
+        .into_iter()
+        .try_fold(None::<CommonAncestorSeed>, |seed, &hash| {
+            let data = store.get_reachability_data(hash)?;
+            let seed = match seed {
+                None => CommonAncestorSeed { hull: data.interval, start: hash, start_data: data },
+                Some(mut seed) => {
+                    seed.hull = seed.hull.hull(data.interval);
+                    if data.height < seed.start_data.height {
+                        seed.start = hash;
+                        seed.start_data = data;
+                    }
+                    seed
+                }
+            };
+            Ok::<_, ReachabilityError>(Some(seed))
+        })?
+        .ok_or(ReachabilityError::BadQuery)?;
+
+    let (mut current, mut data) = (seed.start, seed.start_data);
+    loop {
+        if data.interval.contains(seed.hull) {
+            return Ok(current);
+        }
+        current = data.parent;
+        data = store.get_reachability_data(current)?;
+    }
+}
+
 /// Returns true if `this` is a DAG ancestor of `queried` (i.e., `queried ∈ future(this) ∪ {this}`).
 /// Note: this method will return true if `this == queried`.
 /// The complexity of this method is `O(log(|future_covering_set(this)|))`
@@ -314,6 +381,71 @@ mod tests {
         // Should trigger an earlier than reindex root allocation
         builder.add_block(100.into(), 2.into());
         store.validate_intervals(root).unwrap();
+    }
+
+    #[test]
+    fn test_is_chain_ancestor_of_all() {
+        // Arrange
+        let mut store = MemoryReachabilityStore::new();
+        let root: Hash = 1.into();
+        TreeBuilder::new(&mut store)
+            .init_with_params(root, Interval::new(1, 15))
+            .add_block(2.into(), root)
+            .add_block(3.into(), 2.into())
+            .add_block(4.into(), 3.into())
+            .add_block(5.into(), 3.into())
+            .add_block(6.into(), 2.into())
+            .add_block(7.into(), 6.into());
+
+        // Assert
+        assert!(is_chain_ancestor_of_all(&store, 2.into(), [&4.into(), &5.into(), &7.into()]).unwrap());
+        assert!(is_chain_ancestor_of_all(&store, 3.into(), [&4.into(), &5.into()]).unwrap());
+        assert!(!is_chain_ancestor_of_all(&store, 3.into(), [&4.into(), &7.into()]).unwrap());
+        // a block is an ancestor of itself
+        assert!(is_chain_ancestor_of_all(&store, 4.into(), [&4.into()]).unwrap());
+        // empty queried set
+        assert!(is_chain_ancestor_of_all(&store, 5.into(), std::iter::empty::<&Hash>()).unwrap());
+    }
+
+    #[test]
+    fn test_common_chain_ancestor() {
+        // Arrange
+        let mut store = MemoryReachabilityStore::new();
+        let root: Hash = 1.into();
+        TreeBuilder::new(&mut store)
+            .init_with_params(root, Interval::new(1, 15))
+            .add_block(2.into(), root)
+            .add_block(3.into(), 2.into())
+            .add_block(4.into(), 3.into())
+            .add_block(5.into(), 3.into())
+            .add_block(6.into(), 2.into())
+            .add_block(7.into(), 6.into())
+            .add_block(8.into(), 4.into());
+
+        // Tree:
+        //        1
+        //        2
+        //      /   \
+        //     3     6
+        //    / \    |
+        //   4   5   7
+        //   |
+        //   8
+
+        // Assert
+        assert_eq!(common_chain_ancestor(&store, [&4.into(), &5.into()]).unwrap(), 3.into());
+        assert_eq!(common_chain_ancestor(&store, [&4.into(), &7.into()]).unwrap(), 2.into());
+        // asymmetric heights: deep branch vs shallow branch
+        assert_eq!(common_chain_ancestor(&store, [&8.into(), &7.into()]).unwrap(), 2.into());
+        // a member which is itself the ancestor of the other member
+        assert_eq!(common_chain_ancestor(&store, [&3.into(), &4.into()]).unwrap(), 3.into());
+        assert_eq!(common_chain_ancestor(&store, [&8.into(), &4.into()]).unwrap(), 4.into());
+        // three members spanning both branches
+        assert_eq!(common_chain_ancestor(&store, [&8.into(), &5.into(), &7.into()]).unwrap(), 2.into());
+        // empty members set is rejected
+        assert!(common_chain_ancestor(&store, std::iter::empty::<&Hash>()).is_err());
+        // unknown member hash is rejected
+        assert!(common_chain_ancestor(&store, [&100.into()]).is_err());
     }
 
     #[derive(Clone)]

--- a/consensus/src/processes/reachability/interval.rs
+++ b/consensus/src/processes/reachability/interval.rs
@@ -153,6 +153,11 @@ impl Interval {
     pub fn strictly_contains(&self, other: Self) -> bool {
         self.start <= other.start && other.end < self.end
     }
+
+    /// Returns the bounding interval of `self` and `other`
+    pub fn hull(self, other: Self) -> Self {
+        Self::new(self.start.min(other.start), self.end.max(other.end))
+    }
 }
 
 /// Returns a fraction for each size in sizes


### PR DESCRIPTION
## Summary
- New `common_chain_ancestor` query in the reachability layer (inquirer + `ReachabilityService` trait with `try_` variants), replacing the dagknight executor's inline backward-chain probe walk.
- The walk starts from the shallowest member (tree heights step by exactly one towards the parent, so this is the shortest chain) and probes each candidate against the precomputed interval hull. Cost drops from roughly `walk_steps x members` interval reads, each behind its own store lock, to `members + walk_steps` full-record reads under a single read lock.
- `is_chain_ancestor_of_all` is hull-based as well (containment of a contiguous interval over all queried intervals is equivalent to containment of their hull; monotone, so it short-circuits on the first failing member).
- New `Interval::hull` helper and a `get_reachability_data` full-record reader on `ReachabilityStoreReader` (one cached read covers parent, interval and height).
