### PR TITLE
Dk UMC depth restriction

### DIFF
--- a/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
@@ -68,6 +68,8 @@ where
 
     fn extract_positive_below_zero(&self) -> Option<T>;
     fn extract_negative_at_least_zero(&self) -> Option<T>;
+    fn extract_positive_below_zero_batch(&mut self) -> Vec<T>;
+    fn extract_negative_at_least_zero_batch(&mut self) -> Vec<T>;
 
     fn flip_to_negative(&mut self, leaf: T);
     fn flip_to_positive(&mut self, leaf: T);

--- a/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
@@ -10,7 +10,11 @@ pub enum Bucket {
     Negative,
 }
 
-/// Assigns non-negative scores to the positive bucket and negative scores to the negative bucket.
+/// Returns the canonical initial bucket for a score.
+///
+/// A tree leaf can temporarily be stored in the opposite bucket while a threshold
+/// crossing is pending processing, so this function does not describe every leaf's
+/// current stored bucket.
 pub fn bucket_for_score<S: PartialOrd + Zero>(score: S) -> Bucket {
     if score >= S::zero() { Bucket::Positive } else { Bucket::Negative }
 }
@@ -26,6 +30,7 @@ pub fn bucket_for_score<S: PartialOrd + Zero>(score: S) -> Bucket {
 /// - `range_add`: O(log n)
 /// - `has_positive_below_zero`: O(1)
 /// - `has_negative_at_least_zero`: O(1)
+/// - `has_negative_score_in_prefix`: O(log n)
 /// - `extract_positive_below_zero`: O(1)
 /// - `extract_negative_at_least_zero`: O(1)
 /// - `flip_to_negative`: O(log n)
@@ -46,14 +51,17 @@ where
     where
         Self: Sized;
 
-    /// Appends a leaf after all threshold crossings produced by earlier updates have been consumed.
-    /// Implementations may reject an append while an unconsumed crossing remains.
+    /// Appends a leaf while preserving any threshold crossings already pending in the tree.
     fn append_leaf(&mut self, leaf: T, initial_score: S);
     fn prefix_add(&mut self, prefix_length: usize, delta: S);
     fn range_add(&mut self, range: Range<usize>, delta: S);
 
     fn has_positive_below_zero(&self) -> bool;
     fn has_negative_at_least_zero(&self) -> bool;
+    /// Whether any leaf in the prefix has a negative score, regardless of bucket membership.
+    ///
+    /// This may materialize lazy deltas along visited paths, hence the mutable receiver.
+    fn has_negative_score_in_prefix(&mut self, prefix_length: usize) -> bool;
 
     fn extract_positive_below_zero(&self) -> Option<T>;
     fn extract_negative_at_least_zero(&self) -> Option<T>;

--- a/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
@@ -1,4 +1,4 @@
-use std::ops::{AddAssign, Range};
+use std::ops::{AddAssign, Range, Sub};
 
 use num_traits::Zero;
 
@@ -28,6 +28,7 @@ pub fn bucket_for_score<S: PartialOrd + Zero>(score: S) -> Bucket {
 /// - `append_leaf`: amortized O(log n) due to occasional growth and ancestor rebuild
 /// - `prefix_add`: O(log n)
 /// - `range_add`: O(log n)
+/// - `range_add_batch`: O(d log(n/d)) for `d` disjoint ranges
 /// - `has_positive_below_zero`: O(1)
 /// - `has_negative_at_least_zero`: O(1)
 /// - `has_negative_score_in_prefix`: O(log n)
@@ -39,7 +40,7 @@ pub fn bucket_for_score<S: PartialOrd + Zero>(score: S) -> Bucket {
 /// - `remove_head`: O(log n)
 pub trait AppendableSegmentTreeApi<T, S = i64>
 where
-    S: Copy + PartialOrd + AddAssign + Zero,
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
 {
     fn new() -> Self
     where
@@ -56,6 +57,7 @@ where
     fn append_leaf(&mut self, leaf: T, initial_score: S);
     fn prefix_add(&mut self, prefix_length: usize, delta: S);
     fn range_add(&mut self, range: Range<usize>, delta: S);
+    fn range_add_batch(&mut self, ranges: &[(Range<usize>, S)]);
 
     fn has_positive_below_zero(&self) -> bool;
     fn has_negative_at_least_zero(&self) -> bool;

--- a/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
@@ -36,6 +36,7 @@ pub fn bucket_for_score<S: PartialOrd + Zero>(score: S) -> Bucket {
 /// - `flip_to_negative`: O(log n)
 /// - `flip_to_positive`: O(log n)
 /// - `score`: O(log n)
+/// - `remove_head`: O(log n)
 pub trait AppendableSegmentTreeApi<T, S = i64>
 where
     S: Copy + PartialOrd + AddAssign + Zero,

--- a/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_api.rs
@@ -73,4 +73,9 @@ where
 
     /// Returns all leaves in left-to-right (position) order.
     fn leaves(&self) -> Vec<T>;
+
+    /// Removes `leaf` when it is the most recently appended leaf.
+    ///
+    /// Returns `true` if the tree head was removed, and `false` otherwise.
+    fn remove_head(&mut self, leaf: T) -> bool;
 }

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -232,6 +232,18 @@ where
         self.root().max_negative.filter(|candidate| candidate.score >= S::zero()).map(|candidate| candidate.leaf)
     }
 
+    pub fn extract_positive_below_zero_batch(&mut self) -> Vec<T> {
+        let mut leaves = Vec::new();
+        self.collect_positive_below_zero(ROOT_NODE, self.full_leaf_range(), &mut leaves);
+        leaves
+    }
+
+    pub fn extract_negative_at_least_zero_batch(&mut self) -> Vec<T> {
+        let mut leaves = Vec::new();
+        self.collect_negative_at_least_zero(ROOT_NODE, self.full_leaf_range(), &mut leaves);
+        leaves
+    }
+
     pub fn flip_to_negative(&mut self, leaf: T) {
         self.set_bucket(leaf, Bucket::Negative);
     }
@@ -313,6 +325,42 @@ where
     fn set_bucket(&mut self, leaf: T, new_bucket: Bucket) {
         let target_position = self.position_of(leaf);
         self.set_bucket_at_position(ROOT_NODE, self.full_leaf_range(), target_position, new_bucket);
+    }
+
+    fn collect_positive_below_zero(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, leaves: &mut Vec<T>) {
+        let Some(candidate) = self.nodes[node].min_positive else {
+            return;
+        };
+        if candidate.score >= S::zero() {
+            return;
+        }
+        if node_range.len() == 1 {
+            leaves.push(candidate.leaf);
+            return;
+        }
+
+        self.push_pending_delta(node);
+        let (left_child_range, right_child_range) = split_range(&node_range);
+        self.collect_positive_below_zero(left_child(node), left_child_range, leaves);
+        self.collect_positive_below_zero(right_child(node), right_child_range, leaves);
+    }
+
+    fn collect_negative_at_least_zero(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, leaves: &mut Vec<T>) {
+        let Some(candidate) = self.nodes[node].max_negative else {
+            return;
+        };
+        if candidate.score < S::zero() {
+            return;
+        }
+        if node_range.len() == 1 {
+            leaves.push(candidate.leaf);
+            return;
+        }
+
+        self.push_pending_delta(node);
+        let (left_child_range, right_child_range) = split_range(&node_range);
+        self.collect_negative_at_least_zero(left_child(node), left_child_range, leaves);
+        self.collect_negative_at_least_zero(right_child(node), right_child_range, leaves);
     }
 
     fn remove_position(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, position: LeafPosition) {
@@ -593,6 +641,14 @@ where
 
     fn extract_negative_at_least_zero(&self) -> Option<T> {
         AppendableSegmentTree::extract_negative_at_least_zero(self)
+    }
+
+    fn extract_positive_below_zero_batch(&mut self) -> Vec<T> {
+        AppendableSegmentTree::extract_positive_below_zero_batch(self)
+    }
+
+    fn extract_negative_at_least_zero_batch(&mut self) -> Vec<T> {
+        AppendableSegmentTree::extract_negative_at_least_zero_batch(self)
     }
 
     fn flip_to_negative(&mut self, leaf: T) {

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -322,6 +322,10 @@ where
     }
 
     fn remove_position(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, position: LeafPosition) {
+        // TODO(relaxed): consider if it is worthwhile to shrink the back the tree following a removal
+        // this is standard practice, but in the Dagknight reorg context, removals will likely be
+        // followed by a corresponding number of aditions, hence it likely makes sense not to temporarily shrink
+        // capacity
         if node_range.len() == 1 {
             debug_assert_eq!(node_range.start, position);
             self.nodes[node] = BucketExtrema::empty();

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -267,6 +267,21 @@ where
             .collect()
     }
 
+    /// Removes `leaf` if it is the most recently appended leaf.
+    pub fn remove_head(&mut self, leaf: T) -> bool {
+        let Some(&position) = self.position_by_leaf.get(&leaf) else {
+            return false;
+        };
+        if position + 1 != self.len {
+            return false;
+        }
+
+        self.remove_position(ROOT_NODE, self.full_leaf_range(), position);
+        self.position_by_leaf.remove(&leaf);
+        self.len -= 1;
+        true
+    }
+
     // ---------------------------------------------------------------------
     // Internal queries and bucket transitions
     // ---------------------------------------------------------------------
@@ -304,6 +319,23 @@ where
     fn set_bucket(&mut self, leaf: T, new_bucket: Bucket) {
         let target_position = self.position_of(leaf);
         self.set_bucket_at_position(ROOT_NODE, self.full_leaf_range(), target_position, new_bucket);
+    }
+
+    fn remove_position(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, position: LeafPosition) {
+        if node_range.len() == 1 {
+            debug_assert_eq!(node_range.start, position);
+            self.nodes[node] = BucketExtrema::empty();
+            return;
+        }
+
+        self.push_pending_delta(node);
+        let (left_child_range, right_child_range) = split_range(&node_range);
+        if left_child_range.contains(&position) {
+            self.remove_position(left_child(node), left_child_range, position);
+        } else {
+            self.remove_position(right_child(node), right_child_range, position);
+        }
+        self.recompute_node(node);
     }
 
     fn set_bucket_at_position(
@@ -534,6 +566,10 @@ where
 
     fn leaves(&self) -> Vec<T> {
         AppendableSegmentTree::leaves(self)
+    }
+
+    fn remove_head(&mut self, leaf: T) -> bool {
+        AppendableSegmentTree::remove_head(self, leaf)
     }
 }
 

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     hash::Hash,
-    ops::{AddAssign, Range},
+    ops::{AddAssign, Range, Sub},
 };
 
 use num_traits::Zero;
@@ -12,6 +12,30 @@ use crate::processes::dagknight::appendable_segment_tree_api::{
 
 type LeafPosition = usize;
 type NodeIndex = usize;
+
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum BoundaryKind {
+    End = 0,
+    Start = 1,
+}
+
+#[derive(Clone, Copy)]
+struct RangeBoundary<S> {
+    position: LeafPosition,
+    kind: BoundaryKind,
+    delta: S,
+}
+
+impl<S> RangeBoundary<S> {
+    fn start(position: LeafPosition, delta: S) -> Self {
+        Self { position, kind: BoundaryKind::Start, delta }
+    }
+
+    fn end(position: LeafPosition, delta: S) -> Self {
+        Self { position, kind: BoundaryKind::End, delta }
+    }
+}
 
 const ROOT_NODE: NodeIndex = 1;
 
@@ -63,7 +87,7 @@ struct BucketExtrema<T, S> {
 impl<T, S> BucketExtrema<T, S>
 where
     T: Copy,
-    S: Copy + PartialOrd + AddAssign + Zero,
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
 {
     fn empty() -> Self {
         Self { min_score: None, min_positive: None, max_negative: None, pending_delta: S::zero() }
@@ -158,7 +182,7 @@ pub struct AppendableSegmentTree<T, S = i64> {
 impl<T, S> AppendableSegmentTree<T, S>
 where
     T: Copy + Eq + Hash,
-    S: Copy + PartialOrd + AddAssign + Zero,
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
 {
     // ---------------------------------------------------------------------
     // Public API
@@ -209,12 +233,33 @@ where
 
     /// Add `delta` to the half-open range of logical leaf positions.
     pub fn range_add(&mut self, update_range: Range<LeafPosition>, delta: S) {
+        // TODO(relaxed): avoid code duplication by calling range_add_batch to implement this.
+        // Current version uses direct implementation for easier reviewability 
         assert!(update_range.start <= update_range.end, "range start exceeds range end");
         assert!(update_range.end <= self.len, "range exceeds tree length");
         if update_range.is_empty() || delta.is_zero() {
             return;
         }
         self.add_to_range(ROOT_NODE, self.full_leaf_range(), &update_range, delta);
+    }
+
+    /// Add independent deltas to several ranges in one tree traversal.
+    pub fn range_add_batch(&mut self, ranges: &[(Range<LeafPosition>, S)]) {
+        for (range, _) in ranges {
+            assert!(range.start <= range.end, "range start exceeds range end");
+            assert!(range.end <= self.len, "range exceeds tree length");
+        }
+        if ranges.is_empty() {
+            return;
+        }
+        if ranges.len()==1{
+            // Handle common case without superflous logic
+            let (range, delta) = ranges[0].clone();
+            self.range_add(range, delta);
+            return;
+        }
+        let ranges = Self::coalesce_ranges(ranges);
+        self.add_to_ranges(ROOT_NODE, self.full_leaf_range(), &ranges);
     }
 
     pub fn has_positive_below_zero(&self) -> bool {
@@ -397,6 +442,87 @@ where
         self.recompute_node(node);
     }
 
+    fn add_to_ranges(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, ranges: &[(Range<LeafPosition>, S)]) {
+        // Partition the updates for this subtree. Updates that fully cover the
+        // subtree can be combined into one lazy delta; only partial updates
+        // need to be passed down to the children.
+        let mut partial = Vec::new();
+        let mut full_delta = S::zero();
+        for (range, delta) in ranges {
+            // This update cannot affect the subtree, so discard it here.
+            if ranges_are_disjoint(&node_range, range) || delta.is_zero() {
+                continue;
+            }
+
+            // Multiple full-cover updates are accumulated and applied together
+            // at this node, avoiding separate traversals for their ranges.
+            if range_fully_contains(range, &node_range) {
+                full_delta += *delta;
+            } else {
+                partial.push((range.clone(), *delta));
+            }
+        }
+
+        // Apply all updates that cover this subtree before descending. The
+        // regular lazy-propagation path carries this combined delta to leaves.
+        if !full_delta.is_zero() {
+            self.apply_delta_to_node(node, full_delta);
+        }
+
+        // No partial updates remain, so this subtree is fully updated.
+        if partial.is_empty() {
+            return;
+        }
+
+        // Partial updates require visiting both children and rebuilding this
+        // node's summary from their updated values.
+        self.push_pending_delta(node);
+        let (left_child_range, right_child_range) = split_range(&node_range);
+        self.add_to_ranges(left_child(node), left_child_range, &partial);
+        self.add_to_ranges(right_child(node), right_child_range, &partial);
+        self.recompute_node(node);
+    }
+
+    fn coalesce_ranges(ranges: &[(Range<LeafPosition>, S)]) -> Vec<(Range<LeafPosition>, S)> {
+        // Represent every range by a start event and an end event. The sweep
+        // between two consecutive positions has one constant combined delta.
+        let mut boundary_events = Vec::with_capacity(ranges.len() * 2);
+        for (range, delta) in ranges {
+            if !range.is_empty() && !delta.is_zero() {
+                boundary_events.push(RangeBoundary::start(range.start, *delta));
+                boundary_events.push(RangeBoundary::end(range.end, *delta));
+            }
+        }
+        // End events sort before start events at the same position, so an ended
+        // range is removed before a new range beginning there is added.
+        boundary_events.sort_unstable_by_key(|event| (event.position, event.kind));
+
+        let mut coalesced_ranges = Vec::new();
+        let mut active_delta = S::zero();
+        let mut previous_boundary = None;
+        let mut event_index = 0;
+        while event_index < boundary_events.len() {
+            let current_boundary = boundary_events[event_index].position;
+            if let Some(previous_boundary) = previous_boundary
+                && previous_boundary < current_boundary
+                && !active_delta.is_zero()
+            {
+                coalesced_ranges.push((previous_boundary..current_boundary, active_delta));
+            }
+
+            while event_index < boundary_events.len() && boundary_events[event_index].position == current_boundary {
+                let event = boundary_events[event_index];
+                active_delta = match event.kind {
+                    BoundaryKind::Start => active_delta + event.delta,
+                    BoundaryKind::End => active_delta - event.delta,
+                };
+                event_index += 1;
+            }
+            previous_boundary = Some(current_boundary);
+        }
+        coalesced_ranges
+    }
+
     // ---------------------------------------------------------------------
     // Lazy propagation
     // ---------------------------------------------------------------------
@@ -505,7 +631,7 @@ where
 impl<T, S> Default for AppendableSegmentTree<T, S>
 where
     T: Copy + Eq + Hash,
-    S: Copy + PartialOrd + AddAssign + Zero,
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
 {
     fn default() -> Self {
         Self::new()
@@ -515,7 +641,7 @@ where
 impl<T, S> AppendableSegmentTreeApi<T, S> for AppendableSegmentTree<T, S>
 where
     T: Copy + Eq + Hash,
-    S: Copy + PartialOrd + AddAssign + Zero,
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
 {
     fn with_initial_capacity(initial_capacity: usize) -> Self
     where
@@ -534,6 +660,10 @@ where
 
     fn range_add(&mut self, range: Range<usize>, delta: S) {
         AppendableSegmentTree::range_add(self, range, delta)
+    }
+
+    fn range_add_batch(&mut self, ranges: &[(Range<usize>, S)]) {
+        AppendableSegmentTree::range_add_batch(self, ranges)
     }
 
     fn has_positive_below_zero(&self) -> bool {

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -54,6 +54,11 @@ struct ScoreCandidate<T, S> {
 
 #[derive(Clone, Debug)]
 struct BucketExtrema<T, S> {
+    /// Minimum score across all leaves, independent of bucket membership.
+    ///
+    /// This remains accurate even when a leaf's stored bucket is stale because a
+    /// threshold crossing is waiting to be processed.
+    min_score: Option<ScoreCandidate<T, S>>,
     min_positive: Option<ScoreCandidate<T, S>>,
     max_negative: Option<ScoreCandidate<T, S>>,
     pending_delta: S,
@@ -65,19 +70,30 @@ where
     S: Copy + PartialOrd + AddAssign + Zero,
 {
     fn empty() -> Self {
-        Self { min_positive: None, max_negative: None, pending_delta: S::zero() }
+        Self { min_score: None, min_positive: None, max_negative: None, pending_delta: S::zero() }
+    }
+
+    /// Restores a leaf together with its stored bucket. The bucket is intentionally
+    /// not recomputed from `score`, because a pending crossing may make them disagree.
+    fn restore_leaf_with_bucket(leaf: T, score: S, bucket: Bucket) -> Self {
+        let candidate = ScoreCandidate { score, leaf };
+        match bucket {
+            Bucket::Positive => {
+                Self { min_score: Some(candidate), min_positive: Some(candidate), max_negative: None, pending_delta: S::zero() }
+            }
+            Bucket::Negative => {
+                Self { min_score: Some(candidate), min_positive: None, max_negative: Some(candidate), pending_delta: S::zero() }
+            }
+        }
     }
 
     fn create_leaf_with_score(leaf: T, score: S) -> Self {
-        let candidate = Some(ScoreCandidate { score, leaf });
-        match bucket_for_score(score) {
-            Bucket::Positive => Self { min_positive: candidate, max_negative: None, pending_delta: S::zero() },
-            Bucket::Negative => Self { min_positive: None, max_negative: candidate, pending_delta: S::zero() },
-        }
+        Self::restore_leaf_with_bucket(leaf, score, bucket_for_score(score))
     }
 
     fn merge(left_child: &Self, right_child: &Self) -> Self {
         Self {
+            min_score: minimum_candidate(left_child.min_score, right_child.min_score),
             min_positive: minimum_candidate(left_child.min_positive, right_child.min_positive),
             max_negative: maximum_candidate(left_child.max_negative, right_child.max_negative),
             pending_delta: S::zero(),
@@ -85,6 +101,9 @@ where
     }
 
     fn apply_delta(&mut self, delta: S) {
+        if let Some(candidate) = self.min_score.as_mut() {
+            candidate.score += delta;
+        }
         if let Some(candidate) = self.min_positive.as_mut() {
             candidate.score += delta;
         }
@@ -130,9 +149,8 @@ fn maximum_candidate<T: Copy, S: Copy + PartialOrd>(
 /// - positive score dropping below 0
 /// - negative score rising to at least 0
 ///
-/// Invariant: callers must consume every crossing produced by prior updates before appending
-/// another leaf. Consequently, all bucket memberships agree with their scores whenever growth
-/// can occur.
+/// Bucket memberships may temporarily disagree with scores while threshold crossings are
+/// pending; extraction exposes those crossings and flipping restores the bucket invariant.
 pub struct AppendableSegmentTree<T, S = i64> {
     len: usize,
     leaf_capacity: usize,
@@ -163,12 +181,10 @@ where
         Self { len: 0, leaf_capacity, position_by_leaf: HashMap::new(), nodes: vec![BucketExtrema::empty(); node_count] }
     }
 
-    /// Append a new leaf after every crossing produced by earlier updates has been consumed.
+    /// Append a new leaf while preserving any crossings produced by earlier updates.
     /// The initial bucket is inferred from `initial_score`.
     pub fn append_leaf(&mut self, leaf: T, initial_score: S) {
         assert!(!self.position_by_leaf.contains_key(&leaf), "leaf already present");
-        assert!(!self.has_unconsumed_crossings(), "consume all threshold crossings before appending a leaf");
-
         if self.len == self.leaf_capacity {
             self.grow();
         }
@@ -202,6 +218,11 @@ where
 
     pub fn has_negative_at_least_zero(&self) -> bool {
         self.root().max_negative.is_some_and(|candidate| candidate.score >= S::zero())
+    }
+
+    pub fn has_negative_score_in_prefix(&mut self, prefix_length: usize) -> bool {
+        assert!(prefix_length <= self.len, "prefix exceeds tree length");
+        self.has_negative_score_in_range(ROOT_NODE, self.full_leaf_range(), 0..prefix_length)
     }
 
     pub fn extract_positive_below_zero(&self) -> Option<T> {
@@ -245,8 +266,18 @@ where
     // Internal queries and bucket transitions
     // ---------------------------------------------------------------------
 
-    fn has_unconsumed_crossings(&self) -> bool {
-        self.has_positive_below_zero() || self.has_negative_at_least_zero()
+    fn has_negative_score_in_range(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, query: Range<LeafPosition>) -> bool {
+        if ranges_are_disjoint(&node_range, &query) {
+            return false;
+        }
+        if range_fully_contains(&query, &node_range) {
+            return self.nodes[node].min_score.is_some_and(|candidate| candidate.score < S::zero());
+        }
+
+        self.push_pending_delta(node);
+        let (left_child_range, right_child_range) = split_range(&node_range);
+        self.has_negative_score_in_range(left_child(node), left_child_range, query.clone())
+            || self.has_negative_score_in_range(right_child(node), right_child_range, query)
     }
 
     fn point_score(&mut self, node: NodeIndex, node_range: Range<LeafPosition>, target_position: LeafPosition) -> S {
@@ -402,14 +433,13 @@ where
     }
 
     fn grow(&mut self) {
-        debug_assert!(!self.has_unconsumed_crossings(), "growth requires a crossingless tree");
         let leaves = self.materialized_leaves();
-        self.leaf_capacity *= 2;
+        self.leaf_capacity = self.leaf_capacity.checked_mul(2).expect("segment tree capacity is too large");
         self.nodes = vec![BucketExtrema::empty(); 2 * self.leaf_capacity];
 
-        for (position, candidate) in leaves {
+        for (position, candidate, bucket) in leaves {
             let node = self.leaf_node(position);
-            self.nodes[node] = BucketExtrema::create_leaf_with_score(candidate.leaf, candidate.score);
+            self.nodes[node] = BucketExtrema::restore_leaf_with_bucket(candidate.leaf, candidate.score, bucket);
         }
 
         for node in (ROOT_NODE..self.leaf_capacity).rev() {
@@ -418,15 +448,14 @@ where
     }
 
     /// Flush lazy updates and snapshot the occupied leaves with their stable logical positions.
-    fn materialized_leaves(&mut self) -> Vec<(LeafPosition, ScoreCandidate<T, S>)> {
+    fn materialized_leaves(&mut self) -> Vec<(LeafPosition, ScoreCandidate<T, S>, Bucket)> {
         self.materialize_subtree_deltas(ROOT_NODE, self.full_leaf_range());
         self.position_by_leaf
             .iter()
             .map(|(&leaf, &position)| {
                 let (candidate, bucket) = self.bucketed_leaf_candidate_at(position);
                 debug_assert!(candidate.leaf == leaf);
-                debug_assert_eq!(bucket, bucket_for_score(candidate.score), "growth requires score-aligned buckets");
-                (position, candidate)
+                (position, candidate, bucket)
             })
             .collect()
     }
@@ -472,6 +501,10 @@ where
 
     fn has_negative_at_least_zero(&self) -> bool {
         AppendableSegmentTree::has_negative_at_least_zero(self)
+    }
+
+    fn has_negative_score_in_prefix(&mut self, prefix_length: usize) -> bool {
+        AppendableSegmentTree::has_negative_score_in_prefix(self, prefix_length)
     }
 
     fn extract_positive_below_zero(&self) -> Option<T> {
@@ -618,16 +651,6 @@ mod tests {
         tree.append_leaf(1, 5);
         tree.prefix_add(0, -100);
         assert_eq!(tree.score(1), 5);
-    }
-
-    #[test]
-    #[should_panic(expected = "consume all threshold crossings before appending a leaf")]
-    fn test_append_requires_crossingless_tree() {
-        let mut tree = AppendableSegmentTree::<u64>::new();
-        tree.append_leaf(1, 0);
-        tree.prefix_add(1, -1);
-
-        tree.append_leaf(2, 0);
     }
 
     #[test]

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -183,7 +183,7 @@ where
     /// Add `delta` to the half-open range of logical leaf positions.
     pub fn range_add(&mut self, update_range: Range<LeafPosition>, delta: S) {
         // TODO(relaxed): avoid code duplication by calling range_add_batch to implement this.
-        // Current version uses direct implementation for easier reviewability 
+        // Current version uses direct implementation for easier reviewability
         assert!(update_range.start <= update_range.end, "range start exceeds range end");
         assert!(update_range.end <= self.len, "range exceeds tree length");
         if update_range.is_empty() || delta.is_zero() {

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -180,6 +180,11 @@ where
     /// Append a new leaf while preserving any crossings produced by earlier updates.
     /// The initial bucket is inferred from `initial_score`.
     pub fn append_leaf(&mut self, leaf: T, initial_score: S) {
+        self.append_leaf_with_bucket(leaf, initial_score, bucket_for_score(initial_score));
+    }
+
+    /// Restore a leaf whose bucket may temporarily disagree with its score.
+    pub(crate) fn append_leaf_with_bucket(&mut self, leaf: T, initial_score: S, bucket: Bucket) {
         assert!(!self.position_by_leaf.contains_key(&leaf), "leaf already present");
         if self.len == self.leaf_capacity {
             self.grow();
@@ -190,8 +195,12 @@ where
         self.position_by_leaf.insert(leaf, position);
 
         let node = self.leaf_node(position);
-        self.nodes[node] = BucketExtrema::create_leaf_with_score(leaf, initial_score);
+        self.nodes[node] = BucketExtrema::restore_leaf_with_bucket(leaf, initial_score, bucket);
         self.recompute_ancestors_of(node);
+    }
+
+    pub(crate) fn bucket(&self, leaf: T) -> Bucket {
+        self.bucketed_leaf_candidate_at(self.position_of(leaf)).1
     }
 
     pub fn prefix_add(&mut self, prefix_length: usize, delta: S) {

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -54,10 +54,6 @@ struct ScoreCandidate<T, S> {
 
 #[derive(Clone, Debug)]
 struct BucketExtrema<T, S> {
-    /// Minimum score across all leaves, independent of bucket membership.
-    ///
-    /// This remains accurate even when a leaf's stored bucket is stale because a
-    /// threshold crossing is waiting to be processed.
     min_score: Option<ScoreCandidate<T, S>>,
     min_positive: Option<ScoreCandidate<T, S>>,
     max_negative: Option<ScoreCandidate<T, S>>,

--- a/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
+++ b/consensus/src/processes/dagknight/appendable_segment_tree_impl.rs
@@ -13,62 +13,11 @@ use crate::processes::dagknight::appendable_segment_tree_api::{
 type LeafPosition = usize;
 type NodeIndex = usize;
 
-#[repr(u8)]
-#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-enum BoundaryKind {
-    End = 0,
-    Start = 1,
-}
-
-#[derive(Clone, Copy)]
-struct RangeBoundary<S> {
-    position: LeafPosition,
-    kind: BoundaryKind,
-    delta: S,
-}
-
-impl<S> RangeBoundary<S> {
-    fn start(position: LeafPosition, delta: S) -> Self {
-        Self { position, kind: BoundaryKind::Start, delta }
-    }
-
-    fn end(position: LeafPosition, delta: S) -> Self {
-        Self { position, kind: BoundaryKind::End, delta }
-    }
-}
+use super::segment_tree_ops::{
+    coalesce_ranges, left_child, parent, range_fully_contains, ranges_are_disjoint, right_child, split_range,
+};
 
 const ROOT_NODE: NodeIndex = 1;
-
-/// Node relationships in the tree's one-based heap layout.
-fn left_child(node: NodeIndex) -> NodeIndex {
-    node * 2
-}
-
-fn right_child(node: NodeIndex) -> NodeIndex {
-    node * 2 + 1
-}
-
-fn parent(node: NodeIndex) -> NodeIndex {
-    debug_assert!(node > ROOT_NODE, "root node has no parent");
-    node / 2
-}
-
-/// Half-open ranges that only touch at a boundary are disjoint.
-fn ranges_are_disjoint(first: &Range<LeafPosition>, second: &Range<LeafPosition>) -> bool {
-    first.end <= second.start || second.end <= first.start
-}
-
-/// Returns whether `outer` contains every position in `inner`.
-fn range_fully_contains(outer: &Range<LeafPosition>, inner: &Range<LeafPosition>) -> bool {
-    outer.start <= inner.start && inner.end <= outer.end
-}
-
-/// Splits a non-leaf range into its two contiguous child ranges.
-fn split_range(range: &Range<LeafPosition>) -> (Range<LeafPosition>, Range<LeafPosition>) {
-    debug_assert!(range.len() > 1, "cannot split a leaf range");
-    let midpoint = range.start + range.len() / 2;
-    (range.start..midpoint, midpoint..range.end)
-}
 
 #[derive(Clone, Copy, Debug)]
 struct ScoreCandidate<T, S> {
@@ -252,14 +201,14 @@ where
         if ranges.is_empty() {
             return;
         }
-        if ranges.len()==1{
+        if ranges.len() == 1 {
             // Handle common case without superflous logic
             let (range, delta) = ranges[0].clone();
             self.range_add(range, delta);
             return;
         }
-        let ranges = Self::coalesce_ranges(ranges);
-        self.add_to_ranges(ROOT_NODE, self.full_leaf_range(), &ranges);
+        let coalesced_ranges = coalesce_ranges(ranges);
+        self.add_to_ranges(ROOT_NODE, self.full_leaf_range(), &coalesced_ranges);
     }
 
     pub fn has_positive_below_zero(&self) -> bool {
@@ -481,46 +430,6 @@ where
         self.add_to_ranges(left_child(node), left_child_range, &partial);
         self.add_to_ranges(right_child(node), right_child_range, &partial);
         self.recompute_node(node);
-    }
-
-    fn coalesce_ranges(ranges: &[(Range<LeafPosition>, S)]) -> Vec<(Range<LeafPosition>, S)> {
-        // Represent every range by a start event and an end event. The sweep
-        // between two consecutive positions has one constant combined delta.
-        let mut boundary_events = Vec::with_capacity(ranges.len() * 2);
-        for (range, delta) in ranges {
-            if !range.is_empty() && !delta.is_zero() {
-                boundary_events.push(RangeBoundary::start(range.start, *delta));
-                boundary_events.push(RangeBoundary::end(range.end, *delta));
-            }
-        }
-        // End events sort before start events at the same position, so an ended
-        // range is removed before a new range beginning there is added.
-        boundary_events.sort_unstable_by_key(|event| (event.position, event.kind));
-
-        let mut coalesced_ranges = Vec::new();
-        let mut active_delta = S::zero();
-        let mut previous_boundary = None;
-        let mut event_index = 0;
-        while event_index < boundary_events.len() {
-            let current_boundary = boundary_events[event_index].position;
-            if let Some(previous_boundary) = previous_boundary
-                && previous_boundary < current_boundary
-                && !active_delta.is_zero()
-            {
-                coalesced_ranges.push((previous_boundary..current_boundary, active_delta));
-            }
-
-            while event_index < boundary_events.len() && boundary_events[event_index].position == current_boundary {
-                let event = boundary_events[event_index];
-                active_delta = match event.kind {
-                    BoundaryKind::Start => active_delta + event.delta,
-                    BoundaryKind::End => active_delta - event.delta,
-                };
-                event_index += 1;
-            }
-            previous_boundary = Some(current_boundary);
-        }
-        coalesced_ranges
     }
 
     // ---------------------------------------------------------------------

--- a/consensus/src/processes/dagknight/mod.rs
+++ b/consensus/src/processes/dagknight/mod.rs
@@ -9,6 +9,7 @@ use crate::processes::ghostdag::ordering::SortableBlock;
 
 mod appendable_segment_tree_api;
 mod appendable_segment_tree_impl;
+mod segment_tree_ops;
 pub use appendable_segment_tree_api::{AppendableSegmentTreeApi, Bucket, bucket_for_score};
 pub use appendable_segment_tree_impl::AppendableSegmentTree;
 pub mod manager;

--- a/consensus/src/processes/dagknight/protocol.rs
+++ b/consensus/src/processes/dagknight/protocol.rs
@@ -371,7 +371,7 @@ impl<
             let baseline_result =
                 self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
 
-            if baseline_result.virtual_score != cascade_result.virtual_score {
+            if baseline_result.cascade_score != cascade_result.cascade_score {
                 if baseline_result.accepted != cascade_result.accepted {
                     self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
                 }
@@ -381,8 +381,8 @@ impl<
                      cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
                     k_to_check,
                     conflict_genesis,
-                    baseline_result.virtual_score,
-                    cascade_result.virtual_score,
+                    baseline_result.cascade_score,
+                    cascade_result.cascade_score,
                     baseline_result.accepted,
                     cascade_result.accepted,
                     cascade_result.flips,

--- a/consensus/src/processes/dagknight/protocol.rs
+++ b/consensus/src/processes/dagknight/protocol.rs
@@ -365,10 +365,10 @@ impl<
 
         #[cfg(feature = "baseline-debugging")]
         {
-        // Compare baseline (per-blue recursive) against cascade (global virtual score)
-        // These use different acceptance criteria and are not expected to always agree.
-        // The baseline is Algorithm 6 from the paper; the cascade is the optimized approximated implementation.
- 
+            // Compare baseline (per-blue recursive) against cascade (global virtual score)
+            // These use different acceptance criteria and are not expected to always agree.
+            // The baseline is Algorithm 6 from the paper; the cascade is the optimized approximated implementation.
+
             let baseline_result =
                 self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
             self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);

--- a/consensus/src/processes/dagknight/protocol.rs
+++ b/consensus/src/processes/dagknight/protocol.rs
@@ -363,33 +363,69 @@ impl<
         let cascade_result =
             self.umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
 
-        #[cfg(feature = "baseline-debugging")]
-        {
-            // Compare baseline (per-blue recursive) against cascade (global virtual score)
-            // These use different acceptance criteria and are not expected to always agree.
-            // The baseline is Algorithm 6 from the paper; the cascade is the optimized implementation.
-            let baseline_result =
-                self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
+        // Baseline comparison is temporarily disabled while cascade early-stop and
+        // recovery semantics are being finalized. The reference implementation remains
+        // available under `baseline-debugging` for later reactivation.
+        //
+        // #[cfg(feature = "baseline-debugging")]
+        // {
+        //     // Compare baseline (per-blue recursive) against cascade (global virtual score)
+        //     // These use different acceptance criteria and are not expected to always agree.
+        //     // The baseline is Algorithm 6 from the paper; the cascade is the optimized implementation.
+        //     let baseline_result = self.baseline_umc_cascade_voting(
+        //         conflict_genesis,
+        //         subgroup,
+        //         virtual_gd.clone(),
+        //         k_to_check,
+        //         &conflict_zone_manager,
+        //     );
+        //
+        //     if baseline_result.cascade_score != cascade_result.cascade_score {
+        //         if baseline_result.accepted != cascade_result.accepted {
+        //             self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
+        //         }
+        //
+        //         panic!(
+        //             "BASELINE vs CASCADE SCORE DISAGREEMENT: k={}, conflict_genesis={:?}, baseline_score={}, \
+        //              cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
+        //             k_to_check,
+        //             conflict_genesis,
+        //             baseline_result.cascade_score,
+        //             cascade_result.cascade_score,
+        //             baseline_result.accepted,
+        //             cascade_result.accepted,
+        //             cascade_result.flips,
+        //             cascade_result.voting_blocks
+        //         );
+        //     }
+        // }
+        //   #[cfg(feature = "baseline-debugging")]
+        //     {
+        //         // Compare baseline (per-blue recursive) against cascade (global virtual score)
+        //         // These use different acceptance criteria and are not expected to always agree.
+        //         // The baseline is Algorithm 6 from the paper; the cascade is the optimized implementation.
+        //         let baseline_result =
+        //             self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
 
-            if baseline_result.cascade_score != cascade_result.cascade_score {
-                if baseline_result.accepted != cascade_result.accepted {
-                    self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
-                }
+        //         if baseline_result.cascade_score != cascade_result.cascade_score {
+        //             if baseline_result.accepted != cascade_result.accepted {
+        //                 self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
+        //             }
 
-                panic!(
-                    "BASELINE vs CASCADE SCORE DISAGREEMENT: k={}, conflict_genesis={:?}, baseline_score={}, \
-                     cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
-                    k_to_check,
-                    conflict_genesis,
-                    baseline_result.cascade_score,
-                    cascade_result.cascade_score,
-                    baseline_result.accepted,
-                    cascade_result.accepted,
-                    cascade_result.flips,
-                    cascade_result.voting_blocks
-                );
-            }
-        }
+        //             panic!(
+        //                 "BASELINE vs CASCADE SCORE DISAGREEMENT: k={}, conflict_genesis={:?}, baseline_score={}, \
+        //                  cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
+        //                 k_to_check,
+        //                 conflict_genesis,
+        //                 baseline_result.cascade_score,
+        //                 cascade_result.cascade_score,
+        //                 baseline_result.accepted,
+        //                 cascade_result.accepted,
+        //                 cascade_result.flips,
+        //                 cascade_result.voting_blocks
+        //             );
+        //         }
+        //     }
 
         self.counters.record_cascade_stats(cascade_result.flips, cascade_result.voting_blocks);
         self.counters.record_checkpoint_stats(

--- a/consensus/src/processes/dagknight/protocol.rs
+++ b/consensus/src/processes/dagknight/protocol.rs
@@ -363,69 +363,16 @@ impl<
         let cascade_result =
             self.umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
 
-        // Baseline comparison is temporarily disabled while cascade early-stop and
-        // recovery semantics are being finalized. The reference implementation remains
-        // available under `baseline-debugging` for later reactivation.
-        //
-        // #[cfg(feature = "baseline-debugging")]
-        // {
-        //     // Compare baseline (per-blue recursive) against cascade (global virtual score)
-        //     // These use different acceptance criteria and are not expected to always agree.
-        //     // The baseline is Algorithm 6 from the paper; the cascade is the optimized implementation.
-        //     let baseline_result = self.baseline_umc_cascade_voting(
-        //         conflict_genesis,
-        //         subgroup,
-        //         virtual_gd.clone(),
-        //         k_to_check,
-        //         &conflict_zone_manager,
-        //     );
-        //
-        //     if baseline_result.cascade_score != cascade_result.cascade_score {
-        //         if baseline_result.accepted != cascade_result.accepted {
-        //             self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
-        //         }
-        //
-        //         panic!(
-        //             "BASELINE vs CASCADE SCORE DISAGREEMENT: k={}, conflict_genesis={:?}, baseline_score={}, \
-        //              cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
-        //             k_to_check,
-        //             conflict_genesis,
-        //             baseline_result.cascade_score,
-        //             cascade_result.cascade_score,
-        //             baseline_result.accepted,
-        //             cascade_result.accepted,
-        //             cascade_result.flips,
-        //             cascade_result.voting_blocks
-        //         );
-        //     }
-        // }
-        //   #[cfg(feature = "baseline-debugging")]
-        //     {
-        //         // Compare baseline (per-blue recursive) against cascade (global virtual score)
-        //         // These use different acceptance criteria and are not expected to always agree.
-        //         // The baseline is Algorithm 6 from the paper; the cascade is the optimized implementation.
-        //         let baseline_result =
-        //             self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
-
-        //         if baseline_result.cascade_score != cascade_result.cascade_score {
-        //             if baseline_result.accepted != cascade_result.accepted {
-        //                 self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
-        //             }
-
-        //             panic!(
-        //                 "BASELINE vs CASCADE SCORE DISAGREEMENT: k={}, conflict_genesis={:?}, baseline_score={}, \
-        //                  cascade_score={}, baseline_accepted={}, cascade_accepted={}, flips={}, voting_blocks={}",
-        //                 k_to_check,
-        //                 conflict_genesis,
-        //                 baseline_result.cascade_score,
-        //                 cascade_result.cascade_score,
-        //                 baseline_result.accepted,
-        //                 cascade_result.accepted,
-        //                 cascade_result.flips,
-        //                 cascade_result.voting_blocks
-        //             );
-        //         }
-        //     }
+        #[cfg(feature = "baseline-debugging")]
+        {
+        // Compare baseline (per-blue recursive) against cascade (global virtual score)
+        // These use different acceptance criteria and are not expected to always agree.
+        // The baseline is Algorithm 6 from the paper; the cascade is the optimized approximated implementation.
+ 
+            let baseline_result =
+                self.baseline_umc_cascade_voting(conflict_genesis, subgroup, virtual_gd.clone(), k_to_check, &conflict_zone_manager);
+            self.counters.record_baseline_disagreement(baseline_result.accepted, cascade_result.accepted);
+        }
 
         self.counters.record_cascade_stats(cascade_result.flips, cascade_result.voting_blocks);
         self.counters.record_checkpoint_stats(

--- a/consensus/src/processes/dagknight/segment_tree_ops.rs
+++ b/consensus/src/processes/dagknight/segment_tree_ops.rs
@@ -1,0 +1,104 @@
+use std::ops::{AddAssign, Range, Sub};
+
+use num_traits::Zero;
+
+type LeafPosition = usize;
+type NodeIndex = usize;
+
+/// Node relationships in the tree's one-based heap layout.
+pub(super) fn left_child(node: NodeIndex) -> NodeIndex {
+    node * 2
+}
+
+pub(super) fn right_child(node: NodeIndex) -> NodeIndex {
+    node * 2 + 1
+}
+
+pub(super) fn parent(node: NodeIndex) -> NodeIndex {
+    debug_assert!(node > 1, "root node has no parent");
+    node / 2
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum BoundaryKind {
+    End = 0,
+    Start = 1,
+}
+
+#[derive(Clone, Copy)]
+struct RangeBoundary<S> {
+    position: LeafPosition,
+    kind: BoundaryKind,
+    delta: S,
+}
+
+impl<S> RangeBoundary<S> {
+    fn start(position: LeafPosition, delta: S) -> Self {
+        Self { position, kind: BoundaryKind::Start, delta }
+    }
+
+    fn end(position: LeafPosition, delta: S) -> Self {
+        Self { position, kind: BoundaryKind::End, delta }
+    }
+}
+
+/// Half-open ranges that only touch at a boundary are disjoint.
+pub(super) fn ranges_are_disjoint(first: &Range<LeafPosition>, second: &Range<LeafPosition>) -> bool {
+    first.end <= second.start || second.end <= first.start
+}
+
+/// Returns whether `outer` contains every position in `inner`.
+pub(super) fn range_fully_contains(outer: &Range<LeafPosition>, inner: &Range<LeafPosition>) -> bool {
+    outer.start <= inner.start && inner.end <= outer.end
+}
+
+/// Splits a non-leaf range into its two contiguous child ranges.
+pub(super) fn split_range(range: &Range<LeafPosition>) -> (Range<LeafPosition>, Range<LeafPosition>) {
+    debug_assert!(range.len() > 1, "cannot split a leaf range");
+    let midpoint = range.start + range.len() / 2;
+    (range.start..midpoint, midpoint..range.end)
+}
+
+pub(super) fn coalesce_ranges<S>(ranges: &[(Range<LeafPosition>, S)]) -> Vec<(Range<LeafPosition>, S)>
+where
+    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
+{
+    // Represent every range by a start event and an end event. The sweep
+    // between two consecutive positions has one constant combined delta.
+    let mut boundary_events = Vec::with_capacity(ranges.len() * 2);
+    for (range, delta) in ranges {
+        if !range.is_empty() && !delta.is_zero() {
+            boundary_events.push(RangeBoundary::start(range.start, *delta));
+            boundary_events.push(RangeBoundary::end(range.end, *delta));
+        }
+    }
+    // End events sort before start events at the same position, so an ended
+    // range is removed before a new range beginning there is added.
+    boundary_events.sort_unstable_by_key(|event| (event.position, event.kind));
+
+    let mut coalesced_ranges = Vec::new();
+    let mut active_delta = S::zero();
+    let mut previous_boundary = None;
+    let mut event_index = 0;
+    while event_index < boundary_events.len() {
+        let current_boundary = boundary_events[event_index].position;
+        if let Some(previous_boundary) = previous_boundary
+            && previous_boundary < current_boundary
+            && !active_delta.is_zero()
+        {
+            coalesced_ranges.push((previous_boundary..current_boundary, active_delta));
+        }
+
+        while event_index < boundary_events.len() && boundary_events[event_index].position == current_boundary {
+            let event = boundary_events[event_index];
+            active_delta = match event.kind {
+                BoundaryKind::Start => active_delta + event.delta,
+                BoundaryKind::End => active_delta - event.delta,
+            };
+            event_index += 1;
+        }
+        previous_boundary = Some(current_boundary);
+    }
+    coalesced_ranges
+}

--- a/consensus/src/processes/dagknight/segment_tree_ops.rs
+++ b/consensus/src/processes/dagknight/segment_tree_ops.rs
@@ -1,4 +1,4 @@
-use std::ops::{AddAssign, Range, Sub};
+use std::ops::{Add, Range, Sub};
 
 use num_traits::Zero;
 
@@ -30,16 +30,16 @@ enum BoundaryKind {
 struct RangeBoundary<S> {
     position: LeafPosition,
     kind: BoundaryKind,
-    delta: S,
+    value: S,
 }
 
 impl<S> RangeBoundary<S> {
-    fn start(position: LeafPosition, delta: S) -> Self {
-        Self { position, kind: BoundaryKind::Start, delta }
+    fn start(position: LeafPosition, value: S) -> Self {
+        Self { position, kind: BoundaryKind::Start, value }
     }
 
-    fn end(position: LeafPosition, delta: S) -> Self {
-        Self { position, kind: BoundaryKind::End, delta }
+    fn end(position: LeafPosition, value: S) -> Self {
+        Self { position, kind: BoundaryKind::End, value }
     }
 }
 
@@ -62,15 +62,15 @@ pub(super) fn split_range(range: &Range<LeafPosition>) -> (Range<LeafPosition>, 
 
 pub(super) fn coalesce_ranges<S>(ranges: &[(Range<LeafPosition>, S)]) -> Vec<(Range<LeafPosition>, S)>
 where
-    S: Copy + PartialOrd + AddAssign + Sub<Output = S> + Zero,
+    S: Copy + Add<Output = S> + Sub<Output = S> + Zero,
 {
     // Represent every range by a start event and an end event. The sweep
-    // between two consecutive positions has one constant combined delta.
+    // between two consecutive positions has one constant combined value.
     let mut boundary_events = Vec::with_capacity(ranges.len() * 2);
-    for (range, delta) in ranges {
-        if !range.is_empty() && !delta.is_zero() {
-            boundary_events.push(RangeBoundary::start(range.start, *delta));
-            boundary_events.push(RangeBoundary::end(range.end, *delta));
+    for (range, value) in ranges {
+        if !range.is_empty() && !value.is_zero() {
+            boundary_events.push(RangeBoundary::start(range.start, *value));
+            boundary_events.push(RangeBoundary::end(range.end, *value));
         }
     }
     // End events sort before start events at the same position, so an ended
@@ -78,27 +78,21 @@ where
     boundary_events.sort_unstable_by_key(|event| (event.position, event.kind));
 
     let mut coalesced_ranges = Vec::new();
-    let mut active_delta = S::zero();
+    let mut active_value = S::zero();
     let mut previous_boundary = None;
-    let mut event_index = 0;
-    while event_index < boundary_events.len() {
-        let current_boundary = boundary_events[event_index].position;
+    for event in boundary_events {
         if let Some(previous_boundary) = previous_boundary
-            && previous_boundary < current_boundary
-            && !active_delta.is_zero()
+            && previous_boundary < event.position
+            && !active_value.is_zero()
         {
-            coalesced_ranges.push((previous_boundary..current_boundary, active_delta));
+            coalesced_ranges.push((previous_boundary..event.position, active_value));
         }
-
-        while event_index < boundary_events.len() && boundary_events[event_index].position == current_boundary {
-            let event = boundary_events[event_index];
-            active_delta = match event.kind {
-                BoundaryKind::Start => active_delta + event.delta,
-                BoundaryKind::End => active_delta - event.delta,
-            };
-            event_index += 1;
-        }
-        previous_boundary = Some(current_boundary);
+        // Update the accumulated value for the interval starting at event_position.
+        previous_boundary = Some(event.position);
+        active_value = match event.kind {
+            BoundaryKind::Start => active_value + event.value,
+            BoundaryKind::End => active_value - event.value,
+        };
     }
     coalesced_ranges
 }

--- a/consensus/src/processes/dagknight/umc_baseline.rs
+++ b/consensus/src/processes/dagknight/umc_baseline.rs
@@ -77,10 +77,10 @@ impl<O: HeaderStoreReader + 'static, R: ReachabilityStoreReader + Clone> UmcVote
         let voting_blocks = (blues.len() + reds.len()) as u64;
         let is_ancestor = |a: Hash, b: Hash| self.reachability_service.is_dag_ancestor_of(a, b);
         let helper = BaselineCascadeHelper::new(blues, reds, deficit_work, &is_ancestor, conflict_genesis);
-        let (total_vote, virtual_score, _per_blue_buckets) = helper.compute_all_votes();
+        let (total_vote, cascade_score, _per_blue_buckets) = helper.compute_all_votes();
 
         CascadeResult {
-            virtual_score,
+            cascade_score,
             accepted: total_vote >= SignedWork::zero(),
             flips: 0,
             voting_blocks,
@@ -158,9 +158,9 @@ impl<'a> BaselineCascadeHelper<'a> {
 
         let signed_blue_work = votes.values().copied().fold(SignedWork::zero(), |total, vote| total + vote);
         let red_work: BlueWorkType = self.reds.iter().map(|&(_, work, _)| work).sum();
-        let virtual_score = signed_blue_work + SignedWork::from(self.deficit) - SignedWork::from(red_work);
+        let cascade_score = signed_blue_work + SignedWork::from(self.deficit) - SignedWork::from(red_work);
 
-        (votes[&self.conflict_genesis], virtual_score, per_blue_buckets)
+        (votes[&self.conflict_genesis], cascade_score, per_blue_buckets)
     }
 }
 
@@ -177,7 +177,7 @@ mod tests {
 
         let result = voter.vote(&ctx);
 
-        assert_eq!(result.virtual_score, fixture.expected_score(), "virtual score mismatch");
+        assert_eq!(result.cascade_score, fixture.expected_score(), "cascade score mismatch");
         assert!(result.accepted, "zone should be accepted");
         assert_eq!(result.voting_blocks, 16, "blues 11, 10, 9, 7, 6, 5, 4, 3, 2 + CG + reds 12..17 (gray red 8 excluded)");
     }

--- a/consensus/src/processes/dagknight/umc_baseline.rs
+++ b/consensus/src/processes/dagknight/umc_baseline.rs
@@ -84,6 +84,7 @@ impl<O: HeaderStoreReader + 'static, R: ReachabilityStoreReader + Clone> UmcVote
             accepted: total_vote >= SignedWork::zero(),
             flips: 0,
             voting_blocks,
+            events_diff: Vec::new(),
             from_checkpoint: false,
             estimated_effort_saved: 0,
             estimated_effort_total: 0,

--- a/consensus/src/processes/dagknight/umc_baseline.rs
+++ b/consensus/src/processes/dagknight/umc_baseline.rs
@@ -84,7 +84,6 @@ impl<O: HeaderStoreReader + 'static, R: ReachabilityStoreReader + Clone> UmcVote
             accepted: total_vote >= SignedWork::zero(),
             flips: 0,
             voting_blocks,
-            events_diff: Vec::new(),
             from_checkpoint: false,
             estimated_effort_saved: 0,
             estimated_effort_total: 0,

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -136,20 +136,22 @@ impl CascadeMaintainer {
         self.cascade_score() >= SignedWork::zero()
     }
 
-    fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(
-        &mut self,
-        merging_block: Hash,
-        coloring_reader: &C,
-        reachability: &impl ReachabilityService,
-    ) {
+    fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(&mut self, merging_block: Hash, coloring_reader: &C) {
         let merging_blue_score = coloring_reader.get_coloring_data(merging_block).blue_score;
-        let mut bound_blue_score = coloring_reader.get_coloring_data(self.depth_limit_ancestor).blue_score;
         let max_depth = u64::from(self.k).pow(4);
+        let previous_bound = self.depth_limit_ancestor;
+        let mut bound = merging_block;
 
-        while merging_blue_score.saturating_sub(bound_blue_score) > max_depth {
-            self.depth_limit_ancestor = reachability.get_next_chain_ancestor(merging_block, self.depth_limit_ancestor);
-            bound_blue_score = coloring_reader.get_coloring_data(self.depth_limit_ancestor).blue_score;
+        while bound != previous_bound {
+            let parent = coloring_reader.get_coloring_data(bound).selected_parent;
+            let parent_blue_score = coloring_reader.get_coloring_data(parent).blue_score;
+            if merging_blue_score.saturating_sub(parent_blue_score) > max_depth {
+                break;
+            }
+            bound = parent;
         }
+
+        self.depth_limit_ancestor = bound;
     }
 
     fn violates_depth_restriction(&mut self, reachability: &impl ReachabilityService) -> bool {
@@ -181,11 +183,13 @@ impl CascadeMaintainer {
                 let score = tree.score(block_with_work);
                 let is_negative = score.negative();
                 let abs_score: Uint192 = score.abs();
+                let bucket_positive = tree.bucket(block_with_work) == Bucket::Positive;
                 chain_leaves.push(ChainLeafEntry {
                     hash: block_with_work.hash,
                     work: block_with_work.work,
                     score_abs: abs_score,
                     score_negative: is_negative,
+                    bucket_positive,
                 });
             }
             chains_leaves.push(chain_leaves);
@@ -238,7 +242,8 @@ impl CascadeMaintainer {
                 } else {
                     SignedWork::from(leaf_entry.score_abs)
                 };
-                temp_tree.append_leaf(block, score);
+                let bucket = if leaf_entry.bucket_positive { Bucket::Positive } else { Bucket::Negative };
+                temp_tree.append_leaf_with_bucket(block, score, bucket);
             }
 
             maintainer.chains_score_trees.push(temp_tree);
@@ -475,7 +480,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     // immediately after its selected parent's mergeset, so the bound already
     // reflects the latest concrete chain block.
     if let Some(merging_block) = mergeset.merging_chain_block {
-        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader, reachability);
+        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader);
     }
 
     let mut events = CascadeEvents::new();

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -136,19 +136,19 @@ impl CascadeMaintainer {
         self.cascade_score() >= SignedWork::zero()
     }
 
-    fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(&mut self, merging_block: Hash, coloring_reader: &C) {
+    /// finds the first chain ancestor of the merging block, that is less than k^4 blue score away from it
+    fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(
+        &mut self,
+        merging_block: Hash,
+        coloring_reader: &C,
+        reachability: &impl ReachabilityService,
+    ) {
         let merging_blue_score = coloring_reader.get_coloring_data(merging_block).blue_score;
         let max_depth = u64::from(self.k).pow(4);
-        let previous_bound = self.depth_limit_ancestor;
-        let mut bound = merging_block;
+        let mut bound = self.depth_limit_ancestor;
 
-        while bound != previous_bound {
-            let parent = coloring_reader.get_coloring_data(bound).selected_parent;
-            let parent_blue_score = coloring_reader.get_coloring_data(parent).blue_score;
-            if merging_blue_score.saturating_sub(parent_blue_score) > max_depth {
-                break;
-            }
-            bound = parent;
+        while merging_blue_score.saturating_sub(coloring_reader.get_coloring_data(bound).blue_score) > max_depth {
+            bound = reachability.get_next_chain_ancestor(merging_block, bound);
         }
 
         self.depth_limit_ancestor = bound;
@@ -480,7 +480,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     // immediately after its selected parent's mergeset, so the bound already
     // reflects the latest concrete chain block.
     if let Some(merging_block) = mergeset.merging_chain_block {
-        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader);
+        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader, reachability);
     }
 
     let mut events = CascadeEvents::new();

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -204,6 +204,13 @@ impl CascadeMaintainer {
     ) {
         let mut curr_bound = self.depth_limit_ancestor;
 
+        // The selected-parent path may have changed branches since the last
+        // mergeset. Walk the old bound back until it reaches the new path; the
+        // first ancestor shared by both paths is their lowest common point.
+        while !reachability.is_chain_ancestor_of(curr_bound, merger_selected_parent) {
+            curr_bound = reachability.get_chain_parent(curr_bound);
+        }
+
         while curr_bound != merger_selected_parent {
             let next_bound = reachability.get_next_chain_ancestor(merger_selected_parent, curr_bound);
             let next_distance = merger_blue_score.saturating_sub(coloring_reader.get_coloring_data(next_bound).blue_score);

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -201,7 +201,7 @@ impl CascadeMaintainer {
     // ----- Persistence -----
 
     /// Serialize the current cascade state for checkpoint persistence.
-    pub fn to_persisted_state(&mut self, voting_blocks: u64) -> UmcCascadePersistedState {
+    pub fn to_persisted_state(&mut self, voting_blocks: u64, events_diff: Vec<MergesetEvents>) -> UmcCascadePersistedState {
         let mut chains_leaves: Vec<Vec<ChainLeafEntry>> = Vec::new();
 
         for (chain_id, _chain) in self.blues_chains_decomposition.iter().enumerate() {
@@ -234,6 +234,7 @@ impl CascadeMaintainer {
             red_work: self.red_work,
             negative_blue_work: self.negative_blue_work,
             voting_blocks,
+            events_diff,
             flip_count: self.flip_count,
         }
     }
@@ -307,7 +308,7 @@ impl CascadeMaintainer {
     // ----- Event processing -----
 
     fn process_positive_events(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        while let Some((source, delta)) = events.positive.pop_front() {
+        while let Some((source, delta)) = events.pop_positive() {
             self.apply_event(source, delta, reachability);
             while let Some((chain_id, block)) = self
                 .chains_score_trees
@@ -329,7 +330,7 @@ impl CascadeMaintainer {
         // These are the direct effects of all reds in the current mergeset. They
         // are inherent to the mergeset, so apply every one before examining any
         // consequent negative crossing.
-        while let Some((source, delta)) = events.negative.pop_front() {
+        while let Some((source, delta)) = events.pop_negative() {
             self.apply_event(source, delta, reachability);
         }
     }
@@ -365,7 +366,7 @@ impl CascadeMaintainer {
 
             // Every queued event belongs to a flip already committed in this
             // round, so propagate the complete batch before checking again.
-            while let Some((source, delta)) = events.negative.pop_front() {
+            while let Some((source, delta)) = events.pop_negative() {
                 self.apply_event(source, delta, reachability);
             }
         }
@@ -385,9 +386,10 @@ impl CascadeMaintainer {
         &mut self,
         key: UmcCascadeKey,
         voting_blocks: u64,
+        events_diff: Vec<MergesetEvents>,
         cascade_store: Arc<dyn UmcCascadeStore>,
     ) -> Result<(), StoreError> {
-        let persisted_state = self.to_persisted_state(voting_blocks);
+        let persisted_state = self.to_persisted_state(voting_blocks, events_diff);
         cascade_store.insert_checkpoint(key, persisted_state)
     }
 }
@@ -462,6 +464,7 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     coloring_reader: &C,
 ) -> CascadeResult {
     let mut voting_blocks = 0u64;
+    let mut events_diff = checkpoint_state.as_ref().map(|state| state.events_diff.clone()).unwrap_or_default();
     let from_checkpoint = checkpoint_state.is_some();
 
     // Restore from checkpoint or start fresh
@@ -476,11 +479,14 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     while let Some(mergeset) = mergeset_stack.pop() {
         let checkpoint_key = (!mergeset_stack.is_empty())
             .then(|| UmcCascadeKey::new(conflict_genesis.hash, k, next_chain_ancestor, mergeset.checkpoint_hash()));
-        voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
+        let mergeset_hash = mergeset.checkpoint_hash();
+        let (processed_blocks, mergeset_events) = process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
+        voting_blocks += processed_blocks;
+        events_diff.push(MergesetEvents { mergeset_hash, events: mergeset_events });
 
         // Checkpoint at chain block — persist to store (best-effort)
         if let Some(checkpoint_key) = checkpoint_key {
-            let _ = maintainer.save_state(checkpoint_key, voting_blocks, cascade_store.clone());
+            let _ = maintainer.save_state(checkpoint_key, voting_blocks, events_diff.clone(), cascade_store.clone());
         }
     }
 
@@ -492,6 +498,7 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
         accepted,
         flips: maintainer.flip_count,
         voting_blocks,
+        events_diff,
         from_checkpoint,
         estimated_effort_saved,
         estimated_effort_total,
@@ -507,7 +514,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     mergeset: Mergeset,
     reachability: &impl ReachabilityService,
     coloring_reader: &C,
-) -> u64 {
+) -> (u64, Vec<CascadeEvent>) {
     let selected_parent = mergeset.selected_parent;
     let merger_blue_score = coloring_reader.get_coloring_data(selected_parent).blue_score + mergeset.mergeset_blues.len() as u64;
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -14,7 +14,7 @@ use crate::model::stores::reachability::ReachabilityStoreReader;
 use crate::processes::dagknight::umc_cascade_persistence::{
     ChainLeafEntry, Mergeset, UmcCascadeKey, UmcCascadePersistedState, UmcCascadeStore,
 };
-use crate::processes::dagknight::umc_voting::{CascadeResult, SignedWork, UmcVoter, UmcVotingContext};
+use crate::processes::dagknight::umc_voting::{CascadeResult, ColoringReader, SignedWork, UmcVoter, UmcVotingContext};
 use crate::processes::dagknight::{AppendableSegmentTree, Bucket, bucket_for_score};
 use crate::processes::difficulty::calc_work;
 
@@ -25,6 +25,7 @@ use crate::processes::difficulty::calc_work;
 /// Maintains exact cascade scores for one fixed k using chain decomposition
 /// and lazy segment trees with event-driven bucket-transition propagation.
 pub struct CascadeMaintainer {
+    k: KType,
     blues_chains_decomposition: Vec<Vec<Hash>>,
     chains_score_trees: Vec<AppendableSegmentTree<BlockWithWork, SignedWork>>,
     blk_mapping_to_chains: HashMap<Hash, usize>,
@@ -34,6 +35,7 @@ pub struct CascadeMaintainer {
     negative_blue_work: BlueWorkType,
     /// Total bucket flips observed during cascade stabilization
     flip_count: u64,
+    depth_limit_ancestor: Hash,
     next_chain_ancestor: Hash,
 }
 
@@ -82,6 +84,7 @@ impl CascadeMaintainer {
     pub fn new(conflict_genesis: BlockWithWork, k: KType, next_chain_ancestor: Hash) -> Self {
         let deficit_work = conflict_genesis.work * u64::from(k.isqrt());
         Self {
+            k,
             blues_chains_decomposition: Vec::new(),
             chains_score_trees: Vec::new(),
             blk_mapping_to_chains: HashMap::new(),
@@ -90,6 +93,7 @@ impl CascadeMaintainer {
             red_work: BlueWorkType::ZERO,
             negative_blue_work: BlueWorkType::ZERO,
             flip_count: 0,
+            depth_limit_ancestor: conflict_genesis.hash,
             next_chain_ancestor,
         }
     }
@@ -132,6 +136,22 @@ impl CascadeMaintainer {
         self.cascade_score() >= SignedWork::zero()
     }
 
+    fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(
+        &mut self,
+        merging_block: Hash,
+        coloring_reader: &C,
+        reachability: &impl ReachabilityService,
+    ) {
+        let merging_blue_score = coloring_reader.get_coloring_data(merging_block).blue_score;
+        let mut bound_blue_score = coloring_reader.get_coloring_data(self.depth_limit_ancestor).blue_score;
+        let max_depth = u64::from(self.k).pow(4);
+
+        while merging_blue_score.saturating_sub(bound_blue_score) > max_depth {
+            self.depth_limit_ancestor = reachability.get_next_chain_ancestor(merging_block, self.depth_limit_ancestor);
+            bound_blue_score = coloring_reader.get_coloring_data(self.depth_limit_ancestor).blue_score;
+        }
+    }
+
     /// Returns the total number of bucket flips observed during cascade stabilization.
     pub fn flip_count(&self) -> u64 {
         self.flip_count
@@ -165,6 +185,7 @@ impl CascadeMaintainer {
             blues_chains_decomposition: self.blues_chains_decomposition.clone(),
             chains_leaves,
             blk_mapping_to_chains: self.blk_mapping_to_chains.clone(),
+            depth_limit_ancestor: self.depth_limit_ancestor,
             deficit_work: self.deficit_work,
             blue_work: self.blue_work,
             red_work: self.red_work,
@@ -189,6 +210,7 @@ impl CascadeMaintainer {
         maintainer.red_work = persisted.red_work;
         maintainer.negative_blue_work = persisted.negative_blue_work;
         maintainer.flip_count = persisted.flip_count;
+        maintainer.depth_limit_ancestor = persisted.depth_limit_ancestor;
 
         // Restore chains and trees
         maintainer.blues_chains_decomposition = persisted.blues_chains_decomposition.clone();
@@ -382,7 +404,7 @@ fn strict_ancestor_index(chain: &[Hash], source: Hash, reachability: &impl Reach
 /// `estimated_effort_saved` is the estimated number of blue blocks skipped by checkpointing
 /// (caller's responsibility to calculate from virtual_gd.blue_score - checkpoint_blue_score).
 /// `estimated_effort_total` is virtual_gd.blue_score (total blues in the conflict zone).
-pub fn run_cascade(
+pub fn run_cascade<C: ColoringReader + ?Sized>(
     mut mergeset_stack: Vec<Mergeset>,
     conflict_genesis: BlockWithWork,
     k: KType,
@@ -392,6 +414,7 @@ pub fn run_cascade(
     checkpoint_state: Option<UmcCascadePersistedState>,
     estimated_effort_saved: u64,
     estimated_effort_total: u64,
+    coloring_reader: &C,
 ) -> CascadeResult {
     let mut voting_blocks = 0u64;
     let from_checkpoint = checkpoint_state.is_some();
@@ -407,7 +430,7 @@ pub fn run_cascade(
     // Process remaining mergesets (pop from bottom = CG-first, upward)
     while let Some(mergeset) = mergeset_stack.pop() {
         let chain_block = mergeset.merging_chain_block;
-        voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability);
+        voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
 
         // Checkpoint at chain block — persist to store (best-effort)
         if let Some(chain_block) = chain_block {
@@ -433,7 +456,19 @@ pub fn run_cascade(
 ///
 /// Blue effects are fully stabilized first. All direct red effects are then
 /// applied, followed by the negative event cascade, until stoppage
-fn process_mergeset(maintainer: &mut CascadeMaintainer, mergeset: Mergeset, reachability: &impl ReachabilityService) -> u64 {
+fn process_mergeset<C: ColoringReader + ?Sized>(
+    maintainer: &mut CascadeMaintainer,
+    mergeset: Mergeset,
+    reachability: &impl ReachabilityService,
+    coloring_reader: &C,
+) -> u64 {
+    // The virtual mergeset has no concrete merging-block hash. It is processed
+    // immediately after its selected parent's mergeset, so the bound already
+    // reflects the latest concrete chain block.
+    if let Some(merging_block) = mergeset.merging_chain_block {
+        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader, reachability);
+    }
+
     let mut events = CascadeEvents::new();
     let mut voting_blocks = 0u64;
 
@@ -556,6 +591,7 @@ impl<O: HeaderStoreReader + 'static, E: UmcCascadeStore + Clone + 'static, R: Re
             checkpoint_state,
             estimated_effort_saved,
             estimated_effort_total,
+            coloring_reader,
         )
     }
 }

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use kaspa_consensus_core::{BlueWorkType, KType};
@@ -54,6 +54,25 @@ fn work_delta(work: BlueWorkType, bucket: Bucket) -> SignedWork {
     match bucket {
         Bucket::Positive => magnitude,
         Bucket::Negative => SignedWork::zero() - magnitude,
+    }
+}
+
+struct CascadeEvents {
+    positive: VecDeque<(Hash, SignedWork)>,
+    negative: VecDeque<(Hash, SignedWork)>,
+}
+
+impl CascadeEvents {
+    fn new() -> Self {
+        Self { positive: VecDeque::new(), negative: VecDeque::new() }
+    }
+
+    fn push(&mut self, source: Hash, delta: SignedWork) {
+        if delta >= SignedWork::zero() {
+            self.positive.push_back((source, delta));
+        } else {
+            self.negative.push_back((source, delta));
+        }
     }
 }
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -136,7 +136,7 @@ impl CascadeMaintainer {
         self.cascade_score() >= SignedWork::zero()
     }
 
-    /// finds the first chain ancestor of the merging block, that is less than k^4 blue score away from it
+    /// finds the first chain ancestor of the merging block, that is more than k^4 blue score away from it
     fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(
         &mut self,
         merging_block: Hash,
@@ -147,8 +147,13 @@ impl CascadeMaintainer {
         let max_depth = u64::from(self.k).pow(4);
         let mut bound = self.depth_limit_ancestor;
 
-        while merging_blue_score.saturating_sub(coloring_reader.get_coloring_data(bound).blue_score) > max_depth {
-            bound = reachability.get_next_chain_ancestor(merging_block, bound);
+        while bound != merging_block {
+            let next_bound = reachability.get_next_chain_ancestor(merging_block, bound);
+            let next_distance = merging_blue_score.saturating_sub(coloring_reader.get_coloring_data(next_bound).blue_score);
+            if next_distance < max_depth {
+                break;
+            }
+            bound = next_bound;
         }
 
         self.depth_limit_ancestor = bound;
@@ -305,6 +310,11 @@ impl CascadeMaintainer {
         }
     }
 
+    /// The depth restriction bounds the number of negative flips processed here.
+    /// The blue future of the bound contains at most `k^4 + k^2` blocks (the
+    /// selected-chain interval up to the merger and its mergeset blues), while
+    /// the blue anticone of the bound contributes at most another `k^2` blocks.
+    /// Hence at most `(k^4 + k^2) + k^2` negative flips are processed.
     fn process_negative_crossings(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
         debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -738,22 +738,24 @@ impl<O: HeaderStoreReader + 'static, E: UmcCascadeStore + Clone + 'static, R: Re
 mod checkpoint_tests {
     use super::*;
     use crate::model::services::reachability::MTReachabilityService;
-    use crate::model::stores::reachability::{MemoryReachabilityStore, ReachabilityStore};
+    use crate::model::stores::reachability::MemoryReachabilityStore;
     use crate::processes::dagknight::umc_cascade_persistence::{MemoryUmcCascadeStore, UmcCascadeKey, UmcCascadeStoreReader};
     use crate::processes::dagknight::umc_voting::test_fixtures::{MemoryColoringReader, make_gd};
-    use crate::processes::reachability::interval::Interval;
+    use crate::processes::reachability::inquirer;
     use kaspa_consensus_core::blockhash::ORIGIN;
 
     fn make_reachability()
     -> (MTReachabilityService<MemoryReachabilityStore>, std::sync::Arc<parking_lot::RwLock<MemoryReachabilityStore>>) {
-        let store = MemoryReachabilityStore::new();
+        let mut store = MemoryReachabilityStore::new();
+        inquirer::init(&mut store).unwrap();
         let arc = std::sync::Arc::new(parking_lot::RwLock::new(store));
         (MTReachabilityService::new(arc.clone()), arc)
     }
 
-    fn reach_insert(arc: &std::sync::Arc<parking_lot::RwLock<MemoryReachabilityStore>>, hash: Hash, parent: Hash, height: u64) {
+    fn reach_insert(arc: &std::sync::Arc<parking_lot::RwLock<MemoryReachabilityStore>>, hash: Hash, parent: Hash) {
         let mut store = arc.write();
-        store.insert(hash, parent, Interval::new(height, height), height).unwrap();
+        // Maintain nested intervals and child links required by ancestry queries.
+        inquirer::add_block(&mut *store, hash, parent, &mut std::iter::empty()).unwrap();
     }
 
     fn work() -> BlueWorkType {
@@ -772,11 +774,11 @@ mod checkpoint_tests {
     fn test_checkpoint_reload_produces_identical_result() {
         // Build a simple DAG: 1→2→3→4→5, conflict genesis at 3
         let (reachability, arc) = make_reachability();
-        reach_insert(&arc, Hash::from_u64_word(1), Hash::from_u64_word(0), 1);
-        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1), 2);
-        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(2), 3);
-        reach_insert(&arc, Hash::from_u64_word(4), Hash::from_u64_word(3), 4);
-        reach_insert(&arc, Hash::from_u64_word(5), Hash::from_u64_word(4), 5);
+        reach_insert(&arc, Hash::from_u64_word(1), ORIGIN);
+        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1));
+        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(2));
+        reach_insert(&arc, Hash::from_u64_word(4), Hash::from_u64_word(3));
+        reach_insert(&arc, Hash::from_u64_word(5), Hash::from_u64_word(4));
 
         let store = Arc::new(MemoryUmcCascadeStore::new());
         let cg = BlockWithWork::new(Hash::from_u64_word(3), work());
@@ -838,10 +840,10 @@ mod checkpoint_tests {
     fn test_checkpoint_with_grays_filtered() {
         // Test that gray filtering works correctly with checkpoint reload
         let (reachability, arc) = make_reachability();
-        reach_insert(&arc, Hash::from_u64_word(1), Hash::from_u64_word(0), 1);
-        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1), 2);
-        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(2), 3);
-        reach_insert(&arc, Hash::from_u64_word(4), Hash::from_u64_word(3), 4);
+        reach_insert(&arc, Hash::from_u64_word(1), ORIGIN);
+        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1));
+        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(2));
+        reach_insert(&arc, Hash::from_u64_word(4), Hash::from_u64_word(3));
 
         let store = Arc::new(MemoryUmcCascadeStore::new());
         let cg = BlockWithWork::new(Hash::from_u64_word(2), work());
@@ -896,9 +898,9 @@ mod checkpoint_tests {
     fn test_checkpoint_different_nca_different_key() {
         // Test that different NCA produces different checkpoint key
         let (reachability, arc) = make_reachability();
-        reach_insert(&arc, Hash::from_u64_word(1), ORIGIN, 1);
-        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1), 2);
-        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(1), 3);
+        reach_insert(&arc, Hash::from_u64_word(1), ORIGIN);
+        reach_insert(&arc, Hash::from_u64_word(2), Hash::from_u64_word(1));
+        reach_insert(&arc, Hash::from_u64_word(3), Hash::from_u64_word(1));
 
         let store = Arc::new(MemoryUmcCascadeStore::new());
         let cg = BlockWithWork::new(Hash::from_u64_word(1), work());

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -358,14 +358,11 @@ impl CascadeMaintainer {
     /// and save it to the persistence store
     pub fn save_state(
         &mut self,
-        conflict_genesis: Hash,
-        k: KType,
-        chain_block: Hash,
+        key: UmcCascadeKey,
         voting_blocks: u64,
         cascade_store: Arc<dyn UmcCascadeStore>,
     ) -> Result<(), StoreError> {
         let persisted_state = self.to_persisted_state(voting_blocks);
-        let key = UmcCascadeKey::new(conflict_genesis, k, self.next_chain_ancestor, chain_block);
         cascade_store.insert_checkpoint(key, persisted_state)
     }
 }
@@ -452,12 +449,14 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
 
     // Process remaining mergesets (pop from bottom = CG-first, upward)
     while let Some(mergeset) = mergeset_stack.pop() {
-        let chain_block = mergeset.merging_chain_block;
+        let checkpoint_key = (!mergeset_stack.is_empty()).then(|| {
+            UmcCascadeKey::new(conflict_genesis.hash, k, next_chain_ancestor, mergeset.checkpoint_hash())
+        });
         voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
 
         // Checkpoint at chain block — persist to store (best-effort)
-        if let Some(chain_block) = chain_block {
-            let _ = maintainer.save_state(conflict_genesis.hash, k, chain_block, voting_blocks, cascade_store.clone());
+        if let Some(checkpoint_key) = checkpoint_key {
+            let _ = maintainer.save_state(checkpoint_key, voting_blocks, cascade_store.clone());
         }
     }
 
@@ -485,12 +484,12 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     reachability: &impl ReachabilityService,
     coloring_reader: &C,
 ) -> u64 {
-    // The virtual mergeset has no concrete merging-block hash. It is processed
-    // immediately after its selected parent's mergeset, so the bound already
-    // reflects the latest concrete chain block.
-    if let Some(merging_block) = mergeset.merging_chain_block {
-        maintainer.update_depth_limit_ancestor(merging_block, coloring_reader, reachability);
-    }
+    let selected_parent = mergeset.selected_parent;
+    let merger_blue_score = coloring_reader.get_coloring_data(selected_parent).blue_score + mergeset.mergeset_blues.len() as u64;
+
+    // For the virtual mergeset, the bound uses the virtual blue score and its
+    // concrete selected parent as the chain endpoint.
+    maintainer.update_depth_limit_ancestor(selected_parent, merger_blue_score, coloring_reader, reachability);
 
     let mut events = CascadeEvents::new();
     let mut voting_blocks = 0u64;
@@ -557,34 +556,46 @@ impl<O: HeaderStoreReader + 'static, E: UmcCascadeStore + Clone + 'static, R: Re
         // Collect blues and reds by traversing virtual GD chain backward.
         // Build mergesets into a stack: Virtual first, then ChainN, ..., Chain1, CG last.
         let mut mergeset_stack: Vec<Mergeset> = Vec::new();
-        let mut merging_chain_block: Option<Hash> = None;
+        let mut checkpoint_merger_gd = None;
         let mut checkpoint_state: Option<UmcCascadePersistedState> = None;
 
         let virtual_blue_score = virtual_gd.blue_score;
         let mut curr_gd = Arc::new(virtual_gd.clone());
-
-        while merging_chain_block.is_none() || merging_chain_block.unwrap() != conflict_genesis {
+        loop {
+            let selected_parent = curr_gd.selected_parent;
             let blues: Vec<(Hash, BlueWorkType)> =
                 curr_gd.mergeset_blues.iter().map(|&h| (h, calc_work(self.headers_store.get_bits(h).unwrap()))).collect();
 
             let reds: Vec<(Hash, BlueWorkType)> =
                 curr_gd.mergeset_reds.iter().map(|&h| (h, calc_work(self.headers_store.get_bits(h).unwrap()))).collect();
 
-            mergeset_stack.push(Mergeset { merging_chain_block, mergeset_blues: blues, mergeset_reds: reds });
+            mergeset_stack.push(Mergeset { selected_parent, mergeset_blues: blues, mergeset_reds: reds });
 
-            merging_chain_block = Some(curr_gd.selected_parent);
-            curr_gd = coloring_reader.get_coloring_data(curr_gd.selected_parent);
-
+            let candidate_merger_gd = coloring_reader.get_coloring_data(selected_parent);
+            let state_key = UmcCascadeKey::new(
+                conflict_genesis,
+                k,
+                next_chain_ancestor_of_subgroup,
+                Mergeset::checkpoint_hash_from_hashes(
+                    candidate_merger_gd.selected_parent,
+                    candidate_merger_gd.mergeset_blues.iter().copied(),
+                    candidate_merger_gd.mergeset_reds.iter().copied(),
+                ),
+            );
             // Check if a checkpoint exists for the next chain block.
             // If found, break — run_cascade will reload from that state and skip
             // already-computed mergesets.
-            if let Some(cb) = merging_chain_block {
-                let state_key = UmcCascadeKey::new(conflict_genesis, k, next_chain_ancestor_of_subgroup, cb);
-                if let Ok(Some(existing_state)) = self.umc_persistence_store.get_checkpoint(state_key) {
-                    checkpoint_state = Some(existing_state);
-                    break;
-                }
+            if let Ok(Some(existing_state)) = self.umc_persistence_store.get_checkpoint(state_key) {
+                checkpoint_merger_gd = Some(candidate_merger_gd);
+                checkpoint_state = Some(existing_state);
+                break;
             }
+
+            if selected_parent == conflict_genesis {
+                break;
+            }
+
+            curr_gd = coloring_reader.get_coloring_data(selected_parent);
         }
 
         let from_checkpoint = checkpoint_state.is_some();
@@ -592,9 +603,7 @@ impl<O: HeaderStoreReader + 'static, E: UmcCascadeStore + Clone + 'static, R: Re
         let estimated_effort_saved = if from_checkpoint {
             // Estimate effort saved: virtual_blue_score - checkpoint_block.blue_score
             // This represents the blue blocks we didn't need to visit.
-            let checkpoint_block = merging_chain_block.unwrap();
-            let checkpoint_gd = coloring_reader.get_coloring_data(checkpoint_block);
-            checkpoint_gd.blue_score
+            checkpoint_merger_gd.expect("checkpoint state must have merger GHOSTDAG data").blue_score
         } else {
             0
         };

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -676,25 +676,33 @@ mod checkpoint_tests {
         let cg = BlockWithWork::new(Hash::from_u64_word(3), work());
         let k: KType = 0;
         let nca = Hash::from_u64_word(2);
-        let coloring_reader = coloring_reader(&[(3, 2, 3), (4, 3, 4)]);
+        let mut coloring_reader = coloring_reader(&[(3, 2, 3), (4, 3, 4)]);
+        coloring_reader.add(
+            Hash::from_u64_word(4),
+            make_gd(Hash::from_u64_word(3), vec![Hash::from_u64_word(4)], vec![], 4),
+        );
 
         // Stack: Virtual → Chain4 → CG
         let stack: Vec<Mergeset> = vec![
-            Mergeset { merging_chain_block: None, mergeset_blues: vec![(Hash::from_u64_word(5), work())], mergeset_reds: vec![] },
             Mergeset {
-                merging_chain_block: Some(Hash::from_u64_word(4)),
+                selected_parent: Hash::from_u64_word(4),
+                mergeset_blues: vec![(Hash::from_u64_word(5), work())],
+                mergeset_reds: vec![],
+            },
+            Mergeset {
+                selected_parent: Hash::from_u64_word(3),
                 mergeset_blues: vec![(Hash::from_u64_word(4), work())],
                 mergeset_reds: vec![],
             },
         ];
 
         // First run — from scratch
-        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0, &coloring_reader);
+        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 5, &coloring_reader);
         assert!(!result1.from_checkpoint);
         assert_eq!(result1.estimated_effort_saved, 0);
 
         // Second run — same zone, but the caller loads the checkpoint saved by the first run
-        let checkpoint_key = UmcCascadeKey::new(cg.hash, k, nca, Hash::from_u64_word(4));
+        let checkpoint_key = UmcCascadeKey::new(cg.hash, k, nca, stack[1].checkpoint_hash());
         let checkpoint_state = store.get_checkpoint(checkpoint_key).unwrap();
         assert!(checkpoint_state.is_some(), "checkpoint should have been saved");
 
@@ -736,22 +744,30 @@ mod checkpoint_tests {
         let cg = BlockWithWork::new(Hash::from_u64_word(2), work());
         let k: KType = 0;
         let nca = Hash::from_u64_word(1);
-        let coloring_reader = coloring_reader(&[(2, 1, 2), (3, 2, 3)]);
+        let mut coloring_reader = coloring_reader(&[(2, 1, 2), (3, 2, 3)]);
+        coloring_reader.add(
+            Hash::from_u64_word(3),
+            make_gd(Hash::from_u64_word(2), vec![Hash::from_u64_word(3)], vec![Hash::from_u64_word(1)], 3),
+        );
 
         // Stack with gray block
         let stack: Vec<Mergeset> = vec![
-            Mergeset { merging_chain_block: None, mergeset_blues: vec![(Hash::from_u64_word(4), work())], mergeset_reds: vec![] },
             Mergeset {
-                merging_chain_block: Some(Hash::from_u64_word(3)),
+                selected_parent: Hash::from_u64_word(3),
+                mergeset_blues: vec![(Hash::from_u64_word(4), work())],
+                mergeset_reds: vec![],
+            },
+            Mergeset {
+                selected_parent: Hash::from_u64_word(2),
                 mergeset_blues: vec![(Hash::from_u64_word(3), work())],
                 mergeset_reds: vec![(Hash::from_u64_word(1), work())], // Gray: it is the next chain ancestor
             },
         ];
 
-        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0, &coloring_reader);
+        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 4, &coloring_reader);
 
         // Reload from checkpoint
-        let checkpoint_key = UmcCascadeKey::new(cg.hash, k, nca, Hash::from_u64_word(3));
+        let checkpoint_key = UmcCascadeKey::new(cg.hash, k, nca, stack[1].checkpoint_hash());
         let checkpoint_state = store.get_checkpoint(checkpoint_key).unwrap();
         assert!(checkpoint_state.is_some());
 
@@ -784,37 +800,45 @@ mod checkpoint_tests {
         let store = Arc::new(MemoryUmcCascadeStore::new());
         let cg = BlockWithWork::new(Hash::from_u64_word(1), work());
         let k: KType = 0;
-        let coloring_reader = coloring_reader(&[(1, 0, 1), (2, 1, 2), (3, 1, 2)]);
+        let mut coloring_reader = coloring_reader(&[(1, 0, 1), (2, 1, 2), (3, 1, 2)]);
+        coloring_reader.add(
+            Hash::from_u64_word(2),
+            make_gd(Hash::from_u64_word(1), vec![Hash::from_u64_word(2)], vec![Hash::from_u64_word(3)], 2),
+        );
+        coloring_reader.add(
+            Hash::from_u64_word(3),
+            make_gd(Hash::from_u64_word(1), vec![Hash::from_u64_word(3)], vec![Hash::from_u64_word(2)], 2),
+        );
 
         // First subgroup: NCA = 2
         let nca_1 = Hash::from_u64_word(2);
         let stack_1: Vec<Mergeset> = vec![
-            Mergeset { merging_chain_block: None, mergeset_blues: vec![], mergeset_reds: vec![] },
+            Mergeset { selected_parent: Hash::from_u64_word(2), mergeset_blues: vec![], mergeset_reds: vec![] },
             Mergeset {
-                merging_chain_block: Some(Hash::from_u64_word(2)),
+                selected_parent: Hash::from_u64_word(1),
                 mergeset_blues: vec![(Hash::from_u64_word(2), work())],
                 mergeset_reds: vec![(Hash::from_u64_word(3), work())],
             },
         ];
 
-        let _result1 = run_cascade(stack_1, cg, k, nca_1, &reachability, store.clone(), None, 0, 0, &coloring_reader);
+        let _result1 = run_cascade(stack_1.clone(), cg, k, nca_1, &reachability, store.clone(), None, 0, 2, &coloring_reader);
 
         // Second subgroup: NCA = 3 (different key, should not reuse checkpoint)
         let nca_2 = Hash::from_u64_word(3);
         let stack_2: Vec<Mergeset> = vec![
-            Mergeset { merging_chain_block: None, mergeset_blues: vec![], mergeset_reds: vec![] },
+            Mergeset { selected_parent: Hash::from_u64_word(3), mergeset_blues: vec![], mergeset_reds: vec![] },
             Mergeset {
-                merging_chain_block: Some(Hash::from_u64_word(3)),
+                selected_parent: Hash::from_u64_word(1),
                 mergeset_blues: vec![(Hash::from_u64_word(3), work())],
                 mergeset_reds: vec![(Hash::from_u64_word(2), work())],
             },
         ];
 
-        let _result2 = run_cascade(stack_2, cg, k, nca_2, &reachability, store.clone(), None, 0, 0, &coloring_reader);
+        let _result2 = run_cascade(stack_2.clone(), cg, k, nca_2, &reachability, store.clone(), None, 0, 2, &coloring_reader);
 
         // Verify both checkpoints exist with different keys
-        let key_1 = UmcCascadeKey::new(cg.hash, k, nca_1, Hash::from_u64_word(2));
-        let key_2 = UmcCascadeKey::new(cg.hash, k, nca_2, Hash::from_u64_word(3));
+        let key_1 = UmcCascadeKey::new(cg.hash, k, nca_1, stack_1[1].checkpoint_hash());
+        let key_2 = UmcCascadeKey::new(cg.hash, k, nca_2, stack_2[1].checkpoint_hash());
 
         assert!(store.get_checkpoint(key_1).unwrap().is_some(), "checkpoint for NCA1 should exist");
         assert!(store.get_checkpoint(key_2).unwrap().is_some(), "checkpoint for NCA2 should exist");

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
+use std::{ops::Range, sync::Arc};
 
 use kaspa_consensus_core::{BlueWorkType, KType};
 use kaspa_core::debug;
@@ -181,9 +181,7 @@ impl CascadeMaintainer {
             blue_blocks.extend(mergeset.mergeset_blues.iter().map(|&(hash, work)| BlockWithWork::new(hash, work)));
         }
 
-        while let Some((source, delta)) = inverse_events.pop_front() {
-            self.apply_event(source, delta, reachability);
-        }
+        self.apply_events_batch(inverse_events, reachability);
 
         for block in blue_blocks.into_iter().rev() {
             let chain_id = *self.blk_mapping_to_chains.get(&block.hash).expect("blue block is not present");
@@ -382,9 +380,11 @@ impl CascadeMaintainer {
         // These are the direct effects of all reds in the current mergeset. They
         // are inherent to the mergeset, so apply every one before examining any
         // consequent negative crossing.
-        while let Some((source, delta)) = events.pop_negative() {
-            self.apply_event(source, delta, reachability);
+        let mut direct_events = Vec::new();
+        while let Some(event) = events.pop_negative() {
+            direct_events.push(event);
         }
+        self.apply_events_batch(direct_events, reachability);
     }
 
     /// The depth restriction bounds the number of negative flips processed here.
@@ -418,9 +418,11 @@ impl CascadeMaintainer {
 
             // Every queued event belongs to a flip already committed in this
             // round, so propagate the complete batch before checking again.
-            while let Some((source, delta)) = events.pop_negative() {
-                self.apply_event(source, delta, reachability);
+            let mut crossing_events = Vec::new();
+            while let Some(event) = events.pop_negative() {
+                crossing_events.push(event);
             }
+            self.apply_events_batch(crossing_events, reachability);
         }
     }
 
@@ -429,6 +431,23 @@ impl CascadeMaintainer {
             if let Some(ancestor_index) = strict_ancestor_index(chain, source, reachability) {
                 tree.prefix_add(ancestor_index, delta);
             }
+        }
+    }
+
+    fn apply_events_batch<I>(&mut self, events: I, reachability: &impl ReachabilityService)
+    where
+        I: IntoIterator<Item = (Hash, SignedWork)>,
+    {
+        let mut updates: Vec<Vec<(Range<usize>, SignedWork)>> = (0..self.chains_score_trees.len()).map(|_| Vec::new()).collect();
+        for (source, delta) in events {
+            for (chain_id, chain) in self.blues_chains_decomposition.iter().enumerate() {
+                if let Some(ancestor_index) = strict_ancestor_index(chain, source, reachability) {
+                    updates[chain_id].push((0..ancestor_index, delta));
+                }
+            }
+        }
+        for (tree, chain_updates) in self.chains_score_trees.iter_mut().zip(updates) {
+            tree.range_add_batch(&chain_updates);
         }
     }
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -12,7 +12,7 @@ use crate::model::services::reachability::{MTReachabilityService, ReachabilitySe
 use crate::model::stores::headers::HeaderStoreReader;
 use crate::model::stores::reachability::ReachabilityStoreReader;
 use crate::processes::dagknight::umc_cascade_persistence::{
-    ChainLeafEntry, Mergeset, UmcCascadeKey, UmcCascadePersistedState, UmcCascadeStore,
+    CascadeEvent, ChainLeafEntry, Mergeset, MergesetEvents, UmcCascadeKey, UmcCascadePersistedState, UmcCascadeStore,
 };
 use crate::processes::dagknight::umc_voting::{CascadeResult, ColoringReader, SignedWork, UmcVoter, UmcVotingContext};
 use crate::processes::dagknight::{AppendableSegmentTree, Bucket, bucket_for_score};
@@ -63,11 +63,12 @@ fn work_delta(work: BlueWorkType, bucket: Bucket) -> SignedWork {
 struct CascadeEvents {
     positive: VecDeque<(Hash, SignedWork)>,
     negative: VecDeque<(Hash, SignedWork)>,
+    processed: Vec<CascadeEvent>,
 }
 
 impl CascadeEvents {
     fn new() -> Self {
-        Self { positive: VecDeque::new(), negative: VecDeque::new() }
+        Self { positive: VecDeque::new(), negative: VecDeque::new(), processed: Vec::new() }
     }
 
     fn push(&mut self, source: Hash, delta: SignedWork) {
@@ -76,6 +77,30 @@ impl CascadeEvents {
         } else {
             self.negative.push_back((source, delta));
         }
+    }
+
+    fn pop_positive(&mut self) -> Option<(Hash, SignedWork)> {
+        let event = self.positive.pop_front();
+        if let Some((source, delta)) = event {
+            self.record(source, delta);
+            Some((source, delta))
+        } else {
+            None
+        }
+    }
+
+    fn pop_negative(&mut self) -> Option<(Hash, SignedWork)> {
+        let event = self.negative.pop_front();
+        if let Some((source, delta)) = event {
+            self.record(source, delta);
+            Some((source, delta))
+        } else {
+            None
+        }
+    }
+
+    fn record(&mut self, source: Hash, delta: SignedWork) {
+        self.processed.push(CascadeEvent { source, delta_abs: delta.abs(), delta_negative: delta.negative() });
     }
 }
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -152,6 +152,16 @@ impl CascadeMaintainer {
         }
     }
 
+    fn violates_depth_restriction(&mut self, reachability: &impl ReachabilityService) -> bool {
+        for (chain, tree) in self.blues_chains_decomposition.iter().zip(self.chains_score_trees.iter_mut()) {
+            let prefix_length = strict_ancestor_index(chain, self.depth_limit_ancestor, reachability).unwrap_or(0);
+            if tree.has_negative_score_in_prefix(prefix_length) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Returns the total number of bucket flips observed during cascade stabilization.
     pub fn flip_count(&self) -> u64 {
         self.flip_count
@@ -294,17 +304,16 @@ impl CascadeMaintainer {
         debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
 
         loop {
+            if self.violates_depth_restriction(reachability) {
+                return;
+            }
+
             while let Some((chain_id, block)) = self
                 .chains_score_trees
                 .iter()
                 .enumerate()
                 .find_map(|(chain_id, tree)| tree.extract_positive_below_zero().map(|block| (chain_id, block)))
             {
-                // TODO: stop before processing this crossing when it is in the forbidden zone.
-                let crossing_is_allowed = true;
-                if !crossing_is_allowed {
-                    return;
-                }
                 self.chains_score_trees[chain_id].flip_to_negative(block);
                 self.negative_blue_work = self.negative_blue_work + block.work;
                 self.flip_count += 1;
@@ -439,7 +448,7 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     }
 
     let cascade_score = maintainer.cascade_score();
-    let accepted = maintainer.virtual_accepts();
+    let accepted = !maintainer.violates_depth_restriction(reachability) && maintainer.virtual_accepts();
 
     CascadeResult {
         cascade_score,

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -100,7 +100,7 @@ impl CascadeMaintainer {
     }
 
     /// Returns the aggregate score of the virtual block.
-    pub fn virtual_score(&self) -> SignedWork {
+    pub fn cascade_score(&self) -> SignedWork {
         SignedWork::from(self.blue_work) + SignedWork::from(self.deficit_work)
             - SignedWork::from(self.red_work)
             - SignedWork::from(self.negative_blue_work * 2)
@@ -108,7 +108,7 @@ impl CascadeMaintainer {
 
     /// Check if the virtual block's aggregate cascade score is non-negative.
     pub fn virtual_accepts(&self) -> bool {
-        self.virtual_score() >= SignedWork::zero()
+        self.cascade_score() >= SignedWork::zero()
     }
 
     /// Returns the total number of bucket flips observed during cascade stabilization.
@@ -384,11 +384,11 @@ pub fn run_cascade(
         }
     }
 
-    let virtual_score = maintainer.virtual_score();
-    let accepted = virtual_score >= SignedWork::zero();
+    let cascade_score = maintainer.cascade_score();
+    let accepted = cascade_score >= SignedWork::zero();
 
     CascadeResult {
-        virtual_score,
+        cascade_score,
         accepted,
         flips: maintainer.flip_count,
         voting_blocks,
@@ -585,7 +585,7 @@ mod checkpoint_tests {
 
         // Both should produce identical cascade results
         assert_eq!(result1.accepted, result2.accepted, "accepted mismatch");
-        assert_eq!(result1.virtual_score, result2.virtual_score, "virtual score mismatch");
+        assert_eq!(result1.cascade_score, result2.cascade_score, "cascade score mismatch");
         assert_eq!(result1.flips, result2.flips, "flips mismatch");
     }
 
@@ -633,7 +633,7 @@ mod checkpoint_tests {
         );
 
         assert_eq!(result1.accepted, result2.accepted);
-        assert_eq!(result1.virtual_score, result2.virtual_score);
+        assert_eq!(result1.cascade_score, result2.cascade_score);
         assert!(result2.from_checkpoint);
     }
 
@@ -703,7 +703,7 @@ mod voter_tests {
 
         let result = voter.vote(&ctx);
 
-        assert_eq!(result.virtual_score, fixture.expected_score(), "virtual score mismatch");
+        assert_eq!(result.cascade_score, fixture.expected_score(), "cascade score mismatch");
         assert!(result.accepted, "zone should be accepted");
         assert_eq!(result.voting_blocks, 16, "blues 11, 10, 9, 7, 6, 5, 4, 3, 2 + CG + reds 12..17 (gray red 8 excluded)");
         assert_eq!(result.flips, 0, "segment tree cascade has no flips on this zone");
@@ -726,7 +726,7 @@ mod voter_tests {
         assert!(result2.from_checkpoint, "second vote must reload the persisted checkpoint");
 
         // The cascade outcome must be identical regardless of the checkpoint
-        assert_eq!(result1.virtual_score, result2.virtual_score, "virtual score mismatch");
+        assert_eq!(result1.cascade_score, result2.cascade_score, "cascade score mismatch");
         assert_eq!(result1.accepted, result2.accepted, "accepted mismatch");
         assert_eq!(result1.flips, result2.flips, "flips mismatch");
         assert_eq!(result1.voting_blocks, result2.voting_blocks, "voting blocks mismatch");

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -34,6 +34,7 @@ pub struct CascadeMaintainer {
     negative_blue_work: BlueWorkType,
     /// Total bucket flips observed during cascade stabilization
     flip_count: u64,
+    next_chain_ancestor: Hash,
 }
 
 /// A block identifier paired with that block's own proof-of-work contribution.
@@ -78,7 +79,7 @@ impl CascadeEvents {
 
 impl CascadeMaintainer {
     /// Initializes the cascade with `floor(sqrt(k))` conflict-genesis work as its voting deficit.
-    pub fn new(conflict_genesis: BlockWithWork, k: KType) -> Self {
+    pub fn new(conflict_genesis: BlockWithWork, k: KType, next_chain_ancestor: Hash) -> Self {
         let deficit_work = conflict_genesis.work * u64::from(k.isqrt());
         Self {
             blues_chains_decomposition: Vec::new(),
@@ -89,6 +90,7 @@ impl CascadeMaintainer {
             red_work: BlueWorkType::ZERO,
             negative_blue_work: BlueWorkType::ZERO,
             flip_count: 0,
+            next_chain_ancestor,
         }
     }
 
@@ -173,8 +175,13 @@ impl CascadeMaintainer {
     }
 
     /// Restore cascade state from a persisted checkpoint.
-    pub fn from_persisted_state(persisted: &UmcCascadePersistedState, conflict_genesis: BlockWithWork, k: KType) -> Self {
-        let mut maintainer = Self::new(conflict_genesis, k);
+    pub fn from_persisted_state(
+        persisted: &UmcCascadePersistedState,
+        conflict_genesis: BlockWithWork,
+        k: KType,
+        next_chain_ancestor: Hash,
+    ) -> Self {
+        let mut maintainer = Self::new(conflict_genesis, k, next_chain_ancestor);
 
         // Override counters from persisted state
         maintainer.deficit_work = persisted.deficit_work;
@@ -308,13 +315,12 @@ impl CascadeMaintainer {
         &mut self,
         conflict_genesis: Hash,
         k: KType,
-        next_chain_ancestor: Hash,
         chain_block: Hash,
         voting_blocks: u64,
         cascade_store: Arc<dyn UmcCascadeStore>,
     ) -> Result<(), StoreError> {
         let persisted_state = self.to_persisted_state(voting_blocks);
-        let key = UmcCascadeKey::new(conflict_genesis, k, next_chain_ancestor, chain_block);
+        let key = UmcCascadeKey::new(conflict_genesis, k, self.next_chain_ancestor, chain_block);
         cascade_store.insert_checkpoint(key, persisted_state)
     }
 }
@@ -393,25 +399,19 @@ pub fn run_cascade(
     // Restore from checkpoint or start fresh
     let mut maintainer = if let Some(persisted) = checkpoint_state {
         voting_blocks = persisted.voting_blocks;
-        CascadeMaintainer::from_persisted_state(&persisted, conflict_genesis, k)
+        CascadeMaintainer::from_persisted_state(&persisted, conflict_genesis, k, next_chain_ancestor)
     } else {
-        CascadeMaintainer::new(conflict_genesis, k)
+        CascadeMaintainer::new(conflict_genesis, k, next_chain_ancestor)
     };
+
     // Process remaining mergesets (pop from bottom = CG-first, upward)
     while let Some(mergeset) = mergeset_stack.pop() {
         let chain_block = mergeset.merging_chain_block;
-        voting_blocks += process_mergeset(&mut maintainer, mergeset, next_chain_ancestor, reachability);
+        voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability);
 
         // Checkpoint at chain block — persist to store (best-effort)
         if let Some(chain_block) = chain_block {
-            let _ = maintainer.save_state(
-                conflict_genesis.hash,
-                k,
-                next_chain_ancestor,
-                chain_block,
-                voting_blocks,
-                cascade_store.clone(),
-            );
+            let _ = maintainer.save_state(conflict_genesis.hash, k, chain_block, voting_blocks, cascade_store.clone());
         }
     }
 
@@ -433,12 +433,7 @@ pub fn run_cascade(
 ///
 /// Blue effects are fully stabilized first. All direct red effects are then
 /// applied, followed by the negative event cascade, until stoppage
-fn process_mergeset(
-    maintainer: &mut CascadeMaintainer,
-    mergeset: Mergeset,
-    next_chain_ancestor: Hash,
-    reachability: &impl ReachabilityService,
-) -> u64 {
+fn process_mergeset(maintainer: &mut CascadeMaintainer, mergeset: Mergeset, reachability: &impl ReachabilityService) -> u64 {
     let mut events = CascadeEvents::new();
     let mut voting_blocks = 0u64;
 
@@ -449,7 +444,7 @@ fn process_mergeset(
     maintainer.process_positive_events(reachability, &mut events);
 
     for (hash, work) in mergeset.mergeset_reds {
-        if !reachability.is_chain_ancestor_of(next_chain_ancestor, hash) {
+        if !reachability.is_chain_ancestor_of(maintainer.next_chain_ancestor, hash) {
             maintainer.add_red(BlockWithWork::new(hash, work), &mut events);
             voting_blocks += 1;
         }

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -395,18 +395,21 @@ impl CascadeMaintainer {
     /// intentionally does not use the range-update batching optimization, 
     /// which provides de facto speedup, but is hard to analyze.
     fn process_positive_events(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        while let Some((source, delta)) = events.pop_positive() {
-            self.apply_event(source, delta, reachability);
-            while let Some((chain_id, block)) = self
-                .chains_score_trees
-                .iter()
-                .enumerate()
-                .find_map(|(chain_id, tree)| tree.extract_negative_at_least_zero().map(|block| (chain_id, block)))
-            {
-                self.chains_score_trees[chain_id].flip_to_positive(block);
-                self.negative_blue_work = self.negative_blue_work - block.work;
-                self.flip_count += 1;
-                events.push(block.hash, work_delta(block.work * 2u64, Bucket::Positive));
+        while !events.positive.is_empty() {
+            let mut positive_events = Vec::new();
+            while let Some(event) = events.pop_positive() {
+                positive_events.push(event);
+            }
+            self.apply_events_batch(positive_events, reachability);
+
+            for chain_id in 0..self.chains_score_trees.len() {
+                let crossing_blocks = self.chains_score_trees[chain_id].extract_negative_at_least_zero_batch();
+                for block in crossing_blocks {
+                    self.chains_score_trees[chain_id].flip_to_positive(block);
+                    self.negative_blue_work = self.negative_blue_work - block.work;
+                    self.flip_count += 1;
+                    events.push(block.hash, work_delta(block.work * 2u64, Bucket::Positive));
+                }
             }
         }
     }
@@ -437,16 +440,14 @@ impl CascadeMaintainer {
                 return;
             }
 
-            while let Some((chain_id, block)) = self
-                .chains_score_trees
-                .iter()
-                .enumerate()
-                .find_map(|(chain_id, tree)| tree.extract_positive_below_zero().map(|block| (chain_id, block)))
-            {
-                self.chains_score_trees[chain_id].flip_to_negative(block);
-                self.negative_blue_work = self.negative_blue_work + block.work;
-                self.flip_count += 1;
-                events.push(block.hash, work_delta(block.work * 2u64, Bucket::Negative));
+            for chain_id in 0..self.chains_score_trees.len() {
+                let crossing_blocks = self.chains_score_trees[chain_id].extract_positive_below_zero_batch();
+                for block in crossing_blocks {
+                    self.chains_score_trees[chain_id].flip_to_negative(block);
+                    self.negative_blue_work = self.negative_blue_work + block.work;
+                    self.flip_count += 1;
+                    events.push(block.hash, work_delta(block.work * 2u64, Bucket::Negative));
+                }
             }
 
             if events.negative.is_empty() {
@@ -460,14 +461,6 @@ impl CascadeMaintainer {
                 crossing_events.push(event);
             }
             self.apply_events_batch(crossing_events, reachability);
-        }
-    }
-
-    fn apply_event(&mut self, source: Hash, delta: SignedWork, reachability: &impl ReachabilityService) {
-        for (chain, tree) in self.blues_chains_decomposition.iter().zip(self.chains_score_trees.iter_mut()) {
-            if let Some(ancestor_index) = strict_ancestor_index(chain, source, reachability) {
-                tree.prefix_add(ancestor_index, delta);
-            }
         }
     }
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -92,7 +92,7 @@ impl CascadeMaintainer {
             red_work: BlueWorkType::ZERO,
             negative_blue_work: BlueWorkType::ZERO,
             flip_count: 0,
-            bound_depth: u64::from(k).pow(4)+1,
+            bound_depth: u64::from(k).pow(4) + 1,
             depth_limit_ancestor: conflict_genesis.hash,
             next_chain_ancestor,
         }
@@ -449,9 +449,8 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
 
     // Process remaining mergesets (pop from bottom = CG-first, upward)
     while let Some(mergeset) = mergeset_stack.pop() {
-        let checkpoint_key = (!mergeset_stack.is_empty()).then(|| {
-            UmcCascadeKey::new(conflict_genesis.hash, k, next_chain_ancestor, mergeset.checkpoint_hash())
-        });
+        let checkpoint_key = (!mergeset_stack.is_empty())
+            .then(|| UmcCascadeKey::new(conflict_genesis.hash, k, next_chain_ancestor, mergeset.checkpoint_hash()));
         voting_blocks += process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
 
         // Checkpoint at chain block — persist to store (best-effort)
@@ -677,10 +676,7 @@ mod checkpoint_tests {
         let k: KType = 0;
         let nca = Hash::from_u64_word(2);
         let mut coloring_reader = coloring_reader(&[(3, 2, 3), (4, 3, 4)]);
-        coloring_reader.add(
-            Hash::from_u64_word(4),
-            make_gd(Hash::from_u64_word(3), vec![Hash::from_u64_word(4)], vec![], 4),
-        );
+        coloring_reader.add(Hash::from_u64_word(4), make_gd(Hash::from_u64_word(3), vec![Hash::from_u64_word(4)], vec![], 4));
 
         // Stack: Virtual → Chain4 → CG
         let stack: Vec<Mergeset> = vec![

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -611,6 +611,7 @@ mod checkpoint_tests {
     use crate::model::services::reachability::MTReachabilityService;
     use crate::model::stores::reachability::{MemoryReachabilityStore, ReachabilityStore};
     use crate::processes::dagknight::umc_cascade_persistence::{MemoryUmcCascadeStore, UmcCascadeKey, UmcCascadeStoreReader};
+    use crate::processes::dagknight::umc_voting::test_fixtures::{MemoryColoringReader, make_gd};
     use crate::processes::reachability::interval::Interval;
     use kaspa_consensus_core::blockhash::ORIGIN;
 
@@ -630,6 +631,14 @@ mod checkpoint_tests {
         BlueWorkType::from_u64(100)
     }
 
+    fn coloring_reader(entries: &[(u64, u64, u64)]) -> MemoryColoringReader {
+        let mut reader = MemoryColoringReader::default();
+        for &(hash, selected_parent, blue_score) in entries {
+            reader.add(Hash::from_u64_word(hash), make_gd(Hash::from_u64_word(selected_parent), vec![], vec![], blue_score));
+        }
+        reader
+    }
+
     #[test]
     fn test_checkpoint_reload_produces_identical_result() {
         // Build a simple DAG: 1→2→3→4→5, conflict genesis at 3
@@ -644,6 +653,7 @@ mod checkpoint_tests {
         let cg = BlockWithWork::new(Hash::from_u64_word(3), work());
         let k: KType = 0;
         let nca = Hash::from_u64_word(2);
+        let coloring_reader = coloring_reader(&[(3, 2, 3), (4, 3, 4)]);
 
         // Stack: Virtual → Chain4 → CG
         let stack: Vec<Mergeset> = vec![
@@ -656,7 +666,7 @@ mod checkpoint_tests {
         ];
 
         // First run — from scratch
-        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0);
+        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0, &coloring_reader);
         assert!(!result1.from_checkpoint);
         assert_eq!(result1.estimated_effort_saved, 0);
 
@@ -678,6 +688,7 @@ mod checkpoint_tests {
             checkpoint_state,
             1, // estimated_effort_saved estimate
             5, // estimated_effort_total
+            &coloring_reader,
         );
 
         assert!(result2.from_checkpoint);
@@ -702,6 +713,7 @@ mod checkpoint_tests {
         let cg = BlockWithWork::new(Hash::from_u64_word(2), work());
         let k: KType = 0;
         let nca = Hash::from_u64_word(1);
+        let coloring_reader = coloring_reader(&[(2, 1, 2), (3, 2, 3)]);
 
         // Stack with gray block
         let stack: Vec<Mergeset> = vec![
@@ -713,7 +725,7 @@ mod checkpoint_tests {
             },
         ];
 
-        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0);
+        let result1 = run_cascade(stack.clone(), cg, k, nca, &reachability, store.clone(), None, 0, 0, &coloring_reader);
 
         // Reload from checkpoint
         let checkpoint_key = UmcCascadeKey::new(cg.hash, k, nca, Hash::from_u64_word(3));
@@ -730,6 +742,7 @@ mod checkpoint_tests {
             checkpoint_state,
             1,
             4, // estimated_effort_total
+            &coloring_reader,
         );
 
         assert_eq!(result1.accepted, result2.accepted);
@@ -748,6 +761,7 @@ mod checkpoint_tests {
         let store = Arc::new(MemoryUmcCascadeStore::new());
         let cg = BlockWithWork::new(Hash::from_u64_word(1), work());
         let k: KType = 0;
+        let coloring_reader = coloring_reader(&[(1, 0, 1), (2, 1, 2), (3, 1, 2)]);
 
         // First subgroup: NCA = 2
         let nca_1 = Hash::from_u64_word(2);
@@ -760,7 +774,7 @@ mod checkpoint_tests {
             },
         ];
 
-        let _result1 = run_cascade(stack_1, cg, k, nca_1, &reachability, store.clone(), None, 0, 0);
+        let _result1 = run_cascade(stack_1, cg, k, nca_1, &reachability, store.clone(), None, 0, 0, &coloring_reader);
 
         // Second subgroup: NCA = 3 (different key, should not reuse checkpoint)
         let nca_2 = Hash::from_u64_word(3);
@@ -773,7 +787,7 @@ mod checkpoint_tests {
             },
         ];
 
-        let _result2 = run_cascade(stack_2, cg, k, nca_2, &reachability, store.clone(), None, 0, 0);
+        let _result2 = run_cascade(stack_2, cg, k, nca_2, &reachability, store.clone(), None, 0, 0, &coloring_reader);
 
         // Verify both checkpoints exist with different keys
         let key_1 = UmcCascadeKey::new(cg.hash, k, nca_1, Hash::from_u64_word(2));

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -92,8 +92,8 @@ impl CascadeMaintainer {
         }
     }
 
-    /// Insert a new blue block into the chain decomposition and stabilize cascade.
-    pub fn add_blue(&mut self, block: BlockWithWork, reachability: &impl ReachabilityService) {
+    /// Insert a new blue block into the chain decomposition
+    fn add_blue(&mut self, block: BlockWithWork, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
         let initial_score = SignedWork::from(self.deficit_work);
         let initial_bucket = bucket_for_score(initial_score);
 
@@ -109,13 +109,13 @@ impl CascadeMaintainer {
 
         // A new blue block contributes according to its initial bucket.
         let initial_contribution = work_delta(block.work, initial_bucket);
-        self.process_event(block.hash, initial_contribution, reachability);
+        events.push(block.hash, initial_contribution);
     }
 
     /// Add a new red block and propagate its negative work to ancestor blues.
-    pub fn add_red(&mut self, block: BlockWithWork, reachability: &impl ReachabilityService) {
+    fn add_red(&mut self, block: BlockWithWork, events: &mut CascadeEvents) {
         self.red_work = self.red_work + block.work;
-        self.process_event(block.hash, work_delta(block.work, Bucket::Negative), reachability);
+        events.push(block.hash, work_delta(block.work, Bucket::Negative));
     }
 
     /// Returns the aggregate score of the virtual block.
@@ -233,35 +233,62 @@ impl CascadeMaintainer {
 
     // ----- Event processing -----
 
-    fn process_event(&mut self, source: Hash, delta: SignedWork, reachability: &impl ReachabilityService) {
-        let mut queue = Vec::new();
+    fn process_positive_events(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+        while let Some((source, delta)) = events.positive.pop_front() {
+            self.apply_event(source, delta, reachability);
+            while let Some((chain_id, block)) = self
+                .chains_score_trees
+                .iter()
+                .enumerate()
+                .find_map(|(chain_id, tree)| tree.extract_negative_at_least_zero().map(|block| (chain_id, block)))
+            {
+                self.chains_score_trees[chain_id].flip_to_positive(block);
+                self.negative_blue_work = self.negative_blue_work - block.work;
+                self.flip_count += 1;
+                events.push(block.hash, work_delta(block.work * 2u64, Bucket::Positive));
+            }
+        }
+    }
 
-        self.apply_event(source, delta, reachability);
+    fn apply_direct_red_effects(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+        debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
 
-        // Extract crossings and propagate
-        let mut changed = true;
-        while changed {
-            changed = false;
+        // These are the direct effects of all reds in the current mergeset. They
+        // are inherent to the mergeset, so apply every one before examining any
+        // consequent negative crossing.
+        while let Some((source, delta)) = events.negative.pop_front() {
+            self.apply_event(source, delta, reachability);
+        }
+    }
 
-            for tree in self.chains_score_trees.iter_mut() {
-                while let Some(block) = tree.extract_positive_below_zero() {
-                    tree.flip_to_negative(block);
-                    self.negative_blue_work = self.negative_blue_work + block.work;
-                    self.flip_count += 1;
-                    queue.push((block.hash, work_delta(block.work * 2u64, Bucket::Negative)));
-                    changed = true;
+    fn process_negative_crossings(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+        debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
+
+        loop {
+            while let Some((chain_id, block)) = self
+                .chains_score_trees
+                .iter()
+                .enumerate()
+                .find_map(|(chain_id, tree)| tree.extract_positive_below_zero().map(|block| (chain_id, block)))
+            {
+                // TODO: stop before processing this crossing when it is in the forbidden zone.
+                let crossing_is_allowed = true;
+                if !crossing_is_allowed {
+                    return;
                 }
-
-                while let Some(block) = tree.extract_negative_at_least_zero() {
-                    tree.flip_to_positive(block);
-                    self.negative_blue_work = self.negative_blue_work - block.work;
-                    self.flip_count += 1;
-                    queue.push((block.hash, work_delta(block.work * 2u64, Bucket::Positive)));
-                    changed = true;
-                }
+                self.chains_score_trees[chain_id].flip_to_negative(block);
+                self.negative_blue_work = self.negative_blue_work + block.work;
+                self.flip_count += 1;
+                events.push(block.hash, work_delta(block.work * 2u64, Bucket::Negative));
             }
 
-            for (source, delta) in queue.drain(..) {
+            if events.negative.is_empty() {
+                break;
+            }
+
+            // Every queued event belongs to a flip already committed in this
+            // round, so propagate the complete batch before checking again.
+            while let Some((source, delta)) = events.negative.pop_front() {
                 self.apply_event(source, delta, reachability);
             }
         }
@@ -370,28 +397,13 @@ pub fn run_cascade(
     } else {
         CascadeMaintainer::new(conflict_genesis, k)
     };
-
     // Process remaining mergesets (pop from bottom = CG-first, upward)
     while let Some(mergeset) = mergeset_stack.pop() {
-        // Process blues first (already in topological order)
-        for (hash, work) in mergeset.mergeset_blues {
-            let block_with_work = BlockWithWork::new(hash, work);
-            maintainer.add_blue(block_with_work, reachability);
-            voting_blocks += 1;
-        }
-
-        // Then process reds (already in topological order, skip grays)
-        for (hash, work) in mergeset.mergeset_reds {
-            let is_gray = reachability.is_chain_ancestor_of(next_chain_ancestor, hash);
-            if !is_gray {
-                let block_with_work = BlockWithWork::new(hash, work);
-                maintainer.add_red(block_with_work, reachability);
-                voting_blocks += 1;
-            }
-        }
+        let chain_block = mergeset.merging_chain_block;
+        voting_blocks += process_mergeset(&mut maintainer, mergeset, next_chain_ancestor, reachability);
 
         // Checkpoint at chain block — persist to store (best-effort)
-        if let Some(chain_block) = mergeset.merging_chain_block {
+        if let Some(chain_block) = chain_block {
             let _ = maintainer.save_state(
                 conflict_genesis.hash,
                 k,
@@ -404,7 +416,7 @@ pub fn run_cascade(
     }
 
     let cascade_score = maintainer.cascade_score();
-    let accepted = cascade_score >= SignedWork::zero();
+    let accepted = maintainer.virtual_accepts();
 
     CascadeResult {
         cascade_score,
@@ -417,7 +429,37 @@ pub fn run_cascade(
     }
 }
 
-// ============================================================================
+/// Process one mergeset in protocol order.
+///
+/// Blue effects are fully stabilized first. All direct red effects are then
+/// applied, followed by the negative event cascade, until stoppage
+fn process_mergeset(
+    maintainer: &mut CascadeMaintainer,
+    mergeset: Mergeset,
+    next_chain_ancestor: Hash,
+    reachability: &impl ReachabilityService,
+) -> u64 {
+    let mut events = CascadeEvents::new();
+    let mut voting_blocks = 0u64;
+
+    for (hash, work) in mergeset.mergeset_blues {
+        maintainer.add_blue(BlockWithWork::new(hash, work), reachability, &mut events);
+        voting_blocks += 1;
+    }
+    maintainer.process_positive_events(reachability, &mut events);
+
+    for (hash, work) in mergeset.mergeset_reds {
+        if !reachability.is_chain_ancestor_of(next_chain_ancestor, hash) {
+            maintainer.add_red(BlockWithWork::new(hash, work), &mut events);
+            voting_blocks += 1;
+        }
+    }
+
+    maintainer.apply_direct_red_effects(reachability, &mut events);
+    maintainer.process_negative_crossings(reachability, &mut events);
+    voting_blocks
+}
+
 // Segment Tree UMC Voter
 // ============================================================================
 
@@ -457,7 +499,6 @@ impl<O: HeaderStoreReader + 'static, E: UmcCascadeStore + Clone + 'static, R: Re
         let virtual_gd = ctx.virtual_gd;
         let k = ctx.k;
         let coloring_reader = ctx.coloring_reader;
-
         let next_chain_ancestor_of_subgroup = self.reachability_service.get_next_chain_ancestor(subgroup[0], conflict_genesis);
 
         // Collect blues and reds by traversing virtual GD chain backward.

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -373,7 +373,7 @@ impl CascadeMaintainer {
     /// amortized. Multiplying by the cost of propagating an event gives
     /// `O(k^6 log(n / k^2))` amortized time per mergeset round. Direct events
     /// from the `O(k^2)` newly processed blocks are lower order. This accounting
-    /// intentionally does not use the range-update batching optimization, 
+    /// intentionally does not use the range-update batching optimization,
     /// which provides de facto speedup, but is hard to analyze.
     fn process_positive_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
         while !events.queue.is_empty() {
@@ -399,7 +399,10 @@ impl CascadeMaintainer {
     /// the blue anticone of the bound contributes at most another `k^2` blocks.
     /// Hence at most `(k^4 + k^2) + k^2` negative flips are processed.
     fn process_negative_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        debug_assert!(events.queue.iter().all(|(_, delta)| *delta < SignedWork::zero()), "red processing must start with negative events");
+        debug_assert!(
+            events.queue.iter().all(|(_, delta)| *delta < SignedWork::zero()),
+            "red processing must start with negative events"
+        );
 
         loop {
             self.apply_events_batch(events.drain(), reachability);
@@ -574,7 +577,7 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
 ///
 /// All blue and red effects are queued before stabilization starts. Applying the
 /// positive phase  first and consuming any potential positive flip,  allows us to be
-/// certain that if a negative is found beyond the depth restriction later on, 
+/// certain that if a negative is found beyond the depth restriction later on,
 /// than it is final for this mergeset and the run can be safely stopped.
 fn process_mergeset<C: ColoringReader + ?Sized>(
     maintainer: &mut CascadeMaintainer,

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::{ops::Range, sync::Arc};
 
 use kaspa_consensus_core::{BlueWorkType, KType};
@@ -12,7 +12,7 @@ use crate::model::services::reachability::{MTReachabilityService, ReachabilitySe
 use crate::model::stores::headers::HeaderStoreReader;
 use crate::model::stores::reachability::ReachabilityStoreReader;
 use crate::processes::dagknight::umc_cascade_persistence::{
-    CascadeEvent, ChainLeafEntry, Mergeset, MergesetEvents, UmcCascadeKey, UmcCascadePersistedState, UmcCascadeStore,
+    ChainLeafEntry, Mergeset, UmcCascadeKey, UmcCascadePersistedState, UmcCascadeStore,
 };
 use crate::processes::dagknight::umc_voting::{CascadeResult, ColoringReader, SignedWork, UmcVoter, UmcVotingContext};
 use crate::processes::dagknight::{AppendableSegmentTree, Bucket, bucket_for_score};
@@ -60,33 +60,6 @@ fn work_delta(work: BlueWorkType, bucket: Bucket) -> SignedWork {
     }
 }
 
-struct CascadeEvents {
-    queue: VecDeque<(Hash, SignedWork)>,
-    processed: Vec<CascadeEvent>,
-}
-
-impl CascadeEvents {
-    fn new() -> Self {
-        Self { queue: VecDeque::new(), processed: Vec::new() }
-    }
-
-    fn push(&mut self, source: Hash, delta: SignedWork) {
-        self.queue.push_back((source, delta));
-    }
-
-    fn drain(&mut self) -> Vec<(Hash, SignedWork)> {
-        let events: Vec<_> = self.queue.drain(..).collect();
-        for &(source, delta) in &events {
-            self.record(source, delta);
-        }
-        events
-    }
-
-    fn record(&mut self, source: Hash, delta: SignedWork) {
-        self.processed.push(CascadeEvent { source, delta_abs: delta.abs(), delta_negative: delta.negative() });
-    }
-}
-
 impl CascadeMaintainer {
     /// Initializes the cascade with `floor(sqrt(k))` conflict-genesis work as its voting deficit.
     pub fn new(conflict_genesis: BlockWithWork, k: KType, next_chain_ancestor: Hash) -> Self {
@@ -107,7 +80,7 @@ impl CascadeMaintainer {
     }
 
     /// Insert a new blue block into the chain decomposition
-    fn add_blue(&mut self, block: BlockWithWork, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+    fn add_blue(&mut self, block: BlockWithWork, reachability: &impl ReachabilityService, events: &mut Vec<(Hash, SignedWork)>) {
         let initial_score = SignedWork::from(self.deficit_work);
         let initial_bucket = bucket_for_score(initial_score);
 
@@ -123,63 +96,13 @@ impl CascadeMaintainer {
 
         // A new blue block contributes according to its initial bucket.
         let initial_contribution = work_delta(block.work, initial_bucket);
-        events.push(block.hash, initial_contribution);
+        events.push((block.hash, initial_contribution));
     }
 
     /// Add a new red block and propagate its negative work to ancestor blues.
-    fn add_red(&mut self, block: BlockWithWork, events: &mut CascadeEvents) {
+    fn add_red(&mut self, block: BlockWithWork, events: &mut Vec<(Hash, SignedWork)>) {
         self.red_work = self.red_work + block.work;
-        events.push(block.hash, work_delta(block.work, Bucket::Negative));
-    }
-    /// Undo a path of previously processed mergesets as one operation.
-    ///
-    /// All inverse events are queued and applied before any blue leaves are
-    /// removed. Blue leaves from the complete path are then removed jointly in
-    /// reverse topological order, without running cascade crossing logic.
-    pub fn unprocess_mergesets(
-        &mut self,
-        mergesets: &[Mergeset],
-        events_diff: &[MergesetEvents],
-        reachability: &impl ReachabilityService,
-    ) {
-        assert_eq!(mergesets.len(), events_diff.len(), "each mergeset must have an events diff");
-        let event_count: usize = events_diff.iter().map(|diff| diff.events.len()).sum();
-        let mut inverse_events = VecDeque::with_capacity(event_count);
-        let mut blue_blocks = Vec::new();
-
-        for (mergeset, events) in mergesets.iter().zip(events_diff) {
-            for event in &events.events {
-                let magnitude = SignedWork::from(event.delta_abs);
-                let delta = if event.delta_negative { magnitude } else { SignedWork::zero() - magnitude };
-                inverse_events.push_back((event.source, delta));
-            }
-
-            for &(hash, work) in &mergeset.mergeset_reds {
-                // ignore gray work
-                if !reachability.is_chain_ancestor_of(self.next_chain_ancestor, hash) {
-                    self.red_work = self.red_work - work;
-                }
-            }
-
-            blue_blocks.extend(mergeset.mergeset_blues.iter().map(|&(hash, work)| BlockWithWork::new(hash, work)));
-        }
-
-        self.apply_events_batch(inverse_events, reachability);
-
-        for block in blue_blocks.into_iter().rev() {
-            let chain_id = *self.blk_mapping_to_chains.get(&block.hash).expect("blue block is not present");
-            let chain = &mut self.blues_chains_decomposition[chain_id];
-            assert_eq!(chain.last().copied(), Some(block.hash), "blue removal must follow reverse topological order");
-            let tree = &mut self.chains_score_trees[chain_id];
-            let bucket = tree.bucket(block);
-            assert!(tree.remove_head(block), "blue block must be the current chain head");
-            chain.pop();
-            self.blk_mapping_to_chains.remove(&block.hash);
-            self.blue_work = self.blue_work - block.work;
-            if bucket == Bucket::Negative {
-                self.negative_blue_work = self.negative_blue_work - block.work;
-            }
-        }
+        events.push((block.hash, work_delta(block.work, Bucket::Negative)));
     }
 
     /// Returns the aggregate score of the virtual block.
@@ -241,7 +164,7 @@ impl CascadeMaintainer {
     // ----- Persistence -----
 
     /// Serialize the current cascade state for checkpoint persistence.
-    pub fn to_persisted_state(&mut self, voting_blocks: u64, events_diff: Vec<MergesetEvents>) -> UmcCascadePersistedState {
+    pub fn to_persisted_state(&mut self, voting_blocks: u64) -> UmcCascadePersistedState {
         let mut chains_leaves: Vec<Vec<ChainLeafEntry>> = Vec::new();
 
         for (chain_id, _chain) in self.blues_chains_decomposition.iter().enumerate() {
@@ -274,7 +197,6 @@ impl CascadeMaintainer {
             red_work: self.red_work,
             negative_blue_work: self.negative_blue_work,
             voting_blocks,
-            events_diff,
             flip_count: self.flip_count,
         }
     }
@@ -382,9 +304,9 @@ impl CascadeMaintainer {
     /// from the `O(k^2)` newly processed blocks are lower order. This accounting
     /// intentionally does not use the range-update batching optimization,
     /// which provides de facto speedup, but is hard to analyze.
-    fn process_positive_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        while !events.queue.is_empty() {
-            self.apply_events_batch(events.drain(), reachability);
+    fn process_positive_phase(&mut self, reachability: &impl ReachabilityService, events: &mut Vec<(Hash, SignedWork)>) {
+        while !events.is_empty() {
+            self.apply_events_batch(events.drain(..), reachability);
 
             for chain_id in 0..self.chains_score_trees.len() {
                 let crossing_blocks = self.chains_score_trees[chain_id].extract_negative_at_least_zero_batch();
@@ -392,7 +314,7 @@ impl CascadeMaintainer {
                     self.chains_score_trees[chain_id].flip_to_positive(block);
                     self.negative_blue_work = self.negative_blue_work - block.work;
                     self.flip_count += 1;
-                    events.push(block.hash, work_delta(block.work * 2u64, Bucket::Positive));
+                    events.push((block.hash, work_delta(block.work * 2u64, Bucket::Positive)));
                 }
             }
         }
@@ -405,14 +327,11 @@ impl CascadeMaintainer {
     /// selected-chain interval up to the merger and its mergeset blues), while
     /// the blue anticone of the bound contributes at most another `k^2` blocks.
     /// Hence at most `(k^4 + k^2) + k^2` negative flips are processed.
-    fn process_negative_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        debug_assert!(
-            events.queue.iter().all(|(_, delta)| *delta < SignedWork::zero()),
-            "red processing must start with negative events"
-        );
+    fn process_negative_phase(&mut self, reachability: &impl ReachabilityService, events: &mut Vec<(Hash, SignedWork)>) {
+        debug_assert!(events.iter().all(|(_, delta)| *delta < SignedWork::zero()), "red processing must start with negative events");
 
         loop {
-            self.apply_events_batch(events.drain(), reachability);
+            self.apply_events_batch(events.drain(..), reachability);
 
             if self.violates_depth_restriction(reachability) {
                 return;
@@ -424,11 +343,11 @@ impl CascadeMaintainer {
                     self.chains_score_trees[chain_id].flip_to_negative(block);
                     self.negative_blue_work = self.negative_blue_work + block.work;
                     self.flip_count += 1;
-                    events.push(block.hash, work_delta(block.work * 2u64, Bucket::Negative));
+                    events.push((block.hash, work_delta(block.work * 2u64, Bucket::Negative)));
                 }
             }
 
-            if events.queue.is_empty() {
+            if events.is_empty() {
                 break;
             }
 
@@ -460,10 +379,9 @@ impl CascadeMaintainer {
         &mut self,
         key: UmcCascadeKey,
         voting_blocks: u64,
-        events_diff: Vec<MergesetEvents>,
         cascade_store: Arc<dyn UmcCascadeStore>,
     ) -> Result<(), StoreError> {
-        let persisted_state = self.to_persisted_state(voting_blocks, events_diff);
+        let persisted_state = self.to_persisted_state(voting_blocks);
         cascade_store.insert_checkpoint(key, persisted_state)
     }
 }
@@ -538,7 +456,6 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     coloring_reader: &C,
 ) -> CascadeResult {
     let mut voting_blocks = 0u64;
-    let mut events_diff = checkpoint_state.as_ref().map(|state| state.events_diff.clone()).unwrap_or_default();
     let from_checkpoint = checkpoint_state.is_some();
 
     // Restore from checkpoint or start fresh
@@ -553,14 +470,12 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     while let Some(mergeset) = mergeset_stack.pop() {
         let checkpoint_key = (!mergeset_stack.is_empty())
             .then(|| UmcCascadeKey::new(conflict_genesis.hash, k, next_chain_ancestor, mergeset.checkpoint_hash()));
-        let mergeset_hash = mergeset.checkpoint_hash();
-        let (processed_blocks, mergeset_events) = process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
+        let processed_blocks = process_mergeset(&mut maintainer, mergeset, reachability, coloring_reader);
         voting_blocks += processed_blocks;
-        events_diff.push(MergesetEvents { mergeset_hash, events: mergeset_events });
 
         // Checkpoint at chain block — persist to store (best-effort)
         if let Some(checkpoint_key) = checkpoint_key {
-            let _ = maintainer.save_state(checkpoint_key, voting_blocks, events_diff.clone(), cascade_store.clone());
+            let _ = maintainer.save_state(checkpoint_key, voting_blocks, cascade_store.clone());
         }
     }
 
@@ -573,7 +488,6 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
         accepted,
         flips: maintainer.flip_count,
         voting_blocks,
-        events_diff,
         from_checkpoint,
         estimated_effort_saved,
         estimated_effort_total,
@@ -591,7 +505,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     mergeset: Mergeset,
     reachability: &impl ReachabilityService,
     coloring_reader: &C,
-) -> (u64, Vec<CascadeEvent>) {
+) -> u64 {
     let selected_parent = mergeset.selected_parent;
     let merger_blue_score = coloring_reader.get_coloring_data(selected_parent).blue_score + mergeset.mergeset_blues.len() as u64;
 
@@ -599,7 +513,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
     // concrete selected parent as the chain endpoint.
     maintainer.update_depth_limit_ancestor(selected_parent, merger_blue_score, coloring_reader, reachability);
 
-    let mut events = CascadeEvents::new();
+    let mut events = Vec::new();
     let mut voting_blocks = 0u64;
 
     for (hash, work) in mergeset.mergeset_blues {
@@ -615,7 +529,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
 
     maintainer.process_positive_phase(reachability, &mut events);
     maintainer.process_negative_phase(reachability, &mut events);
-    (voting_blocks, events.processed)
+    voting_blocks
 }
 
 // Segment Tree UMC Voter

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -148,6 +148,58 @@ impl CascadeMaintainer {
         self.red_work = self.red_work + block.work;
         events.push(block.hash, work_delta(block.work, Bucket::Negative));
     }
+    /// Undo a path of previously processed mergesets as one operation.
+    ///
+    /// All inverse events are queued and applied before any blue leaves are
+    /// removed. Blue leaves from the complete path are then removed jointly in
+    /// reverse topological order, without running cascade crossing logic.
+    pub fn unprocess_mergesets(
+        &mut self,
+        mergesets: &[Mergeset],
+        events_diff: &[MergesetEvents],
+        reachability: &impl ReachabilityService,
+    ) {
+        assert_eq!(mergesets.len(), events_diff.len(), "each mergeset must have an events diff");
+        let event_count: usize = events_diff.iter().map(|diff| diff.events.len()).sum();
+        let mut inverse_events = VecDeque::with_capacity(event_count);
+        let mut blue_blocks = Vec::new();
+
+        for (mergeset, events) in mergesets.iter().zip(events_diff) {
+            for event in &events.events {
+                let magnitude = SignedWork::from(event.delta_abs);
+                let delta = if event.delta_negative { magnitude } else { SignedWork::zero() - magnitude };
+                inverse_events.push_back((event.source, delta));
+            }
+
+            for &(hash, work) in &mergeset.mergeset_reds {
+                // ignore gray work
+                if !reachability.is_chain_ancestor_of(self.next_chain_ancestor, hash) {
+                    self.red_work = self.red_work - work;
+                }
+            }
+
+            blue_blocks.extend(mergeset.mergeset_blues.iter().map(|&(hash, work)| BlockWithWork::new(hash, work)));
+        }
+
+        while let Some((source, delta)) = inverse_events.pop_front() {
+            self.apply_event(source, delta, reachability);
+        }
+
+        for block in blue_blocks.into_iter().rev() {
+            let chain_id = *self.blk_mapping_to_chains.get(&block.hash).expect("blue block is not present");
+            let chain = &mut self.blues_chains_decomposition[chain_id];
+            assert_eq!(chain.last().copied(), Some(block.hash), "blue removal must follow reverse topological order");
+            let tree = &mut self.chains_score_trees[chain_id];
+            let bucket = tree.bucket(block);
+            assert!(tree.remove_head(block), "blue block must be the current chain head");
+            chain.pop();
+            self.blk_mapping_to_chains.remove(&block.hash);
+            self.blue_work = self.blue_work - block.work;
+            if bucket == Bucket::Negative {
+                self.negative_blue_work = self.negative_blue_work - block.work;
+            }
+        }
+    }
 
     /// Returns the aggregate score of the virtual block.
     pub fn cascade_score(&self) -> SignedWork {
@@ -540,7 +592,7 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
 
     maintainer.apply_direct_red_effects(reachability, &mut events);
     maintainer.process_negative_crossings(reachability, &mut events);
-    voting_blocks
+    (voting_blocks, events.processed)
 }
 
 // Segment Tree UMC Voter

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -357,6 +357,43 @@ impl CascadeMaintainer {
 
     // ----- Event processing -----
 
+    /// Stabilizes all positive events produced by the current mergeset.
+    ///
+    /// # Amortized complexity
+    ///
+    /// Let the `c = O(k^2)` chains contain `n_1, ..., n_c` blocks, with
+    /// `sum(n_i) = n`. Propagating one event performs one logarithmic prefix
+    /// update on every affected chain. By concavity of the logarithm, its
+    /// worst-case cost is
+    /// `O(sum_i log(1 + n_i)) = O(c log(1 + n/c))`, hence
+    /// `O(k^2 log(1 + n/k^2))` (usually written `O(k^2 log(n/k^2))`).
+    ///
+    /// The depth restriction gives an `O(k^4)` worst-case bound on negative
+    /// flips in one mergeset round, but the same bound does not hold pointwise
+    /// for positive flips: one round may restore arbitrarily many old negative
+    /// blocks. These flips are nevertheless bounded amortized over the (linear) lifetime
+    /// of the maintainer:
+    ///
+    /// 1. During one mergeset round, a block inside the depth boundary flips
+    ///    at most once to negative and at most once to positive. The
+    ///    `O(k^4)` bound on negative flips therefore also bounds all flips
+    ///    inside the boundary by `O(k^4)` for that round.
+    /// 2. A positive flip strictly beyond the boundary can occur at most once.
+    ///    If that block later obtains a negative score, `violates_depth_restriction`
+    ///    stops processing before `process_negative_crossings` changes its bucket
+    ///    back to negative. Its score may subsequently change, but it cannot
+    ///    cause positive flip processing.
+    ///
+    /// Thus each round has `O(k^4)` flips inside the boundary, plus at most one
+    /// beyond-boundary positive flip per block over the complete history
+    /// (including history restored from a checkpoint). Since a mergeset adds at
+    /// most `O(k^2)` blocks, those one-time flips contribute only `O(k^2)` per
+    /// round amortized. The total is therefore `O(k^4)` flip events per round
+    /// amortized. Multiplying by the cost of propagating an event gives
+    /// `O(k^6 log(n / k^2))` amortized time per mergeset round. Direct events
+    /// from the `O(k^2)` newly processed blocks are lower order. This accounting
+    /// intentionally does not use the range-update batching optimization, 
+    /// which provides de facto speedup, but is hard to analyze.
     fn process_positive_events(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
         while let Some((source, delta)) = events.pop_positive() {
             self.apply_event(source, delta, reachability);

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -543,6 +543,7 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
     }
 
     let cascade_score = maintainer.cascade_score();
+    // TODO: Create a rigorous document explaining why this restriction maintains dagknight's security.
     let accepted = !maintainer.violates_depth_restriction(reachability) && maintainer.virtual_accepts();
 
     CascadeResult {

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -61,42 +61,25 @@ fn work_delta(work: BlueWorkType, bucket: Bucket) -> SignedWork {
 }
 
 struct CascadeEvents {
-    positive: VecDeque<(Hash, SignedWork)>,
-    negative: VecDeque<(Hash, SignedWork)>,
+    queue: VecDeque<(Hash, SignedWork)>,
     processed: Vec<CascadeEvent>,
 }
 
 impl CascadeEvents {
     fn new() -> Self {
-        Self { positive: VecDeque::new(), negative: VecDeque::new(), processed: Vec::new() }
+        Self { queue: VecDeque::new(), processed: Vec::new() }
     }
 
     fn push(&mut self, source: Hash, delta: SignedWork) {
-        if delta >= SignedWork::zero() {
-            self.positive.push_back((source, delta));
-        } else {
-            self.negative.push_back((source, delta));
-        }
+        self.queue.push_back((source, delta));
     }
 
-    fn pop_positive(&mut self) -> Option<(Hash, SignedWork)> {
-        let event = self.positive.pop_front();
-        if let Some((source, delta)) = event {
+    fn drain(&mut self) -> Vec<(Hash, SignedWork)> {
+        let events: Vec<_> = self.queue.drain(..).collect();
+        for &(source, delta) in &events {
             self.record(source, delta);
-            Some((source, delta))
-        } else {
-            None
         }
-    }
-
-    fn pop_negative(&mut self) -> Option<(Hash, SignedWork)> {
-        let event = self.negative.pop_front();
-        if let Some((source, delta)) = event {
-            self.record(source, delta);
-            Some((source, delta))
-        } else {
-            None
-        }
+        events
     }
 
     fn record(&mut self, source: Hash, delta: SignedWork) {
@@ -357,8 +340,6 @@ impl CascadeMaintainer {
 
     // ----- Event processing -----
 
-    /// Stabilizes all positive events produced by the current mergeset.
-    ///
     /// # Amortized complexity
     ///
     /// Let the `c = O(k^2)` chains contain `n_1, ..., n_c` blocks, with
@@ -380,7 +361,7 @@ impl CascadeMaintainer {
     ///    inside the boundary by `O(k^4)` for that round.
     /// 2. A positive flip strictly beyond the boundary can occur at most once.
     ///    If that block later obtains a negative score, `violates_depth_restriction`
-    ///    stops processing before `process_negative_crossings` changes its bucket
+    ///    stops processing before `process_negative_phase` changes its bucket
     ///    back to negative. Its score may subsequently change, but it cannot
     ///    cause positive flip processing.
     ///
@@ -394,13 +375,9 @@ impl CascadeMaintainer {
     /// from the `O(k^2)` newly processed blocks are lower order. This accounting
     /// intentionally does not use the range-update batching optimization, 
     /// which provides de facto speedup, but is hard to analyze.
-    fn process_positive_events(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        while !events.positive.is_empty() {
-            let mut positive_events = Vec::new();
-            while let Some(event) = events.pop_positive() {
-                positive_events.push(event);
-            }
-            self.apply_events_batch(positive_events, reachability);
+    fn process_positive_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+        while !events.queue.is_empty() {
+            self.apply_events_batch(events.drain(), reachability);
 
             for chain_id in 0..self.chains_score_trees.len() {
                 let crossing_blocks = self.chains_score_trees[chain_id].extract_negative_at_least_zero_batch();
@@ -414,28 +391,19 @@ impl CascadeMaintainer {
         }
     }
 
-    fn apply_direct_red_effects(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
-
-        // These are the direct effects of all reds in the current mergeset. They
-        // are inherent to the mergeset, so apply every one before examining any
-        // consequent negative crossing.
-        let mut direct_events = Vec::new();
-        while let Some(event) = events.pop_negative() {
-            direct_events.push(event);
-        }
-        self.apply_events_batch(direct_events, reachability);
-    }
-
+    /// Processes queued effects and settles negative bucket crossings.
+    ///
     /// The depth restriction bounds the number of negative flips processed here.
     /// The blue future of the bound contains at most `k^4 + k^2` blocks (the
     /// selected-chain interval up to the merger and its mergeset blues), while
     /// the blue anticone of the bound contributes at most another `k^2` blocks.
     /// Hence at most `(k^4 + k^2) + k^2` negative flips are processed.
-    fn process_negative_crossings(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
-        debug_assert!(events.positive.is_empty(), "positive events must be fully consumed before red processing");
+    fn process_negative_phase(&mut self, reachability: &impl ReachabilityService, events: &mut CascadeEvents) {
+        debug_assert!(events.queue.iter().all(|(_, delta)| *delta < SignedWork::zero()), "red processing must start with negative events");
 
         loop {
+            self.apply_events_batch(events.drain(), reachability);
+
             if self.violates_depth_restriction(reachability) {
                 return;
             }
@@ -450,17 +418,12 @@ impl CascadeMaintainer {
                 }
             }
 
-            if events.negative.is_empty() {
+            if events.queue.is_empty() {
                 break;
             }
 
             // Every queued event belongs to a flip already committed in this
             // round, so propagate the complete batch before checking again.
-            let mut crossing_events = Vec::new();
-            while let Some(event) = events.pop_negative() {
-                crossing_events.push(event);
-            }
-            self.apply_events_batch(crossing_events, reachability);
         }
     }
 
@@ -609,8 +572,10 @@ pub fn run_cascade<C: ColoringReader + ?Sized>(
 
 /// Process one mergeset in protocol order.
 ///
-/// Blue effects are fully stabilized first. All direct red effects are then
-/// applied, followed by the negative event cascade, until stoppage
+/// All blue and red effects are queued before stabilization starts. Applying the
+/// positive phase  first and consuming any potential positive flip,  allows us to be
+/// certain that if a negative is found beyond the depth restriction later on, 
+/// than it is final for this mergeset and the run can be safely stopped.
 fn process_mergeset<C: ColoringReader + ?Sized>(
     maintainer: &mut CascadeMaintainer,
     mergeset: Mergeset,
@@ -631,8 +596,6 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
         maintainer.add_blue(BlockWithWork::new(hash, work), reachability, &mut events);
         voting_blocks += 1;
     }
-    maintainer.process_positive_events(reachability, &mut events);
-
     for (hash, work) in mergeset.mergeset_reds {
         if !reachability.is_chain_ancestor_of(maintainer.next_chain_ancestor, hash) {
             maintainer.add_red(BlockWithWork::new(hash, work), &mut events);
@@ -640,8 +603,8 @@ fn process_mergeset<C: ColoringReader + ?Sized>(
         }
     }
 
-    maintainer.apply_direct_red_effects(reachability, &mut events);
-    maintainer.process_negative_crossings(reachability, &mut events);
+    maintainer.process_positive_phase(reachability, &mut events);
+    maintainer.process_negative_phase(reachability, &mut events);
     (voting_blocks, events.processed)
 }
 

--- a/consensus/src/processes/dagknight/umc_cascade.rs
+++ b/consensus/src/processes/dagknight/umc_cascade.rs
@@ -25,7 +25,6 @@ use crate::processes::difficulty::calc_work;
 /// Maintains exact cascade scores for one fixed k using chain decomposition
 /// and lazy segment trees with event-driven bucket-transition propagation.
 pub struct CascadeMaintainer {
-    k: KType,
     blues_chains_decomposition: Vec<Vec<Hash>>,
     chains_score_trees: Vec<AppendableSegmentTree<BlockWithWork, SignedWork>>,
     blk_mapping_to_chains: HashMap<Hash, usize>,
@@ -35,6 +34,7 @@ pub struct CascadeMaintainer {
     negative_blue_work: BlueWorkType,
     /// Total bucket flips observed during cascade stabilization
     flip_count: u64,
+    bound_depth: u64,
     depth_limit_ancestor: Hash,
     next_chain_ancestor: Hash,
 }
@@ -84,7 +84,6 @@ impl CascadeMaintainer {
     pub fn new(conflict_genesis: BlockWithWork, k: KType, next_chain_ancestor: Hash) -> Self {
         let deficit_work = conflict_genesis.work * u64::from(k.isqrt());
         Self {
-            k,
             blues_chains_decomposition: Vec::new(),
             chains_score_trees: Vec::new(),
             blk_mapping_to_chains: HashMap::new(),
@@ -93,6 +92,7 @@ impl CascadeMaintainer {
             red_work: BlueWorkType::ZERO,
             negative_blue_work: BlueWorkType::ZERO,
             flip_count: 0,
+            bound_depth: u64::from(k).pow(4)+1,
             depth_limit_ancestor: conflict_genesis.hash,
             next_chain_ancestor,
         }
@@ -136,27 +136,26 @@ impl CascadeMaintainer {
         self.cascade_score() >= SignedWork::zero()
     }
 
-    /// finds the first chain ancestor of the merging block, that is more than k^4 blue score away from it
+    /// finds the first chain ancestor of the merging block, that is more than k^4 blue score away from its selected parent
     fn update_depth_limit_ancestor<C: ColoringReader + ?Sized>(
         &mut self,
-        merging_block: Hash,
+        merger_selected_parent: Hash,
+        merger_blue_score: u64,
         coloring_reader: &C,
         reachability: &impl ReachabilityService,
     ) {
-        let merging_blue_score = coloring_reader.get_coloring_data(merging_block).blue_score;
-        let max_depth = u64::from(self.k).pow(4);
-        let mut bound = self.depth_limit_ancestor;
+        let mut curr_bound = self.depth_limit_ancestor;
 
-        while bound != merging_block {
-            let next_bound = reachability.get_next_chain_ancestor(merging_block, bound);
-            let next_distance = merging_blue_score.saturating_sub(coloring_reader.get_coloring_data(next_bound).blue_score);
-            if next_distance < max_depth {
+        while curr_bound != merger_selected_parent {
+            let next_bound = reachability.get_next_chain_ancestor(merger_selected_parent, curr_bound);
+            let next_distance = merger_blue_score.saturating_sub(coloring_reader.get_coloring_data(next_bound).blue_score);
+            if next_distance < self.bound_depth {
                 break;
             }
-            bound = next_bound;
+            curr_bound = next_bound;
         }
 
-        self.depth_limit_ancestor = bound;
+        self.depth_limit_ancestor = curr_bound;
     }
 
     fn violates_depth_restriction(&mut self, reachability: &impl ReachabilityService) -> bool {

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -12,8 +12,10 @@ use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
 
+// Use a new hash domain so checkpoints containing the removed event-history field
+// are not loaded as the current state format.
 kaspa_hashes::blake2b_hasher! {
-    struct UmcCascadeMergesetHasher => b"UmcCascadeMergesetHash",
+    struct UmcCascadeMergesetHasher => b"UmcCascadeMergesetHashV2",
 }
 
 // ============================================================================
@@ -70,21 +72,6 @@ pub struct Mergeset {
     pub mergeset_blues: Vec<(Hash, BlueWorkType)>,
     /// Red blocks in this mergeset (may include grays - caller must filter), also assumed to be in topological order
     pub mergeset_reds: Vec<(Hash, BlueWorkType)>,
-}
-
-/// A single cascade event applied while processing a mergeset.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct CascadeEvent {
-    pub source: Hash,
-    pub delta_abs: Uint192,
-    pub delta_negative: bool,
-}
-
-/// All cascade events processed for one mergeset.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct MergesetEvents {
-    pub mergeset_hash: Hash,
-    pub events: Vec<CascadeEvent>,
 }
 
 impl Mergeset {
@@ -147,9 +134,6 @@ pub struct UmcCascadePersistedState {
     pub negative_blue_work: Uint192,
     /// Number of voting blocks processed up to this checkpoint
     pub voting_blocks: u64,
-    /// Cascade events grouped by the mergeset that produced them.
-    #[serde(default)]
-    pub events_diff: Vec<MergesetEvents>,
     /// Total bucket flips observed up to this checkpoint
     pub flip_count: u64,
 }
@@ -160,8 +144,6 @@ impl MemSizeEstimator for UmcCascadePersistedState {
         bytes += self.blues_chains_decomposition.iter().map(|c| c.len() * size_of::<Hash>()).sum::<usize>();
         bytes += self.chains_leaves.iter().map(|l| l.len() * size_of::<ChainLeafEntry>()).sum::<usize>();
         bytes += self.blk_mapping_to_chains.len() * size_of::<(Hash, usize)>();
-        bytes +=
-            self.events_diff.iter().map(|m| size_of::<MergesetEvents>() + m.events.len() * size_of::<CascadeEvent>()).sum::<usize>();
         bytes
     }
 }
@@ -297,7 +279,6 @@ mod tests {
             red_work: Uint192::ZERO,
             negative_blue_work: Uint192::ZERO,
             voting_blocks,
-            events_diff: vec![],
             flip_count: 0,
         }
     }

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -12,35 +12,39 @@ use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
 
+kaspa_hashes::blake2b_hasher! {
+    struct UmcCascadeMergesetHasher => b"UmcCascadeMergesetHash",
+}
+
 // ============================================================================
 // Persistence Key
 // ============================================================================
 
 /// Key for UMC cascade checkpoint persistence.
 ///
-/// Layout: conflict_genesis(32) || k(u16 BE) || next_chain_ancestor(32) || current_chain_block(32)
+/// Layout: conflict_genesis(32) || k(u16 BE) || next_chain_ancestor(32) || mergeset_hash(32)
 /// Total: 98 bytes
 ///
-/// K-coloring partition is fixed per chain block (determined at block creation time),
-/// so (CG, K, NCA, CB) uniquely identifies the checkpoint state.
+/// The mergeset hash commits to the merger's selected parent and its ordered blue
+/// and red mergesets, so checkpoints from different mergeset views cannot collide.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UmcCascadeKey {
     pub conflict_genesis: Hash,
     pub k: KType,
     pub next_chain_ancestor: Hash,
-    pub current_chain_block: Hash,
+    pub mergeset_hash: Hash,
     /// Precomputed bytes
     bytes: [u8; 98],
 }
 
 impl UmcCascadeKey {
-    pub fn new(conflict_genesis: Hash, k: KType, next_chain_ancestor: Hash, current_chain_block: Hash) -> Self {
+    pub fn new(conflict_genesis: Hash, k: KType, next_chain_ancestor: Hash, mergeset_hash: Hash) -> Self {
         let mut bytes = [0u8; 98];
         bytes[..32].copy_from_slice(conflict_genesis.as_ref());
         bytes[32..34].copy_from_slice(&k.to_be_bytes());
         bytes[34..66].copy_from_slice(next_chain_ancestor.as_ref());
-        bytes[66..98].copy_from_slice(current_chain_block.as_ref());
-        Self { conflict_genesis, k, next_chain_ancestor, current_chain_block, bytes }
+        bytes[66..98].copy_from_slice(mergeset_hash.as_ref());
+        Self { conflict_genesis, k, next_chain_ancestor, mergeset_hash, bytes }
     }
 }
 
@@ -59,12 +63,43 @@ impl AsRef<[u8]> for UmcCascadeKey {
 /// A mergeset from one level of the virtual GD chain.
 #[derive(Debug, Clone)]
 pub struct Mergeset {
-    /// The chain block whose stored gd produced this mergeset (None for the virtual mergeset).
-    pub merging_chain_block: Option<Hash>,
+    /// The merger's selected parent. Together with `mergeset_blues`, this
+    /// determines the merger's blue score.
+    pub selected_parent: Hash,
     /// Blue blocks in this mergeset, assumed to be in topological order
     pub mergeset_blues: Vec<(Hash, BlueWorkType)>,
     /// Red blocks in this mergeset (may include grays - caller must filter), also assumed to be in topological order
     pub mergeset_reds: Vec<(Hash, BlueWorkType)>,
+}
+
+impl Mergeset {
+    /// Hash the complete GHOSTDAG mergeset view used to produce a checkpoint.
+    pub fn checkpoint_hash(&self) -> Hash {
+        Self::checkpoint_hash_from_hashes(
+            self.selected_parent,
+            self.mergeset_blues.iter().map(|(hash, _)| *hash),
+            self.mergeset_reds.iter().map(|(hash, _)| *hash),
+        )
+    }
+
+    /// Hash a GHOSTDAG mergeset view without constructing a `Mergeset`.
+    pub fn checkpoint_hash_from_hashes(
+        selected_parent: Hash,
+        blues: impl ExactSizeIterator<Item = Hash>,
+        reds: impl ExactSizeIterator<Item = Hash>,
+    ) -> Hash {
+        let mut hasher = UmcCascadeMergesetHasher::new();
+        hasher.write(selected_parent.as_ref());
+        hasher.write((blues.len() as u64).to_be_bytes());
+        for hash in blues {
+            hasher.write(hash.as_ref());
+        }
+        hasher.write((reds.len() as u64).to_be_bytes());
+        for hash in reds {
+            hasher.write(hash.as_ref());
+        }
+        hasher.finalize()
+    }
 }
 
 // ============================================================================

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -79,6 +79,8 @@ pub struct ChainLeafEntry {
     /// Absolute score at checkpoint time (positive value + sign flag)
     pub score_abs: Uint192,
     pub score_negative: bool,
+    /// Cascade bucket at checkpoint time; pending crossings can make this differ from the score sign.
+    pub bucket_positive: bool,
 }
 
 /// Persisted checkpoint state for UMC cascade at a specific chain block.

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -89,14 +89,14 @@ impl Mergeset {
         reds: impl ExactSizeIterator<Item = Hash>,
     ) -> Hash {
         let mut hasher = UmcCascadeMergesetHasher::new();
-        hasher.write(selected_parent.as_ref());
+        hasher.write(&selected_parent.as_bytes()[..]);
         hasher.write((blues.len() as u64).to_be_bytes());
         for hash in blues {
-            hasher.write(hash.as_ref());
+            hasher.write(&hash.as_bytes()[..]);
         }
         hasher.write((reds.len() as u64).to_be_bytes());
         for hash in reds {
-            hasher.write(hash.as_ref());
+            hasher.write(&hash.as_bytes()[..]);
         }
         hasher.finalize()
     }

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -87,6 +87,8 @@ pub struct UmcCascadePersistedState {
     pub blues_chains_decomposition: Vec<Vec<Hash>>,
     pub chains_leaves: Vec<Vec<ChainLeafEntry>>,
     pub blk_mapping_to_chains: HashMap<Hash, usize>,
+    /// Oldest chain block still covered by the depth restriction.
+    pub depth_limit_ancestor: Hash,
     pub deficit_work: Uint192,
     pub blue_work: Uint192,
     pub red_work: Uint192,

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -72,6 +72,21 @@ pub struct Mergeset {
     pub mergeset_reds: Vec<(Hash, BlueWorkType)>,
 }
 
+/// A single cascade event applied while processing a mergeset.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CascadeEvent {
+    pub source: Hash,
+    pub delta_abs: Uint192,
+    pub delta_negative: bool,
+}
+
+/// All cascade events processed for one mergeset.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MergesetEvents {
+    pub mergeset_hash: Hash,
+    pub events: Vec<CascadeEvent>,
+}
+
 impl Mergeset {
     /// Hash the complete GHOSTDAG mergeset view used to produce a checkpoint.
     pub fn checkpoint_hash(&self) -> Hash {
@@ -132,6 +147,9 @@ pub struct UmcCascadePersistedState {
     pub negative_blue_work: Uint192,
     /// Number of voting blocks processed up to this checkpoint
     pub voting_blocks: u64,
+    /// Cascade events grouped by the mergeset that produced them.
+    #[serde(default)]
+    pub events_diff: Vec<MergesetEvents>,
     /// Total bucket flips observed up to this checkpoint
     pub flip_count: u64,
 }
@@ -142,6 +160,8 @@ impl MemSizeEstimator for UmcCascadePersistedState {
         bytes += self.blues_chains_decomposition.iter().map(|c| c.len() * size_of::<Hash>()).sum::<usize>();
         bytes += self.chains_leaves.iter().map(|l| l.len() * size_of::<ChainLeafEntry>()).sum::<usize>();
         bytes += self.blk_mapping_to_chains.len() * size_of::<(Hash, usize)>();
+        bytes +=
+            self.events_diff.iter().map(|m| size_of::<MergesetEvents>() + m.events.len() * size_of::<CascadeEvent>()).sum::<usize>();
         bytes
     }
 }
@@ -277,6 +297,7 @@ mod tests {
             red_work: Uint192::ZERO,
             negative_blue_work: Uint192::ZERO,
             voting_blocks,
+            events_diff: vec![],
             flip_count: 0,
         }
     }

--- a/consensus/src/processes/dagknight/umc_cascade_persistence.rs
+++ b/consensus/src/processes/dagknight/umc_cascade_persistence.rs
@@ -234,6 +234,7 @@ mod tests {
             blues_chains_decomposition: vec![],
             chains_leaves: vec![],
             blk_mapping_to_chains: HashMap::new(),
+            depth_limit_ancestor: Hash::default(),
             deficit_work: Uint192::ZERO,
             blue_work: Uint192::ZERO,
             red_work: Uint192::ZERO,

--- a/consensus/src/processes/dagknight/umc_voting.rs
+++ b/consensus/src/processes/dagknight/umc_voting.rs
@@ -4,6 +4,7 @@ use kaspa_consensus_core::{BlueWorkType, KType};
 use kaspa_hashes::Hash;
 use kaspa_math::int::SignedInteger;
 
+use super::umc_cascade_persistence::MergesetEvents;
 use crate::model::stores::ghostdag::GhostdagData;
 
 /// Signed blue work — `SignedInteger<BlueWorkType>` with sign, used for cascade score
@@ -49,6 +50,8 @@ pub struct CascadeResult {
     pub accepted: bool,
     pub flips: u64,
     pub voting_blocks: u64,
+    /// Cascade events grouped by the mergeset that produced them.
+    pub events_diff: Vec<MergesetEvents>,
     /// Whether this cascade started from a persisted checkpoint state.
     pub from_checkpoint: bool,
     /// Estimated blue blocks skipped by loading from checkpoint.

--- a/consensus/src/processes/dagknight/umc_voting.rs
+++ b/consensus/src/processes/dagknight/umc_voting.rs
@@ -45,7 +45,7 @@ pub trait UmcVoter {
 /// Cascade result including flip statistics for performance monitoring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CascadeResult {
-    pub virtual_score: SignedWork,
+    pub cascade_score: SignedWork,
     pub accepted: bool,
     pub flips: u64,
     pub voting_blocks: u64,
@@ -246,11 +246,11 @@ pub mod test_fixtures {
             }
         }
 
-        /// Expected `virtual_score`, hand-calculated from the zone (loaded from
+        /// Expected `cascade_score`, hand-calculated from the zone (loaded from
         /// `umc_fixture.json`) as a protocol-independent oracle (the voters must agree
         /// with this without being able to read it):
         ///
-        ///   virtual_score = Σ_blue vote(B) + deficit − Σ_red work(R)
+        ///   cascade_score = Σ_blue vote(B) + deficit − Σ_red work(R)
         ///
         /// Voting blues: 11, 10, 9, 7, 6, 5, 4, 3, 2 + CG(1);
         /// Voting reds: 12..17
@@ -270,7 +270,7 @@ pub mod test_fixtures {
         /// (Gray red 8 never votes although it is a red in the futures of 2 (the NCA) — the NCA
         /// filter removes it. Reds come from blocks extending NCA=12
         ///
-        /// virtual_score = (10 × +w) + 0 − 6w = 4w
+        /// cascade_score = (10 × +w) + 0 − 6w = 4w
         pub fn expected_score(&self) -> SignedWork {
             let w = calc_work(0x207fffff);
             SignedWork::from(w * 4u64)

--- a/consensus/src/processes/dagknight/umc_voting.rs
+++ b/consensus/src/processes/dagknight/umc_voting.rs
@@ -4,7 +4,6 @@ use kaspa_consensus_core::{BlueWorkType, KType};
 use kaspa_hashes::Hash;
 use kaspa_math::int::SignedInteger;
 
-use super::umc_cascade_persistence::MergesetEvents;
 use crate::model::stores::ghostdag::GhostdagData;
 
 /// Signed blue work — `SignedInteger<BlueWorkType>` with sign, used for cascade score
@@ -50,8 +49,6 @@ pub struct CascadeResult {
     pub accepted: bool,
     pub flips: u64,
     pub voting_blocks: u64,
-    /// Cascade events grouped by the mergeset that produced them.
-    pub events_diff: Vec<MergesetEvents>,
     /// Whether this cascade started from a persisted checkpoint state.
     pub from_checkpoint: bool,
     /// Estimated blue blocks skipped by loading from checkpoint.


### PR DESCRIPTION
This PR updates the UMC algorithm, with a depth restriction: the new algorithm, automatically rejects the coloring, if a deep enough blue block has a negative vote, and skips processing onwards  to check if the actual conflict genesis is negative or positive.

The basic intuition is that if a block flips deep enough, then flipping it can't be that much easier than flipping genesis, so this event should be rare in the grand scheme of things and not actually effect the security of the protocol (even though we sometimes return "false negatives")

It is clarified that this is a consensus change to the vanilla Dagknight protocol as described in the paper. In the coming days I will write a more rigorous argument to why this altered protocol remains asymtotically as secure as vanilla Dagknight.

The bound is currently k^4 blue blocks in the past of merger which is O(K(k)^2) if we follow paper notation.  This allows us to bound the worst case of an incremental step of the algorithm as K(k)^3*log(n/(K(k))), solving the potentially unbounded flipping present in the previous version of the incremental algorithm. 

We can and likely should batch the events in the events queue in subsequent versions, which will provide a de facto speedup, but will not be meaningful in worst case asymptotics.

This is a preliminary version representing a POC for the "bounded DK" implementation. There are possibly some mild issues or inaccuracies worth pondering on.

@michaelsutton @coderofstuff