### PR TITLE
[DK][SSAV2] Make SSAV2 resolve disqualified-from-chain SP to qualified representatives in one pass. 

### DIFF
--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1196,6 +1196,8 @@ impl VirtualStateProcessor {
                     seen.insert(parent);
                     diff_point = self.calculate_utxo_state_relatively(stores, diff, diff_point, parent);
                     if diff_point == parent {
+                        // remove any tips that are DAG descendants of the current parent
+                        tip_set.retain(|t| !self.reachability_service.is_dag_ancestor_of(*t, parent));
                         tip_set.insert(parent);
                     } else {
                         parent_queue.extend(self.relations_service.get_parents(parent).unwrap().iter().copied());

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -49,7 +49,7 @@ use crate::{
     },
 };
 use kaspa_consensus_core::{
-    BlockHashSet, ChainPath,
+    BlockHashSet, ChainPath, HashMapCustomHasher,
     acceptance_data::AcceptanceData,
     api::args::{TransactionValidationArgs, TransactionValidationBatchArgs},
     block::{BlockTemplate, MutableBlock, TemplateBuildMode, TemplateTransactionSelector},
@@ -1166,24 +1166,37 @@ impl VirtualStateProcessor {
                     // let filtering_blue_work = self.topology_ghostdag_store.get_blue_work(filtering_root).unwrap_or_default();
                     return (candidate, parents.into());
                 } else {
-                    debug!("Block candidate {} has invalid UTXO state and is ignored from Virtual chain.", candidate)
+                    debug!("Block candidate {} has invalid UTXO state and is ignored from Virtual chain.", candidate);
+                    tip_set.remove(&candidate);
                 }
             } else if finality_point != pruning_point {
                 // `finality_point == pruning_point` indicates we are at IBD start hence no warning required
                 warn!("Finality Violation Detected. Block {} violates finality and is ignored from Virtual chain.", candidate);
             }
-            // Same as GHOSTDAG sink search popping the heap: drop a rejected candidate
-            // before considering its parents. Leaving it in tip_set makes every parent
-            // look like a DAG ancestor of the current set, so genesis is never added
-            // and the loop retries the same UTXO-invalid tip forever.
-            tip_set.remove(&candidate);
             // PRUNE SAFETY: see comment within [`resolve_virtual`]
             let prune_guard = self.pruning_lock.blocking_read();
-            for parent in self.relations_service.get_parents(candidate).unwrap().iter().copied() {
-                if self.reachability_service.is_dag_ancestor_of(finality_point, parent)
-                    && !self.reachability_service.is_dag_ancestor_of_any(parent, &mut tip_set.iter().copied())
+           
+            // Update the tip set with 'chain qualified' representatives from the ancestory of the candidate block, which are:
+            // 1) not covered by some other tip in the current tip set,
+            // 2) not violating finality,
+            // 3) has a valid utxo state
+            let mut parent_queue: VecDeque<Hash> = self.relations_service.get_parents(candidate).unwrap().iter().copied().collect();
+            let mut seen: BlockHashSet = BlockHashSet::new();
+            while let Some(parent) = parent_queue.pop_front() {
+                if !seen.contains(&parent)
+                    && self.reachability_service.is_dag_ancestor_of(finality_point, parent)
+                    && !self.reachability_service.is_dag_ancestor_of_any(
+                        parent,
+                        &mut tip_set.iter().copied(),
+                    )
                 {
-                    tip_set.insert(parent);
+                    seen.insert(parent);
+                    diff_point = self.calculate_utxo_state_relatively(stores, diff, diff_point, parent);
+                    if diff_point == parent {
+                        tip_set.insert(parent);
+                    } else {
+                        parent_queue.extend(self.relations_service.get_parents(parent).unwrap().iter().copied());
+                    }
                 }
             }
             drop(prune_guard);

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -1167,15 +1167,21 @@ impl VirtualStateProcessor {
                     return (candidate, parents.into());
                 } else {
                     debug!("Block candidate {} has invalid UTXO state and is ignored from Virtual chain.", candidate);
-                    tip_set.remove(&candidate);
                 }
             } else if finality_point != pruning_point {
                 // `finality_point == pruning_point` indicates we are at IBD start hence no warning required
                 warn!("Finality Violation Detected. Block {} violates finality and is ignored from Virtual chain.", candidate);
             }
+
+            // Same as GHOSTDAG sink search popping the heap: drop a rejected candidate
+            // before considering its parents. Leaving it in tip_set makes every parent
+            // look like a DAG ancestor of the current set, so genesis is never added
+            // and the loop retries the same UTXO-invalid tip forever.
+            tip_set.remove(&candidate);
+
             // PRUNE SAFETY: see comment within [`resolve_virtual`]
             let prune_guard = self.pruning_lock.blocking_read();
-           
+
             // Update the tip set with 'chain qualified' representatives from the ancestory of the candidate block, which are:
             // 1) not covered by some other tip in the current tip set,
             // 2) not violating finality,
@@ -1185,10 +1191,7 @@ impl VirtualStateProcessor {
             while let Some(parent) = parent_queue.pop_front() {
                 if !seen.contains(&parent)
                     && self.reachability_service.is_dag_ancestor_of(finality_point, parent)
-                    && !self.reachability_service.is_dag_ancestor_of_any(
-                        parent,
-                        &mut tip_set.iter().copied(),
-                    )
+                    && !self.reachability_service.is_dag_ancestor_of_any(parent, &mut tip_set.iter().copied())
                 {
                     seen.insert(parent);
                     diff_point = self.calculate_utxo_state_relatively(stores, diff, diff_point, parent);


### PR DESCRIPTION
Currently when we try to resolve a disqualified from chain selected parent we only remove it and add its parents to the tip-set. This PR adds full resolution to a qualified set of blocks in the Tip's ancestry (if there are such blocks) in one pass. It is worth noting that current handling is especially ill-fitted due to the fact that the disqualified from chain status has the property of upwards propagation, i.e. if a block in the selected parent chain of some block is disqualified, it will propagate upwards. As such there can be a valid expectation that the next qualified blocks may be well below the selected parent that dagknight chose. Not resolving down in one pass can cause repeated unneeded calls to dagknight as well as pick virtual parents, until resolution happens. 